### PR TITLE
Auto-promote Android production releases on Google Play

### DIFF
--- a/.github/workflows/release-android.yaml
+++ b/.github/workflows/release-android.yaml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       artifact_name: ${{ steps.config.outputs.artifact_name }}
       package_id: ${{ steps.config.outputs.package_id }}
+      track: ${{ steps.config.outputs.track }}
       version_name: ${{ steps.config.outputs.version_name }}
     permissions:
       contents: read
@@ -38,14 +39,17 @@ jobs:
             production)
               echo "flavor=Production" >> "$GITHUB_OUTPUT"
               echo "package_id=ai.vellum.assistant" >> "$GITHUB_OUTPUT"
+              echo "track=production" >> "$GITHUB_OUTPUT"
               ;;
             staging)
               echo "flavor=Staging" >> "$GITHUB_OUTPUT"
               echo "package_id=ai.vellum.assistant.staging" >> "$GITHUB_OUTPUT"
+              echo "track=internal" >> "$GITHUB_OUTPUT"
               ;;
             dev)
               echo "flavor=Dev" >> "$GITHUB_OUTPUT"
               echo "package_id=ai.vellum.assistant.dev" >> "$GITHUB_OUTPUT"
+              echo "track=internal" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Invalid Android environment: $ENVIRONMENT"
@@ -182,7 +186,7 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
-      - name: Publish to Google Play internal track
+      - name: Publish to Google Play
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -195,4 +199,5 @@ jobs:
           bun clients/web/scripts/publish-android-play.ts \
             --bundle "${bundles[0]}" \
             --package-id "${{ needs.build-and-upload.outputs.package_id }}" \
-            --release-name "${{ needs.build-and-upload.outputs.version_name }}"
+            --release-name "${{ needs.build-and-upload.outputs.version_name }}" \
+            --track "${{ needs.build-and-upload.outputs.track }}"

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -480,14 +480,15 @@ wrong identity.
 Release builds enable resource shrinking and R8 optimization. Capacitor plugin
 annotations and methods are retained by `app/proguard-rules.pro`.
 
-## Google Play Internal Releases
+## Google Play Releases
 
 `.github/workflows/release-android.yaml` is the reusable Android release
-workflow. It builds a signed AAB, retains it as an artifact, and uploads it to
-the matching Play internal track through the Android Publisher API. The
-publisher uses Google's official Android Publisher client and repository-owned
-code, not an external Play publishing action. Production-track promotion
-remains manual.
+workflow. It builds a signed AAB, retains it as an artifact, and publishes it
+through the Android Publisher API. Dev and staging releases use their matching
+app's internal track. Production releases use the production track with a
+completed rollout, which submits the release for Play review and publishing.
+The publisher uses Google's official Android Publisher client and
+repository-owned code, not an external Play publishing action.
 When Firebase configuration is available, the workflow validates that it
 matches the selected flavor before including it in the build.
 
@@ -512,8 +513,8 @@ GitHub variables. `GCP_SERVICE_ACCOUNT` must match the environment's
 Never commit Firebase configuration, the keystore, or decoded secret material.
 The workflow removes restored files even when a build fails.
 
-`ANDROID_FIREBASE_CONFIG_B64` remains optional so signing and internal
-distribution do not depend on push setup. When it is absent, the workflow emits
+`ANDROID_FIREBASE_CONFIG_B64` remains optional so signing and Play distribution
+do not depend on push setup. When it is absent, the workflow emits
 a warning and the resulting AAB has no native push support. When it is present,
 malformed base64, invalid JSON, or a package mismatch fails the build.
 
@@ -524,7 +525,7 @@ distribution independently with these repository variables:
 |----------|------------------|
 | `ANDROID_DEV_RELEASE_ENABLED` | Dev releases |
 | `ANDROID_STAGING_RELEASE_ENABLED` | Staging releases |
-| `ANDROID_PRODUCTION_RELEASE_ENABLED` | Production releases |
+| `ANDROID_PRODUCTION_RELEASE_ENABLED` | Production releases to the Play production track |
 
 Set only `ANDROID_DEV_RELEASE_ENABLED` to `true` to test the dev app on its Play
 internal track. Leave the staging and production variables unset or set to
@@ -535,7 +536,7 @@ schedule.
 
 ### Manual Play Prerequisites
 
-Complete the following setup before enabling internal-track uploads:
+Complete the following setup before enabling Google Play publishing:
 
 1. Apply the platform Terraform stacks that enable the Android Publisher API
    in the dev, staging, and production GCP projects.
@@ -548,13 +549,16 @@ Complete the following setup before enabling internal-track uploads:
    upload a completed release.
 5. In Play Console, grant each environment's `GCP_SERVICE_ACCOUNT` access only
    to its matching app, with **View app information (read-only)** and
-   **Release apps to testing tracks**. Do not grant production publishing.
+   **Release apps to testing tracks**. For `ai.vellum.assistant`, also grant the
+   production environment's service account **Release to production, exclude
+   devices, and use Play App Signing**.
 6. Configure the repository and environment secrets above.
 7. Complete each Play listing, privacy policy, Data Safety form, content rating,
    and the declarations required for microphone and camera permissions.
 
-Before wider rollout, test the internal-track AAB on a physical device and
-verify its identity, web origin, authentication, keyboard, and file sharing.
+Before enabling `ANDROID_PRODUCTION_RELEASE_ENABLED`, test a signed production
+AAB on the production app's internal track using a physical device. Verify its
+identity, web origin, authentication, keyboard, and file sharing.
 
 ### Manual Firebase Prerequisites
 

--- a/clients/web/scripts/publish-android-play.ts
+++ b/clients/web/scripts/publish-android-play.ts
@@ -7,7 +7,8 @@ import * as androidpublisher from "@googleapis/androidpublisher";
 
 const ANDROID_PUBLISHER_SCOPE =
   "https://www.googleapis.com/auth/androidpublisher";
-const INTERNAL_TRACK = "internal";
+const PLAY_TRACKS = ["internal", "production"] as const;
+type PlayTrack = (typeof PLAY_TRACKS)[number];
 
 const { values } = parseArgs({
   args: process.argv.slice(2),
@@ -15,6 +16,7 @@ const { values } = parseArgs({
     bundle: { type: "string" },
     "package-id": { type: "string" },
     "release-name": { type: "string" },
+    track: { type: "string" },
   },
   strict: true,
 });
@@ -28,6 +30,7 @@ async function main(): Promise<void> {
   const bundlePath = requireArgument("bundle", values.bundle);
   const packageId = requireArgument("package-id", values["package-id"]);
   const releaseName = requireArgument("release-name", values["release-name"]);
+  const track = requireTrack(values.track);
 
   const auth = new androidpublisher.auth.GoogleAuth({
     scopes: [ANDROID_PUBLISHER_SCOPE],
@@ -67,9 +70,9 @@ async function main(): Promise<void> {
     await publisher.edits.tracks.update({
       packageName: packageId,
       editId,
-      track: INTERNAL_TRACK,
+      track,
       requestBody: {
-        track: INTERNAL_TRACK,
+        track,
         releases: [
           {
             name: releaseName,
@@ -86,7 +89,7 @@ async function main(): Promise<void> {
     });
 
     console.log(
-      `Published ${packageId} version code ${versionCode} to the Google Play ${INTERNAL_TRACK} track`
+      `Published ${packageId} version code ${versionCode} to the Google Play ${track} track`
     );
   } catch (error) {
     await deleteEdit(publisher, packageId, editId);
@@ -100,6 +103,16 @@ function requireArgument(name: string, value: string | undefined): string {
   }
 
   return value;
+}
+
+function requireTrack(value: string | undefined): PlayTrack {
+  const track = requireArgument("track", value);
+
+  if (!PLAY_TRACKS.includes(track as PlayTrack)) {
+    throw new Error(`--track must be one of: ${PLAY_TRACKS.join(", ")}`);
+  }
+
+  return track as PlayTrack;
 }
 
 async function deleteEdit(


### PR DESCRIPTION
## Summary

- Publish Android production releases to the Google Play production track with a completed rollout.
- Keep dev and staging releases on their matching internal tracks.
- Document the production publishing permission and pre-enable validation steps.

## Original prompt

Determine whether Android CD can automatically promote new production releases to Google Play production, then implement it in an isolated worktree and open a PR. Preserve safe behavior for non-production environments and leave the PR open for review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->