### PR TITLE
fix: scope the drop-close to the desktop stream and pin the runtime playwright

### DIFF
--- a/assistant/src/__tests__/browser-playwright-pin.test.ts
+++ b/assistant/src/__tests__/browser-playwright-pin.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The runtime's playwright install has to ask for the same version the image
+ * builds against, because the image bakes Chromium with it
+ * (`assistant/Dockerfile`). A floating install resolves a playwright that
+ * looks for a different browser build id, so the first `browser` call or PDF
+ * export in a pod re-downloads Chromium instead of using the baked copy.
+ */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// The bundled import must miss so the runtime-install path is the one under
+// test; a namespace without `chromium` is exactly what a compiled binary sees.
+mock.module("playwright", () => ({}));
+
+mock.module("../util/bun-runtime.js", () => ({
+  ensureBun: async () => "/nonexistent/bun",
+}));
+
+const { importPlaywright, PLAYWRIGHT_VERSION } =
+  await import("../tools/browser/runtime-check.js");
+const { getExternalDir } = await import("../util/platform.js");
+
+const realSpawn = Bun.spawn;
+afterEach(() => {
+  Bun.spawn = realSpawn;
+});
+
+/** Capture the install command; the import that follows it is expected to fail. */
+async function captureInstallCommand(): Promise<string[] | undefined> {
+  let command: string[] | undefined;
+  Bun.spawn = ((cmd: string[]) => {
+    command = cmd;
+    return {
+      exited: Promise.resolve(0),
+      stderr: new Response("").body,
+    };
+  }) as unknown as typeof Bun.spawn;
+  await importPlaywright().catch(() => {});
+  return command;
+}
+
+describe("runtime playwright install", () => {
+  test("requests the exact version the image builds against", async () => {
+    expect(await captureInstallCommand()).toEqual([
+      "/nonexistent/bun",
+      "add",
+      `playwright@${PLAYWRIGHT_VERSION}`,
+    ]);
+  });
+
+  /**
+   * A copy left behind by an earlier floating install disagrees with the baked
+   * browser, so it is replaced rather than reused.
+   */
+  test("replaces a runtime copy pinned to a different version", async () => {
+    const pwPkg = join(getExternalDir(), "node_modules", "playwright");
+    mkdirSync(pwPkg, { recursive: true });
+    writeFileSync(
+      join(pwPkg, "package.json"),
+      JSON.stringify({ name: "playwright", version: "0.0.1" }),
+    );
+
+    expect(await captureInstallCommand()).toEqual([
+      "/nonexistent/bun",
+      "add",
+      `playwright@${PLAYWRIGHT_VERSION}`,
+    ]);
+  });
+
+  test("reuses a runtime copy already at the pinned version", async () => {
+    const pwPkg = join(getExternalDir(), "node_modules", "playwright");
+    mkdirSync(pwPkg, { recursive: true });
+    writeFileSync(
+      join(pwPkg, "package.json"),
+      JSON.stringify({ name: "playwright", version: PLAYWRIGHT_VERSION }),
+    );
+
+    expect(await captureInstallCommand()).toBeUndefined();
+    expect(existsSync(join(pwPkg, "package.json"))).toBe(true);
+  });
+});

--- a/assistant/src/tools/browser/runtime-check.ts
+++ b/assistant/src/tools/browser/runtime-check.ts
@@ -1,11 +1,23 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import assistantPkg from "../../../package.json" with { type: "json" };
 import { ensureBun } from "../../util/bun-runtime.js";
 import { getLogger } from "../../util/logger.js";
 import { getExternalDir } from "../../util/platform.js";
 
 const log = getLogger("runtime-check");
+
+/**
+ * The playwright the container image builds against, and therefore the one
+ * whose Chromium build id is baked into `/opt/ms-playwright` (see
+ * `assistant/Dockerfile`). The runtime install below asks for this exact
+ * version rather than floating: a different playwright looks for a different
+ * browser build id, so a floating install would re-download Chromium and the
+ * bake would buy the pod nothing. Read from the manifest so the pin has one
+ * home.
+ */
+export const PLAYWRIGHT_VERSION: string = assistantPkg.dependencies.playwright;
 
 export interface BrowserRuntimeStatus {
   playwrightAvailable: boolean;
@@ -52,6 +64,21 @@ async function tryBundledPlaywright(): Promise<
 }
 
 /**
+ * Version of the runtime-installed playwright, or null when there is none.
+ *
+ * A copy left behind by an earlier floating install is a copy that disagrees
+ * with the baked browser, so it is replaced rather than reused.
+ */
+function installedPlaywrightVersion(pkgDir: string): string | null {
+  try {
+    const pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Resolve the package entry point from its package.json exports/main fields.
  */
 function resolvePackageEntry(pkgDir: string): string {
@@ -94,18 +121,21 @@ export async function importPlaywright(): Promise<typeof import("playwright")> {
   const externalDir = getExternalDir();
   const pwPkg = join(externalDir, "node_modules", "playwright");
 
-  if (!existsSync(join(pwPkg, "package.json"))) {
+  if (installedPlaywrightVersion(pwPkg) !== PLAYWRIGHT_VERSION) {
     mkdirSync(externalDir, { recursive: true });
     if (!existsSync(join(externalDir, "package.json"))) {
       writeFileSync(join(externalDir, "package.json"), '{"private":true}\n');
     }
     const bunPath = await ensureBun();
-    const proc = Bun.spawn([bunPath, "add", "playwright"], {
-      cwd: externalDir,
-      stdout: "pipe",
-      stderr: "pipe",
-      windowsHide: true,
-    });
+    const proc = Bun.spawn(
+      [bunPath, "add", `playwright@${PLAYWRIGHT_VERSION}`],
+      {
+        cwd: externalDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        windowsHide: true,
+      },
+    );
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
       const stderr = await new Response(proc.stderr).text();

--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -306,6 +306,16 @@ describe("resolveLiveVoiceWsUrl", () => {
     expect(url.searchParams.get("conversationId")).toBe("conv-xyz");
   });
 
+  /**
+   * A session with no conversation named starts one rather than joining a
+   * thread, so the parameter has to be absent, not present and empty.
+   */
+  test("cloud path: omits conversationId when none is given", async () => {
+    const raw = await resolveLiveVoiceWsUrl({ assistantId: "assistant-1" });
+
+    expect(new URL(raw).searchParams.has("conversationId")).toBe(false);
+  });
+
   test("self-hosted path: dials the gateway with the actor token, no mint", async () => {
     // GIVEN a primed self-hosted connection
     setSelfHostedConnection({

--- a/gateway/src/__tests__/desktop-stream-websocket.test.ts
+++ b/gateway/src/__tests__/desktop-stream-websocket.test.ts
@@ -6,7 +6,11 @@ import {
   makeConfig,
   makeFakeServer,
   mintEdgeToken,
+  settle,
+  startFakeRuntime,
   upgradedData,
+  waitFor,
+  type FakeRuntime,
 } from "./runtime-stream-test-utils.js";
 
 // The pin itself is covered in `guardian-pin.test.ts`; the binding is mocked
@@ -74,53 +78,6 @@ describe("createDesktopStreamWebsocketHandler", () => {
  * the runtime's close code has to arrive as itself.
  */
 describe("getDesktopStreamWebsocketHandlers", () => {
-  type FakeRuntime = {
-    server: ReturnType<typeof Bun.serve>;
-    received: Uint8Array[];
-    /** Resolves with the upstream socket once the pump has dialed in. */
-    connected: Promise<import("bun").ServerWebSocket<unknown>>;
-    upgradeUrl: () => URL | undefined;
-  };
-
-  /** A loopback server that records what it is sent and echoes a banner. */
-  function startFakeRuntime(banner?: Uint8Array): FakeRuntime {
-    const received: Uint8Array[] = [];
-    let upgradeUrl: URL | undefined;
-    let resolveConnected!: (ws: import("bun").ServerWebSocket<unknown>) => void;
-    const connected = new Promise<import("bun").ServerWebSocket<unknown>>(
-      (resolve) => {
-        resolveConnected = resolve;
-      },
-    );
-    const server = Bun.serve({
-      port: 0,
-      fetch(req, srv) {
-        upgradeUrl = new URL(req.url);
-        if (srv.upgrade(req)) {
-          return undefined as never;
-        }
-        return new Response("not a websocket", { status: 400 });
-      },
-      websocket: {
-        open(ws) {
-          if (banner) {
-            ws.send(banner);
-          }
-          resolveConnected(ws);
-        },
-        message(_ws, message) {
-          received.push(
-            typeof message === "string"
-              ? new TextEncoder().encode(message)
-              : new Uint8Array(message),
-          );
-        },
-        close() {},
-      },
-    });
-    return { server, received, connected, upgradeUrl: () => upgradeUrl };
-  }
-
   /** A viewer socket whose pump dials `runtime`. */
   function makeViewerWs(runtime: FakeRuntime, sendStatus?: number) {
     return createFakeDownstreamWs<DesktopStreamSocketData>(
@@ -132,17 +89,6 @@ describe("getDesktopStreamWebsocketHandlers", () => {
       },
       { sendStatus },
     );
-  }
-
-  /** Poll until `predicate` holds, so the tests need no fixed sleeps. */
-  async function waitFor(predicate: () => boolean, timeoutMs = 2000) {
-    const deadline = Date.now() + timeoutMs;
-    while (!predicate()) {
-      if (Date.now() > deadline) {
-        throw new Error("timed out waiting for condition");
-      }
-      await new Promise((r) => setTimeout(r, 5));
-    }
   }
 
   /** The RFB version banner, the first thing a VNC server sends. */
@@ -197,6 +143,23 @@ describe("getDesktopStreamWebsocketHandlers", () => {
 
     expect(ws.closes[0]).toEqual({ code: 1011, reason: "Viewer too slow" });
     expect(upstreamClose).toHaveBeenCalledWith(1011, "Viewer too slow");
+  });
+
+  /**
+   * Bun reports a byte count, so an empty frame writes zero bytes without
+   * having been dropped. Reading that as a drop would tear down a healthy
+   * session.
+   */
+  test("does not treat an empty frame as a dropped one", async () => {
+    runtime = startFakeRuntime(new Uint8Array(0));
+    const handlers = getDesktopStreamWebsocketHandlers();
+    const ws = makeViewerWs(runtime, 0);
+
+    handlers.open(ws as never);
+    await waitFor(() => ws.sent.length > 0);
+    await settle();
+
+    expect(ws.closes).toEqual([]);
   });
 
   test("delivers the viewer's bytes upstream byte-identical, including frames sent before the dial completes", async () => {

--- a/gateway/src/__tests__/runtime-stream-test-utils.ts
+++ b/gateway/src/__tests__/runtime-stream-test-utils.ts
@@ -110,3 +110,78 @@ export function createFakeDownstreamWs<T>(
     }),
   };
 }
+
+/** A loopback WebSocket server standing in for the runtime end of a proxy. */
+export type FakeRuntime = {
+  server: ReturnType<typeof Bun.serve>;
+  /** Every frame the pump forwarded upstream, as bytes. */
+  received: Uint8Array[];
+  /** Resolves with the upstream socket once the pump has dialed in. */
+  connected: Promise<import("bun").ServerWebSocket<unknown>>;
+  upgradeUrl: () => URL | undefined;
+};
+
+/**
+ * Start a loopback server posing as the runtime: it records what it is sent
+ * and, when given a `banner`, sends that downstream the moment a pump
+ * connects. The drop path lives in the pump's upstream message listener, so
+ * exercising it needs a real socket on the other end.
+ */
+export function startFakeRuntime(banner?: string | Uint8Array): FakeRuntime {
+  const received: Uint8Array[] = [];
+  let upgradeUrl: URL | undefined;
+  let resolveConnected!: (ws: import("bun").ServerWebSocket<unknown>) => void;
+  const connected = new Promise<import("bun").ServerWebSocket<unknown>>(
+    (resolve) => {
+      resolveConnected = resolve;
+    },
+  );
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      upgradeUrl = new URL(req.url);
+      if (srv.upgrade(req)) {
+        return undefined as never;
+      }
+      return new Response("not a websocket", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        if (banner !== undefined) {
+          ws.send(banner);
+        }
+        resolveConnected(ws);
+      },
+      message(_ws, message) {
+        received.push(
+          typeof message === "string"
+            ? new TextEncoder().encode(message)
+            : new Uint8Array(message),
+        );
+      },
+      close() {},
+    },
+  });
+  return { server, received, connected, upgradeUrl: () => upgradeUrl };
+}
+
+/** Poll until `predicate` holds, so tests need no fixed sleeps. */
+export async function waitFor(predicate: () => boolean, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error("timed out waiting for condition");
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/**
+ * Let the pump settle after a frame the fake runtime already delivered, so a
+ * test asserting that nothing closed is asserting against a pump that has run.
+ */
+export async function settle(iterations = 5) {
+  for (let i = 0; i < iterations; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -1,11 +1,15 @@
-import { describe, test, expect, mock } from "bun:test";
+import { afterEach, describe, test, expect, mock } from "bun:test";
 import {
   createFakeDownstreamWs,
   makeConfig,
   makeFakeServer,
   mintEdgeToken,
   mintServiceEdgeToken,
+  settle,
+  startFakeRuntime,
   upgradedData,
+  waitFor,
+  type FakeRuntime,
 } from "./runtime-stream-test-utils.js";
 
 // Dictation is NOT a guardian-only surface. The binding lookup is mocked to a
@@ -322,6 +326,56 @@ describe("getSttStreamWebsocketHandlers", () => {
     handlers.close(ws as never, 1000, "normal");
 
     expect(fakeUpstream.close).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Dictation carries JSON transcript and lifecycle frames, each self-contained.
+ * A dropped one costs a fragment, not the session, so the desktop stream's
+ * teardown must not reach this route: the usual trigger is a runtime frame
+ * landing just after the browser socket closed.
+ */
+describe("a dropped downstream frame does not end a dictation session", () => {
+  let runtime: FakeRuntime;
+  afterEach(() => {
+    runtime?.server.stop(true);
+  });
+
+  const makeViewerWs = (sendStatus?: number) =>
+    createFakeDownstreamWs<SttStreamSocketData>(
+      {
+        wsType: "stt-stream",
+        config: makeConfig({
+          assistantRuntimeBaseUrl: `http://127.0.0.1:${runtime.server.port}`,
+        }),
+        mimeType: "audio/webm",
+      },
+      { sendStatus },
+    );
+
+  test("keeps both sides open when a send is dropped", async () => {
+    runtime = startFakeRuntime('{"type":"transcript","text":"hello"}');
+    const handlers = getSttStreamWebsocketHandlers();
+    const ws = makeViewerWs(0);
+
+    handlers.open(ws as never);
+    await waitFor(() => ws.sent.length > 0);
+    await settle();
+
+    expect(ws.closes).toEqual([]);
+    expect(ws.data.upstream!.readyState).toBe(WebSocket.OPEN);
+  });
+
+  test("does not treat an empty frame as a dropped one", async () => {
+    runtime = startFakeRuntime("");
+    const handlers = getSttStreamWebsocketHandlers();
+    const ws = makeViewerWs(0);
+
+    handlers.open(ws as never);
+    await waitFor(() => ws.sent.length > 0);
+    await settle();
+
+    expect(ws.closes).toEqual([]);
   });
 });
 

--- a/gateway/src/__tests__/watch-stream-websocket.test.ts
+++ b/gateway/src/__tests__/watch-stream-websocket.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from "bun:test";
+import { afterEach, describe, test, expect, mock } from "bun:test";
 import type { WatchStreamSocketData } from "../http/routes/watch-stream-websocket.js";
 import {
   GUARDIAN_PRINCIPAL,
@@ -7,7 +7,11 @@ import {
   makeFakeServer,
   mintEdgeToken,
   mintServiceEdgeToken,
+  settle,
+  startFakeRuntime,
   upgradedData,
+  waitFor,
+  type FakeRuntime,
 } from "./runtime-stream-test-utils.js";
 
 // The pin itself is covered in `guardian-pin.test.ts`; the binding is mocked
@@ -316,5 +320,55 @@ describe("getWatchStreamWebsocketHandlers", () => {
     handlers.close(ws as never, 1000, "normal");
 
     expect(upstream.close).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Watch carries JSON lifecycle and timeline frames, each self-contained. A
+ * dropped one costs a fragment, not the session, so the desktop stream's
+ * teardown must not reach this route: the usual trigger is a runtime frame
+ * landing just after the browser socket closed.
+ */
+describe("a dropped downstream frame does not end a watch session", () => {
+  let runtime: FakeRuntime;
+  afterEach(() => {
+    runtime?.server.stop(true);
+  });
+
+  const makeViewerWs = (sendStatus?: number) =>
+    createFakeDownstreamWs<WatchStreamSocketData>(
+      {
+        wsType: "watch-stream",
+        config: makeConfig({
+          assistantRuntimeBaseUrl: `http://127.0.0.1:${runtime.server.port}`,
+        }),
+        mimeType: "audio/pcm",
+      },
+      { sendStatus },
+    );
+
+  test("keeps both sides open when a send is dropped", async () => {
+    runtime = startFakeRuntime('{"type":"session_started"}');
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = makeViewerWs(0);
+
+    handlers.open(ws as never);
+    await waitFor(() => ws.sent.length > 0);
+    await settle();
+
+    expect(ws.closes).toEqual([]);
+    expect(ws.data.upstream!.readyState).toBe(WebSocket.OPEN);
+  });
+
+  test("does not treat an empty frame as a dropped one", async () => {
+    runtime = startFakeRuntime("");
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = makeViewerWs(0);
+
+    handlers.open(ws as never);
+    await waitFor(() => ws.sent.length > 0);
+    await settle();
+
+    expect(ws.closes).toEqual([]);
   });
 });

--- a/gateway/src/http/routes/desktop-stream-websocket.ts
+++ b/gateway/src/http/routes/desktop-stream-websocket.ts
@@ -51,5 +51,9 @@ export function getDesktopStreamWebsocketHandlers() {
     upstreamPath: "/v1/desktop/stream",
     log,
     label: "desktop stream",
+    // RFB has no resync: one dropped frame corrupts the framebuffer for the
+    // rest of the session, so a drop ends it. The JSON streams next door do
+    // not opt in.
+    closeOnDroppedFrame: true,
   });
 }

--- a/gateway/src/http/routes/runtime-audio-stream.ts
+++ b/gateway/src/http/routes/runtime-audio-stream.ts
@@ -42,6 +42,11 @@ import type { GatewayConfig } from "../../config.js";
  */
 const MAX_PENDING_MESSAGES = 100;
 
+/** Payload size of a frame, so an empty one is not mistaken for a dropped one. */
+function byteLength(frame: string | Uint8Array): number {
+  return typeof frame === "string" ? frame.length : frame.byteLength;
+}
+
 /** The state every audio-stream proxy socket carries, whatever it streams. */
 export interface RuntimeAudioStreamState {
   config: GatewayConfig;
@@ -161,6 +166,16 @@ export interface RuntimeAudioStreamHandlerOptions<
   upstreamParams?: (data: T) => Record<string, string>;
   /** Extra fields worth logging alongside every message about this socket. */
   logContext?: (data: T) => Record<string, unknown>;
+  /**
+   * Whether a dropped downstream frame is fatal to the session.
+   *
+   * Only `/v1/desktop/stream` opts in. RFB is an ordered byte stream with no
+   * resync, so a missing frame corrupts the viewer's framebuffer for good and
+   * closing is the only honest outcome. The JSON routes carry self-contained
+   * lifecycle and transcript frames, where losing one costs a transcript
+   * fragment and nothing more, so they log and carry on.
+   */
+  closeOnDroppedFrame?: boolean;
 }
 
 /**
@@ -180,6 +195,7 @@ export function createRuntimeAudioStreamHandlers<
   label,
   upstreamParams = () => ({}),
   logContext = () => ({}),
+  closeOnDroppedFrame = false,
 }: RuntimeAudioStreamHandlerOptions<T>) {
   return {
     open(ws: import("bun").ServerWebSocket<T>) {
@@ -219,14 +235,23 @@ export function createRuntimeAudioStreamHandlers<
           typeof event.data === "string"
             ? event.data
             : new Uint8Array(event.data as ArrayBuffer);
-        // Bun returns 0 when the frame was dropped past its backpressure
-        // limit. A missing frame corrupts an ordered stream (RFB cannot
-        // resync), so both sides close rather than carry on silently.
-        if (ws.send(data) === 0) {
-          log.warn(context, `${label} dropped a downstream frame, closing`);
-          ws.close(1011, "Viewer too slow");
-          upstream.close(1011, "Viewer too slow");
+        // Bun's send returns the byte count it wrote, and 0 for a frame
+        // dropped past its backpressure limit. An empty payload also writes
+        // zero bytes, so the drop only counts when there was something to
+        // send.
+        const dropped = ws.send(data) === 0 && byteLength(data) > 0;
+        if (!dropped) {
+          return;
         }
+        if (!closeOnDroppedFrame) {
+          // Debug, not warn: the usual cause is a runtime frame landing just
+          // after the browser socket closed, once per session and harmless.
+          log.debug(context, `${label} dropped a downstream frame`);
+          return;
+        }
+        log.warn(context, `${label} dropped a downstream frame, closing`);
+        ws.close(1011, "Viewer too slow");
+        upstream.close(1011, "Viewer too slow");
       });
 
       upstream.addEventListener("close", (event) => {


### PR DESCRIPTION
Pre-merge audit fixes for `m-abboud/pod-desktop-streaming`. Targets the feature branch, not main.

## 1. The drop-close leaked into dictation and watch

`runtime-audio-stream.ts` is the shared frame pump behind `/v1/stt/stream`, `/v1/watch/stream` and the new `/v1/desktop/stream`. A change made for the desktop closed **both** sides with `1011 "Viewer too slow"` whenever `ws.send()` returned 0, which applied to all three routes.

The justification is desktop-specific: RFB is an ordered byte stream with no resync, so a lost frame corrupts the framebuffer permanently. The two JSON routes carry small self-contained lifecycle and transcript frames, where a lost frame costs a fragment and nothing more.

- `closeOnDroppedFrame` is now an opt-in option on the handler factory, taken **only** by the desktop stream. stt and watch are back to not closing.
- The non-closing routes still log a genuine drop, at **debug** rather than warn. The common trigger is the benign end-of-session race where a runtime frame lands just after the browser socket closed, and a warn per session would be noise.
- **Zero-byte ambiguity fixed.** Bun's `ws.send()` returns the number of bytes written, so `=== 0` also fired for a legitimately empty frame. A drop now additionally requires a non-empty payload; empty-payload behavior is unchanged.

Tests: the desktop route still closes 1011 on a genuine drop; stt and watch keep both sides open on one; an empty frame trips the drop path on none of the three. The desktop suite's local fake-runtime harness moved into `runtime-stream-test-utils.ts` so all three suites drive the pump against a real loopback socket.

## 2. The Chromium bake and the runtime installer disagreed on version

`assistant/Dockerfile` bakes Chromium into `/opt/ms-playwright` using `/app/assistant`'s **pinned** playwright, but `importPlaywright()` installed a floating `bun add playwright` into `getExternalDir()`. A different playwright looks for a different browser build id, so the bake bought that pod nothing and the first `browser` tool call or PDF export re-downloaded Chromium. This hit the existing browser tool and PDF export in containerized assistants, not only the desktop.

`runtime-check.ts` now reads the pin from `assistant/package.json` (`import ... with { type: "json" }`, the pattern already used in `src/plugins/`) and exports it as `PLAYWRIGHT_VERSION`, so there is one home for the version rather than a duplicated string. The runtime install requests `playwright@<that version>`, and a copy left behind at any other version is replaced instead of reused, so an already-populated external dir is corrected rather than kept wrong forever.

`ensureChromium` / `ensureChromiumHeadlessShell` and `runPlaywrightInstall` are untouched, so a non-containerized host with `PLAYWRIGHT_BROWSERS_PATH` unset behaves exactly as before; that path already runs the CLI from the external dir so its version matches the module, and the pin only makes that agreement stronger.

## 3. A lost live-voice assertion

Restores the assertion dropped when the dead URL builders were deleted: a successful cloud `resolveLiveVoiceWsUrl` **without** `conversationId` produces a URL with no `conversationId` parameter. Production behavior was already correct, just untested.

## Not in scope

The 403 message punctuation on the runtime upgrade paths and `ensureBun()` are untouched, as is the desktop feature's own behavior beyond finding 1.

## Tests

All run one file at a time. gateway: stt 24, watch 21, live-voice 33, speech-relay 27, twilio-media 28, desktop-stream 10, guardian-pin 17. assistant: desktop-feature 1, desktop-session-manager 19, desktop-stream-bridge 9, desktop-presence 17, desktop-stream-upgrade 3, browser-runtime-check 3, browser-playwright-pin 3 (new), browser-status 12, browser-untrusted-content 15, browser-execution-acquire 9, network-recorder 2. web: live-voice connection 25, live-voice-client 48, watch-controller 85, desktop-connection 6, desktop-panel 17, desktop-affordance 2. 435 pass, 0 fail. `tsc --noEmit` clean in gateway, assistant and clients/web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42169" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->