### PR TITLE
Treat a Linux desktop as a desktop in the daemon

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -293,6 +293,14 @@ describe("resolveChannelCapabilities", () => {
     expect(caps.supportsVoiceInput).toBe(true);
   });
 
+  test("vellum channel with linux interface has full desktop capabilities", () => {
+    const caps = resolveChannelCapabilities(undefined, "linux");
+    expect(caps.channel).toBe("vellum");
+    expect(caps.dashboardCapable).toBe(true);
+    expect(caps.supportsDynamicUi).toBe(true);
+    expect(caps.supportsVoiceInput).toBe(true);
+  });
+
   test("vellum channel with vellum interface supports dynamic UI", () => {
     const caps = resolveChannelCapabilities("vellum", "vellum");
     expect(caps.channel).toBe("vellum");

--- a/assistant/src/__tests__/conversation-seed-composer.test.ts
+++ b/assistant/src/__tests__/conversation-seed-composer.test.ts
@@ -79,6 +79,14 @@ describe("resolveVerbosity", () => {
     ).toBe("rich");
   });
 
+  test("explicit interfaceHint=linux overrides to rich", () => {
+    expect(
+      resolveVerbosity("telegram" as NotificationChannel, {
+        interfaceHint: "linux",
+      }),
+    ).toBe("rich");
+  });
+
   test("explicit interfaceHint=telegram overrides to compact", () => {
     expect(
       resolveVerbosity("vellum" as NotificationChannel, {

--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -57,6 +57,14 @@ describe("resolveSlash /commands interface-aware help", () => {
     expect(lines.some((line) => line.startsWith("/fork "))).toBe(true);
   });
 
+  test("renders desktop command help for Linux", async () => {
+    const lines = await resolveCommandsLines(
+      makeSlashContext({ userMessageInterface: "linux" }),
+    );
+    expect(lines.some((line) => line.startsWith("/btw "))).toBe(true);
+    expect(lines.some((line) => line.startsWith("/fork "))).toBe(true);
+  });
+
   test("renders iOS command help with /fork", async () => {
     const lines = await resolveCommandsLines(
       makeSlashContext({ userMessageInterface: "ios" }),

--- a/assistant/src/__tests__/disk-pressure-policy.test.ts
+++ b/assistant/src/__tests__/disk-pressure-policy.test.ts
@@ -97,6 +97,12 @@ describe("classifyDiskPressureTurnPolicy", () => {
       expected: { action: "allow-cleanup-mode", reason: "local-owner" },
     },
     {
+      name: "locked Linux local owner without trust enters cleanup mode",
+      status: status({ acknowledged: true }),
+      metadata: { ...localOwnerTurn, sourceInterface: "linux" },
+      expected: { action: "allow-cleanup-mode", reason: "local-owner" },
+    },
+    {
       name: "locked guardian enters cleanup mode",
       status: status(),
       metadata: guardianTurn,

--- a/assistant/src/__tests__/recording-handler.test.ts
+++ b/assistant/src/__tests__/recording-handler.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ─── Mocks (must be before any imports that depend on them) ─────────────────
@@ -97,8 +98,9 @@ mock.module("../daemon/video-thumbnail.js", () => ({
   generateVideoThumbnailFromPath: async () => null,
 }));
 
-// The allowed recordings directory used by the recording handler
-const ALLOWED_RECORDINGS_DIR = `${process.env.HOME}/Library/Application Support/vellum-assistant/recordings`;
+// Pin the Linux app-data root so the allowed recordings directory resolves
+// under a fake XDG_DATA_HOME instead of the runner's real profile.
+process.env.XDG_DATA_HOME = "/tmp/vellum-xdg-data";
 
 // Mock node:fs for file existence/stat checks and realpathSync in the recording handler
 let mockFileExists = true;
@@ -155,6 +157,15 @@ import {
   handleRecordingStop,
 } from "../daemon/handlers/recording.js";
 import type { RecordingStatus } from "../daemon/message-types/computer-use.js";
+import { getUserAppDataDir } from "../util/platform.js";
+
+// The allowed recordings directory used by the recording handler: the macOS
+// Application Support root locally, $XDG_DATA_HOME on Linux.
+const ALLOWED_RECORDINGS_DIR = join(
+  getUserAppDataDir(),
+  "vellum-assistant",
+  "recordings",
+);
 
 // ─── Test helpers ───────────────────────────────────────────────────────────
 

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -299,14 +299,14 @@ export function isInteractiveInterface(id: InterfaceId): boolean {
 }
 
 /**
- * Whether a surface runs the shared Electron desktop renderer. macOS and Linux
- * ship the same renderer, so a UI capability one has the other has too; the
- * Windows client has its own and answers these questions separately.
+ * Whether a desktop surface exposes the full desktop UI: dashboards, dynamic
+ * UI and voice input. The macOS and Linux clients do; the Windows client does
+ * not carry them yet and is answered separately.
  *
  * Accepts a plain string because callers hold either an `InterfaceId` or the
  * loosely typed `clientOS` capability field.
  */
-export function usesSharedDesktopRenderer(
+export function supportsDesktopUiSurface(
   surface: string | null | undefined,
 ): boolean {
   return surface === "macos" || surface === "linux";

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -299,6 +299,20 @@ export function isInteractiveInterface(id: InterfaceId): boolean {
 }
 
 /**
+ * Whether a surface runs the shared Electron desktop renderer. macOS and Linux
+ * ship the same renderer, so a UI capability one has the other has too; the
+ * Windows client has its own and answers these questions separately.
+ *
+ * Accepts a plain string because callers hold either an `InterfaceId` or the
+ * loosely typed `clientOS` capability field.
+ */
+export function usesSharedDesktopRenderer(
+  surface: string | null | undefined,
+): boolean {
+  return surface === "macos" || surface === "linux";
+}
+
+/**
  * Host proxy capabilities that an interface can support. macOS supports all
  * of them, Windows and Linux withhold app control, and chrome-extension
  * supports only host_browser through the Chrome DevTools Protocol proxy.

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -732,6 +732,23 @@ describe("isToolActiveForContext — ask_question macOS gating", () => {
     ).toBe(false);
   });
 
+  test("ask_question is NOT active when clientOS is linux", () => {
+    // Linux runs the same renderer as macOS, so it lacks the handler too.
+    expect(
+      isToolActiveForContext(
+        "ask_question",
+        makeCtx({
+          hasNoClient: false,
+          channelCapabilities: {
+            channel: "linux",
+            supportsDynamicUi: true,
+            clientOS: "linux",
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
   test("ask_question is active when channelCapabilities is undefined (backwards-compat)", () => {
     expect(
       isToolActiveForContext("ask_question", makeCtx({ hasNoClient: false })),

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -732,8 +732,9 @@ describe("isToolActiveForContext — ask_question macOS gating", () => {
     ).toBe(false);
   });
 
-  test("ask_question is NOT active when clientOS is linux", () => {
-    // Linux runs the same renderer as macOS, so it lacks the handler too.
+  test("ask_question is active when clientOS is linux", () => {
+    // The Linux shell serves the clients/web renderer, which handles
+    // question_request, so the macOS exception must not widen to it.
     expect(
       isToolActiveForContext(
         "ask_question",
@@ -746,7 +747,7 @@ describe("isToolActiveForContext — ask_question macOS gating", () => {
           },
         }),
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("ask_question is active when channelCapabilities is undefined (backwards-compat)", () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -18,7 +18,7 @@ import {
 import {
   type ChannelId,
   parseInterfaceId,
-  usesSharedDesktopRenderer,
+  supportsDesktopUiSurface,
 } from "../channels/types.js";
 import { resolveDefaultProfileForProvider } from "../config/default-profile-catalog.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
@@ -305,7 +305,7 @@ export function resolveChannelCapabilities(
 
   switch (channel) {
     case "vellum": {
-      const supportsDesktopUi = usesSharedDesktopRenderer(iface);
+      const supportsDesktopUi = supportsDesktopUiSurface(iface);
       return {
         channel,
         dashboardCapable: supportsDesktopUi,

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -15,7 +15,11 @@ import {
   resolveAppDir,
   resolveAppSource,
 } from "../apps/app-store.js";
-import { type ChannelId, parseInterfaceId } from "../channels/types.js";
+import {
+  type ChannelId,
+  parseInterfaceId,
+  usesSharedDesktopRenderer,
+} from "../channels/types.js";
 import { resolveDefaultProfileForProvider } from "../config/default-profile-catalog.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
@@ -301,7 +305,7 @@ export function resolveChannelCapabilities(
 
   switch (channel) {
     case "vellum": {
-      const supportsDesktopUi = iface === "macos";
+      const supportsDesktopUi = usesSharedDesktopRenderer(iface);
       return {
         channel,
         dashboardCapable: supportsDesktopUi,

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -298,6 +298,7 @@ const CLEAN_HELP_LINE =
 const FORK_CAPABLE_INTERFACES = new Set<InterfaceId>([
   "macos",
   "windows",
+  "linux",
   "ios",
 ]);
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -12,7 +12,6 @@ import {
   type HostProxyCapability,
   parseClientOs,
   supportsHostProxy,
-  usesSharedDesktopRenderer,
 } from "../channels/types.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
@@ -892,13 +891,10 @@ export function isToolActiveForContext(
     return !hasNoClient;
   }
   if (CLIENT_CAPABILITY_TOOL_NAMES.has(name)) {
-    if (
-      name === "ask_question" &&
-      usesSharedDesktopRenderer(channelCapabilities?.clientOS)
-    ) {
-      // The shared desktop renderer (macOS, Linux) has no UI handler for
-      // question_request yet; hiding the tool avoids a 5-minute prompter
-      // timeout when the LLM would otherwise call it.
+    if (name === "ask_question" && channelCapabilities?.clientOS === "macos") {
+      // macOS has no UI handler for question_request yet; hiding the tool
+      // avoids a 5-minute prompter timeout when the LLM would otherwise call
+      // it. Linux serves the clients/web renderer, which does handle it.
       return false;
     }
     return !hasNoClient;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -12,6 +12,7 @@ import {
   type HostProxyCapability,
   parseClientOs,
   supportsHostProxy,
+  usesSharedDesktopRenderer,
 } from "../channels/types.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
@@ -891,9 +892,13 @@ export function isToolActiveForContext(
     return !hasNoClient;
   }
   if (CLIENT_CAPABILITY_TOOL_NAMES.has(name)) {
-    if (name === "ask_question" && channelCapabilities?.clientOS === "macos") {
-      // macOS has no UI handler for question_request yet; hiding the tool
-      // avoids a 5-minute prompter timeout when the LLM would otherwise call it.
+    if (
+      name === "ask_question" &&
+      usesSharedDesktopRenderer(channelCapabilities?.clientOS)
+    ) {
+      // The shared desktop renderer (macOS, Linux) has no UI handler for
+      // question_request yet; hiding the tool avoids a 5-minute prompter
+      // timeout when the LLM would otherwise call it.
       return false;
     }
     return !hasNoClient;

--- a/assistant/src/daemon/disk-pressure-policy.ts
+++ b/assistant/src/daemon/disk-pressure-policy.ts
@@ -60,6 +60,7 @@ const BACKGROUND_SOURCES = new Set([
 const LOCAL_OWNER_INTERFACES = new Set([
   "macos",
   "windows",
+  "linux",
   "web",
   "vellum",
   "cli",

--- a/assistant/src/daemon/handlers/recording.ts
+++ b/assistant/src/daemon/handlers/recording.ts
@@ -10,6 +10,7 @@ import {
 } from "../../persistence/conversation-crud.js";
 import { syncMessageToDisk } from "../../persistence/conversation-disk-view.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
+import { getUserAppDataDir } from "../../util/platform.js";
 import type { RecordingOptions, RecordingStatus } from "../message-protocol.js";
 import { log } from "./shared.js";
 
@@ -394,8 +395,9 @@ async function finalizeAndPublishRecording(params: {
     resolvedPath = path.resolve(filePath);
   }
   const allowedDir = path.join(
-    process.env.HOME ?? "",
-    "Library/Application Support/vellum-assistant/recordings",
+    getUserAppDataDir(),
+    "vellum-assistant",
+    "recordings",
   );
   let resolvedAllowedDir: string;
   try {

--- a/assistant/src/notifications/conversation-seed-composer.ts
+++ b/assistant/src/notifications/conversation-seed-composer.ts
@@ -28,6 +28,7 @@ const CHANNEL_DEFAULT_INTERFACE: Record<string, InterfaceId> = {
 const RICH_INTERFACES = new Set<InterfaceId>([
   "macos",
   "windows",
+  "linux",
   "ios",
   "web",
 ]);

--- a/assistant/src/runtime/__tests__/desktop-presence.test.ts
+++ b/assistant/src/runtime/__tests__/desktop-presence.test.ts
@@ -54,6 +54,15 @@ describe("isDesktopAttended", () => {
     expect(isDesktopAttended()).toBe(true);
   });
 
+  test("fresh active linux client is attended", () => {
+    registerClient({
+      clientId: "linux-1",
+      interfaceId: "linux",
+      presence: "active",
+    });
+    expect(isDesktopAttended()).toBe(true);
+  });
+
   test("active report older than the staleness bound is not attended", () => {
     registerClient({ clientId: "mac-1", presence: "active" });
     expect(isDesktopAttended({ now: afterStaleness() })).toBe(false);

--- a/assistant/src/runtime/desktop-presence.ts
+++ b/assistant/src/runtime/desktop-presence.ts
@@ -15,7 +15,7 @@ import { getLogger } from "../util/logger.js";
 import { assistantEventHub } from "./assistant-event-hub.js";
 
 const log = getLogger("desktop-presence");
-const DESKTOP_INTERFACES = ["macos", "windows"] as const;
+const DESKTOP_INTERFACES = ["macos", "windows", "linux"] as const;
 
 /**
  * Bounds how long suppression can outlive the desktop sleeping or dropping

--- a/assistant/src/runtime/routes/attachment-routes.test.ts
+++ b/assistant/src/runtime/routes/attachment-routes.test.ts
@@ -22,17 +22,14 @@ const testHomeDir = realpathSync(
 
 const attachmentsDir = join(testWorkspaceDir, "data", "attachments");
 const conversationsDir = join(testWorkspaceDir, "conversations");
-const recordingsDir = join(
-  testHomeDir,
-  "Library/Application Support/vellum-assistant/recordings",
-);
+// XDG-shaped app data root, the Linux answer from getUserAppDataDir().
+const appDataDir = join(testHomeDir, ".local", "share");
+const recordingsDir = join(appDataDir, "vellum-assistant", "recordings");
 const outsideDir = mkdtempSync(join(tmpdir(), "attachment-routes-outside-"));
-
-const originalHome = process.env.HOME;
-process.env.HOME = testHomeDir;
 
 mock.module("../../util/platform.js", () => ({
   getWorkspaceDir: () => testWorkspaceDir,
+  getUserAppDataDir: () => appDataDir,
 }));
 
 import { resolveAllowedFileBackedAttachmentPath } from "./attachment-routes.js";
@@ -44,7 +41,6 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  process.env.HOME = originalHome;
   rmSync(testWorkspaceDir, { recursive: true, force: true });
   rmSync(testHomeDir, { recursive: true, force: true });
   rmSync(outsideDir, { recursive: true, force: true });

--- a/assistant/src/runtime/routes/attachment-routes.ts
+++ b/assistant/src/runtime/routes/attachment-routes.ts
@@ -37,7 +37,7 @@ import {
   jpegFilenameFor,
   normalizeImageBytes,
 } from "../../util/image-conversion.js";
-import { getWorkspaceDir } from "../../util/platform.js";
+import { getUserAppDataDir, getWorkspaceDir } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
@@ -87,8 +87,9 @@ function resolveAllowedAttachmentDirectories(): string[] {
     "attachments",
   );
   const recordingsDir = join(
-    process.env.HOME ?? "",
-    "Library/Application Support/vellum-assistant/recordings",
+    getUserAppDataDir(),
+    "vellum-assistant",
+    "recordings",
   );
   return [workspaceAttachmentsDir, recordingsDir].map((dir) => {
     try {

--- a/assistant/src/tools/__tests__/client-os.test.ts
+++ b/assistant/src/tools/__tests__/client-os.test.ts
@@ -1,0 +1,27 @@
+/**
+ * `desktopClientName` names the desktop client in host tool errors ("Connect a
+ * Linux client to use host_bash..."), so every desktop surface must name
+ * itself rather than falling through to macOS.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { desktopClientName } from "../client-os.js";
+
+describe("desktopClientName", () => {
+  test("names Linux from the client OS", () => {
+    expect(desktopClientName({ clientOs: "linux" })).toBe("Linux");
+  });
+
+  test("names Linux from the transport interface", () => {
+    expect(desktopClientName({ transportInterface: "linux" })).toBe("Linux");
+  });
+
+  test("names Windows from the client OS", () => {
+    expect(desktopClientName({ clientOs: "windows" })).toBe("Windows");
+  });
+
+  test("falls back to macOS", () => {
+    expect(desktopClientName({ transportInterface: "telegram" })).toBe("macOS");
+  });
+});

--- a/assistant/src/tools/client-os.ts
+++ b/assistant/src/tools/client-os.ts
@@ -15,11 +15,15 @@ interface HostClientContext {
 
 export function desktopClientName(
   context: HostClientContext,
-): "Windows" | "macOS" {
-  return context.clientOs === "windows" ||
-    context.transportInterface === "windows"
-    ? "Windows"
-    : "macOS";
+): "Windows" | "Linux" | "macOS" {
+  const surfaces = [context.clientOs, context.transportInterface];
+  if (surfaces.includes("windows")) {
+    return "Windows";
+  }
+  if (surfaces.includes("linux")) {
+    return "Linux";
+  }
+  return "macOS";
 }
 
 export function supportsClientOs(


### PR DESCRIPTION
## Summary
- Adds `linux` to `DESKTOP_INTERFACES`, `RICH_INTERFACES`, `FORK_CAPABLE_INTERFACES` and `LOCAL_OWNER_INTERFACES`, so a Linux desktop turn gets the same presence suppression, rich notification seeds, `/fork` help and disk-pressure treatment as a macOS turn.
- Adds `supportsDesktopUiSurface()` in `channels/types.ts` and uses it for `supportsDesktopUi` in the runtime assembly, so a Linux turn is dashboard, dynamic-UI and voice capable. Windows is unchanged.
- `desktopClientName()` now names Linux in host tool errors, and `recording.ts` / `attachment-routes.ts` resolve the recordings directory from `getUserAppDataDir()` instead of the hardcoded `Library/Application Support` literal, so the path is correct on Linux and Windows.

## Original prompt
This PR is wave 1 of the Linux-to-macOS desktop parity plan at `.private/plans/linux-macos-parity.md`, executed in parallel with strict scope limits. It implements PR 3, "Daemon desktop-interface sets, copy and paths for Linux": the daemon sites that still treat a Linux host as a non-desktop or as macOS. Only the files and steps named in that plan section were touched, plus the tests that cover the changed behavior.

## Deviations
- The plan's step 2 asked for `ask_question` to be hidden on Linux "since both use the same renderer". That premise is wrong: the Linux shell serves the `clients/web` renderer (`clients/linux/src/main/index.ts`), which does dispatch `question_request`, so hiding the tool would have removed a working capability. The macOS-only exception is left as it was and a test pins `ask_question` active for Linux. Flagged by Codex and fixed in 7662814488.
- The plan named the call site for a shared desktop-interface predicate but no home for it; it was added to `assistant/src/channels/types.ts`, the shared interface vocabulary the call site already imports.
- Two existing tests hardcoded the macOS `Library/Application Support` literal and would have failed on the Linux CI runner once the implementation stopped hardcoding it, so `recording-handler.test.ts` and `attachment-routes.test.ts` now derive their allowed directory from the app-data root (XDG-shaped on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFpdtwy68kQcQ4LpDuDB1H