### PR TITLE
Probe Linux sessions and explicitly select the XWayland shell

### DIFF
--- a/clients/linux/README.md
+++ b/clients/linux/README.md
@@ -50,3 +50,23 @@ generation. The AppImage lands in `dist/`.
 bun run typecheck
 bun run test:ci
 ```
+
+## Display backend and desktop validation
+
+The shell explicitly defaults to X11, including XWayland on a Wayland
+session, for window placement and focus restoration. XWayland must be
+installed on Wayland desktops. An explicit `--ozone-platform` argument is
+preserved; native Wayland is experimental and window movement and focus
+restoration are not guaranteed there.
+
+The session probe describes the desktop session, not Electron's backend.
+Running the shell through XWayland does not give X11 tools access to native
+Wayland applications. Portal availability is separate from granted access.
+
+Before advertising desktop integration, validate packaged launches on GNOME
+Wayland, KDE Wayland and X11, recording desktop and portal versions. Cover
+normal launch, background login, ordinary relaunch, missing tray, locked
+keyring, consent cancellation and revocation, helper restart, suspend/resume,
+and mixed-scale monitors. Xvfb startup checks do not validate these desktop
+workflows. Architecture and distribution support require passing packaged
+checks on each advertised target.

--- a/clients/linux/src/main/index.ts
+++ b/clients/linux/src/main/index.ts
@@ -56,6 +56,11 @@ import { installWebContentsSecurity } from "./windows.client";
  * the app is ready.
  */
 
+// Window placement and focus restoration require X11 or XWayland.
+if (!app.commandLine.hasSwitch("ozone-platform")) {
+  app.commandLine.appendSwitch("ozone-platform", "x11");
+}
+
 // Dev-only: override the package `name` (`@vellumai/linux`) so
 // `app.getPath("userData")` resolves to its own directory, cleanly separate
 // from other Vellum installs. Packaged builds get a real `productName` from

--- a/clients/linux/src/main/linux-environment.test.ts
+++ b/clients/linux/src/main/linux-environment.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ExecFileFn, LinuxEnvironmentIo } from "./linux-environment";
+
+mock.module("./logger", () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+  getLogFilePaths: () => [],
+}));
+
+// Imported after the logger mock: ./logger pulls in electron-log, whose
+// initialize() needs a real Electron app.
+const { __resetForTesting, readLinuxEnvironment, sessionBusNameHasOwner } =
+  await import("./linux-environment");
+
+const OS_RELEASE = [
+  "# a comment",
+  "",
+  'NAME="Ubuntu"',
+  'PRETTY_NAME="Ubuntu 24.04.1 LTS"',
+  "ID=ubuntu",
+  'VERSION_ID="24.04"',
+].join("\n");
+
+function io(overrides: Partial<LinuxEnvironmentIo> = {}): LinuxEnvironmentIo {
+  return {
+    readTextFile: () => OS_RELEASE,
+    isWritable: () => true,
+    ...overrides,
+  };
+}
+
+function execStub(result: { error?: Error; stdout?: string }): {
+  exec: ExecFileFn;
+  calls: { file: string; args: string[] }[];
+} {
+  const calls: { file: string; args: string[] }[] = [];
+  const exec: ExecFileFn = (file, args, _options, callback) => {
+    calls.push({ file, args });
+    queueMicrotask(() =>
+      callback(result.error ?? null, result.stdout ?? "", ""),
+    );
+  };
+  return { exec, calls };
+}
+
+describe("readLinuxEnvironment", () => {
+  beforeEach(() => {
+    __resetForTesting();
+  });
+
+  test("reads a declared Wayland session, desktop list and distro", () => {
+    const env = readLinuxEnvironment(
+      {
+        XDG_SESSION_TYPE: "wayland",
+        WAYLAND_DISPLAY: "wayland-0",
+        DISPLAY: ":0",
+        XDG_CURRENT_DESKTOP: "ubuntu:GNOME",
+      },
+      io(),
+    );
+
+    expect(env.sessionType).toBe("wayland");
+    expect(env.desktop).toEqual(["ubuntu", "gnome"]);
+    expect(env.distro).toEqual({
+      id: "ubuntu",
+      versionId: "24.04",
+      prettyName: "Ubuntu 24.04.1 LTS",
+    });
+    expect(env.appImagePath).toBeNull();
+    expect(env.appImageWritable).toBeNull();
+  });
+
+  test("XDG_SESSION_TYPE wins over the display sockets", () => {
+    const env = readLinuxEnvironment(
+      { XDG_SESSION_TYPE: "x11", WAYLAND_DISPLAY: "wayland-0" },
+      io(),
+    );
+
+    expect(env.sessionType).toBe("x11");
+  });
+
+  test("falls back to WAYLAND_DISPLAY then DISPLAY for a tty session type", () => {
+    expect(
+      readLinuxEnvironment(
+        {
+          XDG_SESSION_TYPE: "tty",
+          WAYLAND_DISPLAY: "wayland-0",
+          DISPLAY: ":0",
+        },
+        io(),
+      ).sessionType,
+    ).toBe("wayland");
+
+    __resetForTesting();
+    expect(readLinuxEnvironment({ DISPLAY: ":0" }, io()).sessionType).toBe(
+      "x11",
+    );
+  });
+
+  test("reports an unknown session with no desktop when nothing is set", () => {
+    const env = readLinuxEnvironment({}, io());
+
+    expect(env.sessionType).toBe("unknown");
+    expect(env.desktop).toEqual([]);
+  });
+
+  test("returns a null distro when /etc/os-release is missing", () => {
+    const paths: string[] = [];
+    const env = readLinuxEnvironment(
+      {},
+      io({
+        readTextFile: (filePath) => {
+          paths.push(filePath);
+          return null;
+        },
+      }),
+    );
+
+    expect(paths).toEqual(["/etc/os-release"]);
+    expect(env.distro).toBeNull();
+  });
+
+  test("returns a null distro when os-release carries none of the fields", () => {
+    const env = readLinuxEnvironment(
+      {},
+      io({ readTextFile: () => 'HOME_URL="https://example.com"\n' }),
+    );
+
+    expect(env.distro).toBeNull();
+  });
+
+  test("keeps unset os-release fields null and unescapes quoted values", () => {
+    const env = readLinuxEnvironment(
+      {},
+      io({
+        readTextFile: () => 'PRETTY_NAME="Alpine \\"edge\\""\nID=alpine\n',
+      }),
+    );
+
+    expect(env.distro).toEqual({
+      id: "alpine",
+      versionId: null,
+      prettyName: 'Alpine "edge"',
+    });
+  });
+
+  test("reports AppImage writability from the probed path", () => {
+    const probed: string[] = [];
+    const env = readLinuxEnvironment(
+      { APPIMAGE: "/opt/Vellum.AppImage" },
+      io({
+        isWritable: (filePath) => {
+          probed.push(filePath);
+          return false;
+        },
+      }),
+    );
+
+    expect(env.appImagePath).toBe("/opt/Vellum.AppImage");
+    expect(env.appImageWritable).toBe(false);
+    expect(probed).toEqual(["/opt/Vellum.AppImage"]);
+  });
+
+  test("memoizes the first probe and re-reads after a reset", () => {
+    let reads = 0;
+    const counting = io({
+      readTextFile: () => {
+        reads += 1;
+        return OS_RELEASE;
+      },
+    });
+
+    const first = readLinuxEnvironment({ XDG_SESSION_TYPE: "x11" }, counting);
+    const second = readLinuxEnvironment(
+      { XDG_SESSION_TYPE: "wayland" },
+      counting,
+    );
+
+    expect(second).toBe(first);
+    expect(second.sessionType).toBe("x11");
+    expect(reads).toBe(1);
+
+    __resetForTesting();
+    expect(
+      readLinuxEnvironment({ XDG_SESSION_TYPE: "wayland" }, counting)
+        .sessionType,
+    ).toBe("wayland");
+    expect(reads).toBe(2);
+  });
+});
+
+describe("sessionBusNameHasOwner", () => {
+  test("asks dbus-send on the session bus and reads a true reply", async () => {
+    const { exec, calls } = execStub({
+      stdout:
+        "method return time=1756944000.1 sender=org.freedesktop.DBus -> destination=:1.42\n   boolean true\n",
+    });
+
+    await expect(
+      sessionBusNameHasOwner("org.freedesktop.portal.Desktop", exec),
+    ).resolves.toBe(true);
+    expect(calls).toEqual([
+      {
+        file: "dbus-send",
+        args: [
+          "--session",
+          "--print-reply",
+          "--dest=org.freedesktop.DBus",
+          "/org/freedesktop/DBus",
+          "org.freedesktop.DBus.NameHasOwner",
+          "string:org.freedesktop.portal.Desktop",
+        ],
+      },
+    ]);
+  });
+
+  test("reads a false reply", async () => {
+    const { exec } = execStub({ stdout: "   boolean false\n" });
+
+    await expect(
+      sessionBusNameHasOwner("org.example.Absent", exec),
+    ).resolves.toBe(false);
+  });
+
+  test("returns null when dbus-send is missing", async () => {
+    const { exec } = execStub({
+      error: Object.assign(new Error("spawn dbus-send ENOENT"), {
+        code: "ENOENT",
+      }),
+    });
+
+    await expect(
+      sessionBusNameHasOwner("org.freedesktop.portal.Desktop", exec),
+    ).resolves.toBeNull();
+  });
+
+  test("returns null when the reply carries no boolean", async () => {
+    const { exec } = execStub({ stdout: "method return time=1\n" });
+
+    await expect(
+      sessionBusNameHasOwner("org.example.Odd", exec),
+    ).resolves.toBeNull();
+  });
+});

--- a/clients/linux/src/main/linux-environment.test.ts
+++ b/clients/linux/src/main/linux-environment.test.ts
@@ -108,7 +108,7 @@ describe("readLinuxEnvironment", () => {
     expect(env.desktop).toEqual([]);
   });
 
-  test("returns a null distro when /etc/os-release is missing", () => {
+  test("returns a null distro when no os-release file is readable", () => {
     const paths: string[] = [];
     const env = readLinuxEnvironment(
       {},
@@ -120,8 +120,40 @@ describe("readLinuxEnvironment", () => {
       }),
     );
 
-    expect(paths).toEqual(["/etc/os-release"]);
+    expect(paths).toEqual(["/etc/os-release", "/usr/lib/os-release"]);
     expect(env.distro).toBeNull();
+  });
+
+  test("falls back to /usr/lib/os-release only when /etc has none", () => {
+    const paths: string[] = [];
+    const env = readLinuxEnvironment(
+      {},
+      io({
+        readTextFile: (filePath) => {
+          paths.push(filePath);
+          return filePath === "/usr/lib/os-release" ? "ID=fedora\n" : null;
+        },
+      }),
+    );
+
+    expect(paths).toEqual(["/etc/os-release", "/usr/lib/os-release"]);
+    expect(env.distro?.id).toBe("fedora");
+  });
+
+  test("does not read the fallback when /etc/os-release is present", () => {
+    const paths: string[] = [];
+    const env = readLinuxEnvironment(
+      {},
+      io({
+        readTextFile: (filePath) => {
+          paths.push(filePath);
+          return "ID=debian\n";
+        },
+      }),
+    );
+
+    expect(paths).toEqual(["/etc/os-release"]);
+    expect(env.distro?.id).toBe("debian");
   });
 
   test("returns a null distro when os-release carries none of the fields", () => {

--- a/clients/linux/src/main/linux-environment.ts
+++ b/clients/linux/src/main/linux-environment.ts
@@ -21,6 +21,7 @@ export interface LinuxDistro {
 }
 
 export interface LinuxEnvironment {
+  /** Desktop session, independent of Electron running through XWayland. */
   sessionType: LinuxSessionType;
   /** `XDG_CURRENT_DESKTOP` entries, lowercased, e.g. `["ubuntu", "gnome"]`. */
   desktop: string[];
@@ -88,7 +89,8 @@ export function readLinuxEnvironment(
       appImagePath === null ? null : io.isWritable(appImagePath),
   };
 
-  log.info("[linux-environment] probed session:", cached);
+  const { appImagePath: _appImagePath, ...metadata } = cached;
+  log.info("[linux-environment] probed session:", metadata);
 
   return cached;
 }

--- a/clients/linux/src/main/linux-environment.ts
+++ b/clients/linux/src/main/linux-environment.ts
@@ -1,0 +1,212 @@
+import { execFile } from "node:child_process";
+import { accessSync, constants, readFileSync } from "node:fs";
+
+import log from "./logger";
+
+const OS_RELEASE_PATH = "/etc/os-release";
+const DBUS_SEND_TIMEOUT_MS = 2_000;
+
+/** How the current graphical session talks to its display server. */
+export type LinuxSessionType = "x11" | "wayland" | "unknown";
+
+export interface LinuxDistro {
+  /** `ID` from os-release, e.g. `ubuntu`. */
+  id: string | null;
+  /** `VERSION_ID` from os-release, e.g. `24.04`. */
+  versionId: string | null;
+  /** `PRETTY_NAME` from os-release, e.g. `Ubuntu 24.04.1 LTS`. */
+  prettyName: string | null;
+}
+
+export interface LinuxEnvironment {
+  sessionType: LinuxSessionType;
+  /** `XDG_CURRENT_DESKTOP` entries, lowercased, e.g. `["ubuntu", "gnome"]`. */
+  desktop: string[];
+  /** null when os-release is missing or carries none of the fields. */
+  distro: LinuxDistro | null;
+  /** Absolute path of the running AppImage, or null outside one. */
+  appImagePath: string | null;
+  /** null when not running from an AppImage. */
+  appImageWritable: boolean | null;
+}
+
+export interface LinuxEnvironmentIo {
+  /** File contents, or null when unreadable. */
+  readTextFile: (filePath: string) => string | null;
+  isWritable: (filePath: string) => boolean;
+}
+
+export type ExecFileFn = (
+  file: string,
+  args: string[],
+  options: { timeout: number },
+  callback: (error: Error | null, stdout: string, stderr: string) => void,
+) => void;
+
+const defaultIo: LinuxEnvironmentIo = {
+  readTextFile: (filePath) => {
+    try {
+      return readFileSync(filePath, "utf8");
+    } catch {
+      return null;
+    }
+  },
+  isWritable: (filePath) => {
+    try {
+      accessSync(filePath, constants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+let cached: LinuxEnvironment | null = null;
+
+/**
+ * Probe the session once and reuse the result. Every value comes from the
+ * injected env and io, and anything the session does not state is `null` or
+ * `"unknown"` rather than guessed.
+ */
+export function readLinuxEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+  io: LinuxEnvironmentIo = defaultIo,
+): LinuxEnvironment {
+  if (cached) {
+    return cached;
+  }
+
+  const appImagePath = nonEmpty(env.APPIMAGE);
+  cached = {
+    sessionType: readSessionType(env),
+    desktop: readDesktop(env),
+    distro: parseOsRelease(io.readTextFile(OS_RELEASE_PATH)),
+    appImagePath,
+    appImageWritable:
+      appImagePath === null ? null : io.isWritable(appImagePath),
+  };
+
+  log.info("[linux-environment] probed session:", cached);
+
+  return cached;
+}
+
+/** Reset the memoized probe. Exposed for testing only. */
+export function __resetForTesting(): void {
+  cached = null;
+}
+
+/**
+ * Whether `name` is currently owned on the session bus: `true`, `false`, or
+ * `null` when the answer is unknown (no `dbus-send`, no session bus, timeout).
+ */
+export function sessionBusNameHasOwner(
+  name: string,
+  exec: ExecFileFn = execFile as unknown as ExecFileFn,
+): Promise<boolean | null> {
+  return new Promise((resolve) => {
+    exec(
+      "dbus-send",
+      [
+        "--session",
+        "--print-reply",
+        "--dest=org.freedesktop.DBus",
+        "/org/freedesktop/DBus",
+        "org.freedesktop.DBus.NameHasOwner",
+        `string:${name}`,
+      ],
+      { timeout: DBUS_SEND_TIMEOUT_MS },
+      (error, stdout) => {
+        if (error) {
+          log.info(`[linux-environment] dbus-send ${name} failed:`, error);
+          resolve(null);
+          return;
+        }
+        resolve(parseBooleanReply(stdout));
+      },
+    );
+  });
+}
+
+// `boolean true` / `boolean false` on the reply's value line.
+function parseBooleanReply(stdout: string): boolean | null {
+  const match = /\bboolean\s+(true|false)\b/.exec(stdout);
+  if (!match) {
+    return null;
+  }
+  return match[1] === "true";
+}
+
+function readSessionType(env: NodeJS.ProcessEnv): LinuxSessionType {
+  const declared = env.XDG_SESSION_TYPE?.trim().toLowerCase();
+  if (declared === "wayland" || declared === "x11") {
+    return declared;
+  }
+  // XDG_SESSION_TYPE is absent or non-graphical (tty), so fall back to the
+  // display sockets. Wayland first: a Wayland session usually also exports
+  // DISPLAY for XWayland.
+  if (nonEmpty(env.WAYLAND_DISPLAY)) {
+    return "wayland";
+  }
+  if (nonEmpty(env.DISPLAY)) {
+    return "x11";
+  }
+  return "unknown";
+}
+
+function readDesktop(env: NodeJS.ProcessEnv): string[] {
+  return (env.XDG_CURRENT_DESKTOP ?? "")
+    .split(":")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
+function parseOsRelease(contents: string | null): LinuxDistro | null {
+  if (contents === null) {
+    return null;
+  }
+
+  const fields = new Map<string, string>();
+  for (const line of contents.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separator = trimmed.indexOf("=");
+    if (separator === -1) {
+      continue;
+    }
+    fields.set(
+      trimmed.slice(0, separator).trim(),
+      unquote(trimmed.slice(separator + 1).trim()),
+    );
+  }
+
+  const distro: LinuxDistro = {
+    id: nonEmpty(fields.get("ID")),
+    versionId: nonEmpty(fields.get("VERSION_ID")),
+    prettyName: nonEmpty(fields.get("PRETTY_NAME")),
+  };
+  if (
+    distro.id === null &&
+    distro.versionId === null &&
+    distro.prettyName === null
+  ) {
+    return null;
+  }
+  return distro;
+}
+
+// os-release values may be shell-quoted, with backslash escapes inside.
+function unquote(value: string): string {
+  const quote = value[0];
+  if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+    return value.slice(1, -1).replace(/\\(.)/g, "$1");
+  }
+  return value;
+}
+
+function nonEmpty(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}

--- a/clients/linux/src/main/linux-environment.ts
+++ b/clients/linux/src/main/linux-environment.ts
@@ -3,7 +3,9 @@ import { accessSync, constants, readFileSync } from "node:fs";
 
 import log from "./logger";
 
-const OS_RELEASE_PATH = "/etc/os-release";
+// os-release precedence per the freedesktop spec: /etc wins, /usr/lib is
+// the fallback on distros that ship no /etc copy.
+const OS_RELEASE_PATHS = ["/etc/os-release", "/usr/lib/os-release"];
 const DBUS_SEND_TIMEOUT_MS = 2_000;
 
 /** How the current graphical session talks to its display server. */
@@ -80,7 +82,7 @@ export function readLinuxEnvironment(
   cached = {
     sessionType: readSessionType(env),
     desktop: readDesktop(env),
-    distro: parseOsRelease(io.readTextFile(OS_RELEASE_PATH)),
+    distro: readDistro(io),
     appImagePath,
     appImageWritable:
       appImagePath === null ? null : io.isWritable(appImagePath),
@@ -161,11 +163,17 @@ function readDesktop(env: NodeJS.ProcessEnv): string[] {
     .filter((entry) => entry.length > 0);
 }
 
-function parseOsRelease(contents: string | null): LinuxDistro | null {
-  if (contents === null) {
-    return null;
+function readDistro(io: LinuxEnvironmentIo): LinuxDistro | null {
+  for (const filePath of OS_RELEASE_PATHS) {
+    const contents = io.readTextFile(filePath);
+    if (contents !== null) {
+      return parseOsRelease(contents);
+    }
   }
+  return null;
+}
 
+function parseOsRelease(contents: string): LinuxDistro | null {
   const fields = new Map<string, string>();
   for (const line of contents.split("\n")) {
     const trimmed = line.trim();


### PR DESCRIPTION
Adds injectable, memoized probes for the desktop session, distribution, AppImage location/writability, and D-Bus service availability. Unknown observations stay unknown. Logs omit the full AppImage path.

The Linux shell explicitly selects Electron's x11 backend unless the user supplied an ozone-platform override. Electron 42 defaults to native Wayland on Wayland desktops, which cannot supply all current window positioning/focus behavior. Session type describes the desktop session separately from Electron's selected backend.

The README records the support and validation gates: GNOME/KDE Wayland using the XWayland shell, X11, no-tray sessions, keyring availability, revoked portal access, suspend/resume, mixed-scale displays, and packaged architecture checks. Portal presence is not proof of access.

Validation: 15 environment probe tests and the Linux typecheck pass. Packaged Linux desktop validation is still required; an explicit native Wayland override is experimental.

Part of Linux parity Wave 1 (PR 6).
