### PR TITLE
feat(companion): the assistant points at what a call is shown (JARVIS-1746)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -3096,8 +3096,12 @@ describe("companion window: pointing at what is shared", () => {
     expect(state().coachmarks).toBeUndefined();
   });
 
-  /** A share moving to another surface keeps the marks it was given. */
-  test("holds the marks while the share moves target", () => {
+  /**
+   * The fractions would survive a move to another display or window and
+   * describe that surface instead, so the marks come down with the surface
+   * they were measured against rather than with the share as a whole.
+   */
+  test("a share moving to another surface takes the marks with it", () => {
     shareDisplay();
     send("vellum:companion:setCoachmarks", [MARK]);
     send(
@@ -3107,6 +3111,28 @@ describe("companion window: pointing at what is shared", () => {
         screenShare: { kind: "window", windowId: 9 },
       }),
     );
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  test("marks placed on the surface it moved to stand", () => {
+    shareDisplay();
+    send("vellum:companion:setCoachmarks", [MARK]);
+    send(
+      "vellum:companion:setContext",
+      context({
+        screenShareEnabled: true,
+        screenShare: { kind: "window", windowId: 9 },
+      }),
+    );
+    send("vellum:companion:setCoachmarks", [MARK]);
+    expect(state().coachmarks).toEqual([MARK]);
+  });
+
+  /** A context republished unchanged is not a surface that moved. */
+  test("holds the marks while the share stays where it is", () => {
+    shareDisplay();
+    send("vellum:companion:setCoachmarks", [MARK]);
+    shareDisplay();
     expect(state().coachmarks).toEqual([MARK]);
   });
 

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   companionAnnotationInkSchema,
   companionAnnotationStrokeSchema,
+  companionCoachmarkSchema,
+  COMPANION_COACHMARK_MAX,
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_BASE_MAX_PILL_WIDTH,
   VOICE_START_REQUEST_TTL_MS,
@@ -3002,5 +3004,138 @@ describe("companion window: drawing on what is shared", () => {
         points: [{ x: 0.25, y: 0.5 }],
       }).success,
     ).toBe(true);
+  });
+});
+
+/**
+ * What the assistant points at on the shared surface.
+ *
+ * Main's half is the same half it holds for the drawing: whether the marks
+ * describe anything at all. They are fractions of the surface its frame is
+ * around, so a mark that outlives the share is a ring around whatever has
+ * since moved under it.
+ */
+describe("companion window: pointing at what is shared", () => {
+  const MARK = { x: 0.1, y: 0.2, width: 0.3, height: 0.1, caption: "Press" };
+
+  beforeEach(() => {
+    send("vellum:companion:setContext", context());
+  });
+
+  const shareDisplay = (): void => {
+    send(
+      "vellum:companion:setContext",
+      context({
+        screenShareEnabled: true,
+        screenShare: { kind: "display", displayId: 2 },
+      }),
+    );
+  };
+
+  test("puts the marks on the state the frame reads", () => {
+    shareDisplay();
+    send("vellum:companion:setCoachmarks", [MARK]);
+    expect(state().coachmarks).toEqual([MARK]);
+  });
+
+  /** Nothing pointed at is absence, so a frame reads one shape for it. */
+  test("says nothing rather than nothing-in-a-list", () => {
+    shareDisplay();
+    expect(state().coachmarks).toBeUndefined();
+    send("vellum:companion:setCoachmarks", [MARK]);
+    send("vellum:companion:setCoachmarks", []);
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /**
+   * Marks can never be armed ahead of a share, or the first share to start
+   * would open with a ring around whatever happened to be at those
+   * coordinates.
+   */
+  test("refuses marks with nothing shared", () => {
+    send("vellum:companion:setCoachmarks", [MARK]);
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /**
+   * The frame prefers a watch session's target when both run, so the marks
+   * would be drawn around the surface being read while they describe the one
+   * being shared.
+   */
+  test("refuses marks while a watch session owns the frame", () => {
+    send(
+      "vellum:companion:setContext",
+      context({
+        watching: true,
+        screenShareEnabled: true,
+        screenShare: { kind: "display", displayId: 2 },
+      }),
+    );
+    send("vellum:companion:setCoachmarks", [MARK]);
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  test("a share that ends takes the marks with it", () => {
+    shareDisplay();
+    send("vellum:companion:setCoachmarks", [MARK]);
+    send("vellum:companion:setContext", context());
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  test("a watch session starting takes the marks with it", () => {
+    shareDisplay();
+    send("vellum:companion:setCoachmarks", [MARK]);
+    send(
+      "vellum:companion:setContext",
+      context({
+        watching: true,
+        screenShareEnabled: true,
+        screenShare: { kind: "display", displayId: 2 },
+      }),
+    );
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /** A share moving to another surface keeps the marks it was given. */
+  test("holds the marks while the share moves target", () => {
+    shareDisplay();
+    send("vellum:companion:setCoachmarks", [MARK]);
+    send(
+      "vellum:companion:setContext",
+      context({
+        screenShareEnabled: true,
+        screenShare: { kind: "window", windowId: 9 },
+      }),
+    );
+    expect(state().coachmarks).toEqual([MARK]);
+  });
+
+  /**
+   * Checked against the schema rather than through a send, for the reason the
+   * drawing's bounds are: what the registrar refuses never reaches the
+   * handler, and the two are indistinguishable from here.
+   */
+  test("the wire refuses a mark measured against another surface", () => {
+    expect(
+      companionCoachmarkSchema.safeParse({ ...MARK, x: 1.5 }).success,
+    ).toBe(false);
+    expect(companionCoachmarkSchema.safeParse(MARK).success).toBe(true);
+  });
+
+  test("the wire refuses a caption longer than a caption", () => {
+    expect(
+      companionCoachmarkSchema.safeParse({
+        ...MARK,
+        caption: "a".repeat(400),
+      }).success,
+    ).toBe(false);
+  });
+
+  test("the wire refuses more marks than there are places to look", () => {
+    const many = Array.from(
+      { length: COMPANION_COACHMARK_MAX + 1 },
+      () => MARK,
+    );
+    expect(() => send("vellum:companion:setCoachmarks", many)).toThrow();
   });
 });

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -22,6 +22,8 @@ import {
   companionAnnotationPhaseSchema,
   companionAnnotationStrokeSchema,
   COMPANION_ANNOTATION_MAX_STROKES,
+  companionCoachmarkSchema,
+  COMPANION_COACHMARK_MAX,
   COMPANION_BASE_MAX_PILL_WIDTH,
   VOICE_START_REQUEST_TTL_MS,
   COMPANION_INTRO_ACTIONS,
@@ -34,6 +36,7 @@ import {
   companionScaleFor,
   WATCH_FLAG,
   type CompanionCardGrowth,
+  type CompanionCoachmark,
   type CompanionGrowth,
   type CompanionContext,
   type CompanionIntroAction,
@@ -582,9 +585,13 @@ const currentState = (): CompanionSurfaceState => {
     // Settled to a boolean the way `watchTargets` is: the control this decides
     // starts capturing the user's screen, so not knowing reads as not offering.
     screenShareEnabled: context.screenShareEnabled === true,
-    // Main's own, and the only field here that is. Every line above passes on
-    // what the app's window said; this is what main did with its frame.
+    // Main's own, along with the marks below. Every line above passes on what
+    // the app's window said; these two are what main did with its frame.
     annotating,
+    // Absent rather than empty, so a surface reads one shape for nothing
+    // being pointed at whether the shell holds marks or has never heard of
+    // them.
+    coachmarks: coachmarks.length === 0 ? undefined : coachmarks,
     // Passed through as it arrived, for the reason `watchRetro` is: every value
     // it can hold claims a microphone is doing something.
     dictating: context.dictating,
@@ -1007,8 +1014,12 @@ const glideAvatarTo = (
 let annotating = false;
 
 /**
- * Whether the mode may be on at all: something is shared, and the frame is
- * drawn around *that*.
+ * Whether the frame is drawn around the shared surface: something is shared,
+ * and the frame is around *that*.
+ *
+ * What every mark on the frame depends on, drawn by either end. Coordinates
+ * on it are fractions of the surface the frame encloses, so they describe
+ * what they claim to only while this holds.
  *
  * The second half matters because {@link framedTarget} prefers a watch
  * session's target when both are running. The frame would then be around the
@@ -1016,7 +1027,7 @@ let annotating = false;
  * and a circle drawn on one would arrive on the other, around whatever
  * happened to lie at those coordinates.
  */
-const canAnnotate = (): boolean =>
+const framesTheShare = (): boolean =>
   context.watching !== true && context.screenShare !== undefined;
 
 /** Give the frame the mouse, or give it back to the desktop. */
@@ -1033,12 +1044,47 @@ const applyFrameMouse = (): void => {
  * eating every click on that display.
  */
 const setAnnotating = (next: boolean): void => {
-  const resolved = next && canAnnotate();
+  const resolved = next && framesTheShare();
   if (resolved === annotating) {
     return;
   }
   annotating = resolved;
   applyFrameMouse();
+  pushState();
+};
+
+/**
+ * Nothing being pointed at, as one value.
+ *
+ * Shared rather than a fresh empty list each time, so {@link setCoachmarks}
+ * settles: clearing a frame that is already clear arrives as the value it
+ * already holds, and pushes nothing.
+ */
+const NO_COACHMARKS: readonly CompanionCoachmark[] = [];
+
+/**
+ * What the assistant is pointing at on the shared surface.
+ *
+ * Held by main for the reason {@link annotating} is: the marks are fractions
+ * of the surface the frame encloses, and the frame is main's. A window that
+ * kept its own marks would go on drawing them over a share that had moved to
+ * another target, which is the one thing a mark must never do.
+ */
+let coachmarks: readonly CompanionCoachmark[] = NO_COACHMARKS;
+
+/**
+ * Point at things on the shared surface, or take down what is pointed at.
+ *
+ * Idempotent, and run after every change to the context as well as on the
+ * ask, for the reason {@link setAnnotating} is: a mark that outlives its
+ * share is a ring around whatever has since moved under it.
+ */
+const setCoachmarks = (next: readonly CompanionCoachmark[]): void => {
+  const resolved = framesTheShare() ? next : NO_COACHMARKS;
+  if (resolved === coachmarks) {
+    return;
+  }
+  coachmarks = resolved;
   pushState();
 };
 
@@ -1201,9 +1247,12 @@ const framedTarget = (): WatchCaptureTarget | "screen" | null => {
 
 const syncWatchFrame = (): void => {
   // Before the frame is placed or taken down, so a mode that has lost its
-  // share is off by the time a window could be left holding the mouse for it.
-  // The pushed state that follows carries both facts at once.
+  // share is off by the time a window could be left holding the mouse for it,
+  // and marks that have lost theirs are down before the frame moves off the
+  // surface they were measured against. The pushed state that follows carries
+  // every fact at once.
   setAnnotating(annotating);
+  setCoachmarks(coachmarks);
   const framed = framedTarget();
   if (framed === null) {
     stopFollowingWindow();
@@ -1625,8 +1674,8 @@ export const installCompanionWindow = (): void => {
    * `annotating` on the next push, the same way it learns a share started.
    *
    * A press asking for the mode with nothing shared is refused rather than
-   * remembered ({@link canAnnotate}), so the mode can never be armed ahead of
-   * a share and take a display's clicks the moment one starts.
+   * remembered ({@link framesTheShare}), so the mode can never be armed
+   * ahead of a share and take a display's clicks the moment one starts.
    */
   on("vellum:companion:setAnnotating", z.tuple([z.boolean()]), ([next]) => {
     setAnnotating(next);
@@ -1642,7 +1691,7 @@ export const installCompanionWindow = (): void => {
    *
    * A *mark* is refused unless the mode is on, because the mode is what makes
    * its coordinates mean anything: they are fractions of the frame, and the
-   * frame is only around the shared surface while {@link canAnnotate} holds.
+   * frame is only around the shared surface while {@link framesTheShare} holds.
    *
    * **A release carrying nothing is let through either way**, and the order
    * of events is the whole reason. Lowering the mode is what unmounts the
@@ -1669,6 +1718,30 @@ export const installCompanionWindow = (): void => {
         return;
       }
       dispatchWithoutRaising({ kind: "annotateShare", phase, strokes, ink });
+    },
+  );
+
+  /**
+   * Point at things on the shared surface, from the window holding the
+   * session: what the assistant is pointing at now, or an empty list for
+   * nothing.
+   *
+   * Handled here rather than forwarded, the way the drawing mode's press is,
+   * and for the same reason: the marks are drawn on a window main opened,
+   * around a surface only main knows the frame is still on. An ask made with
+   * nothing shared is refused rather than remembered
+   * ({@link framesTheShare}), so marks can never be armed ahead of a share
+   * and land on a surface nobody chose.
+   *
+   * The whole set every time rather than one mark added or removed. What is
+   * being pointed at is one thought, and a caller that could add to it would
+   * be a caller whose earlier marks it has to remember to take down.
+   */
+  on(
+    "vellum:companion:setCoachmarks",
+    z.tuple([z.array(companionCoachmarkSchema).max(COMPANION_COACHMARK_MAX)]),
+    ([marks]) => {
+      setCoachmarks(marks);
     },
   );
 

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1073,19 +1073,58 @@ const NO_COACHMARKS: readonly CompanionCoachmark[] = [];
 let coachmarks: readonly CompanionCoachmark[] = NO_COACHMARKS;
 
 /**
- * Point at things on the shared surface, or take down what is pointed at.
+ * The surface the standing marks were measured against, or nothing when none
+ * stand.
  *
- * Idempotent, and run after every change to the context as well as on the
- * ask, for the reason {@link setAnnotating} is: a mark that outlives its
- * share is a ring around whatever has since moved under it.
+ * Held beside them because a share can move to another display or window
+ * while they are up. The fractions would survive that move and describe the
+ * new surface instead, putting a ring around whatever lies at those
+ * coordinates there.
  */
+let coachmarkTarget: WatchCaptureTarget | undefined;
+
+/** Whether two picks name the one surface. */
+const sameCaptureTarget = (
+  a: WatchCaptureTarget | undefined,
+  b: WatchCaptureTarget | undefined,
+): boolean => {
+  if (a === undefined || b === undefined) {
+    return a === b;
+  }
+  if (a.kind === "display") {
+    return b.kind === "display" && a.displayId === b.displayId;
+  }
+  return b.kind === "window" && a.windowId === b.windowId;
+};
+
+/** Point at things on the shared surface, or take down what is pointed at. */
 const setCoachmarks = (next: readonly CompanionCoachmark[]): void => {
   const resolved = framesTheShare() ? next : NO_COACHMARKS;
-  if (resolved === coachmarks) {
+  const against = resolved === NO_COACHMARKS ? undefined : context.screenShare;
+  if (resolved === coachmarks && sameCaptureTarget(against, coachmarkTarget)) {
     return;
   }
   coachmarks = resolved;
+  coachmarkTarget = against;
   pushState();
+};
+
+/**
+ * Take the marks down when what they describe is gone: the share ended, a
+ * watch session took the frame, or the share moved to another surface.
+ *
+ * Run after every change to the context, for the reason {@link setAnnotating}
+ * is run there: a mark that outlives the surface it was measured against is a
+ * ring around whatever has since moved under it.
+ */
+const syncCoachmarks = (): void => {
+  if (
+    framesTheShare() &&
+    sameCaptureTarget(context.screenShare, coachmarkTarget)
+  ) {
+    return;
+  }
+  setCoachmarks(NO_COACHMARKS);
 };
 
 /**
@@ -1252,7 +1291,7 @@ const syncWatchFrame = (): void => {
   // surface they were measured against. The pushed state that follows carries
   // every fact at once.
   setAnnotating(annotating);
-  setCoachmarks(coachmarks);
+  syncCoachmarks();
   const framed = framedTarget();
   if (framed === null) {
     stopFollowingWindow();

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -15,6 +15,7 @@ import type {
   BundleScanData,
   CompanionAnnotationPhase,
   CompanionAnnotationStroke,
+  CompanionCoachmark,
   CompanionCapturePick,
   CompanionCaptureSources,
   CompanionContext,
@@ -573,6 +574,9 @@ const bridge: VellumBridge = {
       ink: string,
     ): void => {
       ipcRenderer.send("vellum:companion:annotateShare", phase, strokes, ink);
+    },
+    setCoachmarks: (marks: readonly CompanionCoachmark[]): void => {
+      ipcRenderer.send("vellum:companion:setCoachmarks", marks);
     },
     captureScreen: (
       target: WatchCaptureTarget,

--- a/clients/web/src/components/companion-coachmarks.test.tsx
+++ b/clients/web/src/components/companion-coachmarks.test.tsx
@@ -2,12 +2,20 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 
 import {
+  CAPTION_BUDGET_PX,
   CAPTION_MAX_WIDTH,
   CompanionCoachmarks,
+  captionOffset,
   captionPlacement,
 } from "./companion-coachmarks";
 
 afterEach(cleanup);
+
+/**
+ * A window with room to spare on either side of a mark, which is the case the
+ * placement rules are about. The short window that has none is its own case.
+ */
+const TALL = 1000;
 
 const INK = "#5eead4";
 
@@ -121,20 +129,54 @@ describe("the caption on a mark", () => {
 
   test("hangs below and leading for a mark near the top left", () => {
     expect(
-      captionPlacement({ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }),
+      captionPlacement({ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }, TALL),
     ).toEqual({ above: false, trailing: false });
   });
 
   test("runs back from the right edge for a mark near it", () => {
     expect(
-      captionPlacement({ x: 0.8, y: 0.1, width: 0.1, height: 0.1 }),
+      captionPlacement({ x: 0.8, y: 0.1, width: 0.1, height: 0.1 }, TALL),
     ).toEqual({ above: false, trailing: true });
   });
 
   test("sits above a mark near the bottom", () => {
     expect(
-      captionPlacement({ x: 0.1, y: 0.9, width: 0.1, height: 0.05 }),
+      captionPlacement({ x: 0.1, y: 0.95, width: 0.1, height: 0.04 }, TALL),
     ).toEqual({ above: true, trailing: false });
+  });
+
+  /**
+   * The room a caption needs is a number of pixels, not a fraction of the
+   * surface: the same mark leaves room to spare on a display and none at the
+   * foot of a short window.
+   */
+  test("reads the room below in pixels rather than in fractions", () => {
+    const mark = { x: 0.1, y: 0.6, width: 0.1, height: 0.2 };
+    expect(captionPlacement(mark, TALL).above).toBe(false);
+    expect(captionPlacement(mark, 120).above).toBe(true);
+  });
+
+  /**
+   * A window too short for a caption on either side still has to draw one
+   * somewhere, and the side with more room is where it is least covered.
+   */
+  test("takes the roomier side when neither side has enough", () => {
+    expect(
+      captionPlacement({ x: 0.1, y: 0.7, width: 0.1, height: 0.1 }, 80).above,
+    ).toBe(true);
+    expect(
+      captionPlacement({ x: 0.1, y: 0.2, width: 0.1, height: 0.1 }, 80).above,
+    ).toBe(false);
+  });
+
+  test("holds a caption off the edge of a window too short for it", () => {
+    const mark = { x: 0.1, y: 0.8, width: 0.1, height: 0.15 };
+    expect(captionOffset(mark, 120, false)).toBe(120 - CAPTION_BUDGET_PX);
+  });
+
+  test("leaves a caption at its mark when the window has the room", () => {
+    const mark = { x: 0.1, y: 0.1, width: 0.1, height: 0.1 };
+    expect(captionOffset(mark, TALL, false)).toBe(0.2 * TALL + 10);
   });
 
   /**
@@ -143,12 +185,10 @@ describe("the caption on a mark", () => {
    * edge, which is what makes the two thresholds enough on their own.
    */
   test("cannot run off the surface it flipped to stay on", () => {
-    const flipped = captionPlacement({
-      x: 0.6,
-      y: 0.1,
-      width: 0.001,
-      height: 0.1,
-    });
+    const flipped = captionPlacement(
+      { x: 0.6, y: 0.1, width: 0.001, height: 0.1 },
+      TALL,
+    );
     expect(flipped.trailing).toBe(true);
     expect(0.6 + CAPTION_MAX_WIDTH).toBeLessThanOrEqual(1);
   });
@@ -163,7 +203,9 @@ describe("the caption on a mark", () => {
     const caption = captionOf(container);
     expect(caption?.textContent).toBe("Press");
     expect(caption?.style.right).toBe("20%");
-    expect(caption?.style.bottom).toBe("10%");
+    expect(caption?.style.bottom).toBe(
+      `${captionOffset({ x: 0.7, y: 0.9, width: 0.1, height: 0.05 }, window.innerHeight, true)}px`,
+    );
     expect(caption?.dataset.above).toBe("");
     expect(caption?.dataset.trailing).toBe("");
   });

--- a/clients/web/src/components/companion-coachmarks.test.tsx
+++ b/clients/web/src/components/companion-coachmarks.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import {
+  CAPTION_MAX_WIDTH,
+  CompanionCoachmarks,
+  captionPlacement,
+} from "./companion-coachmarks";
+
+afterEach(cleanup);
+
+const INK = "#5eead4";
+
+const markOf = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>("[data-testid='companion-coachmark']");
+
+const captionOf = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>(
+    "[data-testid='companion-coachmark-caption']",
+  );
+
+/**
+ * The mark itself. Its coordinates are fractions of the shared surface and
+ * the window is that surface exactly, so what these pin is that a fraction
+ * reaches CSS as the same fraction of the window.
+ */
+describe("a mark on the shared surface", () => {
+  test("is placed as fractions of the window", () => {
+    const { container } = render(
+      <CompanionCoachmarks
+        marks={[{ x: 0.25, y: 0.5, width: 0.1, height: 0.2 }]}
+        ink={INK}
+      />,
+    );
+    const mark = markOf(container);
+    expect(mark?.style.left).toBe("25%");
+    expect(mark?.style.top).toBe("50%");
+    expect(mark?.style.width).toBe("10%");
+    expect(mark?.style.height).toBe("20%");
+  });
+
+  test("takes no mouse events, so the press lands on the app underneath", () => {
+    const { container } = render(
+      <CompanionCoachmarks
+        marks={[{ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }]}
+        ink={INK}
+      />,
+    );
+    const layer = container.querySelector<HTMLElement>(
+      "[data-testid='companion-coachmarks']",
+    );
+    expect(layer?.className).toContain("pointer-events-none");
+  });
+
+  test("draws in the accent it is handed", () => {
+    const { container } = render(
+      <CompanionCoachmarks
+        marks={[{ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }]}
+        ink="#ff8800"
+      />,
+    );
+    const layer = container.querySelector<HTMLElement>(
+      "[data-testid='companion-coachmarks']",
+    );
+    expect(layer?.style.getPropertyValue("--companion-ring-accent")).toBe(
+      "#ff8800",
+    );
+  });
+
+  /**
+   * A mark whose far edge sits past the surface is a control against the side
+   * of a window, which is a real answer. What must not happen is a negative
+   * offset, which would hang the caption off the far edge instead.
+   */
+  test("holds a mark that runs past the edge inside the surface", () => {
+    const { container } = render(
+      <CompanionCoachmarks
+        marks={[{ x: 0.9, y: 0.1, width: 0.3, height: 0.1, caption: "Here" }]}
+        ink={INK}
+      />,
+    );
+    expect(captionOf(container)?.style.right).toBe("0%");
+  });
+
+  /**
+   * Each mark is its own element rather than a position in a list, so a mark
+   * replacing another plays the entrance that says a new place to look.
+   */
+  test("replaces the element when the mark it draws changes", () => {
+    const { container, rerender } = render(
+      <CompanionCoachmarks
+        marks={[{ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }]}
+        ink={INK}
+      />,
+    );
+    const first = markOf(container);
+    rerender(
+      <CompanionCoachmarks
+        marks={[{ x: 0.4, y: 0.1, width: 0.1, height: 0.1 }]}
+        ink={INK}
+      />,
+    );
+    expect(markOf(container)).not.toBe(first);
+  });
+});
+
+/**
+ * The caption, which hangs off a corner of its mark. A mark can sit anywhere
+ * on the surface, so the corner is what keeps the caption on it.
+ */
+describe("the caption on a mark", () => {
+  test("is absent when the ring is the whole message", () => {
+    const { container } = render(
+      <CompanionCoachmarks
+        marks={[{ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }]}
+        ink={INK}
+      />,
+    );
+    expect(captionOf(container)).toBeNull();
+  });
+
+  test("hangs below and leading for a mark near the top left", () => {
+    expect(
+      captionPlacement({ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }),
+    ).toEqual({ above: false, trailing: false });
+  });
+
+  test("runs back from the right edge for a mark near it", () => {
+    expect(
+      captionPlacement({ x: 0.8, y: 0.1, width: 0.1, height: 0.1 }),
+    ).toEqual({ above: false, trailing: true });
+  });
+
+  test("sits above a mark near the bottom", () => {
+    expect(
+      captionPlacement({ x: 0.1, y: 0.9, width: 0.1, height: 0.05 }),
+    ).toEqual({ above: true, trailing: false });
+  });
+
+  /**
+   * The flip and the width the caption may take are one decision: a caption
+   * that starts at the flip and runs its full width ends exactly at the far
+   * edge, which is what makes the two thresholds enough on their own.
+   */
+  test("cannot run off the surface it flipped to stay on", () => {
+    const flipped = captionPlacement({
+      x: 0.6,
+      y: 0.1,
+      width: 0.001,
+      height: 0.1,
+    });
+    expect(flipped.trailing).toBe(true);
+    expect(0.6 + CAPTION_MAX_WIDTH).toBeLessThanOrEqual(1);
+  });
+
+  test("is anchored to the corner it was placed at", () => {
+    const { container } = render(
+      <CompanionCoachmarks
+        marks={[{ x: 0.7, y: 0.9, width: 0.1, height: 0.05, caption: "Press" }]}
+        ink={INK}
+      />,
+    );
+    const caption = captionOf(container);
+    expect(caption?.textContent).toBe("Press");
+    expect(caption?.style.right).toBe("20%");
+    expect(caption?.style.bottom).toBe("10%");
+    expect(caption?.dataset.above).toBe("");
+    expect(caption?.dataset.trailing).toBe("");
+  });
+});

--- a/clients/web/src/components/companion-coachmarks.tsx
+++ b/clients/web/src/components/companion-coachmarks.tsx
@@ -20,40 +20,86 @@
 
 import { Fragment } from "react";
 
+import { useWindowBox } from "@/components/companion-window-box";
 import type { CompanionCoachmark } from "@vellumai/ipc-contract";
 
 /**
- * Where a caption goes rather than off the edge of the surface.
+ * Which side of its mark a caption hangs from, across the surface.
  *
- * A caption hangs off one corner of its mark, so a mark near an edge is the
- * case that decides the corner. Past `FLIP_X` of the way across, the caption
- * hangs from the mark's right edge and runs left; past `FLIP_Y` down, it sits
- * above the mark instead of below. The thresholds pair with the width the
- * caption is allowed ({@link CAPTION_MAX_WIDTH}): a caption starting at
- * `FLIP_X` and running the full width it may take ends exactly at the far
- * edge, so neither flip can leave one hanging off the surface.
+ * A fraction, because the horizontal constraint is one: past `FLIP_X` of the
+ * way across, the caption hangs from the mark's right edge and runs back
+ * left. It pairs with the width a caption may take
+ * ({@link CAPTION_MAX_WIDTH}), which is a fraction of the same surface: one
+ * starting at `FLIP_X` and running the full width it is allowed ends exactly
+ * at the far edge, so the flip cannot leave a caption hanging off the side.
  */
 const CAPTION_FLIP_X = 0.6;
-const CAPTION_FLIP_Y = 0.85;
 export const CAPTION_MAX_WIDTH = 0.4;
 
-/** Which corner of a mark its caption hangs from. */
+/**
+ * The tallest a caption is drawn, in the window's pixels, plus the gap it
+ * keeps from its mark.
+ *
+ * Pixels rather than a fraction, and that is the whole reason this constant
+ * exists. The height a caption needs is set by the text in it, not by the
+ * surface it is drawn on: a fraction that leaves room on a display leaves
+ * none at the foot of a short window. The cap is real, held by the
+ * `max-height` on `.companion-coachmark-caption`, so the two must move
+ * together.
+ */
+export const CAPTION_BUDGET_PX = 58;
+const CAPTION_GAP_PX = 10;
+
+/** Which side of a mark its caption hangs from. */
 export interface CaptionPlacement {
   above: boolean;
   trailing: boolean;
 }
 
 /**
- * The corner a mark's caption hangs from, chosen so it stays on the surface.
+ * The side a mark's caption hangs from, chosen so it stays on the surface.
  *
- * Read off the mark's own far edges rather than its origin: what has to stay
- * on screen is the caption, and the caption starts where the mark ends.
+ * Below unless the room under the mark is short of what a caption can need,
+ * measured against the window rather than assumed from a fraction of it. When
+ * neither side has the room, the caption goes where there is more of it and
+ * is held against that edge by {@link captionOffset}.
+ *
+ * Read off the mark's far edge rather than its origin: what has to stay on
+ * screen is the caption, and the caption starts where the mark ends.
  */
-export function captionPlacement(mark: CompanionCoachmark): CaptionPlacement {
+export function captionPlacement(
+  mark: CompanionCoachmark,
+  windowHeight: number,
+): CaptionPlacement {
+  const below = (1 - (mark.y + mark.height)) * windowHeight;
+  const above = mark.y * windowHeight;
   return {
-    above: mark.y + mark.height > CAPTION_FLIP_Y,
+    above: below < CAPTION_BUDGET_PX && above > below,
     trailing: mark.x + mark.width > CAPTION_FLIP_X,
   };
+}
+
+/**
+ * How far a caption sits from the edge it is anchored to, in the window's
+ * pixels.
+ *
+ * Held back from the far edge by the budget, so a mark against the foot of a
+ * short window puts its caption above that edge rather than through it. The
+ * caption is then nearer its mark than the gap asks for, which is the right
+ * trade: a caption touching its mark still reads as belonging to it, and one
+ * off the surface reads as nothing at all.
+ */
+export function captionOffset(
+  mark: CompanionCoachmark,
+  windowHeight: number,
+  above: boolean,
+): number {
+  const edge = above ? 1 - mark.y : mark.y + mark.height;
+  const room = Math.max(windowHeight - CAPTION_BUDGET_PX, 0);
+  // Whole pixels, for the reason {@link percent} rounds: the offset is a
+  // fraction of a measured height, and the tail of that has nowhere to land
+  // on a screen.
+  return Math.round(Math.min(edge * windowHeight + CAPTION_GAP_PX, room));
 }
 
 /**
@@ -87,6 +133,7 @@ export function CompanionCoachmarks({
   marks: readonly CompanionCoachmark[];
   ink: string;
 }) {
+  const box = useWindowBox();
   return (
     <div
       className="pointer-events-none fixed inset-0"
@@ -95,7 +142,8 @@ export function CompanionCoachmarks({
       role="presentation"
     >
       {marks.map((mark) => {
-        const { above, trailing } = captionPlacement(mark);
+        const { above, trailing } = captionPlacement(mark, box.height);
+        const offset = `${captionOffset(mark, box.height, above)}px`;
         return (
           // A fragment rather than a box around the pair: both are placed
           // against this layer, and a wrapper that positioned neither would
@@ -121,9 +169,7 @@ export function CompanionCoachmarks({
                   ...(trailing
                     ? { right: percent(1 - (mark.x + mark.width)) }
                     : { left: percent(mark.x) }),
-                  ...(above
-                    ? { bottom: percent(1 - mark.y) }
-                    : { top: percent(mark.y + mark.height) }),
+                  ...(above ? { bottom: offset } : { top: offset }),
                   maxWidth: percent(CAPTION_MAX_WIDTH),
                 }}
               >

--- a/clients/web/src/components/companion-coachmarks.tsx
+++ b/clients/web/src/components/companion-coachmarks.tsx
@@ -33,8 +33,8 @@ import type { CompanionCoachmark } from "@vellumai/ipc-contract";
  * `FLIP_X` and running the full width it may take ends exactly at the far
  * edge, so neither flip can leave one hanging off the surface.
  */
-export const CAPTION_FLIP_X = 0.6;
-export const CAPTION_FLIP_Y = 0.85;
+const CAPTION_FLIP_X = 0.6;
+const CAPTION_FLIP_Y = 0.85;
 export const CAPTION_MAX_WIDTH = 0.4;
 
 /** Which corner of a mark its caption hangs from. */

--- a/clients/web/src/components/companion-coachmarks.tsx
+++ b/clients/web/src/components/companion-coachmarks.tsx
@@ -1,0 +1,138 @@
+/**
+ * What the assistant is pointing at on the surface a call is being shown.
+ *
+ * Mounted inside the frame's window (`companion-watch-frame-page.tsx`), which
+ * the macOS shell sizes to exactly what is being shared. That is what lets
+ * this stay simple: a mark is a rectangle in fractions of the window, so a
+ * percentage is the whole of the arithmetic and nothing here measures
+ * anything.
+ *
+ * The ring is drawn outside the bounds it is given, never over them. The
+ * point of the mark is that the user goes and uses the thing inside it, and a
+ * ring that dimmed or covered the control would be pointing at something it
+ * had just taken away.
+ *
+ * **Click-through, always.** The user's own drawing is the one layer on this
+ * window that takes the mouse, and it takes it because a press is a mark
+ * rather than a click. A coachmark is the opposite errand: it says press
+ * *that*, so the press has to land on the app underneath.
+ */
+
+import { Fragment } from "react";
+
+import type { CompanionCoachmark } from "@vellumai/ipc-contract";
+
+/**
+ * Where a caption goes rather than off the edge of the surface.
+ *
+ * A caption hangs off one corner of its mark, so a mark near an edge is the
+ * case that decides the corner. Past `FLIP_X` of the way across, the caption
+ * hangs from the mark's right edge and runs left; past `FLIP_Y` down, it sits
+ * above the mark instead of below. The thresholds pair with the width the
+ * caption is allowed ({@link CAPTION_MAX_WIDTH}): a caption starting at
+ * `FLIP_X` and running the full width it may take ends exactly at the far
+ * edge, so neither flip can leave one hanging off the surface.
+ */
+export const CAPTION_FLIP_X = 0.6;
+export const CAPTION_FLIP_Y = 0.85;
+export const CAPTION_MAX_WIDTH = 0.4;
+
+/** Which corner of a mark its caption hangs from. */
+export interface CaptionPlacement {
+  above: boolean;
+  trailing: boolean;
+}
+
+/**
+ * The corner a mark's caption hangs from, chosen so it stays on the surface.
+ *
+ * Read off the mark's own far edges rather than its origin: what has to stay
+ * on screen is the caption, and the caption starts where the mark ends.
+ */
+export function captionPlacement(mark: CompanionCoachmark): CaptionPlacement {
+  return {
+    above: mark.y + mark.height > CAPTION_FLIP_Y,
+    trailing: mark.x + mark.width > CAPTION_FLIP_X,
+  };
+}
+
+/**
+ * A fraction of the surface, held inside it, as a CSS percentage.
+ *
+ * Rounded, because a fraction reaches this as the difference of two others
+ * and binary arithmetic leaves a tail well past what a display can draw. Four
+ * places is a ten-thousandth of a screen, which is under a pixel on anything.
+ */
+function percent(fraction: number): string {
+  const held = Math.min(Math.max(fraction, 0), 1) * 100;
+  return `${Number(held.toFixed(4))}%`;
+}
+
+/**
+ * A mark as its own identity, so one replacing another at the same position
+ * in the set is a new element and plays its own entrance.
+ *
+ * What the assistant points at changes step by step through a task, and each
+ * step is a new place to look. Reusing the element would move a ring the user
+ * had already found rather than putting one where they have not looked yet.
+ */
+function markKey(mark: CompanionCoachmark): string {
+  return `${mark.x},${mark.y},${mark.width},${mark.height},${mark.caption ?? ""}`;
+}
+
+export function CompanionCoachmarks({
+  marks,
+  ink,
+}: {
+  marks: readonly CompanionCoachmark[];
+  ink: string;
+}) {
+  return (
+    <div
+      className="pointer-events-none fixed inset-0"
+      data-testid="companion-coachmarks"
+      style={{ ["--companion-ring-accent" as string]: ink }}
+      role="presentation"
+    >
+      {marks.map((mark) => {
+        const { above, trailing } = captionPlacement(mark);
+        return (
+          // A fragment rather than a box around the pair: both are placed
+          // against this layer, and a wrapper that positioned neither would
+          // still be a node between them and the surface they measure from.
+          <Fragment key={markKey(mark)}>
+            <div
+              className="companion-coachmark"
+              data-testid="companion-coachmark"
+              style={{
+                left: percent(mark.x),
+                top: percent(mark.y),
+                width: percent(mark.width),
+                height: percent(mark.height),
+              }}
+            />
+            {mark.caption !== undefined && mark.caption !== "" && (
+              <div
+                className="companion-coachmark-caption"
+                data-testid="companion-coachmark-caption"
+                data-above={above ? "" : undefined}
+                data-trailing={trailing ? "" : undefined}
+                style={{
+                  ...(trailing
+                    ? { right: percent(1 - (mark.x + mark.width)) }
+                    : { left: percent(mark.x) }),
+                  ...(above
+                    ? { bottom: percent(1 - mark.y) }
+                    : { top: percent(mark.y + mark.height) }),
+                  maxWidth: percent(CAPTION_MAX_WIDTH),
+                }}
+              >
+                {mark.caption}
+              </div>
+            )}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/clients/web/src/components/companion-share-annotation.tsx
+++ b/clients/web/src/components/companion-share-annotation.tsx
@@ -29,6 +29,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useWindowBox } from "@/components/companion-window-box";
 import { annotateCompanionShare } from "@/runtime/companion-surface";
 import {
   COMPANION_ANNOTATION_MAX_POINTS,
@@ -76,28 +77,6 @@ export function movedEnough(
   const dx = (next.x - last.x) * aspect;
   const dy = next.y - last.y;
   return dx * dx + dy * dy >= COMPANION_ANNOTATION_MIN_STEP ** 2;
-}
-
-/** The window's own size, tracked so the marks can be drawn in its pixels. */
-function useWindowBox(): { width: number; height: number } {
-  const [box, setBox] = useState(() => ({
-    width: typeof window === "undefined" ? 0 : window.innerWidth,
-    height: typeof window === "undefined" ? 0 : window.innerHeight,
-  }));
-  useEffect(() => {
-    // The shell resizes this window whenever the share moves to another
-    // target, and follows a picked window as the user drags it, so the box is
-    // not something that can be read once.
-    const measure = (): void => {
-      setBox({ width: window.innerWidth, height: window.innerHeight });
-    };
-    measure();
-    window.addEventListener("resize", measure);
-    return () => {
-      window.removeEventListener("resize", measure);
-    };
-  }, []);
-  return box;
 }
 
 export function CompanionShareAnnotation({ ink }: { ink: string }) {

--- a/clients/web/src/components/companion-watch-frame-page.test.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.test.tsx
@@ -53,6 +53,15 @@ const inkOf = (container: HTMLElement): HTMLElement | null =>
     "[data-testid='companion-share-annotation']",
   );
 
+const marksOf = (container: HTMLElement): HTMLElement[] =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(
+      "[data-testid='companion-coachmark']",
+    ),
+  );
+
+const MARK = { x: 0.1, y: 0.2, width: 0.2, height: 0.1 };
+
 const LISTENING_CALL = {
   phase: "listening" as const,
   label: "Listening",
@@ -289,6 +298,58 @@ describe("the frame around what is read", () => {
       pushState({ ...STATE, annotating: true });
       pushState({ ...STATE, annotating: false });
       expect(inkOf(container)).toBeNull();
+    });
+  });
+
+  /**
+   * What the assistant points at, which is drawn off the share rather than
+   * off the mode: nothing about it takes the mouse, and what it needs is for
+   * this window to be around the surface the marks were measured against.
+   */
+  describe("what the assistant points at", () => {
+    test("draws the marks on the shared surface", () => {
+      const { container } = render(<CompanionWatchFramePage />);
+      pushState({
+        ...STATE,
+        call: LISTENING_CALL,
+        screenShare: { kind: "display", displayId: 1 },
+        coachmarks: [MARK],
+      });
+      expect(marksOf(container)).toHaveLength(1);
+    });
+
+    test("draws nothing with no share to measure against", () => {
+      const { container } = render(<CompanionWatchFramePage />);
+      pushState({ ...STATE, coachmarks: [MARK] });
+      expect(marksOf(container)).toHaveLength(0);
+    });
+
+    /**
+     * The frame is around the watched surface while both run
+     * (`framedTarget`), so the fractions describe a surface this window is no
+     * longer on.
+     */
+    test("draws nothing while a watch session outranks the share", () => {
+      const { container } = render(<CompanionWatchFramePage />);
+      pushState({
+        ...STATE,
+        watching: true,
+        screenShare: { kind: "display", displayId: 1 },
+        coachmarks: [MARK],
+      });
+      expect(marksOf(container)).toHaveLength(0);
+    });
+
+    test("takes the marks down when they are withdrawn", () => {
+      const { container } = render(<CompanionWatchFramePage />);
+      const shared = {
+        ...STATE,
+        call: LISTENING_CALL,
+        screenShare: { kind: "display" as const, displayId: 1 },
+      };
+      pushState({ ...shared, coachmarks: [MARK] });
+      pushState(shared);
+      expect(marksOf(container)).toHaveLength(0);
     });
   });
 });

--- a/clients/web/src/components/companion-watch-frame-page.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.tsx
@@ -45,6 +45,7 @@ import {
   companionAccentHexFor,
   COMPANION_DEFAULT_ACCENT,
 } from "@/components/companion-accent";
+import { CompanionCoachmarks } from "@/components/companion-coachmarks";
 import { CompanionShareAnnotation } from "@/components/companion-share-annotation";
 import {
   getCompanionState,
@@ -145,6 +146,13 @@ export function CompanionWatchFramePage() {
   // layer mounted over that would swallow presses that go nowhere.
   const annotating = state?.annotating === true;
 
+  // A mark is a fraction of the surface the frame encloses, and a watch
+  // session outranks a share for the frame (`framedTarget` in
+  // `companion-window.ts`). So the marks describe what this window is around
+  // only while no session is being read beside the share. Main holds them to
+  // the same terms; this is that fact read where it is drawn.
+  const coachmarks = sharing && !watching ? (state?.coachmarks ?? []) : [];
+
   return (
     <div
       className="pointer-events-none h-screen w-screen bg-transparent"
@@ -176,6 +184,16 @@ export function CompanionWatchFramePage() {
           so the default the class carries is named for it. */}
       {annotating && (
         <CompanionShareAnnotation ink={accentHex ?? COMPANION_DEFAULT_ACCENT} />
+      )}
+      {/* Above the user's own ink in the markup for the reason it is drawn at
+          all: a mark says where to go next, and the user's marks are about
+          where they have already been. Neither takes the mouse, so the order
+          is about the eye alone. */}
+      {coachmarks.length > 0 && (
+        <CompanionCoachmarks
+          marks={coachmarks}
+          ink={accentHex ?? COMPANION_DEFAULT_ACCENT}
+        />
       )}
     </div>
   );

--- a/clients/web/src/components/companion-window-box.ts
+++ b/clients/web/src/components/companion-window-box.ts
@@ -1,0 +1,36 @@
+/**
+ * The size of the window a layer is drawing in, as its own pixels.
+ *
+ * Shared by the layers on the companion's frame window, which is sized by the
+ * macOS shell to exactly the surface a call is being shown. Everything drawn
+ * there is described in fractions of that surface, so the box is what turns
+ * a fraction into somewhere to draw and what decides whether something fits.
+ */
+
+import { useEffect, useState } from "react";
+
+export interface WindowBox {
+  width: number;
+  height: number;
+}
+
+export function useWindowBox(): WindowBox {
+  const [box, setBox] = useState<WindowBox>(() => ({
+    width: typeof window === "undefined" ? 0 : window.innerWidth,
+    height: typeof window === "undefined" ? 0 : window.innerHeight,
+  }));
+  useEffect(() => {
+    // The shell resizes this window whenever the share moves to another
+    // target, and follows a picked window as the user drags it, so the box is
+    // not something that can be read once.
+    const measure = (): void => {
+      setBox({ width: window.innerWidth, height: window.innerHeight });
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => {
+      window.removeEventListener("resize", measure);
+    };
+  }, []);
+  return box;
+}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -459,24 +459,30 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 .companion-coachmark-caption {
   position: absolute;
   width: max-content;
-  margin-top: 10px;
+  /* Capped, and the cap is load-bearing: the layer places a caption by how
+     many pixels of window are left beside its mark, and it can only do that
+     against a height a caption cannot exceed. `CAPTION_BUDGET_PX` in
+     `companion-coachmarks.tsx` is this height plus the gap, and the two move
+     together. Three lines of the size below, plus the padding. */
+  max-height: 57px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
   padding: 4px 10px;
   /* A caption is the assistant's own words about a control, and a control can
      be named by something long and unbroken (a path, an identifier). Held
      inside the width it is allowed rather than running off the surface. */
   overflow-wrap: anywhere;
-  border-radius: 999px;
+  /* Rounded rather than a pill: a caption that wraps is a tall box, and a pill
+     radius on one draws a lozenge around three lines of text. */
+  border-radius: 10px;
   font-size: 12px;
   line-height: 1.35;
   color: #fff;
   background: color-mix(in srgb, black 78%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent);
   animation: companion-coachmark-in 260ms ease-out 1;
-}
-
-.companion-coachmark-caption[data-above] {
-  margin-top: 0;
-  margin-bottom: 10px;
 }
 
 /* Held drawn rather than dropped, the way the frame is: the mark is where the

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -428,6 +428,62 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   }
 }
 
+/* What the assistant is pointing at on that same surface. The ring sits
+ * outside the bounds it is given, so the control the user is being sent to is
+ * exactly as visible as it was before anything was drawn on it, and the dark
+ * halo outside the accent is what keeps the ring found over a white document
+ * and a dark editor alike. One entrance and then still: a ring that went on
+ * pulsing over someone's work would be the loudest thing on their screen for
+ * as long as they took to follow it. */
+@keyframes companion-coachmark-in {
+  from {
+    opacity: 0;
+    transform: scale(1.06);
+  }
+}
+
+.companion-coachmark {
+  position: absolute;
+  border-radius: 6px;
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 90%, transparent),
+    0 0 0 5px color-mix(in srgb, black 30%, transparent);
+  animation: companion-coachmark-in 260ms ease-out 1;
+}
+
+/* The line about what to do with it, hung off whichever corner of the mark
+ * keeps it on the surface. Dark with an accent rim rather than filled with the
+ * accent: the colour has to tie the caption to its ring across every palette
+ * an assistant can have, and only the rim can do that at a contrast that
+ * holds. */
+.companion-coachmark-caption {
+  position: absolute;
+  width: max-content;
+  margin-top: 10px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  line-height: 1.35;
+  color: #fff;
+  background: color-mix(in srgb, black 78%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent);
+  animation: companion-coachmark-in 260ms ease-out 1;
+}
+
+.companion-coachmark-caption[data-above] {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+/* Held drawn rather than dropped, the way the frame is: the mark is where the
+ * user is being sent, and its entrance is decoration on top of that. */
+@media (prefers-reduced-motion: reduce) {
+  .companion-coachmark,
+  .companion-coachmark-caption {
+    animation: none;
+  }
+}
+
 /* Live-voice transcript caret — a thin bar blinking like a text caret at the
  * end of the streaming speech transcript in the composer (Light 55). The
  * component also holds it static via useReducedMotion; the media query is

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -461,6 +461,10 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   width: max-content;
   margin-top: 10px;
   padding: 4px 10px;
+  /* A caption is the assistant's own words about a control, and a control can
+     be named by something long and unbroken (a path, an identifier). Held
+     inside the width it is allowed rather than running off the surface. */
+  overflow-wrap: anywhere;
   border-radius: 999px;
   font-size: 12px;
   line-height: 1.35;

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -13,6 +13,7 @@ import type {
   CompanionAnnotationPhase,
   CompanionAnnotationStroke,
   CompanionCapturePick,
+  CompanionCoachmark,
   CompanionCaptureSources,
   CompanionContext,
   CompanionDictating,
@@ -162,6 +163,21 @@ export function annotateCompanionShare(
   ink: string,
 ): void {
   bridge()?.annotateShare?.(phase, strokes, ink);
+}
+
+/**
+ * Point at things on the surface a call is being shown, or take down what is
+ * pointed at by asking for none.
+ *
+ * The whole set each time: what is being pointed at is one thought, and a
+ * call that added to it would leave the caller owing a call to take the rest
+ * down. The answer comes back as `coachmarks` on the pushed state, which main
+ * empties when the share the marks were measured against ends.
+ */
+export function setCompanionCoachmarks(
+  marks: readonly CompanionCoachmark[],
+): void {
+  bridge()?.setCoachmarks?.(marks);
 }
 
 /**

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -25,6 +25,7 @@ import type {
   CompanionCapturePick,
   CompanionCaptureSources,
   CompanionCharacter,
+  CompanionCoachmark,
   CompanionGrowth,
   CompanionContext,
   CompanionIntroAction,
@@ -411,6 +412,7 @@ declare global {
           strokes: readonly CompanionAnnotationStroke[],
           ink: string,
         ): void;
+        setCoachmarks?(marks: readonly CompanionCoachmark[]): void;
         captureScreen?(
           target: WatchCaptureTarget,
         ): Promise<ScreenCaptureFrame | null>;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -26,6 +26,7 @@ import type {
   BundleScanData,
   CompanionAnnotationPhase,
   CompanionAnnotationStroke,
+  CompanionCoachmark,
   CompanionCharacter,
   CompanionContext,
   CompanionIntroAction,
@@ -660,6 +661,20 @@ export interface VellumBridge {
       strokes: readonly CompanionAnnotationStroke[],
       ink: string,
     ): void;
+    /**
+     * Point at things on the surface a call is being shown, or take down
+     * whatever is being pointed at by sending none.
+     *
+     * Main's own state for the reason `setAnnotating` is, and with the same
+     * consequence: the marks are fractions of the surface the frame is drawn
+     * around, so only main can say whether they still describe anything.
+     * What comes back is `coachmarks` on `onState`, which the frame's window
+     * draws.
+     *
+     * Absent on a shell that predates the marks, the bargain
+     * `setScreenShare` makes.
+     */
+    setCoachmarks?(marks: readonly CompanionCoachmark[]): void;
     /**
      * One frame of `target`, as the helper takes it, for the window holding a
      * shared call to hand to the session. Resolves to null when no frame

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -201,6 +201,7 @@ export const COMPANION_LIST_CAPTURE_SOURCES =
 export const COMPANION_SET_SCREEN_SHARE = "vellum:companion:setScreenShare";
 export const COMPANION_SET_ANNOTATING = "vellum:companion:setAnnotating";
 export const COMPANION_ANNOTATE_SHARE = "vellum:companion:annotateShare";
+export const COMPANION_SET_COACHMARKS = "vellum:companion:setCoachmarks";
 export const COMPANION_CAPTURE_SCREEN = "vellum:companion:captureScreen";
 export const COMPANION_ANSWER_WATCH_RETRO = "vellum:companion:answerWatchRetro";
 export const COMPANION_ANSWER_DICTATION_OFFER =

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 import {
   ASSISTANT_STATUSES,
   COMPANION_ANNOTATION_MAX_POINTS,
+  COMPANION_COACHMARK_CAPTION_MAX,
   COMPANION_DICTATION_TAIL,
   NOTIFICATION_CATEGORIES,
   VOICE_ACTIVITY_CONTROL_ACTIONS,
@@ -168,6 +169,23 @@ export const companionAnnotationPhaseSchema = z.enum(["drawing", "released"]);
 export const companionAnnotationInkSchema = z
   .string()
   .regex(/^#[0-9a-fA-F]{6}$/);
+
+/**
+ * One thing the assistant is pointing at on the shared surface.
+ *
+ * Bounded per axis rather than as a rectangle inside the surface: a mark that
+ * runs past an edge is a real answer (a control against the side of a
+ * window), and the frame's window draws whatever part of it is on screen. A
+ * corner outside `0`..`1` is a mark measured against some other surface, and
+ * that is what the bounds refuse.
+ */
+export const companionCoachmarkSchema = z.object({
+  x: z.number().min(0).max(1),
+  y: z.number().min(0).max(1),
+  width: z.number().min(0).max(1),
+  height: z.number().min(0).max(1),
+  caption: z.string().max(COMPANION_COACHMARK_CAPTION_MAX).optional(),
+});
 
 /** What the app's window tells main about the assistant the surface is for. */
 export const companionContextSchema = z.object({

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1371,6 +1371,51 @@ export const COMPANION_ANNOTATION_MAX_POINTS = 512;
 export const COMPANION_ANNOTATION_STROKE = 0.006;
 
 /**
+ * One thing the assistant is pointing at on the surface a call is being
+ * shown: the bounds of the thing, and a line about what to do with it.
+ *
+ * **In fractions of the shared surface, from `0` to `1`**, for the reason
+ * {@link CompanionAnnotationStroke} carries fractions. The overlay is a
+ * window sized in points, and what the mark was resolved from is measured in
+ * the target's own units; a fraction of the surface is the one description
+ * both ends agree on, and it survives the scaling between them.
+ *
+ * The bounds are the thing itself rather than the ring drawn for it. The ring
+ * goes outside them, so the control a user is being pointed at stays as
+ * visible as it was before anything was drawn on it.
+ *
+ * A rectangle, not a stroke, because this end knows what it is pointing at:
+ * the user draws freehand at something they can already see, and the
+ * assistant resolves an element that has bounds.
+ */
+export interface CompanionCoachmark {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /**
+   * What to do with the thing, in the user's language, or nothing when the
+   * ring is the whole message.
+   *
+   * Short by contract ({@link COMPANION_COACHMARK_CAPTION_MAX}): it is drawn
+   * over the user's own work, in a window they cannot scroll or dismiss, and
+   * anything longer than a caption belongs in what the assistant is saying.
+   */
+  caption?: string;
+}
+
+/**
+ * How many marks stand at once, and how long a caption may be.
+ *
+ * A mark is where to look next, so a surface covered in them is nowhere to
+ * look. The bound is low because it is the shape of the feature rather than a
+ * safeguard: past a few marks at once, what is being drawn is not a place to
+ * go but a diagram, and the call is where a diagram gets explained.
+ */
+export const COMPANION_COACHMARK_MAX = 4;
+export const COMPANION_COACHMARK_CAPTION_MAX = 80;
+
+/**
  * One frame of a {@link WatchCaptureTarget}, as the helper took it: a JPEG,
  * with the size it was encoded at. Base64 rather than bytes because it
  * crosses the bridge as JSON.
@@ -1791,6 +1836,21 @@ export interface CompanionSurfaceState {
    * about where the next click goes.
    */
   annotating?: boolean;
+
+  /**
+   * What the assistant is pointing at on the shared surface, drawn on the
+   * frame around it. See {@link CompanionCoachmark}.
+   *
+   * Main's rather than the app window's, in the sense that main decides
+   * whether any of them stand: the coordinates are fractions of the surface
+   * the frame is drawn around, so a mark only means anything while the frame
+   * is around the surface the marks were resolved against. Main takes them
+   * down when it is not.
+   *
+   * Optional, and absence means nothing is being pointed at. An empty array
+   * never travels: a shell with nothing to draw says nothing.
+   */
+  coachmarks?: readonly CompanionCoachmark[];
 
   /**
    * Whether Watch is offered at all, as the flag was last evaluated for the


### PR DESCRIPTION
## Summary

- Adds `coachmarks` to `CompanionSurfaceState`: rectangles in fractions of the shared surface, each with an optional caption, drawn as a new layer in the frame window that already surrounds what a call is being shown. The coordinate contract and the schema shape follow `companionAnnotationStrokeSchema`, which established fractions-of-the-shared-surface for the user's own ink.
- Main owns them, as it owns the drawing mode. `canAnnotate` becomes `framesTheShare`, since "the frame is around the shared surface" is what both the mode and the marks depend on; marks are refused when nothing is shared and taken down when a share ends or a watch session outranks it.
- The layer is `pointer-events-none` and the ring is drawn outside the bounds it is given, so a mark never covers or intercepts the control it points at. `setIgnoreMouseEvents` stays keyed on `annotating` alone.

Rendering only: no tool, no daemon wire, no AX resolution, no anchor lifetime. Those are separate follow-ups. The new channel (`vellum:companion:setCoachmarks`) is what the host wire will call once it exists.

**Design library:** the mark and its caption are hand-rolled CSS in `index.css` beside `.companion-watch-frame` and `.companion-share-ink`, not design-library primitives. This window is a click-through overlay drawn over other applications in the assistant's accent, with no app chrome and no theme; its existing decorations are all local classes for the same reason.

**Tests:** new cases in `companion-coachmarks.test.tsx`, `companion-watch-frame-page.test.tsx`, and `companion-window.test.ts`. Each behavioural assertion was negative-checked (share-end clearing, the share gate, and the page's draw predicate each reverted, and the expected tests went red). `clients/macos` is 33/33 on `bun scripts/run-tests.ts`; `clients/web` companion suites are green file by file.

## Original prompt

Voice calls let a user draw on the screen they are sharing and send it to the assistant, and that works well. Alex asked for the other direction: when someone is in a complicated app and wants to learn how to do something rather than have it done for them, the assistant should be able to put an overlay on their screen showing where to go and then say what to do, resolved from the accessibility tree with a screenshot where one is needed. Scoped to inside a call with a share already running, so it rides the screen-share capability that exists. This is step 1 of four: the marks themselves, fed by hand, with the resolution and lifetime work to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNwGYEPVEspgJtFmsN1QFM