### PR TITLE
Linux voice guidance and desktop automation skill

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -502,6 +502,32 @@
       "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
+      "id": "linux-automation",
+      "name": "linux-automation",
+      "description": "Automate native Linux desktop apps and system interactions with xdg-open, desktop entries, D-Bus and xdg-desktop-portal calls, and X11 window tools through the Linux host executor. Use for launching or inspecting desktop apps, opening desktop settings pages, sending desktop notifications, reading and writing the clipboard, and controlling windows when no direct CLI or API is available.",
+      "metadata": {
+        "icon": "assets/icon.svg",
+        "emoji": "🐧",
+        "vellum": {
+          "category": "system",
+          "display-name": "Linux Automation",
+          "platforms": [
+            "linux"
+          ],
+          "activation-hints": [
+            "Interacting with native Linux desktop apps or desktop settings",
+            "Sending a desktop notification or using the clipboard on the host",
+            "Finding, focusing, or inspecting a window on an X11 session"
+          ],
+          "avoid-when": [
+            "The task can be completed in the sandbox or through a direct CLI or API"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants on Linux",
+      "updatedAt": "2026-09-04T21:39:57.000Z"
+    },
+    {
       "id": "llm-cost-optimizer",
       "name": "llm-cost-optimizer",
       "description": "Analyze and reduce LLM spend: read usage breakdowns by call site, model, and inference profile, understand single-winner profile resolution, and pin call sites to managed profiles (Balanced / Quality / Budget / Fast) only where they should deviate from shipped defaults.",
@@ -1179,7 +1205,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-04T16:14:06.000Z"
+      "updatedAt": "2026-09-04T16:57:56.000Z"
     },
     {
       "id": "vellum-self-knowledge",
@@ -1241,14 +1267,15 @@
         "vellum": {
           "platforms": [
             "macos",
-            "windows"
+            "windows",
+            "linux"
           ],
           "category": "content",
           "display-name": "Sounds"
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-26T00:15:53.000Z"
+      "updatedAt": "2026-09-04T21:39:57.000Z"
     },
     {
       "id": "vellum-terminal-sessions",
@@ -1338,7 +1365,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-26T00:50:29.000Z"
+      "updatedAt": "2026-09-04T21:39:57.000Z"
     },
     {
       "id": "watch-together",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1365,7 +1365,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-04T21:55:34.000Z"
+      "updatedAt": "2026-09-04T22:01:59.000Z"
     },
     {
       "id": "watch-together",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -525,7 +525,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants on Linux",
-      "updatedAt": "2026-09-04T21:39:57.000Z"
+      "updatedAt": "2026-09-04T21:45:42.000Z"
     },
     {
       "id": "llm-cost-optimizer",
@@ -1275,7 +1275,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-04T21:39:57.000Z"
+      "updatedAt": "2026-09-04T21:45:42.000Z"
     },
     {
       "id": "vellum-terminal-sessions",
@@ -1365,7 +1365,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-04T21:39:57.000Z"
+      "updatedAt": "2026-09-04T21:55:34.000Z"
     },
     {
       "id": "watch-together",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -525,7 +525,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants on Linux",
-      "updatedAt": "2026-09-04T21:45:42.000Z"
+      "updatedAt": "2026-09-04T23:01:35.000Z"
     },
     {
       "id": "llm-cost-optimizer",
@@ -1365,7 +1365,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-04T22:01:59.000Z"
+      "updatedAt": "2026-09-04T23:01:35.000Z"
     },
     {
       "id": "watch-together",

--- a/skills/linux-automation/SKILL.md
+++ b/skills/linux-automation/SKILL.md
@@ -92,7 +92,7 @@ gdbus call --session --dest org.freedesktop.FileManager1 \
   --method org.freedesktop.FileManager1.ShowItems "['file:///home/user/notes.txt']" ""
 ```
 
-Portal methods under `org.freedesktop.portal.*` are asynchronous: the call returns a request object path, and the result arrives as a `Response` signal. A portal request can also open a user consent dialog, so treat a call that appears to hang as one waiting on the user rather than retrying it.
+Screen capture and remote desktop portal requests are asynchronous: the result arrives as a `Response` signal. A long-lived client must own the D-Bus connection, request, and session and handle cancellation or revocation. Do not use a one-shot `gdbus call` to establish a capture or input session. Use an application that implements the complete portal lifecycle. A stored restore token is not proof of current permission; it can expire or be revoked and must be replaced when the portal returns a new token.
 
 ## Send a notification
 
@@ -162,7 +162,7 @@ Use keyboard input only after activation succeeds. Never use keyboard input to t
 ## Troubleshooting
 
 - An empty window list on a Wayland session is expected, not a failure. Native Wayland clients are invisible to X11 tools by design. Do not work around it with blind keystrokes.
-- A launcher fails on a desktop entry that needs a terminal or a field code. Run the entry's `Exec` line directly in that case, after reading it.
+- If a desktop entry fails to launch, inspect its fields and the launcher's error. Use `gtk-launch` or `gio launch`; never execute the raw `Exec` value as shell code, since desktop-entry quoting and field codes are not shell syntax.
 - App names, window titles, and settings labels are localized. Prefer desktop IDs, window classes, and process IDs.
 - A D-Bus call that reports an unknown method usually means the service version differs. Introspect the live object instead of trusting documentation for another release.
 - `host_bash` is non-interactive. Do not use commands that wait for terminal input, and never run `sudo`, which cannot prompt for a password.

--- a/skills/linux-automation/SKILL.md
+++ b/skills/linux-automation/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: linux-automation
+description: Automate native Linux desktop apps and system interactions with xdg-open, desktop entries, D-Bus and xdg-desktop-portal calls, and X11 window tools through the Linux host executor. Use for launching or inspecting desktop apps, opening desktop settings pages, sending desktop notifications, reading and writing the clipboard, and controlling windows when no direct CLI or API is available.
+compatibility: "Designed for Vellum personal assistants on Linux"
+metadata:
+  icon: assets/icon.svg
+  emoji: "🐧"
+  vellum:
+    category: "system"
+    display-name: "Linux Automation"
+    platforms:
+      - linux
+    activation-hints:
+      - "Interacting with native Linux desktop apps or desktop settings"
+      - "Sending a desktop notification or using the clipboard on the host"
+      - "Finding, focusing, or inspecting a window on an X11 session"
+    avoid-when:
+      - "The task can be completed in the sandbox or through a direct CLI or API"
+---
+
+Use `host_bash` for every command in this skill. On Linux, `host_bash` runs bash on the user's desktop session, so use POSIX paths and non-interactive commands.
+
+Prefer automation methods in this order:
+
+1. A documented CLI, URI scheme, or desktop entry
+2. A documented D-Bus interface or `xdg-desktop-portal` call
+3. X11 window tools, only on an X11 or XWayland session
+4. Keyboard input only when the target and focus are verified
+
+Avoid screen coordinates and blind keystrokes. They are fragile and can affect the wrong app. Use computer control only when the methods above cannot complete the task or the user explicitly requests it.
+
+## Check the session first
+
+Almost every branch below depends on the session type and desktop environment. Read them before choosing a tool.
+
+```bash
+echo "session=${XDG_SESSION_TYPE:-unknown} desktop=${XDG_CURRENT_DESKTOP:-unknown}"
+```
+
+- `x11`: window and input tools such as `wmctrl` and `xdotool` work.
+- `wayland`: those tools see only XWayland clients and cannot enumerate or focus native Wayland windows. Use D-Bus, portals, and app CLIs instead, and tell the user when something is not possible rather than falling back to blind keystrokes.
+
+Tools in this skill are not all installed by default. Check with `command -v <tool>` before using one. If it is missing, do not install it. Tell the user which package provides it for their distribution, for example `wmctrl`, `xdotool`, `xclip`, `wl-clipboard`, or `libnotify-bin` on Debian and Ubuntu.
+
+## Discover and launch apps
+
+Applications are described by desktop entries, and the entry's file name is its desktop ID.
+
+```bash
+# Find an installed app's desktop ID
+grep -l -i "calculator" /usr/share/applications/*.desktop ~/.local/share/applications/*.desktop 2>/dev/null
+
+# Launch by desktop ID, which applies the entry's own environment and scaling
+gio launch org.gnome.Calculator.desktop
+gtk-launch org.gnome.Calculator   # fallback when gio is unavailable
+
+# Open a file, folder, or URL with the user's default handler
+xdg-open ~/Documents
+xdg-open https://example.com
+
+# Inspect running desktop apps
+ps -eo pid,comm,args --sort=-pcpu | head -30
+```
+
+Prefer a desktop ID, a stable executable, or a URI scheme over a localized window title. `xdg-settings get default-web-browser` and `xdg-mime query default <mimetype>` report which app will handle an open.
+
+## Open desktop settings
+
+Settings panes are desktop-specific and have no shared URI scheme. Match the command to `XDG_CURRENT_DESKTOP`.
+
+```bash
+gnome-control-center sound          # GNOME
+systemsettings kcm_pulseaudio       # KDE Plasma
+xfce4-settings-manager              # Xfce
+```
+
+If the matching command is missing, describe the path through the desktop's settings app instead of guessing another command.
+
+## Use D-Bus and portals
+
+Most desktop services expose D-Bus interfaces. Introspect before calling so the method signature is known rather than assumed.
+
+```bash
+# List session services and inspect one
+busctl --user list
+gdbus introspect --session --dest org.freedesktop.portal.Desktop \
+  --object-path /org/freedesktop/portal/desktop --only-properties
+
+# Call a documented method
+gdbus call --session --dest org.freedesktop.FileManager1 \
+  --object-path /org/freedesktop/FileManager1 \
+  --method org.freedesktop.FileManager1.ShowItems "['file:///home/user/notes.txt']" ""
+```
+
+Portal methods under `org.freedesktop.portal.*` are asynchronous: the call returns a request object path, and the result arrives as a `Response` signal. A portal request can also open a user consent dialog, so treat a call that appears to hang as one waiting on the user rather than retrying it.
+
+## Send a notification
+
+```bash
+notify-send "Backup finished" "42 files copied"
+notify-send -u critical -i dialog-warning "Disk almost full" "3% free on /"
+```
+
+`notify-send` is the documented wrapper over `org.freedesktop.Notifications`. Use `gdbus call` against that interface directly only when an action or a replacement ID is needed.
+
+## Read and write the clipboard
+
+The clipboard tool depends on the session type.
+
+```bash
+# X11
+printf '%s' "text to copy" | xclip -selection clipboard
+xclip -selection clipboard -o
+
+# Wayland
+printf '%s' "text to copy" | wl-copy
+wl-paste --no-newline
+```
+
+The clipboard belongs to the user. Read it only when the user asked for its contents, and say what was written before replacing it.
+
+## Inspect and control windows on X11
+
+These commands work on an X11 session and on XWayland clients only. Skip them when `XDG_SESSION_TYPE` is `wayland`.
+
+```bash
+# List windows with their IDs, desktop, and title
+wmctrl -l -p
+
+# Find a window by class rather than a localized title
+xdotool search --classname "gnome-terminal"
+
+# Activate a specific window ID
+xdotool windowactivate 0x03400007
+
+# Read the currently focused window
+xdotool getactivewindow getwindowname
+```
+
+Prefer a window class or process ID over a title. Titles are localized and change as the user works.
+
+## Consequential actions are unsupported
+
+Do not use this skill to save, send, delete, or overwrite content. The Linux host executor does not provide an in-process confirmation gate that works for both local and remote assistants.
+
+Treat every existing document, message, note, calendar item, file, and cloud-backed resource as read-only. Autosave can persist an edit without an explicit save command. Only edit an isolated temporary document that the automation created during the current task, has no storage path or cloud connection, and has autosave definitively disabled. If those conditions cannot be verified, do not edit it.
+
+If the user requests a consequential action, use a dedicated skill or product workflow with its own hard confirmation gate. If none is available, explain the limitation and ask the user to perform that final action manually.
+
+## Focus and keyboard fallback
+
+If an app exposes no useful CLI or D-Bus interface, verify focus before sending keys, and only on X11:
+
+```bash
+target=$(xdotool search --classname "gedit" | head -1)
+xdotool windowactivate --sync "$target" || { echo "Could not activate the window"; exit 1; }
+xdotool key --window "$target" ctrl+f
+```
+
+Use keyboard input only after activation succeeds. Never use keyboard input to trigger a consequential action prohibited above.
+
+## Troubleshooting
+
+- An empty window list on a Wayland session is expected, not a failure. Native Wayland clients are invisible to X11 tools by design. Do not work around it with blind keystrokes.
+- `gio launch` fails on a desktop entry that needs a terminal or a field code. Run the entry's `Exec` line directly in that case, after reading it.
+- App names, window titles, and settings labels are localized. Prefer desktop IDs, window classes, and process IDs.
+- A D-Bus call that reports an unknown method usually means the service version differs. Introspect the live object instead of trusting documentation for another release.
+- `host_bash` is non-interactive. Do not use commands that wait for terminal input, and never run `sudo`, which cannot prompt for a password.

--- a/skills/linux-automation/SKILL.md
+++ b/skills/linux-automation/SKILL.md
@@ -51,8 +51,8 @@ Applications are described by desktop entries, and the entry's file name is its 
 grep -l -i "calculator" /usr/share/applications/*.desktop ~/.local/share/applications/*.desktop 2>/dev/null
 
 # Launch by desktop ID, which applies the entry's own environment and scaling
-gio launch org.gnome.Calculator.desktop
-gtk-launch org.gnome.Calculator   # fallback when gio is unavailable
+gtk-launch org.gnome.Calculator
+gio launch /usr/share/applications/org.gnome.Calculator.desktop   # takes a path, not an ID
 
 # Open a file, folder, or URL with the user's default handler
 xdg-open ~/Documents
@@ -84,7 +84,7 @@ Most desktop services expose D-Bus interfaces. Introspect before calling so the 
 # List session services and inspect one
 busctl --user list
 gdbus introspect --session --dest org.freedesktop.portal.Desktop \
-  --object-path /org/freedesktop/portal/desktop --only-properties
+  --object-path /org/freedesktop/portal/desktop
 
 # Call a documented method
 gdbus call --session --dest org.freedesktop.FileManager1 \
@@ -162,7 +162,7 @@ Use keyboard input only after activation succeeds. Never use keyboard input to t
 ## Troubleshooting
 
 - An empty window list on a Wayland session is expected, not a failure. Native Wayland clients are invisible to X11 tools by design. Do not work around it with blind keystrokes.
-- `gio launch` fails on a desktop entry that needs a terminal or a field code. Run the entry's `Exec` line directly in that case, after reading it.
+- A launcher fails on a desktop entry that needs a terminal or a field code. Run the entry's `Exec` line directly in that case, after reading it.
 - App names, window titles, and settings labels are localized. Prefer desktop IDs, window classes, and process IDs.
 - A D-Bus call that reports an unknown method usually means the service version differs. Introspect the live object instead of trusting documentation for another release.
 - `host_bash` is non-interactive. Do not use commands that wait for terminal input, and never run `sudo`, which cannot prompt for a password.

--- a/skills/linux-automation/assets/icon.svg
+++ b/skills/linux-automation/assets/icon.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="2" width="12" height="11" fill="#2d2d2d" stroke="#111" stroke-width="1"/>
+<rect x="3" y="3" width="10" height="9" fill="#1a1a1a"/>
+<path d="M 4.5 5.5 L 6.5 7.5 L 4.5 9.5" stroke="#f0c14b" stroke-width="1.2" fill="none"/>
+<rect x="7.5" y="9" width="4" height="1" fill="#f0c14b"/>
+<rect x="3" y="13" width="10" height="1" fill="#111"/>
+<rect x="4" y="14" width="8" height="1" fill="#f0c14b"/>
+</svg>

--- a/skills/vellum-sounds/SKILL.md
+++ b/skills/vellum-sounds/SKILL.md
@@ -136,13 +136,16 @@ bun run scripts/update-config.ts --event <key> --clear-sounds
 
 ## Mode 5: Preview a sound on Linux
 
-The desktop app plays these sounds itself, so a preview is only needed when the user wants to hear a file before assigning it. On Linux, play it on the host with `host_bash`, trying the players in order until one succeeds:
+The desktop app plays these sounds itself, so a preview is only needed when the user wants to hear a file before assigning it. `host_bash` runs on the connected Linux desktop, so pass it a path that exists there and try the players in order until one succeeds:
 
 ```bash
-dir={workspaceDir}/data/sounds   # unquoted so a leading ~ expands
-f="$dir/<filename>"
+# host_bash, on the Linux desktop
+dir={workspaceDir}   # unquoted so a leading ~ expands
+f="$dir/data/sounds/<filename>"
 paplay "$f" || aplay "$f" || ffplay -nodisp -autoexit "$f"
 ```
+
+That workspace path only resolves when the assistant runs on the same machine as the desktop app. For a remote assistant the sandbox and the desktop are separate filesystems, so confirm the file exists on the host before playing it, and otherwise ask the user to play it from their file manager instead of guessing a host path.
 
 `paplay` ships in `pulseaudio-utils` and works on PulseAudio and PipeWire sessions. `aplay` ships in `alsa-utils` and talks to ALSA directly. `ffplay` comes with `ffmpeg` and is the only one of the three that reliably plays `.mp3` and `.m4a`.
 

--- a/skills/vellum-sounds/SKILL.md
+++ b/skills/vellum-sounds/SKILL.md
@@ -8,24 +8,25 @@ metadata:
     platforms:
       - macos
       - windows
+      - linux
     category: "content"
     display-name: "Sounds"
 ---
 
-You are helping the user customize the sound effects their desktop app plays. Sounds are configured in two places: a `data/sounds/` directory of audio files and a `data/sounds/config.json` that controls what plays, at what volume, and whether it is enabled. The Settings > Sounds tab reads the same files on macOS and Windows, so changes appear there live without a restart.
+You are helping the user customize the sound effects their desktop app plays. Sounds are configured in two places: a `data/sounds/` directory of audio files and a `data/sounds/config.json` that controls what plays, at what volume, and whether it is enabled. The Settings > Sounds tab reads the same files on macOS, Windows, and Linux, so changes appear there live without a restart.
 
-**All commands in this skill use the `bash` tool.** `$VELLUM_WORKSPACE_DIR` is available in the sandbox environment — do not use `host_bash`.
+**Every command in this skill uses the `bash` tool** except the Linux preview commands in Mode 5, which need the host's audio devices. `$VELLUM_WORKSPACE_DIR` is available in the sandbox environment.
 
 ## What you're configuring
 
 Two stores, both under `$VELLUM_WORKSPACE_DIR/data/sounds/`:
 
-- **Sound files:** `.aiff`, `.wav`, `.mp3`, `.m4a`, or `.caf`. No other extensions are accepted. The app scans this directory to populate the dropdown for each event. Prefer `.wav`, `.mp3`, or `.m4a` when the same file must play on both macOS and Windows.
+- **Sound files:** `.aiff`, `.wav`, `.mp3`, `.m4a`, or `.caf`. No other extensions are accepted. The app scans this directory to populate the dropdown for each event. Prefer `.wav`, `.mp3`, or `.m4a` when the same file must play on macOS, Windows, and Linux.
 - **`config.json`:** a single JSON file that stores the global on/off switch, the master volume, and a per-event map of `{ enabled, sounds }`. Each event's `sounds` is a **pool** of filenames; the app picks one at random on playback. An empty pool falls back to the platform's default blip.
 
 ## Sound events
 
-macOS supports all nine events below. Windows supports the eight events other than `app_open`. Do not configure `app_open` on Windows because it is not displayed or played there. Other keys are ignored by the app.
+macOS supports all nine events below. Windows and Linux support the eight events other than `app_open`. Do not configure `app_open` on Windows or Linux because it is not displayed or played there. Other keys are ignored by the app.
 
 | Event key          | Fires when                                 |
 | ------------------ | ------------------------------------------ |
@@ -133,19 +134,33 @@ bun run scripts/update-config.ts --event <key> --clear-sounds
 
 (The app already falls back to the platform's default blip if every referenced file is missing, but cleaning up the config is tidier.)
 
+## Mode 5: Preview a sound on Linux
+
+The desktop app plays these sounds itself, so a preview is only needed when the user wants to hear a file before assigning it. On Linux, play it on the host with `host_bash`, trying the players in order until one succeeds:
+
+```bash
+dir={workspaceDir}/data/sounds   # unquoted so a leading ~ expands
+f="$dir/<filename>"
+paplay "$f" || aplay "$f" || ffplay -nodisp -autoexit "$f"
+```
+
+`paplay` ships in `pulseaudio-utils` and works on PulseAudio and PipeWire sessions. `aplay` ships in `alsa-utils` and talks to ALSA directly. `ffplay` comes with `ffmpeg` and is the only one of the three that reliably plays `.mp3` and `.m4a`.
+
+If none is installed, do not install anything yourself. Tell the user which package to add, `pulseaudio-utils` for `paplay` or `alsa-utils` for `aplay`, and offer to continue without a preview. Silence with no error usually means the player chose the wrong sink, so check that the desktop's output device is the one the user is listening on.
+
 ## UX Guidelines
 
 - **Always check current state first.** Don't ask "what do you want to do" if they already have sounds configured — summarize what's set up, then ask what to change.
 - **The master switch is the #1 gotcha.** `globalEnabled` defaults to `false`. If the user assigns a sound to an event and doesn't hear anything, check that flag first. When assigning the user's first sound, offer to flip the master switch on for them.
 - **Per-event enabled is the #2 gotcha.** Each event has its own `enabled` bool. Setting a sound alone doesn't enable the event.
-- **Pool editing in the UI.** The Settings > Sounds tab supports pool editing on macOS and Windows. Users can add and remove entries there without running this script. Power users can weight a sound more heavily by hand-editing `config.json` to include duplicates. For example, `["a.wav","a.wav","b.wav"]` makes `a.wav` twice as likely. The script de-dupes on `--add-sound` but does not re-sort or de-dupe on read, so hand-edited duplicates survive round-trips.
+- **Pool editing in the UI.** The Settings > Sounds tab supports pool editing on macOS, Windows, and Linux. Users can add and remove entries there without running this script. Power users can weight a sound more heavily by hand-editing `config.json` to include duplicates. For example, `["a.wav","a.wav","b.wav"]` makes `a.wav` twice as likely. The script de-dupes on `--add-sound` but does not re-sort or de-dupe on read, so hand-edited duplicates survive round-trips.
 - **Filename sanity.** When the user sends a file named something like `Screen Recording 2026-04-13 at 11.47.23.m4a`, rename it to something memorable before copying — they'll have to pick it from a dropdown later.
 - **Confirm after changes.** Tell the user the Settings > Sounds tab will reflect changes live. Offer to open it: "You can preview it in Settings > Sounds, or I can play it for you next time that event fires."
-- **Don't invent events.** macOS supports the nine keys above, while Windows supports eight and excludes `app_open`. There is currently no event for voice-mode activation or typing indicators. If the user asks for those, tell them it needs a desktop app code change.
+- **Don't invent events.** macOS supports the nine keys above, while Windows and Linux support eight and exclude `app_open`. There is currently no event for voice-mode activation or typing indicators. If the user asks for those, tell them it needs a desktop app code change.
 
 ## Config shape reference
 
-If the user inspects `config.json` directly, this is the macOS superset they may see. On Windows, omit the `app_open` entry. Defaults otherwise match the shared desktop sound configuration.
+If the user inspects `config.json` directly, this is the macOS superset they may see. On Windows and Linux, omit the `app_open` entry. Defaults otherwise match the shared desktop sound configuration.
 
 ```json
 {

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -174,7 +174,7 @@ Get-Content $log.FullName -Wait
 tail -f ~/.config/Vellum*/logs/vellum.log
 ```
 
-For Desktop Talk, look for live voice, WebSocket, and speech-to-text provider errors. For one-shot dictation, look for `[win-helper]` on Windows and `linux helper` on Linux, plus `dictation`, permission, and recognizer messages. Do not ask the user to share transcript contents from logs.
+For Desktop Talk, look for live voice, WebSocket, and speech-to-text provider errors. For one-shot dictation, look for `[win-helper]`, which the Linux client currently reuses as well, plus `linux helper` from the sidecar supervisor and any `dictation`, permission, or recognizer messages. Do not ask the user to share transcript contents from logs.
 
 ## Rules
 

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -20,17 +20,17 @@ metadata:
       - 'If "voice" is in a Twilio/phone context, load phone-calls instead'
 ---
 
-You are helping the user set up and troubleshoot voice features entirely within this conversation. Use the `client_os:` line in `<turn_context>` to choose the macOS or Windows instructions below. Do not give macOS commands or key names to a Windows user, or Windows guidance to a macOS user.
+You are helping the user set up and troubleshoot voice features entirely within this conversation. Use the `client_os:` line in `<turn_context>` to choose the macOS, Windows, or Linux instructions below. Never give one platform's commands or key names to a user on another platform.
 
 Before using a desktop tool, check `client_os`:
 
-- If it is `macos` or `windows`, follow that platform's branch.
-- If it is `web`, `ios`, `android`, or absent, do not call `open_system_settings` or give desktop shortcut instructions. Explain that permissions and the Talk shortcut must be configured from the Mac or Windows desktop app. You can still complete provider, voice, language, and timeout configuration in the current conversation.
+- If it is `macos`, `windows`, or `linux`, follow that platform's branch.
+- If it is `web`, `ios`, `android`, or absent, do not call `open_system_settings` or give desktop shortcut instructions. Explain that permissions and the Talk shortcut must be configured from the Mac, Windows, or Linux desktop app. You can still complete provider, voice, language, and timeout configuration in the current conversation.
 
 ## Available Tools
 
 - `voice_config_update` changes shared voice settings such as the legacy macOS PTT activation key, conversation timeout, speech providers, and TTS voice ID.
-- `open_system_settings` opens the correct macOS System Settings or Windows Settings privacy page. Call it only when `client_os` is `macos` or `windows`, and pass that value as `platform`.
+- `open_system_settings` opens the correct macOS System Settings or Windows Settings privacy page. Call it only when `client_os` is `macos`, `windows`, or `linux`, and pass that value as `platform`. On Linux there is no shared settings URI scheme, so the tool returns the desktop settings command to offer the user instead of opening a page.
 - `navigate_settings_tab` opens Vellum settings. Use it for review, or when the desktop-owned Talk shortcut must be recorded in the app.
 - `assistant credentials prompt` collects API keys securely for ElevenLabs or Deepgram.
 
@@ -51,13 +51,14 @@ If access is denied or the user is unsure:
 3. Give the matching instruction:
    - **macOS:** In **System Settings > Privacy & Security > Microphone**, turn on **Vellum** or **Vellum Assistant**.
    - **Windows:** In **Settings > Privacy & security > Microphone**, turn on **Microphone access** and **Let desktop apps access your microphone**. Windows groups non-packaged desktop apps under the desktop-app toggle rather than always showing an individual Vellum switch.
+   - **Linux:** There is no per-app microphone toggle on most desktops. Run the settings command the tool returns, then check the sound settings input tab for the right device, an unmuted level, and an input meter that moves while the user speaks. If the session routes capture through a portal, the first recording shows a portal prompt the user has to allow.
 4. Ask the user to return after changing it, then verify with the short recording test in section 4.
 
 If the user confirms access is granted, continue without opening system settings.
 
 ### 2. Talk and Push-to-Talk Shortcut
 
-On macOS, first determine whether the user means the current desktop **Talk** shortcut or the legacy PTT activation setting. Windows supports the desktop Talk shortcut only.
+On macOS, first determine whether the user means the current desktop **Talk** shortcut or the legacy PTT activation setting. Windows and Linux support the desktop Talk shortcut only.
 
 #### Desktop Talk shortcut
 
@@ -65,6 +66,7 @@ The Talk shortcut starts or ends a voice conversation.
 
 - **macOS:** Offer **Fn** or a custom global chord. Fn is the Mac-specific helper path and can require Input Monitoring. If macOS refuses Fn registration, direct the user to **System Settings > Privacy & Security > Input Monitoring**, then have them reopen Vellum. A custom chord should be one the user can spare system-wide.
 - **Windows:** Fn is unavailable because Windows does not receive the hardware Fn key. Recommend a custom chord for system-wide Talk. The app also offers **Ctrl+Shift** and **Alt** taps, but those bare-modifier choices work only while a Vellum window is focused. Warn that another global shortcut can prevent a custom chord from registering.
+- **Linux:** Fn is unavailable for the same reason. Recommend a custom chord for system-wide Talk. Holding a bare modifier such as **Ctrl+Shift** or **Alt** system-wide needs the native helper's keyboard monitor, which reads raw key events. The Voice settings permissions card reports that as **Input monitoring** and carries the remediation, which is adding the user's account to the `input` group and signing out and back in. Without it, those holds work only while a Vellum window is focused. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
 
 Ask which behavior they want, then use `navigate_settings_tab` with `tab: "Voice"` so they can record the desktop-owned shortcut. Do not claim that `voice_config_update` changed this shortcut.
 
@@ -79,7 +81,7 @@ This setting is macOS-only. If a Mac user explicitly wants the legacy hold-to-ta
 
 After the user chooses, call `voice_config_update` with `setting: "activation_key"` and the matching canonical value.
 
-On Windows, do not offer or call the legacy activation setting. It has no Windows client consumer. Use the desktop Talk shortcut flow instead.
+On Windows and Linux, do not offer or call the legacy activation setting. It has no client consumer there. Use the desktop Talk shortcut flow instead.
 
 ### 3. Text-to-Speech Voice (Optional)
 
@@ -105,7 +107,7 @@ After setup:
 2. Ask the user to test the selected shortcut and speak a short sentence.
 3. Offer to open the Voice settings tab for review with `navigate_settings_tab` and `tab: "Voice"`.
 
-Desktop Talk starts a live voice session. Its audio is transcribed through the assistant's configured speech-to-text provider over the live voice connection. The Windows native helper provides partials only for one-shot dictation from the microphone button. Ask which surface the user tested before troubleshooting missing text.
+Desktop Talk starts a live voice session. Its audio is transcribed through the assistant's configured speech-to-text provider over the live voice connection. The Windows and Linux native helpers provide partials only for one-shot dictation from the microphone button. Ask which surface the user tested before troubleshooting missing text.
 
 ## Troubleshooting Decision Trees
 
@@ -116,8 +118,9 @@ Desktop Talk starts a live voice session. Its audio is transcribed through the a
 3. Apply the platform-specific checks:
    - **macOS:** Fn requires the native helper and may require Input Monitoring. The Globe key can also be assigned to macOS Dictation or the emoji picker, so suggest a custom chord if both actions fire.
    - **Windows:** Fn cannot work. A Ctrl+Shift or Alt tap requires Vellum to be focused. For use from another app, record a custom global chord and make sure no other app owns it.
+   - **Linux:** Fn cannot work. Open the Voice settings permissions card: if **Input monitoring** is not granted, a system-wide Ctrl+Shift or Alt hold cannot fire, and the card's remediation is the fix. A custom chord is registered through the desktop environment, so confirm no compositor or app shortcut already owns it.
 4. If the user reports Speech Recognition permission as denied or not determined, call `open_system_settings` with `pane: "speech_recognition"` and the current `platform`.
-5. If the Windows shortcut fires but capture does not start, choose **Restart** from the Vellum tray menu and retry.
+5. If the Windows or Linux shortcut fires but capture does not start, restart Vellum from the tray menu and retry.
 
 ### "Talk starts but no transcript"
 
@@ -134,8 +137,9 @@ This path applies to the microphone button's one-shot dictation, not Desktop Tal
 1. If the user reports Speech Recognition permission as denied or unknown, open the platform's privacy page with `open_system_settings`.
 2. Ask whether dictation partials appear. If capture starts without partials, troubleshoot the native helper and local recognizer.
 3. On Windows, the helper uses an installed Windows speech recognizer and prefers the current Windows display language. If no matching recognizer is installed, add that language's speech feature or select an installed language.
-4. Reduce background noise or move closer to the microphone.
-5. On Windows, choose **Restart** from the Vellum tray menu and retry. This relaunches Vellum and its one-shot dictation helper.
+4. On Linux, dictation runs through the native helper, which reports an unavailable reason instead of failing silently. Ask what the app showed: a missing helper, a missing capture device, and a denied portal request each need a different fix, and only the last is retried by allowing the portal prompt.
+5. Reduce background noise or move closer to the microphone.
+6. On Windows and Linux, restart Vellum from the tray menu and retry. This relaunches Vellum and its one-shot dictation helper.
 
 ### "Changed a setting but it didn't work"
 
@@ -164,7 +168,13 @@ $log = Get-ChildItem "$env:APPDATA\Vellum*\logs\vellum.log" |
 Get-Content $log.FullName -Wait
 ```
 
-For Desktop Talk, look for live voice, WebSocket, and speech-to-text provider errors. For one-shot dictation, look for `[win-helper]`, `dictation`, permission, and recognizer messages. Do not ask the user to share transcript contents from logs.
+**Linux:**
+
+```bash
+tail -f ~/.config/Vellum*/logs/vellum.log
+```
+
+For Desktop Talk, look for live voice, WebSocket, and speech-to-text provider errors. For one-shot dictation, look for `[win-helper]` on Windows and `linux helper` on Linux, plus `dictation`, permission, and recognizer messages. Do not ask the user to share transcript contents from logs.
 
 ## Rules
 

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -30,7 +30,7 @@ Before using a desktop tool, check `client_os`:
 ## Available Tools
 
 - `voice_config_update` changes shared voice settings such as the legacy macOS PTT activation key, conversation timeout, speech providers, and TTS voice ID.
-- `open_system_settings` opens the correct macOS System Settings or Windows Settings privacy page. Call it only when `client_os` is `macos`, `windows`, or `linux`, and pass that value as `platform`. On Linux there is no shared settings URI scheme, so the tool returns the desktop settings command to offer the user instead of opening a page.
+- `open_system_settings` opens the correct macOS System Settings or Windows Settings privacy page. Call it only when `client_os` is `macos`, `windows`, or `linux`, and pass that value as `platform`. On Linux there is no shared settings URI scheme, so the tool returns the desktop settings command to offer the user instead of opening a page. If the tool rejects `linux` on the user's build, do not retry: name the settings path for their desktop and continue.
 - `navigate_settings_tab` opens Vellum settings. Use it for review, or when the desktop-owned Talk shortcut must be recorded in the app.
 - `assistant credentials prompt` collects API keys securely for ElevenLabs or Deepgram.
 
@@ -51,7 +51,7 @@ If access is denied or the user is unsure:
 3. Give the matching instruction:
    - **macOS:** In **System Settings > Privacy & Security > Microphone**, turn on **Vellum** or **Vellum Assistant**.
    - **Windows:** In **Settings > Privacy & security > Microphone**, turn on **Microphone access** and **Let desktop apps access your microphone**. Windows groups non-packaged desktop apps under the desktop-app toggle rather than always showing an individual Vellum switch.
-   - **Linux:** There is no per-app microphone toggle on most desktops. Run the settings command the tool returns, then check the sound settings input tab for the right device, an unmuted level, and an input meter that moves while the user speaks. If the session routes capture through a portal, the first recording shows a portal prompt the user has to allow.
+   - **Linux:** There is no per-app microphone toggle on most desktops. Open the desktop's sound settings, GNOME Settings > Sound or System Settings > Audio on KDE, and check the input tab for the right device, an unmuted level, and an input meter that moves while the user speaks. If the session routes capture through a portal, the first recording shows a portal prompt the user has to allow.
 4. Ask the user to return after changing it, then verify with the short recording test in section 4.
 
 If the user confirms access is granted, continue without opening system settings.
@@ -66,7 +66,7 @@ The Talk shortcut starts or ends a voice conversation.
 
 - **macOS:** Offer **Fn** or a custom global chord. Fn is the Mac-specific helper path and can require Input Monitoring. If macOS refuses Fn registration, direct the user to **System Settings > Privacy & Security > Input Monitoring**, then have them reopen Vellum. A custom chord should be one the user can spare system-wide.
 - **Windows:** Fn is unavailable because Windows does not receive the hardware Fn key. Recommend a custom chord for system-wide Talk. The app also offers **Ctrl+Shift** and **Alt** taps, but those bare-modifier choices work only while a Vellum window is focused. Warn that another global shortcut can prevent a custom chord from registering.
-- **Linux:** Fn is unavailable for the same reason. Recommend a custom chord for system-wide Talk. Holding a bare modifier such as **Ctrl+Shift** or **Alt** system-wide needs the native helper's keyboard monitor, which reads raw key events. The Voice settings permissions card reports that as **Input monitoring** and carries the remediation, which is adding the user's account to the `input` group and signing out and back in. Without it, those holds work only while a Vellum window is focused. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
+- **Linux:** Fn is unavailable for the same reason. Recommend a custom chord for system-wide Talk. Holding a bare modifier such as **Ctrl+Shift** or **Alt** system-wide needs the native helper's keyboard monitor, which reads raw key events. That needs read access to `/dev/input`, so the remedy is adding the user's account to the `input` group and signing out and back in. Until the helper reports it, the Voice settings permissions card shows input monitoring as not applicable rather than as a denial, so treat the group membership as the check. Without it, those holds work only while a Vellum window is focused. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
 
 Ask which behavior they want, then use `navigate_settings_tab` with `tab: "Voice"` so they can record the desktop-owned shortcut. Do not claim that `voice_config_update` changed this shortcut.
 
@@ -118,7 +118,7 @@ Desktop Talk starts a live voice session. Its audio is transcribed through the a
 3. Apply the platform-specific checks:
    - **macOS:** Fn requires the native helper and may require Input Monitoring. The Globe key can also be assigned to macOS Dictation or the emoji picker, so suggest a custom chord if both actions fire.
    - **Windows:** Fn cannot work. A Ctrl+Shift or Alt tap requires Vellum to be focused. For use from another app, record a custom global chord and make sure no other app owns it.
-   - **Linux:** Fn cannot work. Open the Voice settings permissions card: if **Input monitoring** is not granted, a system-wide Ctrl+Shift or Alt hold cannot fire, and the card's remediation is the fix. A custom chord is registered through the desktop environment, so confirm no compositor or app shortcut already owns it.
+   - **Linux:** Fn cannot work. A system-wide Ctrl+Shift or Alt hold needs the helper's keyboard monitor, so check that the user's account is in the `input` group and that they signed out and back in since. A custom chord is registered through the desktop environment, so confirm no compositor or app shortcut already owns it.
 4. If the user reports Speech Recognition permission as denied or not determined, call `open_system_settings` with `pane: "speech_recognition"` and the current `platform`.
 5. If the Windows or Linux shortcut fires but capture does not start, restart Vellum from the tray menu and retry.
 

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -66,7 +66,7 @@ The Talk shortcut starts or ends a voice conversation.
 
 - **macOS:** Offer **Fn** or a custom global chord. Fn is the Mac-specific helper path and can require Input Monitoring. If macOS refuses Fn registration, direct the user to **System Settings > Privacy & Security > Input Monitoring**, then have them reopen Vellum. A custom chord should be one the user can spare system-wide.
 - **Windows:** Fn is unavailable because Windows does not receive the hardware Fn key. Recommend a custom chord for system-wide Talk. The app also offers **Ctrl+Shift** and **Alt** taps, but those bare-modifier choices work only while a Vellum window is focused. Warn that another global shortcut can prevent a custom chord from registering.
-- **Linux:** Fn is unavailable for the same reason. Recommend a custom chord for system-wide Talk. Holding a bare modifier such as **Ctrl+Shift** or **Alt** system-wide needs the native helper's keyboard monitor, which reads raw key events. That needs read access to `/dev/input`, so the remedy is adding the user's account to the `input` group and signing out and back in. Until the helper reports it, the Voice settings permissions card shows input monitoring as not applicable rather than as a denial, so treat the group membership as the check. Without it, those holds work only while a Vellum window is focused. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
+- **Linux:** Fn is unavailable for the same reason. Recommend a custom chord for system-wide Talk, which the app registers through the desktop environment. Do not offer a system-wide bare-modifier hold such as **Ctrl+Shift** or **Alt**: it needs the native helper's keyboard monitor, which no current Linux build ships, so those holds work only while a Vellum window is focused. When the helper does ship it will read raw key events from `/dev/input`, which needs the user's account in the `input` group, but do not send anyone through that change today. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
 
 Ask which behavior they want, then use `navigate_settings_tab` with `tab: "Voice"` so they can record the desktop-owned shortcut. Do not claim that `voice_config_update` changed this shortcut.
 
@@ -107,7 +107,7 @@ After setup:
 2. Ask the user to test the selected shortcut and speak a short sentence.
 3. Offer to open the Voice settings tab for review with `navigate_settings_tab` and `tab: "Voice"`.
 
-Desktop Talk starts a live voice session. Its audio is transcribed through the assistant's configured speech-to-text provider over the live voice connection. The Windows and Linux native helpers provide partials only for one-shot dictation from the microphone button. Ask which surface the user tested before troubleshooting missing text.
+Desktop Talk starts a live voice session. Its audio is transcribed through the assistant's configured speech-to-text provider over the live voice connection. The Windows native helper provides partials only for one-shot dictation from the microphone button, and the Linux helper will do the same once it ships. Ask which surface the user tested before troubleshooting missing text.
 
 ## Troubleshooting Decision Trees
 
@@ -118,7 +118,7 @@ Desktop Talk starts a live voice session. Its audio is transcribed through the a
 3. Apply the platform-specific checks:
    - **macOS:** Fn requires the native helper and may require Input Monitoring. The Globe key can also be assigned to macOS Dictation or the emoji picker, so suggest a custom chord if both actions fire.
    - **Windows:** Fn cannot work. A Ctrl+Shift or Alt tap requires Vellum to be focused. For use from another app, record a custom global chord and make sure no other app owns it.
-   - **Linux:** Fn cannot work. A system-wide Ctrl+Shift or Alt hold needs the helper's keyboard monitor, so check that the user's account is in the `input` group and that they signed out and back in since. A custom chord is registered through the desktop environment, so confirm no compositor or app shortcut already owns it.
+   - **Linux:** Fn cannot work, and a system-wide Ctrl+Shift or Alt hold cannot work either until the native helper ships. Say so rather than sending the user through host permission changes, and move them to a custom chord. A chord is registered through the desktop environment, so confirm no compositor or app shortcut already owns it.
 4. If the user reports Speech Recognition permission as denied or not determined, call `open_system_settings` with `pane: "speech_recognition"` and the current `platform`.
 5. If the Windows or Linux shortcut fires but capture does not start, restart Vellum from the tray menu and retry.
 
@@ -137,7 +137,7 @@ This path applies to the microphone button's one-shot dictation, not Desktop Tal
 1. If the user reports Speech Recognition permission as denied or unknown, open the platform's privacy page with `open_system_settings`.
 2. Ask whether dictation partials appear. If capture starts without partials, troubleshoot the native helper and local recognizer.
 3. On Windows, the helper uses an installed Windows speech recognizer and prefers the current Windows display language. If no matching recognizer is installed, add that language's speech feature or select an installed language.
-4. On Linux, dictation runs through the native helper, which reports an unavailable reason instead of failing silently. Ask what the app showed: a missing helper, a missing capture device, and a denied portal request each need a different fix, and only the last is retried by allowing the portal prompt.
+4. On Linux, dictation runs through the native helper, which no current build ships, so it reports unavailable rather than failing silently. Confirm that is what the app showed and tell the user the feature is not available yet instead of troubleshooting further.
 5. Reduce background noise or move closer to the microphone.
 6. On Windows and Linux, restart Vellum from the tray menu and retry. This relaunches Vellum and its one-shot dictation helper.
 

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -66,7 +66,7 @@ The Talk shortcut starts or ends a voice conversation.
 
 - **macOS:** Offer **Fn** or a custom global chord. Fn is the Mac-specific helper path and can require Input Monitoring. If macOS refuses Fn registration, direct the user to **System Settings > Privacy & Security > Input Monitoring**, then have them reopen Vellum. A custom chord should be one the user can spare system-wide.
 - **Windows:** Fn is unavailable because Windows does not receive the hardware Fn key. Recommend a custom chord for system-wide Talk. The app also offers **Ctrl+Shift** and **Alt** taps, but those bare-modifier choices work only while a Vellum window is focused. Warn that another global shortcut can prevent a custom chord from registering.
-- **Linux:** Fn is unavailable for the same reason. Recommend a custom chord for system-wide Talk, which the app registers through the desktop environment. Do not offer a system-wide bare-modifier hold such as **Ctrl+Shift** or **Alt**: it needs the native helper's keyboard monitor, which no current Linux build ships, so those holds work only while a Vellum window is focused. When the helper does ship it will read raw key events from `/dev/input`, which needs the user's account in the `input` group, but do not send anyone through that change today. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
+- **Linux:** Fn is unavailable for the same reason. A custom chord is the only working option: the client registers it as a global shortcut through the desktop session. Do not offer **Ctrl+Shift** or **Alt**, because Linux rejects modifier-only bindings entirely, focused or not. Those need the native helper's keyboard monitor, which no current Linux build ships, so do not send anyone through host permission changes for them yet. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
 
 Ask which behavior they want, then use `navigate_settings_tab` with `tab: "Voice"` so they can record the desktop-owned shortcut. Do not claim that `voice_config_update` changed this shortcut.
 
@@ -118,7 +118,7 @@ Desktop Talk starts a live voice session. Its audio is transcribed through the a
 3. Apply the platform-specific checks:
    - **macOS:** Fn requires the native helper and may require Input Monitoring. The Globe key can also be assigned to macOS Dictation or the emoji picker, so suggest a custom chord if both actions fire.
    - **Windows:** Fn cannot work. A Ctrl+Shift or Alt tap requires Vellum to be focused. For use from another app, record a custom global chord and make sure no other app owns it.
-   - **Linux:** Fn cannot work, and a system-wide Ctrl+Shift or Alt hold cannot work either until the native helper ships. Say so rather than sending the user through host permission changes, and move them to a custom chord. A chord is registered through the desktop environment, so confirm no compositor or app shortcut already owns it.
+   - **Linux:** Fn cannot work, and a Ctrl+Shift or Alt binding is rejected outright, so neither is a fix. Say so rather than sending the user through host permission changes, and move them to a custom chord. The chord is registered through the desktop session, so confirm no compositor or app shortcut already owns it.
 4. If the user reports Speech Recognition permission as denied or not determined, call `open_system_settings` with `pane: "speech_recognition"` and the current `platform`.
 5. If the Windows or Linux shortcut fires but capture does not start, restart Vellum from the tray menu and retry.
 
@@ -137,9 +137,9 @@ This path applies to the microphone button's one-shot dictation, not Desktop Tal
 1. If the user reports Speech Recognition permission as denied or unknown, open the platform's privacy page with `open_system_settings`.
 2. Ask whether dictation partials appear. If capture starts without partials, troubleshoot the native helper and local recognizer.
 3. On Windows, the helper uses an installed Windows speech recognizer and prefers the current Windows display language. If no matching recognizer is installed, add that language's speech feature or select an installed language.
-4. On Linux, dictation runs through the native helper, which no current build ships, so it reports unavailable rather than failing silently. Confirm that is what the app showed and tell the user the feature is not available yet instead of troubleshooting further.
+4. On Linux, dictation runs through the native helper, which no current build ships, so it reports unavailable rather than failing silently. Confirm that is what the app showed, tell the user the feature is not available yet, and stop here. A restart cannot change the result.
 5. Reduce background noise or move closer to the microphone.
-6. On Windows and Linux, restart Vellum from the tray menu and retry. This relaunches Vellum and its one-shot dictation helper.
+6. On Windows, restart Vellum from the tray menu and retry. This relaunches Vellum and its one-shot dictation helper.
 
 ### "Changed a setting but it didn't work"
 

--- a/skills/voice-setup/SKILL.md
+++ b/skills/voice-setup/SKILL.md
@@ -51,7 +51,7 @@ If access is denied or the user is unsure:
 3. Give the matching instruction:
    - **macOS:** In **System Settings > Privacy & Security > Microphone**, turn on **Vellum** or **Vellum Assistant**.
    - **Windows:** In **Settings > Privacy & security > Microphone**, turn on **Microphone access** and **Let desktop apps access your microphone**. Windows groups non-packaged desktop apps under the desktop-app toggle rather than always showing an individual Vellum switch.
-   - **Linux:** There is no per-app microphone toggle on most desktops. Open the desktop's sound settings, GNOME Settings > Sound or System Settings > Audio on KDE, and check the input tab for the right device, an unmuted level, and an input meter that moves while the user speaks. If the session routes capture through a portal, the first recording shows a portal prompt the user has to allow.
+   - **Linux:** There is no per-app microphone toggle on most desktops. Open the desktop's sound settings, GNOME Settings > Sound or System Settings > Audio on KDE, and check the input tab for the right device, an unmuted level, and an input meter that moves while the user speaks. If recording shows a desktop permission prompt, ask the user to approve it. A saved portal choice does not prove access is still granted.
 4. Ask the user to return after changing it, then verify with the short recording test in section 4.
 
 If the user confirms access is granted, continue without opening system settings.
@@ -66,7 +66,7 @@ The Talk shortcut starts or ends a voice conversation.
 
 - **macOS:** Offer **Fn** or a custom global chord. Fn is the Mac-specific helper path and can require Input Monitoring. If macOS refuses Fn registration, direct the user to **System Settings > Privacy & Security > Input Monitoring**, then have them reopen Vellum. A custom chord should be one the user can spare system-wide.
 - **Windows:** Fn is unavailable because Windows does not receive the hardware Fn key. Recommend a custom chord for system-wide Talk. The app also offers **Ctrl+Shift** and **Alt** taps, but those bare-modifier choices work only while a Vellum window is focused. Warn that another global shortcut can prevent a custom chord from registering.
-- **Linux:** Fn is unavailable for the same reason. A custom chord is the only working option: the client registers it as a global shortcut through the desktop session. Do not offer **Ctrl+Shift** or **Alt**, because Linux rejects modifier-only bindings entirely, focused or not. Those need the native helper's keyboard monitor, which no current Linux build ships, so do not send anyone through host permission changes for them yet. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
+- **Linux:** Fn and modifier-only bindings are not supported. Offer a custom chord when the current desktop session can register it, or use the in-app Talk button. Do not offer **Ctrl+Shift** or **Alt**, because Linux rejects modifier-only bindings entirely, focused or not. Those need the native helper's keyboard monitor, which no current Linux build ships, so do not send anyone through host permission changes for them yet. Warn that the desktop environment or another app can already own a chord, in which case it never reaches Vellum.
 
 Ask which behavior they want, then use `navigate_settings_tab` with `tab: "Voice"` so they can record the desktop-owned shortcut. Do not claim that `voice_config_update` changed this shortcut.
 
@@ -118,9 +118,9 @@ Desktop Talk starts a live voice session. Its audio is transcribed through the a
 3. Apply the platform-specific checks:
    - **macOS:** Fn requires the native helper and may require Input Monitoring. The Globe key can also be assigned to macOS Dictation or the emoji picker, so suggest a custom chord if both actions fire.
    - **Windows:** Fn cannot work. A Ctrl+Shift or Alt tap requires Vellum to be focused. For use from another app, record a custom global chord and make sure no other app owns it.
-   - **Linux:** Fn cannot work, and a Ctrl+Shift or Alt binding is rejected outright, so neither is a fix. Say so rather than sending the user through host permission changes, and move them to a custom chord. The chord is registered through the desktop session, so confirm no compositor or app shortcut already owns it.
+   - **Linux:** Fn cannot work, and a Ctrl+Shift or Alt binding is rejected outright, so neither is a fix. Say so rather than sending the user through host permission changes, and move them to a custom chord. Confirm the app registered the chord and no compositor or app shortcut already owns it. If registration fails, use the in-app Talk button.
 4. If the user reports Speech Recognition permission as denied or not determined, call `open_system_settings` with `pane: "speech_recognition"` and the current `platform`.
-5. If the Windows or Linux shortcut fires but capture does not start, restart Vellum from the tray menu and retry.
+5. If the Windows or Linux shortcut fires but capture does not start, fully quit and reopen Vellum, using the tray menu if available, and retry.
 
 ### "Talk starts but no transcript"
 
@@ -134,12 +134,12 @@ Desktop Talk starts a live voice session. Its audio is transcribed through the a
 
 This path applies to the microphone button's one-shot dictation, not Desktop Talk.
 
-1. If the user reports Speech Recognition permission as denied or unknown, open the platform's privacy page with `open_system_settings`.
-2. Ask whether dictation partials appear. If capture starts without partials, troubleshoot the native helper and local recognizer.
+1. On macOS, check Speech Recognition permission with `open_system_settings`. On Linux, check microphone capture in the desktop sound settings; there is no shared Speech Recognition permission pane.
+2. Ask whether dictation partials appear. Missing native partials alone does not mean transcription is unavailable: the app also uses streaming and recorded-audio transcription through the configured provider.
 3. On Windows, the helper uses an installed Windows speech recognizer and prefers the current Windows display language. If no matching recognizer is installed, add that language's speech feature or select an installed language.
-4. On Linux, dictation runs through the native helper, which no current build ships, so it reports unavailable rather than failing silently. Confirm that is what the app showed, tell the user the feature is not available yet, and stop here. A restart cannot change the result.
+4. On Linux, native partials are unavailable until a build includes the recognizer helper. One-shot dictation can still transcribe through the configured provider. Check microphone capture, provider configuration, credentials, and connection errors before concluding dictation is unavailable. Do not send the user through host permission changes to enable an absent helper.
 5. Reduce background noise or move closer to the microphone.
-6. On Windows, restart Vellum from the tray menu and retry. This relaunches Vellum and its one-shot dictation helper.
+6. On Windows, fully quit and reopen Vellum, using the tray menu if available, and retry. This relaunches Vellum and its one-shot dictation helper.
 
 ### "Changed a setting but it didn't work"
 


### PR DESCRIPTION
Adds Linux branches to voice setup and sound guidance plus a portable Linux automation skill. Voice troubleshooting distinguishes unavailable native partials from the existing provider-based streaming and recorded-audio transcription fallbacks. Custom shortcuts are conditional on successful desktop registration; in-app Talk remains the fallback. Setup does not recommend raw input-group access.

Portal capture/input sessions require a long-lived D-Bus client with cancellation and revocation handling. Desktop entries are launched through gtk-launch or gio rather than interpreting Exec as shell code.

Validation: changed skills pass spec validation; the catalog is regenerated from committed skill history. Existing renderer tests confirm transcription survives an unavailable native helper.

Part of Linux parity Wave 1 (PR 5). Desktop-specific capture and input implementations remain later work.
