### PR TITLE
Permissions card, settings links and window chrome for a Linux host

### DIFF
--- a/clients/web/src/components/sidebar-shell.tsx
+++ b/clients/web/src/components/sidebar-shell.tsx
@@ -72,15 +72,18 @@ export function SidebarShell({
 
   const electron = isElectron();
 
-  // In the macOS Electron shell the window controls (traffic lights) sit in an
-  // inline title-bar zone at the top of the renderer (see `ChatLayoutHeader` /
-  // the desktop app's `MAIN_TRAFFIC_LIGHT_POSITION`). Unlike chat, this shell
-  // has no inline header row, so reserve top space to clear the controls AND
-  // match the chat layout, whose sidebar/content sits below the 44px title bar
-  // plus the 16px content inset (`p-4`), i.e. 60px (3.75rem) from the top.
-  // Windows and Linux draw their own title bar above the renderer, so there is
-  // nothing to clear there and the inset stays at the standard 1rem.
-  const macosShell = detectElectronHostOS() === "macos";
+  // macOS and Windows hide the native title bar and put its band inside the
+  // renderer instead: macOS keeps the traffic lights there (see
+  // `ChatLayoutHeader` / the desktop app's `MAIN_TRAFFIC_LIGHT_POSITION`) and
+  // Windows overlays the caption controls plus the `WindowDragRegion` menu
+  // bar. Unlike chat, this shell has no inline header row, so reserve top
+  // space to clear that band AND match the chat layout, whose sidebar/content
+  // sits below the 44px title bar plus the 16px content inset (`p-4`), i.e.
+  // 60px (3.75rem) from the top. Linux keeps its window manager decorations
+  // outside the renderer, so it needs no clearance, and off Electron the
+  // inset stays at the standard 1rem.
+  const hostOS = detectElectronHostOS();
+  const inlineTitleBar = hostOS === "macos" || hostOS === "windows";
 
   const mobileBackLabel = isMenuRoute
     ? t("sidebarShell.backFrom", { title })
@@ -120,7 +123,7 @@ export function SidebarShell({
       ref={swipeContainerRef}
       className="flex h-full min-h-0 w-full flex-1 flex-col gap-4 p-4 sm:p-6 md:gap-0"
       style={{
-        paddingTop: macosShell ? "3.75rem" : "1rem",
+        paddingTop: inlineTitleBar ? "3.75rem" : "1rem",
       }}
     >
       {/* Mobile header */}

--- a/clients/web/src/components/sidebar-shell.tsx
+++ b/clients/web/src/components/sidebar-shell.tsx
@@ -10,6 +10,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTranslation } from "@/i18n";
 import { navigateWithPageTransition } from "@/lib/page-transition";
 import { isElectron } from "@/runtime/is-electron";
+import { detectElectronHostOS } from "@/runtime/platform-detection";
 import { routes } from "@/utils/routes";
 
 interface SidebarShellProps {
@@ -69,14 +70,17 @@ export function SidebarShell({
     prefetchHref: mobileBackHref,
   });
 
-  // In the Electron shell the macOS window controls (traffic lights) sit in an
+  const electron = isElectron();
+
+  // In the macOS Electron shell the window controls (traffic lights) sit in an
   // inline title-bar zone at the top of the renderer (see `ChatLayoutHeader` /
   // the desktop app's `MAIN_TRAFFIC_LIGHT_POSITION`). Unlike chat, this shell
   // has no inline header row, so reserve top space to clear the controls AND
   // match the chat layout, whose sidebar/content sits below the 44px title bar
-  // plus the 16px content inset (`p-4`) — i.e. 60px (3.75rem) from the top.
-  // Off Electron it stays at the standard 1rem inset.
-  const electron = isElectron();
+  // plus the 16px content inset (`p-4`), i.e. 60px (3.75rem) from the top.
+  // Windows and Linux draw their own title bar above the renderer, so there is
+  // nothing to clear there and the inset stays at the standard 1rem.
+  const macosShell = detectElectronHostOS() === "macos";
 
   const mobileBackLabel = isMenuRoute
     ? t("sidebarShell.backFrom", { title })
@@ -116,7 +120,7 @@ export function SidebarShell({
       ref={swipeContainerRef}
       className="flex h-full min-h-0 w-full flex-1 flex-col gap-4 p-4 sm:p-6 md:gap-0"
       style={{
-        paddingTop: electron ? "3.75rem" : "1rem",
+        paddingTop: macosShell ? "3.75rem" : "1rem",
       }}
     >
       {/* Mobile header */}

--- a/clients/web/src/components/system-permissions-card.test.tsx
+++ b/clients/web/src/components/system-permissions-card.test.tsx
@@ -18,7 +18,7 @@ let state: SystemPermissionsState | null;
 let supported = true;
 let unreadBadgeSurface = "Dock icon";
 let unreadBadgesSupported = true;
-let hostOS: "macos" | "windows" = "macos";
+let hostOS: "macos" | "windows" | "linux" = "macos";
 
 const openSystemPermissionSettings = mock(async () => null);
 const requestSystemPermission = mock(async () => null);
@@ -78,6 +78,7 @@ mock.module("@/runtime/dock", () => ({
 
 mock.module("@/runtime/platform-detection", () => ({
   detectElectronHostOS: () => hostOS,
+  resolveDesktopHostOS: () => hostOS,
 }));
 
 const { SystemPermissionsCard } = await import("./system-permissions-card");
@@ -137,6 +138,8 @@ describe("SystemPermissionsCard", () => {
 
   test("shows only Windows-meaningful rows with Windows copy on a Windows host", () => {
     hostOS = "windows";
+    // The Windows shell reports the kinds it has no concept of.
+    state = makeState({ accessibility: "not-applicable" });
 
     render(<SystemPermissionsCard />);
 
@@ -149,6 +152,26 @@ describe("SystemPermissionsCard", () => {
       screen.getByText(/show Windows notifications for approvals/),
     ).toBeTruthy();
     expect(screen.queryByText(/macOS alerts/)).toBeNull();
+  });
+
+  test("shows the applicable rows with Linux copy on a Linux host", () => {
+    hostOS = "linux";
+    state = makeState({ accessibility: "not-applicable" });
+
+    render(<SystemPermissionsCard />);
+
+    expect(screen.queryByRole("switch", { name: "Accessibility" })).toBeNull();
+    expect(
+      screen.getByRole("switch", { name: "Screen Recording" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/approve screen sharing in the desktop portal/),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/send desktop notifications for approvals/),
+    ).toBeTruthy();
+    expect(screen.queryByText(/macOS alerts/)).toBeNull();
+    expect(screen.queryByText(/Windows notifications/)).toBeNull();
   });
 
   test("hides permissions reported as not applicable", () => {

--- a/clients/web/src/components/system-permissions-card.test.tsx
+++ b/clients/web/src/components/system-permissions-card.test.tsx
@@ -28,12 +28,15 @@ const setDockBadge = mock(() => undefined);
 function item(
   kind: SystemPermissionKind,
   status: SystemPermissionStatus,
+  remediation: { canRequest?: boolean; canOpenSettings?: boolean } = {},
 ): SystemPermissionStateItem {
   return {
     kind,
     status,
-    canRequest: status !== "granted" && status !== "restricted",
-    canOpenSettings: status !== "granted",
+    canRequest:
+      remediation.canRequest ??
+      (status !== "granted" && status !== "restricted"),
+    canOpenSettings: remediation.canOpenSettings ?? status !== "granted",
     requiresRestart: false,
   };
 }
@@ -182,6 +185,30 @@ describe("SystemPermissionsCard", () => {
     expect(
       screen.queryByRole("switch", { name: "Screen Recording" }),
     ).toBeNull();
+  });
+
+  test("disables a row the host can neither prompt for nor open settings for", () => {
+    hostOS = "linux";
+    // The Linux shell has no settings URI scheme and no prompt outside
+    // notifications, so the microphone toggle would do nothing.
+    state = makeState();
+    state.microphone = item("microphone", "denied", {
+      canRequest: false,
+      canOpenSettings: false,
+    });
+
+    render(<SystemPermissionsCard />);
+
+    expect(
+      screen
+        .getByRole("switch", { name: "Microphone" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen
+        .getByRole("switch", { name: "Notifications" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
   });
 
   test("updates the Dock badge setting without requesting a macOS permission", async () => {

--- a/clients/web/src/components/system-permissions-card.test.tsx
+++ b/clients/web/src/components/system-permissions-card.test.tsx
@@ -211,6 +211,19 @@ describe("SystemPermissionsCard", () => {
     ).toBe(false);
   });
 
+  test("does not offer a granted Linux permission a nonexistent settings action", () => {
+    hostOS = "linux";
+    state = makeState();
+    state.microphone = item("microphone", "granted", {
+      canRequest: false,
+      canOpenSettings: false,
+    });
+    render(<SystemPermissionsCard />);
+    const toggle = screen.getByRole("switch", { name: "Microphone" });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(toggle.hasAttribute("disabled")).toBe(true);
+  });
+
   test("updates the Dock badge setting without requesting a macOS permission", async () => {
     localStorage.setItem("device:dock_badges_enabled", "true");
 

--- a/clients/web/src/components/system-permissions-card.test.tsx
+++ b/clients/web/src/components/system-permissions-card.test.tsx
@@ -81,7 +81,7 @@ mock.module("@/runtime/dock", () => ({
 
 mock.module("@/runtime/platform-detection", () => ({
   detectElectronHostOS: () => hostOS,
-  resolveDesktopHostOS: () => hostOS,
+  resolveDesktopHostOS: () => hostOS ?? "macos",
 }));
 
 const { SystemPermissionsCard } = await import("./system-permissions-card");

--- a/clients/web/src/components/system-permissions-card.tsx
+++ b/clients/web/src/components/system-permissions-card.tsx
@@ -292,12 +292,11 @@ export function SystemPermissionsCard({
 
       const copy = systemPermissionCopy(meta.id, t, hostOS);
 
-      // A host that can neither prompt nor open a settings pane for a kind
-      // has nothing for the toggle to do, so do not offer a dead control.
-      // A granted row is exempt: it stays clickable so the user can go and
-      // revoke, which is what `handleSystemToggle` does with it.
+      // macOS and Windows retain settings links for revoking granted access.
       const noRemediation =
-        !item.canRequest && !item.canOpenSettings && item.status !== "granted";
+        !item.canRequest &&
+        !item.canOpenSettings &&
+        (hostOS === "linux" || item.status !== "granted");
 
       return {
         id: meta.id,

--- a/clients/web/src/components/system-permissions-card.tsx
+++ b/clients/web/src/components/system-permissions-card.tsx
@@ -292,12 +292,22 @@ export function SystemPermissionsCard({
 
       const copy = systemPermissionCopy(meta.id, t, hostOS);
 
+      // A host that can neither prompt nor open a settings pane for a kind
+      // has nothing for the toggle to do, so do not offer a dead control.
+      // A granted row is exempt: it stays clickable so the user can go and
+      // revoke, which is what `handleSystemToggle` does with it.
+      const noRemediation =
+        !item.canRequest && !item.canOpenSettings && item.status !== "granted";
+
       return {
         id: meta.id,
         label: copy.label,
         description: copy.description,
         checked: item.status === "granted",
-        disabled: pendingKind === meta.id || item.status === "restricted",
+        disabled:
+          pendingKind === meta.id ||
+          item.status === "restricted" ||
+          noRemediation,
         ...(item.error ? { error: item.error } : {}),
       };
     }).filter(Boolean) as PermissionRowViewModel[];

--- a/clients/web/src/components/system-permissions-card.tsx
+++ b/clients/web/src/components/system-permissions-card.tsx
@@ -6,7 +6,10 @@ import {
   setDockBadge,
   supportsUnreadBadges,
 } from "@/runtime/dock";
-import { detectElectronHostOS } from "@/runtime/platform-detection";
+import {
+  resolveDesktopHostOS,
+  type ElectronHostOS,
+} from "@/runtime/platform-detection";
 import {
   openSystemPermissionSettings,
   requestSystemPermission,
@@ -29,7 +32,6 @@ interface SystemPermissionRowMeta {
   id: SystemPermissionKind;
   type: "system";
   sourceKind: SystemPermissionKind;
-  availableOnWindows?: boolean;
 }
 
 interface LocalPermissionRowMeta {
@@ -56,25 +58,21 @@ const SYSTEM_PERMISSION_ROWS: SystemPermissionRowMeta[] = [
     id: "screen",
     type: "system",
     sourceKind: "screen",
-    availableOnWindows: true,
   },
   {
     id: "microphone",
     type: "system",
     sourceKind: "microphone",
-    availableOnWindows: true,
   },
   {
     id: "speechRecognition",
     type: "system",
     sourceKind: "speechRecognition",
-    availableOnWindows: true,
   },
   {
     id: "notifications",
     type: "system",
     sourceKind: "notifications",
-    availableOnWindows: true,
   },
 ];
 
@@ -87,21 +85,38 @@ const LOCAL_PERMISSION_ROWS: LocalPermissionRowMeta[] = [
 
 type SystemPermissionRowId = (typeof SYSTEM_PERMISSION_ROWS)[number]["id"];
 
+/** Pick the host's wording for a row, falling back to the macOS default. */
+function hostDescription(
+  hostOS: ElectronHostOS,
+  base: string,
+  overrides: Partial<Record<ElectronHostOS, string>>,
+): string {
+  return overrides[hostOS] ?? base;
+}
+
 function systemPermissionCopy(
   id: SystemPermissionRowId,
   t: TFunction,
-  isWindowsHost: boolean,
+  hostOS: ElectronHostOS,
 ): { label: string; description: string } {
   switch (id) {
     case "accessibility":
       return {
         label: t("systemPermissionsCard.accessibilityLabel"),
-        description: t("systemPermissionsCard.accessibilityDescription"),
+        description: hostDescription(
+          hostOS,
+          t("systemPermissionsCard.accessibilityDescription"),
+          { linux: t("systemPermissionsCard.accessibilityLinuxDescription") },
+        ),
       };
     case "screen":
       return {
         label: t("systemPermissionsCard.screenLabel"),
-        description: t("systemPermissionsCard.screenDescription"),
+        description: hostDescription(
+          hostOS,
+          t("systemPermissionsCard.screenDescription"),
+          { linux: t("systemPermissionsCard.screenLinuxDescription") },
+        ),
       };
     case "microphone":
       return {
@@ -111,20 +126,32 @@ function systemPermissionCopy(
     case "speechRecognition":
       return {
         label: t("systemPermissionsCard.speechRecognitionLabel"),
-        description: isWindowsHost
-          ? t("systemPermissionsCard.speechRecognitionWindowsDescription")
-          : t("systemPermissionsCard.speechRecognitionDescription"),
+        description: hostDescription(
+          hostOS,
+          t("systemPermissionsCard.speechRecognitionDescription"),
+          {
+            windows: t(
+              "systemPermissionsCard.speechRecognitionWindowsDescription",
+            ),
+            linux: t("systemPermissionsCard.speechRecognitionLinuxDescription"),
+          },
+        ),
       };
     case "notifications":
       return {
         label: t("systemPermissionsCard.notificationsLabel"),
-        description: isWindowsHost
-          ? t("systemPermissionsCard.notificationsWindowsDescription")
-          : t("systemPermissionsCard.notificationsDescription"),
+        description: hostDescription(
+          hostOS,
+          t("systemPermissionsCard.notificationsDescription"),
+          {
+            windows: t("systemPermissionsCard.notificationsWindowsDescription"),
+            linux: t("systemPermissionsCard.notificationsLinuxDescription"),
+          },
+        ),
       };
     default: {
       // Rows only use the kinds above; other SystemPermissionKind values
-      // (inputMonitoring, automation) are not shown in this card.
+      // (inputMonitoring, automation) have their own settings surfaces.
       throw new Error(`Unsupported system permission row: ${id}`);
     }
   }
@@ -235,14 +262,7 @@ export function SystemPermissionsCard({
   const [notificationBadgesEnabled, setNotificationBadgesEnabled] =
     useNotificationBadgesEnabled();
 
-  const isWindowsHost = detectElectronHostOS() === "windows";
-  const visibleSystemRows = useMemo(
-    () =>
-      SYSTEM_PERMISSION_ROWS.filter(
-        (meta) => !isWindowsHost || meta.availableOnWindows,
-      ),
-    [isWindowsHost],
-  );
+  const hostOS = resolveDesktopHostOS();
 
   const systemRowsById = useMemo(() => {
     const rows = new Map<
@@ -253,7 +273,7 @@ export function SystemPermissionsCard({
       return rows;
     }
 
-    for (const meta of visibleSystemRows) {
+    for (const meta of SYSTEM_PERMISSION_ROWS) {
       const item = state[meta.sourceKind];
       if (item && item.status !== "not-applicable") {
         rows.set(meta.id, { meta, item });
@@ -261,28 +281,26 @@ export function SystemPermissionsCard({
     }
 
     return rows;
-  }, [state, visibleSystemRows]);
+  }, [state]);
 
   const rows = useMemo<PermissionRowViewModel[]>(() => {
-    const systemRows = visibleSystemRows
-      .map((meta) => {
-        const item = systemRowsById.get(meta.id)?.item;
-        if (!item) {
-          return null;
-        }
+    const systemRows = SYSTEM_PERMISSION_ROWS.map((meta) => {
+      const item = systemRowsById.get(meta.id)?.item;
+      if (!item) {
+        return null;
+      }
 
-        const copy = systemPermissionCopy(meta.id, t, isWindowsHost);
+      const copy = systemPermissionCopy(meta.id, t, hostOS);
 
-        return {
-          id: meta.id,
-          label: copy.label,
-          description: copy.description,
-          checked: item.status === "granted",
-          disabled: pendingKind === meta.id || item.status === "restricted",
-          ...(item.error ? { error: item.error } : {}),
-        };
-      })
-      .filter(Boolean) as PermissionRowViewModel[];
+      return {
+        id: meta.id,
+        label: copy.label,
+        description: copy.description,
+        checked: item.status === "granted",
+        disabled: pendingKind === meta.id || item.status === "restricted",
+        ...(item.error ? { error: item.error } : {}),
+      };
+    }).filter(Boolean) as PermissionRowViewModel[];
 
     const badgeSurface =
       getUnreadBadgeSurface() === "taskbar icon"
@@ -303,14 +321,7 @@ export function SystemPermissionsCard({
       : [];
 
     return [...systemRows, ...localRows];
-  }, [
-    isWindowsHost,
-    notificationBadgesEnabled,
-    pendingKind,
-    systemRowsById,
-    t,
-    visibleSystemRows,
-  ]);
+  }, [hostOS, notificationBadgesEnabled, pendingKind, systemRowsById, t]);
 
   if (!supported && rows.length === 0) {
     return null;

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -613,6 +613,7 @@
   "systemPermissionsCard": {
     "accessibilityDescription": "Allows your assistant to click, type, and control apps on your behalf.",
     "accessibilityLabel": "Accessibility",
+    "accessibilityLinuxDescription": "Allows your assistant to click, type, and control apps through AT-SPI assistive technology.",
     "checking": "Checking permissions...",
     "dockIcon": "Dock icon",
     "microphoneDescription": "Allows your assistant to capture audio for voice input and recordings.",
@@ -621,11 +622,14 @@
     "notificationBadgesLabel": "Notification Badges",
     "notificationsDescription": "Allows your assistant to send macOS alerts for approvals, messages, and task updates.",
     "notificationsLabel": "Notifications",
+    "notificationsLinuxDescription": "Allows your assistant to send desktop notifications for approvals, messages, and task updates.",
     "notificationsWindowsDescription": "Allows your assistant to show Windows notifications for approvals, messages, and task updates.",
     "screenDescription": "Allows your assistant to capture screen context during computer-use tasks.",
     "screenLabel": "Screen Recording",
+    "screenLinuxDescription": "Allows your assistant to capture screen context once you approve screen sharing in the desktop portal.",
     "speechRecognitionDescription": "Allows your assistant to transcribe your speech into text on-device.",
     "speechRecognitionLabel": "Speech Recognition",
+    "speechRecognitionLinuxDescription": "Allows your assistant to transcribe your speech into text with an on-device model.",
     "speechRecognitionWindowsDescription": "Allows your assistant to transcribe your speech into text with Windows speech recognition.",
     "taskbarIcon": "taskbar icon",
     "title": "System Permissions"

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -611,6 +611,7 @@
   "systemPermissionsCard": {
     "accessibilityDescription": "Permite que tu asistente haga clic, escriba y controle apps en tu nombre.",
     "accessibilityLabel": "Accesibilidad",
+    "accessibilityLinuxDescription": "Permite que tu asistente haga clic, escriba y controle apps mediante la tecnología de asistencia AT-SPI.",
     "checking": "Comprobando permisos...",
     "dockIcon": "icono del Dock",
     "microphoneDescription": "Permite que tu asistente capture audio para entrada de voz y grabaciones.",
@@ -619,11 +620,14 @@
     "notificationBadgesLabel": "Insignias de notificación",
     "notificationsDescription": "Permite que tu asistente envíe alertas de macOS para aprobaciones, mensajes y actualizaciones de tareas.",
     "notificationsLabel": "Notificaciones",
+    "notificationsLinuxDescription": "Permite que tu asistente envíe notificaciones de escritorio para aprobaciones, mensajes y actualizaciones de tareas.",
     "notificationsWindowsDescription": "Permite que tu asistente muestre notificaciones de Windows para aprobaciones, mensajes y actualizaciones de tareas.",
     "screenDescription": "Permite que tu asistente capture el contexto de la pantalla durante tareas de uso del ordenador.",
     "screenLabel": "Grabación de pantalla",
+    "screenLinuxDescription": "Permite que tu asistente capture el contexto de la pantalla cuando apruebas compartir pantalla en el portal de escritorio.",
     "speechRecognitionDescription": "Permite que tu asistente transcriba tu voz a texto en el dispositivo.",
     "speechRecognitionLabel": "Reconocimiento de voz",
+    "speechRecognitionLinuxDescription": "Permite que tu asistente transcriba tu voz a texto con un modelo en el dispositivo.",
     "speechRecognitionWindowsDescription": "Permite que tu asistente transcriba tu voz a texto con el reconocimiento de voz de Windows.",
     "taskbarIcon": "icono de la barra de tareas",
     "title": "Permisos del sistema"

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -610,6 +610,7 @@
   "systemPermissionsCard": {
     "accessibilityDescription": "允許您的助理代表您點擊、輸入和控制應用程式。",
     "accessibilityLabel": "輔助使用",
+    "accessibilityLinuxDescription": "允許您的助理透過 AT-SPI 輔助技術點擊、輸入和控制應用程式。",
     "checking": "正在檢查權限...",
     "dockIcon": "Dock 圖示",
     "microphoneDescription": "允許您的助理擷取音訊以進行語音輸入和錄音。",
@@ -618,11 +619,14 @@
     "notificationBadgesLabel": "通知標記",
     "notificationsDescription": "允許您的助理傳送 macOS 警示以進行核准、訊息和任務更新。",
     "notificationsLabel": "通知",
+    "notificationsLinuxDescription": "允許您的助理傳送桌面通知以進行核准、訊息和任務更新。",
     "notificationsWindowsDescription": "允許您的助理顯示 Windows 通知以進行核准、訊息和任務更新。",
     "screenDescription": "允許您的助理在電腦使用任務期間擷取螢幕內容。",
     "screenLabel": "螢幕錄影",
+    "screenLinuxDescription": "在您於桌面入口網站核准螢幕分享後，允許您的助理擷取螢幕內容。",
     "speechRecognitionDescription": "允許您的助理在裝置上將您的語音轉錄為文字。",
     "speechRecognitionLabel": "語音辨識",
+    "speechRecognitionLinuxDescription": "允許您的助理使用裝置上的模型將您的語音轉錄為文字。",
     "speechRecognitionWindowsDescription": "允許您的助理使用 Windows 語音辨識將您的語音轉錄為文字。",
     "taskbarIcon": "工作列圖示",
     "title": "系統權限"

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -611,6 +611,7 @@
   "systemPermissionsCard": {
     "accessibilityDescription": "允许您的助手代表您点击、输入和控制应用程序。",
     "accessibilityLabel": "辅助功能",
+    "accessibilityLinuxDescription": "允许您的助手通过 AT-SPI 辅助技术点击、输入和控制应用程序。",
     "checking": "正在检查权限...",
     "dockIcon": "程序坞图标",
     "microphoneDescription": "允许您的助手捕获音频用于语音输入和录音。",
@@ -619,11 +620,14 @@
     "notificationBadgesLabel": "通知标记",
     "notificationsDescription": "允许您的助手发送 macOS 提醒，用于审批、消息和任务更新。",
     "notificationsLabel": "通知",
+    "notificationsLinuxDescription": "允许您的助手发送桌面通知，用于审批、消息和任务更新。",
     "notificationsWindowsDescription": "允许您的助手显示 Windows 通知，用于审批、消息和任务更新。",
     "screenDescription": "允许您的助手在计算机使用任务期间捕获屏幕上下文。",
     "screenLabel": "屏幕录制",
+    "screenLinuxDescription": "在您于桌面门户批准屏幕共享后，允许您的助手捕获屏幕上下文。",
     "speechRecognitionDescription": "允许您的助手在设备上将您的语音转录为文本。",
     "speechRecognitionLabel": "语音识别",
+    "speechRecognitionLinuxDescription": "允许您的助手使用设备上的模型将您的语音转录为文本。",
     "speechRecognitionWindowsDescription": "允许您的助手使用 Windows 语音识别将您的语音转录为文本。",
     "taskbarIcon": "任务栏图标",
     "title": "系统权限"

--- a/clients/web/src/lib/sentry/sentry-init.test.ts
+++ b/clients/web/src/lib/sentry/sentry-init.test.ts
@@ -48,13 +48,14 @@ env.VITE_SENTRY_DSN_IOS = "https://ios@example.com/ios";
 env.VITE_SENTRY_DSN_ANDROID = "https://android@example.com/android";
 env.VITE_SENTRY_DSN_MACOS = "https://macos@example.com/macos";
 env.VITE_SENTRY_DSN_WINDOWS = "https://windows@example.com/windows";
+env.VITE_SENTRY_DSN_LINUX = "https://linux@example.com/linux";
 
 const { initSentry } = await import("@/lib/sentry/sentry-init");
 
 // The Electron host is read off `window.vellum.hostOS`; without it the
 // resolver falls back to `navigator.platform`, which happy-dom reports
 // differently per machine.
-const setElectronHost = (hostOS: "macos" | "windows"): void => {
+const setElectronHost = (hostOS: "macos" | "windows" | "linux"): void => {
   electron = true;
   window.vellum = { hostOS } as never;
 };
@@ -98,6 +99,12 @@ describe("initSentry DSN selection", () => {
     setElectronHost("windows");
     initSentry();
     expect(syncedOptions?.dsn).toBe(import.meta.env.VITE_SENTRY_DSN_WINDOWS);
+  });
+
+  test("uses the Linux DSN in the Linux Electron renderer", () => {
+    setElectronHost("linux");
+    initSentry();
+    expect(syncedOptions?.dsn).toBe(import.meta.env.VITE_SENTRY_DSN_LINUX);
   });
 });
 

--- a/clients/web/src/runtime/system-permissions.ts
+++ b/clients/web/src/runtime/system-permissions.ts
@@ -6,7 +6,10 @@ import {
   type SystemPermissionStateItem,
   type SystemPermissionsState,
 } from "@/runtime/is-electron";
-import { detectElectronHostOS } from "@/runtime/platform-detection";
+import {
+  detectElectronHostOS,
+  type ElectronHostOS,
+} from "@/runtime/platform-detection";
 
 export type {
   SystemPermissionKind,
@@ -25,34 +28,30 @@ export const SYSTEM_PERMISSION_KINDS: SystemPermissionKind[] = [
   "notifications",
 ];
 
+/**
+ * Deep links a host's own settings UI answers, per host. A host with no
+ * scheme of its own carries an empty map rather than being left out of the
+ * type, so the no-op is a stated fact instead of a missing case: Linux
+ * desktops share no settings URI scheme, so nothing is routed there.
+ */
 const SYSTEM_PERMISSION_SETTINGS_URLS: Readonly<
-  Record<
-    string,
-    { hostOS: "macos" | "windows"; kind: SystemPermissionKind }
-  >
+  Record<ElectronHostOS, Readonly<Record<string, SystemPermissionKind>>>
 > = {
-  "ms-settings:privacy-microphone": {
-    hostOS: "windows",
-    kind: "microphone",
+  windows: {
+    "ms-settings:privacy-microphone": "microphone",
+    "ms-settings:privacy-speech": "speechRecognition",
+    "ms-settings:privacy-graphicscaptureprogrammatic": "screen",
+    "ms-settings:notifications": "notifications",
   },
-  "ms-settings:privacy-speech": {
-    hostOS: "windows",
-    kind: "speechRecognition",
+  macos: {
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone":
+      "microphone",
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition":
+      "speechRecognition",
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture":
+      "screen",
   },
-  "ms-settings:privacy-graphicscaptureprogrammatic": {
-    hostOS: "windows",
-    kind: "screen",
-  },
-  "ms-settings:notifications": {
-    hostOS: "windows",
-    kind: "notifications",
-  },
-  "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone":
-    { hostOS: "macos", kind: "microphone" },
-  "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition":
-    { hostOS: "macos", kind: "speechRecognition" },
-  "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture":
-    { hostOS: "macos", kind: "screen" },
+  linux: {},
 };
 
 export function supportsSystemPermissions(): boolean {
@@ -94,17 +93,18 @@ export type SystemPermissionSettingsUrlOutcome =
 export function dispatchSystemPermissionSettingsUrl(
   url: string,
 ): SystemPermissionSettingsUrlOutcome {
-  const target = SYSTEM_PERMISSION_SETTINGS_URLS[url];
-  if (!target) {
+  const owner = (
+    Object.keys(SYSTEM_PERMISSION_SETTINGS_URLS) as ElectronHostOS[]
+  ).find((candidate) => url in SYSTEM_PERMISSION_SETTINGS_URLS[candidate]);
+  if (!owner) {
     return "unrecognized";
   }
-  if (
-    detectElectronHostOS() !== target.hostOS ||
-    !supportsSystemPermissions()
-  ) {
+  if (detectElectronHostOS() !== owner || !supportsSystemPermissions()) {
     return "ignored";
   }
-  void openSystemPermissionSettings(target.kind);
+  void openSystemPermissionSettings(
+    SYSTEM_PERMISSION_SETTINGS_URLS[owner][url]!,
+  );
   return "opened";
 }
 

--- a/packages/design-library/src/components/shortcut-keys.test.tsx
+++ b/packages/design-library/src/components/shortcut-keys.test.tsx
@@ -123,7 +123,7 @@ describe("detectShortcutPlatform", () => {
     ["X11; Darwin arm64", "mac"],
     ["iPhone", "mac"],
     ["Win32", "windows"],
-    ["Linux x86_64", "windows"],
+    ["Linux x86_64", "linux"],
     ["", "mac"],
   ];
   for (const [platform, expected] of platforms) {
@@ -143,6 +143,55 @@ describe("detectShortcutPlatform", () => {
       }
     });
   }
+
+  test("prefers the Electron preload's host OS over navigator", () => {
+    const original = navigator.platform;
+    Object.defineProperty(navigator, "platform", {
+      value: "MacIntel",
+      configurable: true,
+    });
+    (globalThis as { vellum?: unknown }).vellum = { hostOS: "linux" };
+    try {
+      expect(detectShortcutPlatform()).toBe("linux");
+    } finally {
+      delete (globalThis as { vellum?: unknown }).vellum;
+      Object.defineProperty(navigator, "platform", {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+});
+
+describe("Linux key caps", () => {
+  test("labels the Super key rather than the Windows key", () => {
+    expect(parseAccelerator("Super+Shift+N", "linux")).toEqual([
+      "Super",
+      "Shift",
+      "N",
+    ]);
+    expect(parseAccelerator("CmdOrCtrl+Shift+N", "linux")).toEqual([
+      "Ctrl",
+      "Shift",
+      "N",
+    ]);
+  });
+
+  test("otherwise reuses the Windows vocabulary", () => {
+    expect(parseAccelerator("Alt+Escape", "linux")).toEqual(
+      parseAccelerator("Alt+Escape", "windows"),
+    );
+    expect(formatAcceleratorHint("CmdOrCtrl+Shift+O", "linux")).toBe(
+      "Ctrl+Shift+O",
+    );
+  });
+
+  test("announces Super as Meta to assistive technology", () => {
+    expect(acceleratorToAriaKeyShortcuts("Super+N", "linux")).toBe("Meta+N");
+    expect(acceleratorToAriaKeyShortcuts("CmdOrCtrl+Shift+P", "linux")).toBe(
+      "Control+Shift+P",
+    );
+  });
 });
 
 describe("formatAcceleratorHint", () => {

--- a/packages/design-library/src/components/shortcut-keys.tsx
+++ b/packages/design-library/src/components/shortcut-keys.tsx
@@ -13,16 +13,27 @@ import { cn } from "../utils/cn";
  * renders nothing, which callers use to show a "disabled" binding.
  */
 
-/** Which key-cap vocabulary to render: macOS glyphs or Windows text labels. */
-export type ShortcutPlatform = "mac" | "windows";
+/**
+ * Which key-cap vocabulary to render: macOS glyphs, Windows text labels, or
+ * the Linux labels, which are the Windows ones with Super in place of Win.
+ */
+export type ShortcutPlatform = "mac" | "windows" | "linux";
 
 /**
- * Detect the shortcut vocabulary for the current host from `navigator`. Apple
- * hosts (and unknown hosts, e.g. SSR or test DOMs) get glyphs; Windows and
- * Linux get text labels. Electron renderers report the host OS here too, so
- * this is correct inside the desktop apps.
+ * Detect the shortcut vocabulary for the current host. The Electron preload
+ * states its host OS, which is the only signal that tells a Linux desktop
+ * apart from a Linux browser reliably; otherwise fall back to `navigator`.
+ * Apple hosts (and unknown hosts, e.g. SSR or test DOMs) get glyphs.
  */
 export const detectShortcutPlatform = (): ShortcutPlatform => {
+  const hostOS = (globalThis as { vellum?: { hostOS?: string } }).vellum
+    ?.hostOS;
+  if (hostOS === "macos") {
+    return "mac";
+  }
+  if (hostOS === "windows" || hostOS === "linux") {
+    return hostOS;
+  }
   if (typeof navigator === "undefined") {
     return "mac";
   }
@@ -34,7 +45,10 @@ export const detectShortcutPlatform = (): ShortcutPlatform => {
   if (/mac|darwin|iphone|ipad|ipod/.test(platform)) {
     return "mac";
   }
-  return /win|linux/.test(platform) ? "windows" : "mac";
+  if (/linux/.test(platform)) {
+    return "linux";
+  }
+  return /win/.test(platform) ? "windows" : "mac";
 };
 
 const MAC_MODIFIER_SYMBOLS: Record<string, string> = {
@@ -65,6 +79,16 @@ const WINDOWS_MODIFIER_LABELS: Record<string, string> = {
   option: "Alt",
   altgr: "AltGr",
   shift: "Shift",
+};
+
+// Linux desktops call the Windows key Super, and otherwise write modifiers
+// the same way Windows does.
+const LINUX_MODIFIER_LABELS: Record<string, string> = {
+  ...WINDOWS_MODIFIER_LABELS,
+  command: "Super",
+  cmd: "Super",
+  super: "Super",
+  meta: "Super",
 };
 
 const MAC_KEY_SYMBOLS: Record<string, string> = {
@@ -113,6 +137,7 @@ const TOKEN_MAPS: Record<
 > = {
   mac: { modifiers: MAC_MODIFIER_SYMBOLS, keys: MAC_KEY_SYMBOLS },
   windows: { modifiers: WINDOWS_MODIFIER_LABELS, keys: WINDOWS_KEY_LABELS },
+  linux: { modifiers: LINUX_MODIFIER_LABELS, keys: WINDOWS_KEY_LABELS },
 };
 
 /**
@@ -172,10 +197,12 @@ const MODIFIER_IDS: Record<string, ModifierId | "platform"> = {
  * so `⇧⌘N` is correct and `⌘⇧N` is not, and Windows leads with the Windows
  * key then Ctrl, Alt, Shift per
  * [Microsoft's keyboard UX guidance](https://learn.microsoft.com/en-us/windows/win32/uxguide/inter-keyboard).
+ * Linux desktops follow the same order with Super in the Windows key's place.
  */
 const MODIFIER_ORDER: Record<ShortcutPlatform, readonly ModifierId[]> = {
   mac: ["control", "alt", "shift", "command"],
   windows: ["command", "control", "alt", "shift"],
+  linux: ["command", "control", "alt", "shift"],
 };
 
 const modifierId = (
@@ -244,6 +271,21 @@ export const formatAcceleratorHint = (
 ): string =>
   parseAccelerator(accelerator, platform).join(platform === "mac" ? "" : "+");
 
+const NON_MAC_ARIA_MODIFIERS: Record<string, string> = {
+  command: "Meta",
+  cmd: "Meta",
+  commandorcontrol: "Control",
+  cmdorctrl: "Control",
+  super: "Meta",
+  meta: "Meta",
+  control: "Control",
+  ctrl: "Control",
+  alt: "Alt",
+  option: "Alt",
+  altgr: "AltGraph",
+  shift: "Shift",
+};
+
 /**
  * Modifier names [`aria-keyshortcuts`](https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts)
  * takes, which are the UI Events modifier key values rather than the glyphs a
@@ -265,20 +307,10 @@ const ARIA_MODIFIERS: Record<ShortcutPlatform, Record<string, string>> = {
     altgr: "AltGraph",
     shift: "Shift",
   },
-  windows: {
-    command: "Meta",
-    cmd: "Meta",
-    commandorcontrol: "Control",
-    cmdorctrl: "Control",
-    super: "Meta",
-    meta: "Meta",
-    control: "Control",
-    ctrl: "Control",
-    alt: "Alt",
-    option: "Alt",
-    altgr: "AltGraph",
-    shift: "Shift",
-  },
+  windows: NON_MAC_ARIA_MODIFIERS,
+  // Super is the Meta key, so assistive technology hears the same value it
+  // does on Windows even though the drawn cap says Super.
+  linux: NON_MAC_ARIA_MODIFIERS,
 };
 
 /**


### PR DESCRIPTION
Linux permission rows and window chrome use Linux wording and capabilities. Permission controls stay disabled whenever Linux offers neither a request action nor a settings action, including already-granted permissions. macOS and Windows retain their existing behavior. The shared host resolver fixture also integrates cleanly with the renderer-copy PR.

Validation: permission-card behavior tests, affected renderer tests on the combined Wave 1 tree, and ESLint pass.

Part of Linux parity Wave 1 (PR 2). Native portal permission ownership and revocation handling remain later implementation work.
