### PR TITLE
Reliable XDG autostart and hidden startup on Linux

### DIFF
--- a/clients/linux/build-resources/app-identity.cjs
+++ b/clients/linux/build-resources/app-identity.cjs
@@ -1,0 +1,4 @@
+exports.resolveLinuxAppId = (environment) =>
+  environment === "production"
+    ? "com.vellum.vellum-assistant-electron"
+    : `com.vellum.vellum-assistant-electron-${environment}`;

--- a/clients/linux/build-resources/app-identity.d.cts
+++ b/clients/linux/build-resources/app-identity.d.cts
@@ -1,0 +1,1 @@
+export function resolveLinuxAppId(environment: string): string;

--- a/clients/linux/electron-builder.config.cjs
+++ b/clients/linux/electron-builder.config.cjs
@@ -11,10 +11,8 @@ const productName =
     ? "Vellum"
     : `Vellum ${env.charAt(0).toUpperCase() + env.slice(1)}`;
 
-const appId =
-  env === "production"
-    ? "com.vellum.vellum-assistant-electron"
-    : `com.vellum.vellum-assistant-electron-${env}`;
+const { resolveLinuxAppId } = require("./build-resources/app-identity.cjs");
+const appId = resolveLinuxAppId(env);
 
 const schemes =
   env === "production"

--- a/clients/linux/src/main/autostart.test.ts
+++ b/clients/linux/src/main/autostart.test.ts
@@ -25,7 +25,7 @@ mock.module("./logger", () => ({
   getLogFilePaths: () => [],
 }));
 
-const { autostartEntryPath, autostartLoginItemBackend, resolveAutostartAppId } =
+const { autostartEntryPath, autostartLoginItemBackend } =
   await import("./autostart");
 
 let configHome = "";
@@ -59,17 +59,6 @@ afterEach(() => {
   restore("XDG_CONFIG_HOME", originalXdg);
   restore("VELLUM_ENVIRONMENT", originalEnvironment);
   restore("APPIMAGE", originalAppImage);
-});
-
-describe("resolveAutostartAppId", () => {
-  test("mirrors the per-environment electron-builder app id", () => {
-    expect(resolveAutostartAppId("production")).toBe(
-      "com.vellum.vellum-assistant-electron",
-    );
-    expect(resolveAutostartAppId("staging")).toBe(
-      "com.vellum.vellum-assistant-electron-staging",
-    );
-  });
 });
 
 describe("autostartLoginItemBackend", () => {
@@ -117,10 +106,10 @@ describe("autostartLoginItemBackend", () => {
     const foreign = "[Desktop Entry]\nType=Application\nExec=/usr/bin/vellum\n";
     writeFileSync(path, foreign);
 
-    autostartLoginItemBackend.write(false);
+    expect(autostartLoginItemBackend.write(false)).toBe(false);
     expect(readFileSync(path, "utf8")).toBe(foreign);
 
-    autostartLoginItemBackend.write(true);
+    expect(autostartLoginItemBackend.write(true)).toBe(false);
     expect(readFileSync(path, "utf8")).toBe(foreign);
     expect(warnings).toHaveLength(2);
   });
@@ -130,8 +119,38 @@ describe("autostartLoginItemBackend", () => {
     // regardless of the running user.
     writeFileSync(join(configHome, "autostart"), "not a directory");
 
-    expect(() => autostartLoginItemBackend.write(true)).not.toThrow();
+    expect(autostartLoginItemBackend.write(true)).toBe(false);
     expect(errors).toHaveLength(1);
     expect(autostartLoginItemBackend.read()).toBe(false);
   });
+});
+
+test("respects a GNOME-disabled entry", () => {
+  autostartLoginItemBackend.write(true);
+  const path = autostartEntryPath();
+  writeFileSync(
+    path,
+    readFileSync(path, "utf8").replace(
+      "X-GNOME-Autostart-enabled=true",
+      "X-GNOME-Autostart-enabled=false",
+    ),
+  );
+  expect(autostartLoginItemBackend.read()).toBe(false);
+});
+
+test("rejects paths that could introduce another desktop-entry field", () => {
+  process.env.APPIMAGE = "/opt/Vellum\nExec=other.AppImage";
+  expect(autostartLoginItemBackend.write(true)).toBe(false);
+  expect(existsSync(autostartEntryPath())).toBe(false);
+});
+
+test("escapes Exec metacharacters without introducing arguments or field codes", () => {
+  process.env.APPIMAGE = '/opt/Apps/Vellum "test" $value %U.AppImage';
+  expect(autostartLoginItemBackend.write(true)).toBe(true);
+  const entry = readFileSync(autostartEntryPath(), "utf8");
+  expect(entry).toContain('%%U.AppImage" --hidden');
+  expect(entry).toContain(String.raw`\\"test\\" \\$value`);
+  expect(
+    entry.split("\n").filter((line) => line.startsWith("Exec=")),
+  ).toHaveLength(1);
 });

--- a/clients/linux/src/main/autostart.test.ts
+++ b/clients/linux/src/main/autostart.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const warnings: string[] = [];
+const errors: string[] = [];
+
+mock.module("./logger", () => ({
+  default: {
+    info: () => undefined,
+    warn: (message: string) => {
+      warnings.push(message);
+    },
+    error: (message: string) => {
+      errors.push(message);
+    },
+  },
+  getLogFilePaths: () => [],
+}));
+
+const { autostartEntryPath, autostartLoginItemBackend, resolveAutostartAppId } =
+  await import("./autostart");
+
+let configHome = "";
+const originalXdg = process.env.XDG_CONFIG_HOME;
+const originalEnvironment = process.env.VELLUM_ENVIRONMENT;
+const originalAppImage = process.env.APPIMAGE;
+
+const restore = (key: string, value: string | undefined): void => {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+};
+
+beforeEach(() => {
+  warnings.length = 0;
+  errors.length = 0;
+  configHome = join(
+    tmpdir(),
+    `vellum-autostart-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+  mkdirSync(configHome, { recursive: true });
+  process.env.XDG_CONFIG_HOME = configHome;
+  process.env.VELLUM_ENVIRONMENT = "production";
+  delete process.env.APPIMAGE;
+});
+
+afterEach(() => {
+  rmSync(configHome, { force: true, recursive: true });
+  restore("XDG_CONFIG_HOME", originalXdg);
+  restore("VELLUM_ENVIRONMENT", originalEnvironment);
+  restore("APPIMAGE", originalAppImage);
+});
+
+describe("resolveAutostartAppId", () => {
+  test("mirrors the per-environment electron-builder app id", () => {
+    expect(resolveAutostartAppId("production")).toBe(
+      "com.vellum.vellum-assistant-electron",
+    );
+    expect(resolveAutostartAppId("staging")).toBe(
+      "com.vellum.vellum-assistant-electron-staging",
+    );
+  });
+});
+
+describe("autostartLoginItemBackend", () => {
+  test("enabling writes a desktop entry that launches the AppImage hidden", () => {
+    process.env.APPIMAGE = "/home/user/Apps/Vellum.AppImage";
+
+    expect(autostartLoginItemBackend.read()).toBe(false);
+    autostartLoginItemBackend.write(true);
+
+    const path = join(
+      configHome,
+      "autostart",
+      "com.vellum.vellum-assistant-electron.desktop",
+    );
+    expect(autostartEntryPath()).toBe(path);
+    const entry = readFileSync(path, "utf8");
+    expect(entry).toContain('Exec="/home/user/Apps/Vellum.AppImage" --hidden');
+    expect(entry).toContain("Hidden=false");
+    expect(entry).toContain("X-GNOME-Autostart-enabled=true");
+    expect(autostartLoginItemBackend.read()).toBe(true);
+  });
+
+  test("disabling removes the entry it wrote", () => {
+    autostartLoginItemBackend.write(true);
+    autostartLoginItemBackend.write(false);
+
+    expect(existsSync(autostartEntryPath())).toBe(false);
+    expect(autostartLoginItemBackend.read()).toBe(false);
+  });
+
+  test("reports a Hidden entry as disabled", () => {
+    autostartLoginItemBackend.write(true);
+    const path = autostartEntryPath();
+    writeFileSync(
+      path,
+      readFileSync(path, "utf8").replace("Hidden=false", "Hidden=true"),
+    );
+
+    expect(autostartLoginItemBackend.read()).toBe(false);
+  });
+
+  test("leaves an entry written by someone else untouched", () => {
+    const path = autostartEntryPath();
+    mkdirSync(join(configHome, "autostart"), { recursive: true });
+    const foreign = "[Desktop Entry]\nType=Application\nExec=/usr/bin/vellum\n";
+    writeFileSync(path, foreign);
+
+    autostartLoginItemBackend.write(false);
+    expect(readFileSync(path, "utf8")).toBe(foreign);
+
+    autostartLoginItemBackend.write(true);
+    expect(readFileSync(path, "utf8")).toBe(foreign);
+    expect(warnings).toHaveLength(2);
+  });
+
+  test("logs instead of throwing when the autostart directory cannot be created", () => {
+    // A regular file where the autostart directory belongs makes mkdir fail
+    // regardless of the running user.
+    writeFileSync(join(configHome, "autostart"), "not a directory");
+
+    expect(() => autostartLoginItemBackend.write(true)).not.toThrow();
+    expect(errors).toHaveLength(1);
+    expect(autostartLoginItemBackend.read()).toBe(false);
+  });
+});

--- a/clients/linux/src/main/autostart.ts
+++ b/clients/linux/src/main/autostart.ts
@@ -1,13 +1,4 @@
-/**
- * Launch at login on Linux, via an XDG autostart desktop entry.
- *
- * Electron's `app.setLoginItemSettings` is a no-op on Linux, so the
- * `@vellumai/electron-desktop` login-item backend seam points here instead.
- * The entry lives at `$XDG_CONFIG_HOME/autostart/<appId>.desktop`, where
- * `appId` mirrors `electron-builder.config.cjs` per environment.
- *
- * Spec: https://specifications.freedesktop.org/autostart-spec/latest/
- */
+/** XDG autostart entries owned by this app. */
 
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -18,16 +9,12 @@ import { app } from "electron";
 import type { LoginItemBackend } from "@vellumai/electron-desktop/login-item";
 import { resolveEnvironmentName } from "@vellumai/local-mode";
 
+import { resolveLinuxAppId } from "../../build-resources/app-identity.cjs";
+import { LINUX_RELEASE_INFO } from "./app-config";
 import log from "./logger";
 
 /** Key stamped on entries we own, so foreign files are never clobbered. */
 const OWNER_KEY = "X-Vellum-Autostart";
-
-/** Mirrors the `appId` computed in `electron-builder.config.cjs`. */
-export const resolveAutostartAppId = (env: string): string =>
-  env === "production"
-    ? "com.vellum.vellum-assistant-electron"
-    : `com.vellum.vellum-assistant-electron-${env}`;
 
 const autostartDir = (): string =>
   join(
@@ -38,23 +25,42 @@ const autostartDir = (): string =>
 export const autostartEntryPath = (): string =>
   join(
     autostartDir(),
-    `${resolveAutostartAppId(resolveEnvironmentName(process.env))}.desktop`,
+    `${resolveLinuxAppId(app.isPackaged ? LINUX_RELEASE_INFO.releaseChannel : resolveEnvironmentName(process.env))}.desktop`,
   );
 
-/**
- * The AppImage runtime exposes the outer image path in `APPIMAGE`;
- * `process.execPath` points at the extracted binary, which does not survive
- * a reboot.
- */
-const execCommand = (): string =>
-  `"${process.env.APPIMAGE || process.execPath}" --hidden`;
+const escapeValue = (value: string): string =>
+  value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+
+const execCommand = (): string => {
+  const executable = process.env.APPIMAGE || process.execPath;
+  if (!executable.startsWith("/") || /[\x00-\x1f=]/.test(executable)) {
+    throw new Error(
+      "The application path cannot be used in an autostart entry",
+    );
+  }
+  const args = [executable];
+  if (!app.isPackaged && !process.env.APPIMAGE && process.argv[1]) {
+    args.push(process.argv[1]);
+  }
+  return [
+    ...args.map(
+      (arg) =>
+        `"${escapeValue(arg.replace(/["`$\\]/g, "\\$&").replace(/%/g, "%%"))}"`,
+    ),
+    "--hidden",
+  ].join(" ");
+};
 
 const desktopEntry = (): string =>
   [
     "[Desktop Entry]",
     "Type=Application",
     "Version=1.0",
-    `Name=${app.getName()}`,
+    `Name=${escapeValue(app.getName())}`,
     `Exec=${execCommand()}`,
     "Terminal=false",
     "Hidden=false",
@@ -82,25 +88,32 @@ const isTrue = (contents: string, key: string): boolean =>
  */
 const readAutostart = (): boolean => {
   const contents = readEntry(autostartEntryPath());
-  return contents !== null && !isTrue(contents, "Hidden");
+  return (
+    contents !== null &&
+    !isTrue(contents, "Hidden") &&
+    !/^X-GNOME-Autostart-enabled=false\s*$/m.test(contents)
+  );
 };
 
-const writeAutostart = (enabled: boolean): void => {
+const writeAutostart = (enabled: boolean): boolean => {
   const path = autostartEntryPath();
   const existing = readEntry(path);
   if (existing !== null && !isTrue(existing, OWNER_KEY)) {
     log.warn(`Leaving an autostart entry we do not own untouched: ${path}`);
-    return;
+    return false;
   }
   try {
     if (!enabled) {
       rmSync(path, { force: true });
-      return;
+      return true;
     }
+    const contents = desktopEntry();
     mkdirSync(autostartDir(), { recursive: true });
-    writeFileSync(path, desktopEntry(), { mode: 0o644 });
+    writeFileSync(path, contents, { mode: 0o644 });
+    return true;
   } catch (error) {
     log.error(`Failed to update the autostart entry at ${path}`, error);
+    return false;
   }
 };
 

--- a/clients/linux/src/main/autostart.ts
+++ b/clients/linux/src/main/autostart.ts
@@ -1,0 +1,110 @@
+/**
+ * Launch at login on Linux, via an XDG autostart desktop entry.
+ *
+ * Electron's `app.setLoginItemSettings` is a no-op on Linux, so the
+ * `@vellumai/electron-desktop` login-item backend seam points here instead.
+ * The entry lives at `$XDG_CONFIG_HOME/autostart/<appId>.desktop`, where
+ * `appId` mirrors `electron-builder.config.cjs` per environment.
+ *
+ * Spec: https://specifications.freedesktop.org/autostart-spec/latest/
+ */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { app } from "electron";
+
+import type { LoginItemBackend } from "@vellumai/electron-desktop/login-item";
+import { resolveEnvironmentName } from "@vellumai/local-mode";
+
+import log from "./logger";
+
+/** Key stamped on entries we own, so foreign files are never clobbered. */
+const OWNER_KEY = "X-Vellum-Autostart";
+
+/** Mirrors the `appId` computed in `electron-builder.config.cjs`. */
+export const resolveAutostartAppId = (env: string): string =>
+  env === "production"
+    ? "com.vellum.vellum-assistant-electron"
+    : `com.vellum.vellum-assistant-electron-${env}`;
+
+const autostartDir = (): string =>
+  join(
+    process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config"),
+    "autostart",
+  );
+
+export const autostartEntryPath = (): string =>
+  join(
+    autostartDir(),
+    `${resolveAutostartAppId(resolveEnvironmentName(process.env))}.desktop`,
+  );
+
+/**
+ * The AppImage runtime exposes the outer image path in `APPIMAGE`;
+ * `process.execPath` points at the extracted binary, which does not survive
+ * a reboot.
+ */
+const execCommand = (): string =>
+  `"${process.env.APPIMAGE || process.execPath}" --hidden`;
+
+const desktopEntry = (): string =>
+  [
+    "[Desktop Entry]",
+    "Type=Application",
+    "Version=1.0",
+    `Name=${app.getName()}`,
+    `Exec=${execCommand()}`,
+    "Terminal=false",
+    "Hidden=false",
+    "X-GNOME-Autostart-enabled=true",
+    `${OWNER_KEY}=true`,
+    "",
+  ].join("\n");
+
+const readEntry = (path: string): string | null => {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+};
+
+const isTrue = (contents: string, key: string): boolean =>
+  contents
+    .split("\n")
+    .some((line) => line.trim().toLowerCase() === `${key.toLowerCase()}=true`);
+
+/**
+ * An entry counts as enabled when it exists and is not marked `Hidden=true`,
+ * which is how desktop environments disable an entry without deleting it.
+ */
+const readAutostart = (): boolean => {
+  const contents = readEntry(autostartEntryPath());
+  return contents !== null && !isTrue(contents, "Hidden");
+};
+
+const writeAutostart = (enabled: boolean): void => {
+  const path = autostartEntryPath();
+  const existing = readEntry(path);
+  if (existing !== null && !isTrue(existing, OWNER_KEY)) {
+    log.warn(`Leaving an autostart entry we do not own untouched: ${path}`);
+    return;
+  }
+  try {
+    if (!enabled) {
+      rmSync(path, { force: true });
+      return;
+    }
+    mkdirSync(autostartDir(), { recursive: true });
+    writeFileSync(path, desktopEntry(), { mode: 0o644 });
+  } catch (error) {
+    log.error(`Failed to update the autostart entry at ${path}`, error);
+  }
+};
+
+export const autostartLoginItemBackend: LoginItemBackend = {
+  read: readAutostart,
+  write: writeAutostart,
+};

--- a/clients/linux/src/main/features/deep-links.ts
+++ b/clients/linux/src/main/features/deep-links.ts
@@ -45,7 +45,6 @@ const deepLinksFeature: CapabilityModule<DesktopCapabilityRegistry> = {
     installDeepLinks();
 
     configureLoginItem({
-      // Electron's login-item API is a no-op on Linux; XDG autostart is not.
       backend: autostartLoginItemBackend,
       handle,
       store: {

--- a/clients/linux/src/main/features/deep-links.ts
+++ b/clients/linux/src/main/features/deep-links.ts
@@ -1,5 +1,3 @@
-import { app } from "electron";
-
 import type {
   CapabilityModule,
   DesktopCapabilityRegistry,
@@ -23,6 +21,7 @@ import {
 } from "@vellumai/electron-desktop/settings";
 import { resolveEnvironmentName } from "@vellumai/local-mode";
 
+import { autostartLoginItemBackend } from "../autostart";
 import { handle, on } from "../ipc.client";
 import { ensureVisible } from "../main-window";
 
@@ -46,11 +45,9 @@ const deepLinksFeature: CapabilityModule<DesktopCapabilityRegistry> = {
     installDeepLinks();
 
     configureLoginItem({
+      // Electron's login-item API is a no-op on Linux; XDG autostart is not.
+      backend: autostartLoginItemBackend,
       handle,
-      identity:
-        !app.isPackaged && process.argv[1]
-          ? { path: process.execPath, args: [process.argv[1]] }
-          : undefined,
       store: {
         read: () => readSetting("launchAtLogin"),
         subscribe: (listener) => onSettingChange("launchAtLogin", listener),

--- a/clients/linux/src/main/index.ts
+++ b/clients/linux/src/main/index.ts
@@ -45,7 +45,6 @@ import { provisionCliForWrapper } from "./cli-path-installer";
 import { installMainFeatures } from "./features";
 import { handleSync } from "./ipc.client";
 import log from "./logger";
-import { ensureVisible } from "./main-window";
 import { installWebContentsSecurity } from "./windows.client";
 
 /**
@@ -273,10 +272,6 @@ app
   .catch((err: unknown) => {
     log.error("[app] whenReady setup failed:", err);
   });
-
-app.on("second-instance", () => {
-  ensureVisible();
-});
 
 app.on("window-all-closed", () => {
   // Keep the notification-area tray available to reopen the window.

--- a/clients/linux/src/main/main-window.ts
+++ b/clients/linux/src/main/main-window.ts
@@ -25,6 +25,7 @@ import { isAllowedOrigin, resolveAllowedOrigin } from "./app-origin.client";
 import { handle, on } from "./ipc.client";
 import log from "./logger";
 import { createWindow } from "./windows.client";
+import { installStartupActivation } from "./startup-activation";
 
 const MAIN_DEFAULT_BOUNDS = { width: 1280, height: 800 } as const;
 const MAIN_MIN_SIZE = { width: 800, height: 600 } as const;
@@ -57,10 +58,7 @@ const installSameOriginNavigationGuard = (win: BrowserWindow): void => {
 };
 
 const createMainWindow = (): BrowserWindow => {
-  const { maximized, ...bounds } = restoreBounds(
-    "main",
-    MAIN_DEFAULT_BOUNDS,
-  );
+  const { maximized, ...bounds } = restoreBounds("main", MAIN_DEFAULT_BOUNDS);
   const overlay = readTitleBarOverlayTheme();
   if (overlay) {
     syncNativeColorScheme(overlay.colorScheme);
@@ -236,13 +234,9 @@ export const installMainWindow = (): void => {
   handle(MAIN_WINDOW_ENSURE_VISIBLE, z.tuple([]), async () => {
     await ensureVisible();
   });
-  handle(
-    MAIN_WINDOW_SET_ONBOARDING,
-    z.tuple([z.boolean()]),
-    ([active]) => {
-      setOnboarding(active);
-    },
-  );
+  handle(MAIN_WINDOW_SET_ONBOARDING, z.tuple([z.boolean()]), ([active]) => {
+    setOnboarding(active);
+  });
   handle(
     MAIN_WINDOW_SET_TITLE_BAR_OVERLAY,
     z.tuple([titleBarOverlayThemeSchema]),
@@ -261,7 +255,7 @@ export const installMainWindow = (): void => {
     setAssistantName(name);
   });
 
-  void ensureVisible();
+  installStartupActivation(ensureVisible);
 };
 
 export const __resetForTesting = (): void => {

--- a/clients/linux/src/main/startup-activation.test.ts
+++ b/clients/linux/src/main/startup-activation.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+let secondInstance: (_event: unknown, args: string[]) => void;
+mock.module("electron", () => ({
+  app: {
+    on: (_event: string, callback: typeof secondInstance) => {
+      secondInstance = callback;
+    },
+  },
+}));
+const { installStartupActivation } = await import("./startup-activation");
+const show = mock(async () => {});
+beforeEach(() => show.mockClear());
+
+test("a background login stays hidden and an ordinary relaunch opens it", () => {
+  installStartupActivation(show, ["/opt/Vellum.AppImage", "--hidden"]);
+  expect(show).not.toHaveBeenCalled();
+  secondInstance({}, ["/opt/Vellum.AppImage", "--hidden"]);
+  expect(show).not.toHaveBeenCalled();
+  secondInstance({}, ["/opt/Vellum.AppImage"]);
+  expect(show).toHaveBeenCalledTimes(1);
+});
+
+test("an ordinary launch opens and a background relaunch does not steal focus", () => {
+  installStartupActivation(show, ["/opt/Vellum.AppImage"]);
+  expect(show).toHaveBeenCalledTimes(1);
+  secondInstance({}, ["/opt/Vellum.AppImage", "--hidden"]);
+  expect(show).toHaveBeenCalledTimes(1);
+});

--- a/clients/linux/src/main/startup-activation.ts
+++ b/clients/linux/src/main/startup-activation.ts
@@ -1,0 +1,14 @@
+import { app } from "electron";
+
+export function installStartupActivation(
+  show: () => Promise<void>,
+  argv: string[] = process.argv,
+): void {
+  const activate = (args: string[]) => {
+    if (!args.includes("--hidden")) {
+      void show();
+    }
+  };
+  app.on("second-instance", (_event, args) => activate(args));
+  activate(argv);
+}

--- a/packages/electron-desktop/src/login-item.test.ts
+++ b/packages/electron-desktop/src/login-item.test.ts
@@ -95,3 +95,65 @@ test("keeps a persisted setting synchronized with the login item", () => {
   expect(write).toHaveBeenLastCalledWith(true);
   expect(setLoginItemSettings).toHaveBeenLastCalledWith({ openAtLogin: true });
 });
+
+test("routes reads and writes through a platform backend", () => {
+  let entryEnabled = true;
+  const backend = {
+    read: () => entryEnabled,
+    write: mock((enabled: boolean) => {
+      entryEnabled = enabled;
+    }),
+  };
+
+  configureLoginItem({ backend, handle });
+  installLoginItemIpc();
+
+  expect(handlers.get("vellum:launchAtLogin:get")?.([])).toBe(true);
+  handlers.get("vellum:launchAtLogin:set")?.([false]);
+
+  expect(backend.write).toHaveBeenCalledWith(false);
+  expect(handlers.get("vellum:launchAtLogin:get")?.([])).toBe(false);
+  expect(setLoginItemSettings).not.toHaveBeenCalled();
+  expect(getLoginItemSettings).not.toHaveBeenCalled();
+});
+
+test("seeds and synchronizes a persisted setting through the backend", () => {
+  let stored: boolean | null = null;
+  let notify = (): void => undefined;
+  let entryEnabled = true;
+  const backend = {
+    read: () => entryEnabled,
+    write: mock((enabled: boolean) => {
+      entryEnabled = enabled;
+    }),
+  };
+
+  configureLoginItem({
+    backend,
+    handle,
+    store: {
+      read: () => stored,
+      subscribe: (next) => {
+        notify = next;
+        return () => {
+          notify = () => undefined;
+        };
+      },
+      write: (enabled) => {
+        stored = enabled;
+      },
+    },
+  });
+
+  installLoginItem();
+  installLoginItemIpc();
+
+  // The pre-existing autostart entry seeds the empty setting.
+  expect(stored).toBe(true);
+
+  handlers.get("vellum:launchAtLogin:set")?.([false]);
+  notify();
+
+  expect(backend.write).toHaveBeenLastCalledWith(false);
+  expect(setLoginItemSettings).not.toHaveBeenCalled();
+});

--- a/packages/electron-desktop/src/login-item.test.ts
+++ b/packages/electron-desktop/src/login-item.test.ts
@@ -151,7 +151,7 @@ test("seeds and synchronizes a persisted setting through the backend", () => {
   installLoginItemIpc();
 
   // The pre-existing autostart entry seeds the empty setting.
-  expect(stored).toBe(true);
+  expect<boolean | null>(stored).toBe(true);
 
   handlers.get("vellum:launchAtLogin:set")?.([false]);
   notify();

--- a/packages/electron-desktop/src/login-item.test.ts
+++ b/packages/electron-desktop/src/login-item.test.ts
@@ -102,6 +102,7 @@ test("routes reads and writes through a platform backend", () => {
     read: () => entryEnabled,
     write: mock((enabled: boolean) => {
       entryEnabled = enabled;
+      return true;
     }),
   };
 
@@ -125,6 +126,7 @@ test("seeds and synchronizes a persisted setting through the backend", () => {
     read: () => entryEnabled,
     write: mock((enabled: boolean) => {
       entryEnabled = enabled;
+      return true;
     }),
   };
 
@@ -156,4 +158,51 @@ test("seeds and synchronizes a persisted setting through the backend", () => {
 
   expect(backend.write).toHaveBeenLastCalledWith(false);
   expect(setLoginItemSettings).not.toHaveBeenCalled();
+});
+
+test("a rejected backend write leaves the persisted preference unchanged", () => {
+  let stored = false;
+  configureLoginItem({
+    handle,
+    backend: { read: () => false, write: () => false },
+    store: {
+      read: () => stored,
+      write: (value) => {
+        stored = value;
+      },
+      subscribe: () => () => {},
+    },
+  });
+  installLoginItem();
+  installLoginItemIpc();
+  expect(() => handlers.get("vellum:launchAtLogin:set")?.([true])).toThrow(
+    "Could not update",
+  );
+  expect(stored).toBe(false);
+  expect(handlers.get("vellum:launchAtLogin:get")?.([])).toBe(false);
+});
+
+test("failed subscription updates roll back without recursive writes", () => {
+  let stored = false;
+  let notify = () => {};
+  const write = mock((value: boolean) => {
+    stored = value;
+    notify();
+  });
+  configureLoginItem({
+    handle,
+    backend: { read: () => false, write: () => false },
+    store: {
+      read: () => stored,
+      write,
+      subscribe: (listener) => {
+        notify = listener;
+        return () => {};
+      },
+    },
+  });
+  installLoginItem();
+  write(true);
+  expect(stored).toBe(false);
+  expect(write).toHaveBeenCalledTimes(2);
 });

--- a/packages/electron-desktop/src/login-item.ts
+++ b/packages/electron-desktop/src/login-item.ts
@@ -10,7 +10,18 @@ export interface LaunchAtLoginStore {
   write: (enabled: boolean) => void;
 }
 
+/**
+ * Platform hook for systems where Electron's login-item API is a no-op.
+ * Linux supplies an XDG autostart implementation; macOS and Windows omit it
+ * and keep using `app.get/setLoginItemSettings`.
+ */
+export interface LoginItemBackend {
+  read: () => boolean;
+  write: (enabled: boolean) => void;
+}
+
 export interface LoginItemRuntime {
+  backend?: LoginItemBackend;
   handle: IpcHandle;
   identity?: { path: string; args: string[] };
   store?: LaunchAtLoginStore;
@@ -38,10 +49,25 @@ const requireRuntime = (): LoginItemRuntime => {
   return runtime;
 };
 
-const readLaunchAtLogin = (): boolean => {
-  const stored = runtime?.store?.read();
-  return stored ?? app.getLoginItemSettings(runtime?.identity).openAtLogin;
+/** Current operating-system state, ignoring the persisted setting. */
+const readOpenAtLogin = (): boolean => {
+  const backend = runtime?.backend;
+  return backend
+    ? backend.read()
+    : app.getLoginItemSettings(runtime?.identity).openAtLogin;
 };
+
+const applyOpenAtLogin = (enabled: boolean): void => {
+  const backend = runtime?.backend;
+  if (backend) {
+    backend.write(enabled);
+    return;
+  }
+  app.setLoginItemSettings({ openAtLogin: enabled, ...runtime?.identity });
+};
+
+const readLaunchAtLogin = (): boolean =>
+  runtime?.store?.read() ?? readOpenAtLogin();
 
 const writeLaunchAtLogin = (enabled: boolean): void => {
   const store = runtime?.store;
@@ -49,14 +75,11 @@ const writeLaunchAtLogin = (enabled: boolean): void => {
     store.write(enabled);
     return;
   }
-  app.setLoginItemSettings({ openAtLogin: enabled, ...runtime?.identity });
+  applyOpenAtLogin(enabled);
 };
 
 const syncLoginItem = (): void => {
-  app.setLoginItemSettings({
-    openAtLogin: readLaunchAtLogin(),
-    ...runtime?.identity,
-  });
+  applyOpenAtLogin(readLaunchAtLogin());
 };
 
 export const installLoginItemIpc = (): void => {
@@ -68,13 +91,12 @@ export const installLoginItemIpc = (): void => {
 };
 
 export const installLoginItem = (): void => {
-  const configured = requireRuntime();
-  const { store } = configured;
+  const { store } = requireRuntime();
   if (!store || teardown) {
     return;
   }
   if (store.read() === null) {
-    store.write(app.getLoginItemSettings(configured.identity).openAtLogin);
+    store.write(readOpenAtLogin());
   }
   syncLoginItem();
   teardown = store.subscribe(syncLoginItem);

--- a/packages/electron-desktop/src/login-item.ts
+++ b/packages/electron-desktop/src/login-item.ts
@@ -17,7 +17,7 @@ export interface LaunchAtLoginStore {
  */
 export interface LoginItemBackend {
   read: () => boolean;
-  write: (enabled: boolean) => void;
+  write: (enabled: boolean) => boolean;
 }
 
 export interface LoginItemRuntime {
@@ -57,13 +57,13 @@ const readOpenAtLogin = (): boolean => {
     : app.getLoginItemSettings(runtime?.identity).openAtLogin;
 };
 
-const applyOpenAtLogin = (enabled: boolean): void => {
+const applyOpenAtLogin = (enabled: boolean): boolean => {
   const backend = runtime?.backend;
   if (backend) {
-    backend.write(enabled);
-    return;
+    return backend.write(enabled);
   }
   app.setLoginItemSettings({ openAtLogin: enabled, ...runtime?.identity });
+  return true;
 };
 
 const readLaunchAtLogin = (): boolean =>
@@ -71,15 +71,35 @@ const readLaunchAtLogin = (): boolean =>
 
 const writeLaunchAtLogin = (enabled: boolean): void => {
   const store = runtime?.store;
+  if (runtime?.backend && !applyOpenAtLogin(enabled)) {
+    throw new Error("Could not update launch at login");
+  }
   if (store) {
     store.write(enabled);
     return;
   }
-  applyOpenAtLogin(enabled);
+  if (!runtime?.backend) {
+    applyOpenAtLogin(enabled);
+  }
 };
 
+let syncing = false;
 const syncLoginItem = (): void => {
-  applyOpenAtLogin(readLaunchAtLogin());
+  if (syncing) {
+    return;
+  }
+  syncing = true;
+  try {
+    const enabled = readLaunchAtLogin();
+    if (runtime?.backend && readOpenAtLogin() === enabled) {
+      return;
+    }
+    if (!applyOpenAtLogin(enabled)) {
+      runtime?.store?.write(readOpenAtLogin());
+    }
+  } finally {
+    syncing = false;
+  }
 };
 
 export const installLoginItemIpc = (): void => {


### PR DESCRIPTION
Launch at login uses an XDG desktop entry with shared release-channel app identity and correctly escaped Exec/Name fields. It honors Hidden and X-GNOME-Autostart-enabled, preserves foreign entries, and includes the application entry point in development launches.

Backend writes report success before the preference is persisted. Failed writes leave the stored preference unchanged; failed subscription updates roll back without recursion. Hidden login startup and repeated hidden invocations do not open a main window. Ordinary activation and actual deep links can still show the app.

Validation: 8 autostart tests, 2 startup activation tests, 7 shared login-item tests, Linux and shared desktop typechecks, and combined Wave 1 main-window tests pass. OS-level login behavior still needs packaged Linux validation.

Part of Linux parity Wave 1 (PR 7).
