### PR TITLE
Behavior tests for the Linux shell composed features

### DIFF
--- a/clients/linux/src/main/auxiliary-windows.test.ts
+++ b/clients/linux/src/main/auxiliary-windows.test.ts
@@ -1,0 +1,243 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import type { CreateWindowOptions } from "@vellumai/electron-desktop/windows";
+
+type Listener = (...args: unknown[]) => void;
+
+const created: Array<{ options: CreateWindowOptions; window: StubWindow }> = [];
+const handleListeners = new Map<string, Listener>();
+const onListeners = new Map<string, Listener>();
+const shortcutListeners = new Map<string, Listener>();
+const appListeners = new Map<string, Listener>();
+let focusedWindow: object | null = null;
+let workArea: Electron.Rectangle = { x: 0, y: 0, width: 1600, height: 900 };
+
+const makeWindow = () => {
+  const listeners = new Map<string, Listener[]>();
+  let destroyed = false;
+  const emit = (event: string, ...args: unknown[]): void => {
+    destroyed ||= event === "closed";
+    for (const listener of listeners.get(event) ?? []) listener(...args);
+  };
+  const addListener = (event: string, listener: Listener): void => {
+    listeners.set(event, [...(listeners.get(event) ?? []), listener]);
+  };
+  return {
+    webContents: {
+      isDestroyed: () => destroyed,
+      on: () => undefined,
+      send: mock(() => undefined),
+      getZoomFactor: () => 1,
+    },
+    close: mock(() => emit("closed")),
+    emit,
+    focus: mock(() => undefined),
+    getBounds: () => workArea,
+    hide: mock(() => undefined),
+    isDestroyed: () => destroyed,
+    isMinimized: () => false,
+    loadURL: mock(() => Promise.resolve()),
+    on: addListener,
+    once: addListener,
+    restore: mock(() => undefined),
+    setAlwaysOnTop: mock(() => undefined),
+    setIgnoreMouseEvents: mock(() => undefined),
+    setPosition: mock(() => undefined),
+    setVisibleOnAllWorkspaces: mock(() => undefined),
+    show: mock(() => undefined),
+    showInactive: mock(() => undefined),
+  };
+};
+
+type StubWindow = ReturnType<typeof makeWindow>;
+
+const createWindow = mock((options: CreateWindowOptions) => {
+  const window = makeWindow();
+  created.push({ options, window });
+  return window;
+});
+const dispatchToMain = mock(() => undefined);
+
+mock.module("electron", () => ({
+  app: {
+    isPackaged: false,
+    on: (event: string, listener: Listener) =>
+      appListeners.set(event, listener),
+    off: (event: string) => appListeners.delete(event),
+  },
+  BrowserWindow: class {
+    static getAllWindows() {
+      return created
+        .map(({ window }) => window)
+        .filter((w) => !w.isDestroyed());
+    }
+    static getFocusedWindow() {
+      return focusedWindow;
+    }
+  },
+  globalShortcut: {
+    register: (accelerator: string, listener: Listener) => {
+      shortcutListeners.set(accelerator, listener);
+      return true;
+    },
+    unregister: (accelerator: string) => shortcutListeners.delete(accelerator),
+  },
+  screen: {
+    getCursorScreenPoint: () => ({ x: workArea.x, y: workArea.y }),
+    getDisplayMatching: () => ({ workArea }),
+    getDisplayNearestPoint: () => ({ workArea }),
+    on: () => undefined,
+  },
+}));
+const restoreBounds = mock(
+  (_key: string, defaults: { width: number; height: number }) => defaults,
+);
+const trackWindowState = mock((_key: string, _win: unknown) => undefined);
+mock.module("@vellumai/electron-desktop/window-state", () => ({
+  restoreBounds,
+  track: trackWindowState,
+}));
+mock.module("./windows.client", () => ({ createWindow }));
+mock.module("./ipc.client", () => ({
+  handle: (channel: string, _schema: unknown, listener: Listener) => {
+    handleListeners.set(channel, listener);
+  },
+  on: (channel: string, _schema: unknown, listener: Listener) => {
+    onListeners.set(channel, listener);
+  },
+}));
+mock.module("./main-window", () => ({
+  current: () => null,
+  dispatchToMain,
+  ensureVisible: mock(() => undefined),
+}));
+mock.module("./logger", () => ({
+  default: { info: () => undefined, warn: () => undefined },
+}));
+
+const { default: auxiliaryWindows } =
+  await import("./features/auxiliary-windows");
+const { toggleQuickInput } =
+  await import("@vellumai/electron-desktop/quick-input-window");
+
+const setOverlayState = (state: Record<string, unknown>): void => {
+  onListeners.get("vellum:dictationOverlay:setState")?.([state]);
+};
+
+beforeAll(() => {
+  auxiliaryWindows.install({} as never);
+});
+beforeEach(() => {
+  created.length = 0;
+  focusedWindow = null;
+  dispatchToMain.mockClear();
+  workArea = { x: 0, y: 0, width: 1600, height: 900 };
+});
+afterEach(() => {
+  for (const { window } of created) {
+    if (!window.isDestroyed()) window.close();
+  }
+});
+
+describe("Linux auxiliary windows", () => {
+  test("reuses a focused command palette with the non-panel frame policy", () => {
+    handleListeners.get("vellum:commandPalette:open")?.([]);
+    handleListeners.get("vellum:commandPalette:open")?.([]);
+    expect(created).toHaveLength(1);
+    const { options, window } = created[0]!;
+    expect(options.browserWindow).toMatchObject({
+      frame: false,
+      focusable: true,
+      skipTaskbar: true,
+    });
+    // `type: "panel"` is a macOS-only window level.
+    expect(options.browserWindow).not.toHaveProperty("type");
+    expect(window.focus).toHaveBeenCalledTimes(2);
+  });
+
+  test("opens Quick Input on the cursor's display and closes on blur", () => {
+    workArea = { x: 1600, y: 40, width: 1200, height: 800 };
+    toggleQuickInput();
+    const { options, window } = created[0]!;
+    window.emit("ready-to-show");
+    expect(options.browserWindow).toMatchObject({
+      x: 1840,
+      y: 324,
+      alwaysOnTop: true,
+    });
+    expect(window.loadURL).toHaveBeenCalledWith(
+      "http://localhost:5173/assistant/quick-input",
+    );
+    window.emit("blur");
+    expect(window.isDestroyed()).toBe(true);
+  });
+
+  test("keeps the dictation overlay passive, topmost, and click-testable", async () => {
+    setOverlayState({ kind: "recording", transcription: "hello" });
+    const { options, window } = created[0]!;
+    expect(options.browserWindow).toMatchObject({
+      focusable: false,
+      skipTaskbar: true,
+    });
+    expect(window.setAlwaysOnTop).toHaveBeenCalledWith(true, "screen-saver");
+    expect(window.showInactive).toHaveBeenCalledTimes(1);
+    expect(window.loadURL).toHaveBeenCalledWith(
+      "http://localhost:5173/assistant/floating/dictation-overlay",
+    );
+
+    // Main hit-tests the cursor against the Stop region the overlay page
+    // reports; the mocked cursor sits at the window's origin.
+    onListeners.get("vellum:dictationOverlay:setHitRegion")?.([
+      { x: 0, y: 0, width: 24, height: 24 },
+    ]);
+    await Bun.sleep(120);
+    expect(window.setIgnoreMouseEvents).toHaveBeenCalledWith(false);
+
+    setOverlayState({ kind: "dismiss" });
+    expect(window.isDestroyed()).toBe(true);
+  });
+
+  test("Escape cancels dictation only while Vellum is unfocused", () => {
+    setOverlayState({ kind: "recording", transcription: "" });
+    shortcutListeners.get("Escape")?.();
+    expect(dispatchToMain).toHaveBeenCalledWith({ kind: "cancelDictation" });
+
+    dispatchToMain.mockClear();
+    focusedWindow = created[0]!.window;
+    appListeners.get("browser-window-focus")?.();
+    expect(shortcutListeners.has("Escape")).toBe(false);
+
+    focusedWindow = null;
+    appListeners.get("browser-window-blur")?.();
+    setOverlayState({ kind: "dismiss" });
+    expect(shortcutListeners.has("Escape")).toBe(false);
+    expect(dispatchToMain).not.toHaveBeenCalled();
+  });
+
+  test("keeps popouts independent from the main window", () => {
+    handleListeners.get("vellum:popout:open")?.(["conv-123"]);
+    const { options, window: popout } = created[0]!;
+    popout.emit("ready-to-show");
+    handleListeners.get("vellum:popout:open")?.(["conv-123"]);
+    expect(popout.isDestroyed()).toBe(false);
+    expect(restoreBounds).toHaveBeenCalledWith("thread.conv-123", {
+      width: 720,
+      height: 800,
+    });
+    expect(trackWindowState).toHaveBeenCalledWith("thread.conv-123", popout);
+    expect(options.browserWindow).not.toHaveProperty("parent");
+    expect(options.backgroundThrottling).toBe(false);
+    expect(popout.loadURL).toHaveBeenCalledWith(
+      "http://localhost:5173/assistant/conversations/conv-123?popout=1",
+    );
+    expect(popout.focus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clients/linux/src/main/auxiliary-windows.test.ts
+++ b/clients/linux/src/main/auxiliary-windows.test.ts
@@ -25,7 +25,9 @@ const makeWindow = () => {
   let destroyed = false;
   const emit = (event: string, ...args: unknown[]): void => {
     destroyed ||= event === "closed";
-    for (const listener of listeners.get(event) ?? []) listener(...args);
+    for (const listener of listeners.get(event) ?? []) {
+      listener(...args);
+    }
   };
   const addListener = (event: string, listener: Listener): void => {
     listeners.set(event, [...(listeners.get(event) ?? []), listener]);
@@ -143,7 +145,9 @@ beforeEach(() => {
 });
 afterEach(() => {
   for (const { window } of created) {
-    if (!window.isDestroyed()) window.close();
+    if (!window.isDestroyed()) {
+      window.close();
+    }
   }
 });
 

--- a/clients/linux/src/main/bundles-feature.test.ts
+++ b/clients/linux/src/main/bundles-feature.test.ts
@@ -1,116 +1,14 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-const installBundleFlowMock = mock(() => undefined);
-const handleBundleFileMock = mock(async (_filePath: string) => undefined);
-const stopFileOpenMock = mock(() => undefined);
-const onFileOpenMock = mock(
-  (_handler: (filePath: string) => void) => stopFileOpenMock,
-);
-const appOnceMock = mock((_event: string, _handler: () => void) => undefined);
-const resolveInvocationMock = mock(async () => ({
-  command: "/opt/vellum/bun",
-  baseArgs: [] as string[],
-}));
-const getGuardianAccessTokenMock = mock(async () => ({
-  ok: true as const,
-  accessToken: "guardian-token",
-}));
-
-mock.module("electron", () => ({
-  app: {
-    getPath: () => "/home/user/.config/Vellum",
-    isPackaged: true,
-    once: appOnceMock,
-  },
-  BrowserWindow: class {},
-  session: { defaultSession: {} },
-  shell: {},
-}));
-
-mock.module("@vellumai/electron-desktop/bundle-flow", () => ({
-  installBundleFlow: installBundleFlowMock,
-  handleBundleFile: handleBundleFileMock,
-}));
-
-mock.module("@vellumai/electron-desktop/file-open", () => ({
-  onFileOpen: onFileOpenMock,
-}));
-
-const localMode = await import("@vellumai/local-mode");
-mock.module("@vellumai/local-mode", () => ({
-  ...localMode,
-  getGuardianAccessToken: getGuardianAccessTokenMock,
-  getLockfileData: () => ({ ok: false, error: "missing" }),
-  resolveConfigDir: () => "/home/user/.config/vellum",
-  resolveLockfilePaths: () => ["/home/user/.config/vellum/lockfile.json"],
-}));
+import { mock } from "bun:test";
+import { runBundleFeatureSuite } from "@vellumai/electron-desktop/testing/bundle-feature-suite";
 
 mock.module("./ipc.client", () => ({
   handle: () => undefined,
   on: () => undefined,
 }));
 
-const {
-  bundleFileHandlerToken,
-  getBundlePlatform,
-  resetBundlePlatformForTest,
-} = await import("@vellumai/electron-desktop/bundle-platform");
-const { DesktopCapabilityRegistry } =
-  await import("@vellumai/electron-desktop/capability-registry");
-const { LOCAL_MODE_CLI } =
-  await import("@vellumai/electron-desktop/local-mode");
-const { default: bundles } = await import("./features/bundles");
-
-beforeEach(() => {
-  resetBundlePlatformForTest();
-  installBundleFlowMock.mockClear();
-  handleBundleFileMock.mockClear();
-  onFileOpenMock.mockClear();
-  stopFileOpenMock.mockClear();
-  appOnceMock.mockClear();
-  resolveInvocationMock.mockClear();
-  getGuardianAccessTokenMock.mockClear();
-});
-
-describe("Linux bundle workflow", () => {
-  test("installs the bundle flow and file-open handler", () => {
-    const registry = new DesktopCapabilityRegistry();
-    bundles.install(registry);
-
-    expect(registry.get(bundleFileHandlerToken)).toBe(handleBundleFileMock);
-    expect(installBundleFlowMock).toHaveBeenCalledTimes(1);
-    expect(onFileOpenMock).toHaveBeenCalledTimes(1);
-    onFileOpenMock.mock.calls[0]![0]("/home/user/bundle.vellum");
-    expect(handleBundleFileMock).toHaveBeenCalledWith(
-      "/home/user/bundle.vellum",
-    );
-    expect(appOnceMock).toHaveBeenCalledWith("before-quit", stopFileOpenMock);
-    expect(getBundlePlatform().bundlesRoot()).toBe(
-      "/home/user/.config/Vellum/bundles",
-    );
-  });
-
-  test("mints gateway tokens through the CLI provider installed later", async () => {
-    const registry = new DesktopCapabilityRegistry();
-    bundles.install(registry);
-
-    // Without the provider, the token request degrades to null.
-    await expect(
-      getBundlePlatform().acquireGatewayToken("assistant-1"),
-    ).resolves.toBeNull();
-
-    // A cold launch from a `.vellum` file asks for the token in the same
-    // tick that installs the remaining modules, including the CLI provider.
-    const pending = getBundlePlatform().acquireGatewayToken("assistant-1");
-    registry.provide(LOCAL_MODE_CLI, {
-      resolveInvocation: resolveInvocationMock,
-    });
-    await expect(pending).resolves.toBe("guardian-token");
-    expect(getGuardianAccessTokenMock).toHaveBeenCalledWith(
-      "assistant-1",
-      "/home/user/.config/vellum",
-      { command: "/opt/vellum/bun", baseArgs: [] },
-      true,
-    );
-  });
+await runBundleFeatureSuite("Linux", () => import("./features/bundles"), {
+  appData: "/home/user/.config/Vellum",
+  config: "/home/user/.config/vellum",
+  bundleFile: "/home/user/bundle.vellum",
+  command: "/opt/vellum/bun",
 });

--- a/clients/linux/src/main/bundles-feature.test.ts
+++ b/clients/linux/src/main/bundles-feature.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const installBundleFlowMock = mock(() => undefined);
+const handleBundleFileMock = mock(async (_filePath: string) => undefined);
+const stopFileOpenMock = mock(() => undefined);
+const onFileOpenMock = mock(
+  (_handler: (filePath: string) => void) => stopFileOpenMock,
+);
+const appOnceMock = mock((_event: string, _handler: () => void) => undefined);
+const resolveInvocationMock = mock(async () => ({
+  command: "/opt/vellum/bun",
+  baseArgs: [] as string[],
+}));
+const getGuardianAccessTokenMock = mock(async () => ({
+  ok: true as const,
+  accessToken: "guardian-token",
+}));
+
+mock.module("electron", () => ({
+  app: {
+    getPath: () => "/home/user/.config/Vellum",
+    isPackaged: true,
+    once: appOnceMock,
+  },
+  BrowserWindow: class {},
+  session: { defaultSession: {} },
+  shell: {},
+}));
+
+mock.module("@vellumai/electron-desktop/bundle-flow", () => ({
+  installBundleFlow: installBundleFlowMock,
+  handleBundleFile: handleBundleFileMock,
+}));
+
+mock.module("@vellumai/electron-desktop/file-open", () => ({
+  onFileOpen: onFileOpenMock,
+}));
+
+const localMode = await import("@vellumai/local-mode");
+mock.module("@vellumai/local-mode", () => ({
+  ...localMode,
+  getGuardianAccessToken: getGuardianAccessTokenMock,
+  getLockfileData: () => ({ ok: false, error: "missing" }),
+  resolveConfigDir: () => "/home/user/.config/vellum",
+  resolveLockfilePaths: () => ["/home/user/.config/vellum/lockfile.json"],
+}));
+
+mock.module("./ipc.client", () => ({
+  handle: () => undefined,
+  on: () => undefined,
+}));
+
+const {
+  bundleFileHandlerToken,
+  getBundlePlatform,
+  resetBundlePlatformForTest,
+} = await import("@vellumai/electron-desktop/bundle-platform");
+const { DesktopCapabilityRegistry } =
+  await import("@vellumai/electron-desktop/capability-registry");
+const { LOCAL_MODE_CLI } =
+  await import("@vellumai/electron-desktop/local-mode");
+const { default: bundles } = await import("./features/bundles");
+
+beforeEach(() => {
+  resetBundlePlatformForTest();
+  installBundleFlowMock.mockClear();
+  handleBundleFileMock.mockClear();
+  onFileOpenMock.mockClear();
+  stopFileOpenMock.mockClear();
+  appOnceMock.mockClear();
+  resolveInvocationMock.mockClear();
+  getGuardianAccessTokenMock.mockClear();
+});
+
+describe("Linux bundle workflow", () => {
+  test("installs the bundle flow and file-open handler", () => {
+    const registry = new DesktopCapabilityRegistry();
+    bundles.install(registry);
+
+    expect(registry.get(bundleFileHandlerToken)).toBe(handleBundleFileMock);
+    expect(installBundleFlowMock).toHaveBeenCalledTimes(1);
+    expect(onFileOpenMock).toHaveBeenCalledTimes(1);
+    onFileOpenMock.mock.calls[0]![0]("/home/user/bundle.vellum");
+    expect(handleBundleFileMock).toHaveBeenCalledWith(
+      "/home/user/bundle.vellum",
+    );
+    expect(appOnceMock).toHaveBeenCalledWith("before-quit", stopFileOpenMock);
+    expect(getBundlePlatform().bundlesRoot()).toBe(
+      "/home/user/.config/Vellum/bundles",
+    );
+  });
+
+  test("mints gateway tokens through the CLI provider installed later", async () => {
+    const registry = new DesktopCapabilityRegistry();
+    bundles.install(registry);
+
+    // Without the provider, the token request degrades to null.
+    await expect(
+      getBundlePlatform().acquireGatewayToken("assistant-1"),
+    ).resolves.toBeNull();
+
+    // A cold launch from a `.vellum` file asks for the token in the same
+    // tick that installs the remaining modules, including the CLI provider.
+    const pending = getBundlePlatform().acquireGatewayToken("assistant-1");
+    registry.provide(LOCAL_MODE_CLI, {
+      resolveInvocation: resolveInvocationMock,
+    });
+    await expect(pending).resolves.toBe("guardian-token");
+    expect(getGuardianAccessTokenMock).toHaveBeenCalledWith(
+      "assistant-1",
+      "/home/user/.config/vellum",
+      { command: "/opt/vellum/bun", baseArgs: [] },
+      true,
+    );
+  });
+});

--- a/clients/linux/src/main/cli-provisioning.test.ts
+++ b/clients/linux/src/main/cli-provisioning.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Real temp dirs: the wrapper flow is mostly filesystem behavior, so only the
+// Electron, logging and login-shell edges are faked.
+const root = mkdtempSync(path.join(tmpdir(), "vellum linux cli "));
+const home = path.join(root, "home");
+const userData = path.join(root, "userData");
+
+Object.defineProperty(process, "resourcesPath", {
+  value: path.join(root, "resources"),
+  writable: true,
+});
+
+mock.module("electron", () => ({
+  app: {
+    getPath: () => userData,
+    getVersion: () => "1.0.0",
+    isPackaged: true,
+  },
+}));
+mock.module("./logger", () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+
+const realOs = await import("node:os");
+mock.module("node:os", () => ({ ...realOs, homedir: () => home }));
+
+// Controlled per test. Null mirrors "could not read the login-shell PATH".
+let shellPathValue: string | null = "";
+let shellPathHits: string[] = [];
+const realShellPath = await import("./shell-path");
+mock.module("./shell-path", () => ({
+  ...realShellPath,
+  resolveShellPath: async () => shellPathValue,
+  findExecutablesInPath: () => shellPathHits,
+}));
+
+const ensureCliInstalled = mock(async () => undefined);
+const realCliInstaller = await import("./cli-installer");
+mock.module("./cli-installer", () => ({
+  ...realCliInstaller,
+  ensureCliInstalled,
+}));
+
+const { getCliBinPath } = realCliInstaller;
+const {
+  WRAPPER_MARKER,
+  getCliPathInstallState,
+  getWrapperDir,
+  getWrapperPath,
+  installWrapper,
+  provisionCliForWrapper,
+  readWrapperOwnership,
+  uninstallWrapper,
+} = await import("./cli-path-installer");
+
+const installRuntime = (): void => {
+  mkdirSync(path.dirname(getCliBinPath()), { recursive: true });
+  writeFileSync(getCliBinPath(), "#!/bin/sh\n", "utf8");
+};
+
+beforeEach(() => {
+  shellPathValue = "";
+  shellPathHits = [];
+  ensureCliInstalled.mockClear();
+});
+
+// Each test starts from a bare temp root.
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+test("installs an executable POSIX wrapper into ~/.local/bin", () => {
+  expect(getWrapperDir()).toBe(path.join(home, ".local", "bin"));
+
+  expect(installWrapper({ overwriteForeign: false })).toBe("installed");
+
+  const script = readFileSync(getWrapperPath(), "utf8");
+  expect(script.startsWith("#!/bin/sh\n")).toBe(true);
+  expect(script).toContain(WRAPPER_MARKER);
+  // The wrapper is machine-stable: every machine-specific path is sourced
+  // from the locator the app rewrites on launch.
+  expect(script).toContain('. "$LOCATOR"');
+  expect(script).toContain('exec "$VELLUM_BUN" "$VELLUM_CLI_BIN" "$@"');
+  expect(statSync(getWrapperPath()).mode & 0o777).toBe(0o755);
+  expect(readWrapperOwnership()).toBe("ours");
+});
+
+test("never clobbers a foreign wrapper without confirmation", () => {
+  mkdirSync(getWrapperDir(), { recursive: true });
+  writeFileSync(getWrapperPath(), "#!/bin/sh\necho other\n", "utf8");
+
+  expect(readWrapperOwnership()).toBe("foreign");
+  expect(installWrapper({ overwriteForeign: false })).toBe(
+    "needs-overwrite-confirmation",
+  );
+  expect(readFileSync(getWrapperPath(), "utf8")).toContain("echo other");
+
+  expect(installWrapper({ overwriteForeign: true })).toBe("installed");
+  expect(readWrapperOwnership()).toBe("ours");
+});
+
+test("treats a dangling symlink as foreign rather than absent", () => {
+  mkdirSync(getWrapperDir(), { recursive: true });
+  symlinkSync(path.join(root, "gone", "vellum"), getWrapperPath());
+
+  expect(readWrapperOwnership()).toBe("foreign");
+  expect(installWrapper({ overwriteForeign: false })).toBe(
+    "needs-overwrite-confirmation",
+  );
+});
+
+test("uninstall removes only a wrapper we own", () => {
+  expect(uninstallWrapper()).toBe("absent");
+
+  mkdirSync(getWrapperDir(), { recursive: true });
+  writeFileSync(getWrapperPath(), "foreign", "utf8");
+  expect(uninstallWrapper()).toBe("not-ours");
+  expect(readFileSync(getWrapperPath(), "utf8")).toBe("foreign");
+
+  installWrapper({ overwriteForeign: true });
+  expect(uninstallWrapper()).toBe("removed");
+  expect(existsSync(getWrapperPath())).toBe(false);
+});
+
+test("reports how the wrapper resolves on the login-shell PATH", async () => {
+  // A missing or foreign wrapper is classified without probing the shell.
+  shellPathValue = null;
+  await expect(getCliPathInstallState()).resolves.toEqual({
+    kind: "not-installed",
+  });
+  mkdirSync(getWrapperDir(), { recursive: true });
+  writeFileSync(getWrapperPath(), "foreign", "utf8");
+  await expect(getCliPathInstallState()).resolves.toEqual({
+    kind: "foreign-file",
+  });
+
+  // An unreadable login-shell PATH degrades rather than guessing.
+  installWrapper({ overwriteForeign: true });
+  await expect(getCliPathInstallState()).resolves.toEqual({
+    kind: "installed",
+    inPath: false,
+    runtimeReady: false,
+  });
+
+  // An earlier PATH entry wins over the wrapper.
+  const shadow = path.join(root, "npm-global", "vellum");
+  shellPathValue = `${path.dirname(shadow)}:${getWrapperDir()}`;
+  shellPathHits = [shadow];
+  await expect(getCliPathInstallState()).resolves.toEqual({
+    kind: "shadowed",
+    shadowedBy: shadow,
+    inPath: true,
+    runtimeReady: false,
+  });
+
+  // Once the pinned runtime is provisioned the wrapper can actually run.
+  shellPathHits = [getWrapperPath()];
+  installRuntime();
+  await expect(getCliPathInstallState()).resolves.toEqual({
+    kind: "installed",
+    inPath: true,
+    runtimeReady: true,
+  });
+});
+
+test("self-heals the pinned CLI only for a wrapper we own", async () => {
+  await expect(provisionCliForWrapper()).resolves.toBe(false);
+  expect(ensureCliInstalled).not.toHaveBeenCalled();
+
+  installWrapper({ overwriteForeign: false });
+  await expect(provisionCliForWrapper()).resolves.toBe(true);
+  expect(ensureCliInstalled).toHaveBeenCalledTimes(1);
+});

--- a/clients/linux/src/main/file-open.test.ts
+++ b/clients/linux/src/main/file-open.test.ts
@@ -1,0 +1,90 @@
+import { expect, mock, test } from "bun:test";
+import path from "node:path";
+
+import { FILE_OPEN_DRAIN, FILE_OPEN_EVENT } from "@vellumai/ipc-contract";
+
+type Listener = (...args: unknown[]) => unknown;
+
+const appListeners = new Map<string, Listener[]>();
+const invokeListeners = new Map<string, Listener>();
+const sent = mock(() => undefined);
+const ensureVisible = mock(() => undefined);
+
+mock.module("electron", () => ({
+  app: {
+    isReady: () => true,
+    on: (event: string, listener: Listener) => {
+      appListeners.set(event, [...(appListeners.get(event) ?? []), listener]);
+    },
+  },
+  BrowserWindow: {
+    getAllWindows: () => [
+      {
+        isDestroyed: () => false,
+        webContents: { send: sent },
+      },
+    ],
+  },
+  ipcMain: {
+    handle: (channel: string, listener: Listener) => {
+      invokeListeners.set(channel, listener);
+    },
+    on: () => undefined,
+  },
+}));
+mock.module("./main-window", () => ({ ensureVisible }));
+
+const { default: fileOpenModule } = await import("./features/file-open");
+const { resolveAllowedOrigin } = await import("./app-origin.client");
+
+const makeEvent = () => {
+  let destroyed: (() => void) | undefined;
+  const allowed = resolveAllowedOrigin();
+  return {
+    event: {
+      senderFrame: { origin: `${allowed.protocol}//${allowed.host}` },
+      sender: {
+        once: (event: string, listener: () => void) => {
+          if (event === "destroyed") {
+            destroyed = listener;
+          }
+        },
+      },
+    },
+    destroy: () => destroyed?.(),
+  };
+};
+
+test("delivers canonical first-instance and second-instance file paths once", () => {
+  const originalArgv = process.argv;
+  const firstPath = "exports/例.vellum";
+  process.argv = ["vellum", firstPath, firstPath, "notes.txt"];
+  try {
+    fileOpenModule.install({} as never);
+  } finally {
+    process.argv = originalArgv;
+  }
+
+  const firstEvent = makeEvent();
+  expect(invokeListeners.get(FILE_OPEN_DRAIN)?.(firstEvent.event)).toEqual([
+    path.resolve(firstPath),
+  ]);
+  firstEvent.destroy();
+
+  const secondWorkingDirectory = path.resolve("secondary-launch");
+  const secondRelativePath = "exports/second.vellum";
+  const secondPath = path.resolve(secondWorkingDirectory, secondRelativePath);
+  for (const listener of appListeners.get("second-instance") ?? []) {
+    listener(
+      {},
+      ["vellum", secondRelativePath, secondRelativePath, "archive.vellum.bak"],
+      secondWorkingDirectory,
+    );
+  }
+
+  expect(invokeListeners.get(FILE_OPEN_DRAIN)?.(makeEvent().event)).toEqual([
+    secondPath,
+  ]);
+  expect(sent).toHaveBeenCalledWith(FILE_OPEN_EVENT, secondPath);
+  expect(ensureVisible).toHaveBeenCalledTimes(2);
+});

--- a/clients/linux/src/main/host-proxy-feature.test.ts
+++ b/clients/linux/src/main/host-proxy-feature.test.ts
@@ -56,8 +56,7 @@ test("installs the bridge with the portable executors and tears down on quit", a
   expect(__testing.executors.size).toBe(0);
   await Bun.sleep(0);
 
-  // No native helper on Linux yet, so `host_cu` is absent unless the
-  // computer-use capability contributes it.
+  // An empty registry contributes no computer-use executor.
   expect([...__testing.executors.keys()].sort()).toEqual([
     "host_bash",
     "host_browser",

--- a/clients/linux/src/main/host-proxy-feature.test.ts
+++ b/clients/linux/src/main/host-proxy-feature.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, expect, mock, test } from "bun:test";
+
+const quitListeners: Array<() => void> = [];
+
+mock.module("electron", () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => "/tmp",
+    once: (event: string, listener: () => void) => {
+      if (event === "before-quit") {
+        quitListeners.push(listener);
+      }
+    },
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+  powerMonitor: {
+    on: () => undefined,
+    off: () => undefined,
+    getSystemIdleTime: () => 0,
+    getSystemIdleState: () => "active",
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString(),
+  },
+}));
+
+mock.module("./logger", () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { __testing } =
+  await import("@vellumai/electron-desktop/host-proxy/router");
+const { default: hostProxyFeature } = await import("./features/host-proxy");
+const { COMPUTER_USE_ACTION_EXECUTORS } =
+  await import("./features/computer-use-actions");
+const { DesktopCapabilityRegistry } =
+  await import("@vellumai/electron-desktop/capability-registry");
+
+afterEach(() => {
+  __testing.reset();
+  quitListeners.length = 0;
+});
+
+test("installs the bridge with the portable executors and tears down on quit", async () => {
+  hostProxyFeature.install(new DesktopCapabilityRegistry());
+
+  // The bridge install is deferred a microtask so the lockfile watcher's
+  // initial read (a later-sorted feature) lands first.
+  expect(__testing.executors.size).toBe(0);
+  await Bun.sleep(0);
+
+  // No native helper on Linux yet, so `host_cu` is absent unless the
+  // computer-use capability contributes it.
+  expect([...__testing.executors.keys()].sort()).toEqual([
+    "host_bash",
+    "host_browser",
+    "host_file",
+    "host_transfer",
+    "host_ui_snapshot",
+  ]);
+  expect(__testing.connections.size).toBe(0);
+
+  expect(quitListeners).toHaveLength(1);
+  quitListeners[0]!();
+  expect(__testing.executors.size).toBe(0);
+});
+
+test("installs the computer-use executor contributed by its capability", async () => {
+  const registry = new DesktopCapabilityRegistry();
+  registry.provide(COMPUTER_USE_ACTION_EXECUTORS, {
+    host_cu: {
+      handleRequest: () => undefined,
+      handleCancel: () => undefined,
+    },
+    teardown: () => undefined,
+  });
+
+  hostProxyFeature.install(registry);
+  await Bun.sleep(0);
+
+  expect(__testing.executors.has("host_cu")).toBe(true);
+});

--- a/clients/linux/src/main/local-mode-feature.test.ts
+++ b/clients/linux/src/main/local-mode-feature.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+mock.module("electron", () => ({
+  app: {
+    getAppPath: () => import.meta.dir,
+    getPath: () => import.meta.dir,
+    getVersion: () => "0.0.0",
+    isPackaged: false,
+  },
+}));
+
+const configureLocalMode = mock(() => undefined);
+const installLocalMode = mock(() => undefined);
+mock.module("@vellumai/electron-desktop/local-mode", () => ({
+  configureLocalMode,
+  installLocalMode,
+  LOCAL_MODE_CLI: { id: "desktop.local-mode-cli" },
+  LOCAL_MODE_PATHS: { id: "desktop.local-mode-paths" },
+  LOCAL_MODE_SESSION: { id: "desktop.local-mode-session" },
+}));
+
+const refreshLockfileNow = mock(() => undefined);
+mock.module("@vellumai/electron-desktop/lockfile-watcher", () => ({
+  refreshLockfileNow,
+}));
+mock.module("./ipc.client", () => ({ handle: mock(() => undefined) }));
+mock.module("./logger", () => ({
+  default: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+}));
+mock.module("@vellumai/electron-desktop/session-token-store", () => ({
+  getSessionToken: () => "session-token",
+}));
+
+const { DesktopCapabilityRegistry } =
+  await import("@vellumai/electron-desktop/capability-registry");
+const { default: localModeFeature } = await import("./features/local-mode");
+
+beforeEach(() => {
+  mock.clearAllMocks();
+});
+
+test("installs the full runtime with the Linux providers", () => {
+  const registry = new DesktopCapabilityRegistry();
+
+  localModeFeature.install(registry);
+
+  expect(configureLocalMode).toHaveBeenCalledWith(
+    expect.objectContaining({
+      cli: expect.objectContaining({ resolveInvocation: expect.any(Function) }),
+      paths: expect.objectContaining({ lockfilePaths: expect.any(Array) }),
+      refreshLockfile: refreshLockfileNow,
+      session: expect.objectContaining({ getToken: expect.any(Function) }),
+    }),
+  );
+  expect(installLocalMode).toHaveBeenCalledTimes(1);
+});

--- a/clients/linux/src/main/main-window.test.ts
+++ b/clients/linux/src/main/main-window.test.ts
@@ -91,6 +91,9 @@ mock.module("./logger", () => ({ default: { error: () => undefined } }));
 mock.module("electron", () => ({
   app: {
     isPackaged: false,
+    on: (event: string, listener: () => void) => {
+      appListeners.set(event, listener);
+    },
     once: (event: string, listener: () => void) => {
       appListeners.set(event, listener);
     },

--- a/clients/linux/src/main/main-window.test.ts
+++ b/clients/linux/src/main/main-window.test.ts
@@ -36,11 +36,15 @@ const makeWindow = (options: {
     },
     emit(event: string, payload?: { preventDefault: () => void }) {
       state.destroyed ||= event === "closed";
-      for (const handler of listeners.get(event) ?? []) handler(payload);
+      for (const handler of listeners.get(event) ?? []) {
+        handler(payload);
+      }
     },
     webContents: {
       emit: (event: string) => {
-        for (const handler of webListeners.get(event) ?? []) handler();
+        for (const handler of webListeners.get(event) ?? []) {
+          handler();
+        }
       },
       isDestroyed: () => state.destroyed,
       on: mock(() => undefined),
@@ -137,7 +141,9 @@ const {
 
 const destroyWindows = (): void => {
   for (const win of constructed) {
-    if (!win.state.destroyed) win.emit("closed");
+    if (!win.state.destroyed) {
+      win.emit("closed");
+    }
   }
   constructed.length = 0;
 };

--- a/clients/linux/src/main/main-window.test.ts
+++ b/clients/linux/src/main/main-window.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  IDENTITY_NAME,
+  MAIN_WINDOW_ENSURE_VISIBLE,
+  MAIN_WINDOW_SET_ONBOARDING,
+  MAIN_WINDOW_SET_TITLE_BAR_OVERLAY,
+  type TitleBarOverlayTheme,
+} from "@vellumai/ipc-contract";
+
+type Listener = (event?: { preventDefault: () => void }) => void;
+
+const appListeners = new Map<string, () => void>();
+const constructed: StubWindow[] = [];
+
+const makeWindow = (options: {
+  browserWindow: Record<string, unknown>;
+  backgroundThrottling?: boolean;
+}) => {
+  const state = {
+    destroyed: false,
+    focused: false,
+    minimized: false,
+    visible: false,
+  };
+  const listeners = new Map<string, Listener[]>();
+  const webListeners = new Map<string, Array<() => void>>();
+  const addListener = (event: string, handler: Listener) => {
+    listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+    return stub;
+  };
+  const stub = {
+    state,
+    options: {
+      ...options.browserWindow,
+      backgroundThrottling: options.backgroundThrottling,
+    },
+    emit(event: string, payload?: { preventDefault: () => void }) {
+      state.destroyed ||= event === "closed";
+      for (const handler of listeners.get(event) ?? []) handler(payload);
+    },
+    webContents: {
+      emit: (event: string) => {
+        for (const handler of webListeners.get(event) ?? []) handler();
+      },
+      isDestroyed: () => state.destroyed,
+      on: mock(() => undefined),
+      once: (event: string, handler: () => void) => {
+        webListeners.set(event, [...(webListeners.get(event) ?? []), handler]);
+      },
+      send: mock(() => undefined),
+    },
+    focus: mock(() => {
+      state.focused = true;
+    }),
+    hide: mock(() => {
+      state.visible = false;
+    }),
+    loadURL: mock(() => Promise.resolve()),
+    maximize: mock(() => undefined),
+    restore: mock(() => {
+      state.minimized = false;
+    }),
+    setTitle: mock(() => undefined),
+    show: mock(() => {
+      state.visible = true;
+    }),
+    isDestroyed: () => state.destroyed,
+    isFocused: () => state.focused,
+    isMinimized: () => state.minimized,
+    isVisible: () => state.visible,
+    on: addListener,
+    once: addListener,
+  };
+  return stub;
+};
+
+type StubWindow = ReturnType<typeof makeWindow>;
+
+const createWindow = mock((options: Parameters<typeof makeWindow>[0]) => {
+  const stub = makeWindow(options);
+  constructed.push(stub);
+  return stub;
+});
+
+mock.module("./windows.client", () => ({ createWindow }));
+mock.module("./logger", () => ({ default: { error: () => undefined } }));
+mock.module("electron", () => ({
+  app: {
+    isPackaged: false,
+    once: (event: string, listener: () => void) => {
+      appListeners.set(event, listener);
+    },
+  },
+  BrowserWindow: class {},
+  nativeTheme: { themeSource: "system", shouldUseDarkColors: false },
+  shell: { openExternal: () => Promise.resolve() },
+}));
+
+let restoredBounds: Record<string, unknown> = { width: 1280, height: 800 };
+const track = mock(() => undefined);
+const writeOnboardingActive = mock((_active: boolean) => undefined);
+const writeTitleBarOverlayTheme = mock(
+  (_theme: TitleBarOverlayTheme) => undefined,
+);
+
+mock.module("@vellumai/electron-desktop/window-state", () => ({
+  restoreBounds: () => restoredBounds,
+  track,
+  readOnboardingActive: () => false,
+  writeOnboardingActive,
+  readTitleBarOverlayTheme: () => null,
+  writeTitleBarOverlayTheme,
+}));
+
+const invokeHandlers = new Map<
+  string,
+  (args: unknown[], event: { sender: unknown }) => unknown
+>();
+const eventHandlers = new Map<string, (args: unknown[]) => void>();
+
+mock.module("./ipc.client", () => ({
+  handle: (channel: string, _schema: unknown, handler: unknown) => {
+    invokeHandlers.set(channel, handler as never);
+  },
+  on: (channel: string, _schema: unknown, handler: unknown) => {
+    eventHandlers.set(channel, handler as never);
+  },
+}));
+
+const {
+  __resetForTesting,
+  dispatchToMain,
+  ensureVisible,
+  installMainWindow,
+  toggleVisibility,
+} = await import("./main-window");
+
+const destroyWindows = (): void => {
+  for (const win of constructed) {
+    if (!win.state.destroyed) win.emit("closed");
+  }
+  constructed.length = 0;
+};
+
+beforeEach(() => {
+  destroyWindows();
+  __resetForTesting();
+  appListeners.clear();
+  invokeHandlers.clear();
+  eventHandlers.clear();
+  restoredBounds = { width: 1280, height: 800 };
+  track.mockClear();
+  writeOnboardingActive.mockClear();
+  writeTitleBarOverlayTheme.mockClear();
+});
+
+afterEach(destroyWindows);
+
+describe("Linux main window", () => {
+  test("restores bounds and a maximized session with live-voice timers on", () => {
+    restoredBounds = {
+      x: 40,
+      y: 60,
+      width: 1000,
+      height: 700,
+      maximized: true,
+    };
+    void ensureVisible();
+
+    const win = constructed[0]!;
+    expect(win.options).toMatchObject({
+      x: 40,
+      y: 60,
+      width: 1000,
+      height: 700,
+      minWidth: 800,
+      minHeight: 600,
+      backgroundThrottling: false,
+    });
+    // Linux keeps the desktop's own frame: no native caption overlay.
+    expect(win.options).not.toHaveProperty("titleBarOverlay");
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(win.maximize).not.toHaveBeenCalled();
+    win.emit("ready-to-show");
+    expect(win.maximize).toHaveBeenCalledTimes(1);
+  });
+
+  test("restores a minimized window and recreates a destroyed one", () => {
+    void ensureVisible();
+    const first = constructed[0]!;
+    first.state.minimized = true;
+    void ensureVisible();
+    expect(first.restore).toHaveBeenCalledTimes(1);
+
+    first.emit("closed");
+    void ensureVisible();
+    expect(constructed).toHaveLength(2);
+  });
+
+  test("readiness waits for load and show", async () => {
+    let resolved = false;
+    const ready = ensureVisible().then(() => {
+      resolved = true;
+    });
+    const win = constructed[0]!;
+
+    win.webContents.emit("did-finish-load");
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    win.emit("ready-to-show");
+    await ready;
+    expect(win.show).toHaveBeenCalledTimes(1);
+    expect(win.focus).toHaveBeenCalledTimes(1);
+  });
+
+  test("registers controls, onboarding, and the live assistant title", () => {
+    installMainWindow();
+    expect(invokeHandlers.has(MAIN_WINDOW_ENSURE_VISIBLE)).toBe(true);
+
+    invokeHandlers.get(MAIN_WINDOW_SET_ONBOARDING)?.([true], {
+      sender: constructed[0]?.webContents,
+    });
+    expect(writeOnboardingActive).toHaveBeenCalledWith(true);
+
+    eventHandlers.get(IDENTITY_NAME)?.(["  Alice  "]);
+    expect(constructed[0]?.setTitle).toHaveBeenLastCalledWith("Alice");
+
+    // A recreated window keeps the latest title.
+    constructed[0]?.emit("closed");
+    void ensureVisible();
+    expect(constructed[1]?.setTitle).toHaveBeenCalledWith("Alice");
+  });
+
+  test("dispatches commands to the current renderer", () => {
+    void ensureVisible();
+    dispatchToMain({ kind: "openSettings" });
+    expect(constructed[0]?.webContents.send).toHaveBeenCalledWith(
+      "vellum:command",
+      { kind: "openSettings" },
+    );
+  });
+
+  test("persists the main window's theme and ignores every other sender", () => {
+    // Auxiliary windows run the same renderer bundle: the offscreen
+    // theme-stage window applies arbitrary workspace tokens for screenshots,
+    // and persisting those would leak a staged palette into the next launch.
+    installMainWindow();
+    const theme = {
+      color: "#17191C",
+      symbolColor: "#F6F5F4",
+      colorScheme: "dark",
+    };
+
+    invokeHandlers.get(MAIN_WINDOW_SET_TITLE_BAR_OVERLAY)?.([theme], {
+      sender: { staged: true },
+    });
+    expect(writeTitleBarOverlayTheme).not.toHaveBeenCalled();
+
+    invokeHandlers.get(MAIN_WINDOW_SET_TITLE_BAR_OVERLAY)?.([theme], {
+      sender: constructed[0]?.webContents,
+    });
+    expect(writeTitleBarOverlayTheme).toHaveBeenCalledWith(theme);
+  });
+
+  test("toggling only hides a live window that is visible and focused", () => {
+    // GIVEN no window yet, a toggle creates one rather than hiding
+    toggleVisibility();
+    const win = constructed[0]!;
+    expect(win.hide).not.toHaveBeenCalled();
+    win.emit("ready-to-show");
+
+    // WHEN it is on screen but unfocused, it is brought forward
+    win.state.focused = false;
+    toggleVisibility();
+    expect(win.hide).not.toHaveBeenCalled();
+
+    // WHEN it has the user's attention, it hides
+    win.state.focused = true;
+    win.state.visible = true;
+    toggleVisibility();
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(win.state.visible).toBe(false);
+
+    // WHEN it is off screen, it comes back rather than hiding again
+    toggleVisibility();
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(win.state.visible).toBe(true);
+  });
+
+  test("hides on close and allows close while quitting", () => {
+    installMainWindow();
+    const win = constructed[0]!;
+    const hideClose = mock(() => undefined);
+
+    win.emit("close", { preventDefault: hideClose });
+    expect(hideClose).toHaveBeenCalledTimes(1);
+    expect(win.hide).toHaveBeenCalledTimes(1);
+
+    const quitClose = mock(() => undefined);
+    appListeners.get("before-quit")?.();
+    win.emit("close", { preventDefault: quitClose });
+    expect(quitClose).not.toHaveBeenCalled();
+    expect(win.hide).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/linux/src/main/notifications-share-feature.test.ts
+++ b/clients/linux/src/main/notifications-share-feature.test.ts
@@ -175,7 +175,9 @@ describe("share feature", () => {
   const installShare = (): ShareHandler => {
     shareFeature.install(new DesktopCapabilityRegistry());
     const handler = handlers.get("vellum:share:file");
-    if (!handler) throw new Error("share handler was not registered");
+    if (!handler) {
+      throw new Error("share handler was not registered");
+    }
     return handler;
   };
 

--- a/clients/linux/src/main/notifications-share-feature.test.ts
+++ b/clients/linux/src/main/notifications-share-feature.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Linux pieces only: the helper-toast factory wiring and the Save As share
+// fallback. Shared behavior is covered in packages/electron-desktop.
+
+let saveDialogResult: { canceled: boolean; filePath?: string } = {
+  canceled: true,
+};
+const saveDialogCalls: Array<{ defaultPath?: string }> = [];
+
+mock.module("electron", () => ({
+  app: { getAppPath: () => "/nonexistent-app-path", once: () => undefined },
+  dialog: {
+    showSaveDialog: (_window: unknown, options: { defaultPath?: string }) => {
+      saveDialogCalls.push(options);
+      return Promise.resolve(saveDialogResult);
+    },
+  },
+  BrowserWindow: { fromWebContents: () => ({ id: 1 }) },
+}));
+
+type ShareHandler = (args: unknown[], event: unknown) => unknown;
+const handlers = new Map<string, ShareHandler>();
+mock.module("./ipc.client", () => ({
+  handle: (channel: string, _schema: unknown, fn: ShareHandler) => {
+    handlers.set(channel, fn);
+  },
+}));
+mock.module("./logger", () => ({
+  default: { info: () => undefined, warn: () => undefined },
+}));
+mock.module("./main-window", () => ({
+  ensureVisible: () => Promise.resolve(),
+}));
+// The shared module imports `electron.Notification`, which does not exist
+// outside an Electron runtime.
+const configureNotifications = mock(
+  (_options: Record<string, unknown>) => undefined,
+);
+mock.module("@vellumai/electron-desktop/notifications", () => ({
+  configureNotifications,
+  installNotifications: () => undefined,
+}));
+
+class FakeSidecarClient {
+  static instances: FakeSidecarClient[] = [];
+  static throwOnCall: string | null = null;
+  readonly calls: Array<{ method: string; params: unknown }> = [];
+  readonly listeners = new Map<string, (params: unknown) => void>();
+
+  constructor() {
+    FakeSidecarClient.instances.push(this);
+  }
+
+  onNotification(
+    method: string,
+    _schema: unknown,
+    listener: (params: unknown) => void,
+  ): () => void {
+    this.listeners.set(method, listener);
+    return () => undefined;
+  }
+
+  call(method: string, params?: unknown): Promise<unknown> {
+    // Mirrors NativeSidecarClient.call, which throws synchronously when the
+    // helper cannot be spawned.
+    if (FakeSidecarClient.throwOnCall !== null) {
+      throw new Error(FakeSidecarClient.throwOnCall);
+    }
+    this.calls.push({ method, params });
+    return Promise.resolve({ success: true });
+  }
+}
+mock.module("@vellumai/native-sidecar/supervisor", () => ({
+  NativeSidecarClient: FakeSidecarClient,
+}));
+
+const { createHelperToastFactory, default: notificationsFeature } =
+  await import("./features/notifications");
+const { default: shareFeature, sanitizeFilename } =
+  await import("./features/share");
+const { DesktopCapabilityRegistry } =
+  await import("@vellumai/electron-desktop/capability-registry");
+
+beforeEach(() => {
+  handlers.clear();
+  saveDialogCalls.length = 0;
+  saveDialogResult = { canceled: true };
+  FakeSidecarClient.instances.length = 0;
+  configureNotifications.mockClear();
+});
+
+describe("notifications feature", () => {
+  test("falls back to Electron toasts while no helper binary is installed", () => {
+    notificationsFeature.install(new DesktopCapabilityRegistry());
+
+    expect(configureNotifications.mock.calls[0]![0]).not.toHaveProperty(
+      "create",
+    );
+  });
+
+  test("show sends the toast over RPC and activation events route by token", async () => {
+    const create = createHelperToastFactory("/opt/vellum/vellum-linux-helper");
+    const seen: Array<{ event: string; index?: number }> = [];
+    const toast = create({
+      title: "T",
+      body: "B",
+      silent: false,
+      actions: [
+        { type: "button", text: "Allow" },
+        { type: "button", text: "Deny" },
+      ],
+    });
+    toast.on("click", () => seen.push({ event: "click" }));
+    toast.on("action", (_event: unknown, index: number) =>
+      seen.push({ event: "action", index }),
+    );
+    toast.on("show", () => seen.push({ event: "show" }));
+    toast.show();
+    await Bun.sleep(0);
+
+    const client = FakeSidecarClient.instances[0]!;
+    expect(client.calls).toEqual([
+      {
+        method: "notifications/show",
+        params: {
+          token: expect.stringMatching(/^toast-/) as unknown as string,
+          title: "T",
+          body: "B",
+          actions: [{ text: "Allow" }, { text: "Deny" }],
+        },
+      },
+    ]);
+
+    const { token } = client.calls[0]!.params as { token: string };
+    const emit = client.listeners.get("notifications/event")!;
+    emit({ token, kind: "action", actionIndex: 1 });
+    emit({ token, kind: "click" });
+    emit({ token: "unknown-token", kind: "click" }); // dropped
+    emit({ token, kind: "action" }); // no index: dropped, never "Allow"
+    expect(seen).toEqual([
+      { event: "show" },
+      { event: "action", index: 1 },
+      { event: "click" },
+    ]);
+  });
+
+  test("a synchronous client throw acks as a failed delivery", async () => {
+    FakeSidecarClient.throwOnCall = "linux-helper is not available";
+    try {
+      const create = createHelperToastFactory("/opt/vellum/helper");
+      const failures: unknown[] = [];
+      const toast = create({
+        title: "T",
+        body: "B",
+        silent: false,
+        actions: [],
+      });
+      toast.on("failed", (_event: unknown, message: string) => {
+        failures.push(message);
+      });
+      expect(() => toast.show()).not.toThrow();
+      await Bun.sleep(0);
+      expect(failures).toEqual(["linux-helper is not available"]);
+    } finally {
+      FakeSidecarClient.throwOnCall = null;
+    }
+  });
+});
+
+describe("share feature", () => {
+  const installShare = (): ShareHandler => {
+    shareFeature.install(new DesktopCapabilityRegistry());
+    const handler = handlers.get("vellum:share:file");
+    if (!handler) throw new Error("share handler was not registered");
+    return handler;
+  };
+
+  test("sanitizeFilename strips directories and invalid characters", () => {
+    expect(sanitizeFilename("../../évil<name>.txt")).toBe("évil_name_.txt");
+    expect(sanitizeFilename("nested/dir/受信 rėsumė.txt")).toBe(
+      "受信 rėsumė.txt",
+    );
+    expect(sanitizeFilename("///")).toBe("download");
+  });
+
+  test("writes the bytes to the picked path and cancelling writes nothing", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "vellum-share-test-"));
+    try {
+      const target = path.join(dir, "out.bin");
+      saveDialogResult = { canceled: false, filePath: target };
+      const bytes = new Uint8Array([1, 2, 3]);
+      await installShare()([bytes, "../report:v1.pdf"], { sender: {} });
+      expect(saveDialogCalls[0]!.defaultPath).toBe("report_v1.pdf");
+      expect(new Uint8Array(await readFile(target))).toEqual(bytes);
+
+      saveDialogResult = { canceled: true };
+      await expect(
+        installShare()([bytes, "a.txt"], { sender: {} }),
+      ).resolves.toBeUndefined();
+      expect(saveDialogCalls).toHaveLength(2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/clients/linux/src/main/permissions-feature.test.ts
+++ b/clients/linux/src/main/permissions-feature.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+import {
+  PERMISSIONS_GET_STATE,
+  PERMISSIONS_OPEN_SETTINGS,
+  PERMISSIONS_REQUEST,
+  TEXT_INSERT,
+} from "@vellumai/ipc-contract";
+
+type Handler = (args: unknown[]) => unknown;
+
+const handlers = new Map<string, Handler>();
+const openExternal = mock(async () => undefined);
+const mediaStatus = mock((_kind: string): string => "granted");
+let notificationOutcome: "show" | "failed" = "show";
+
+class FakeNotification {
+  static isSupported = () => true;
+  private listeners = new Map<string, () => void>();
+  once(event: string, listener: () => void) {
+    this.listeners.set(event, listener);
+    return this;
+  }
+  show() {
+    this.listeners.get(notificationOutcome)?.();
+  }
+}
+
+const defaultHelperCall = async (method: string): Promise<unknown> => {
+  if (method === "permissions.state") {
+    return {
+      microphone: "granted",
+      speechRecognition: "denied",
+      notifications: "granted",
+    };
+  }
+  return { status: "inserted", reason: null };
+};
+const helperCall = mock(defaultHelperCall);
+
+let onFocus: (() => void) | null = null;
+
+mock.module("electron", () => ({
+  app: {
+    on: mock((event: string, listener: () => void) => {
+      if (event === "browser-window-focus") {
+        onFocus = listener;
+      }
+    }),
+    quit: mock(() => undefined),
+    relaunch: mock(() => undefined),
+  },
+  BrowserWindow: { getAllWindows: () => [], getFocusedWindow: () => null },
+  shell: { openExternal },
+  systemPreferences: { getMediaAccessStatus: mediaStatus },
+  Notification: FakeNotification,
+}));
+mock.module("./ipc.client", () => ({
+  handle: (channel: string, _schema: unknown, handler: Handler) => {
+    handlers.set(channel, handler);
+  },
+}));
+mock.module("./logger", () => ({ default: { warn: mock(() => undefined) } }));
+mock.module("./main-window", () => ({ current: () => null }));
+mock.module("./linux-helper", () => ({
+  getLinuxHelperClient: () => ({ call: helperCall }),
+}));
+
+const { default: permissionsFeature } = await import("./features/permissions");
+
+beforeEach(() => {
+  handlers.clear();
+  helperCall.mockReset();
+  helperCall.mockImplementation(defaultHelperCall);
+  openExternal.mockClear();
+  mediaStatus.mockReset();
+  mediaStatus.mockImplementation(() => "granted");
+  notificationOutcome = "show";
+  permissionsFeature.install({} as never);
+});
+
+test("uses the Linux helper for permission states and text insertion", async () => {
+  await expect(handlers.get(PERMISSIONS_GET_STATE)!([])).resolves.toMatchObject(
+    {
+      microphone: { status: "granted" },
+      speechRecognition: { status: "denied" },
+      notifications: { status: "granted" },
+    },
+  );
+  await expect(handlers.get(TEXT_INSERT)!(["hello"])).resolves.toEqual({
+    status: "inserted",
+  });
+
+  expect(helperCall).toHaveBeenCalledWith("permissions.state");
+  expect(helperCall).toHaveBeenCalledWith("text.insert", { text: "hello" });
+});
+
+test("fails closed and falls back to Electron when the helper is silent", async () => {
+  helperCall.mockImplementation(async () => {
+    throw new Error("no linux helper");
+  });
+  mediaStatus.mockImplementation(() => "denied");
+
+  // Only the microphone has an Electron-side status; everything else the
+  // helper would answer stays unknown rather than being faked.
+  await expect(handlers.get(PERMISSIONS_GET_STATE)!([])).resolves.toMatchObject(
+    {
+      microphone: { status: "denied" },
+      screen: { status: "unknown" },
+      speechRecognition: { status: "unknown" },
+    },
+  );
+  await expect(handlers.get(TEXT_INSERT)!(["hello"])).resolves.toEqual({
+    status: "blocked",
+  });
+});
+
+test("reports not-applicable rows and offers no settings pane", async () => {
+  // Linux desktops share no settings URI scheme, so no kind can be remediated
+  // from the app.
+  await expect(handlers.get(PERMISSIONS_GET_STATE)!([])).resolves.toMatchObject(
+    {
+      accessibility: { status: "not-applicable" },
+      inputMonitoring: { status: "not-applicable" },
+      automation: { status: "not-applicable" },
+      screen: { status: "unknown", canOpenSettings: false },
+    },
+  );
+
+  await handlers.get(PERMISSIONS_OPEN_SETTINGS)!(["screen"]);
+
+  expect(mediaStatus).not.toHaveBeenCalledWith("screen");
+  expect(openExternal).not.toHaveBeenCalled();
+});
+
+test("requests notifications by probing instead of opening settings", async () => {
+  helperCall.mockImplementation(async () => ({ notifications: "unknown" }));
+  await expect(handlers.get(PERMISSIONS_GET_STATE)!([])).resolves.toMatchObject(
+    { notifications: { status: "unknown", canRequest: true } },
+  );
+
+  notificationOutcome = "failed";
+  await expect(
+    handlers.get(PERMISSIONS_REQUEST)!(["notifications"]),
+  ).resolves.toMatchObject({ status: "denied" });
+  expect(openExternal).not.toHaveBeenCalled();
+
+  // A desktop-side change seen by the helper supersedes the probe result.
+  helperCall.mockImplementation(async () => ({ notifications: "granted" }));
+  await expect(handlers.get(PERMISSIONS_GET_STATE)!([])).resolves.toMatchObject(
+    { notifications: { status: "granted", canRequest: false } },
+  );
+});
+
+test("regaining focus drops the notification probe result", async () => {
+  helperCall.mockImplementation(async () => ({ notifications: "granted" }));
+  notificationOutcome = "failed";
+  await expect(
+    handlers.get(PERMISSIONS_REQUEST)!(["notifications"]),
+  ).resolves.toMatchObject({ status: "denied" });
+
+  onFocus!();
+  await expect(handlers.get(PERMISSIONS_GET_STATE)!([])).resolves.toMatchObject(
+    { notifications: { status: "granted" } },
+  );
+});

--- a/clients/windows/src/main/bundles-feature.test.ts
+++ b/clients/windows/src/main/bundles-feature.test.ts
@@ -1,112 +1,14 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-const installBundleFlowMock = mock(() => undefined);
-const handleBundleFileMock = mock(async (_filePath: string) => undefined);
-const stopFileOpenMock = mock(() => undefined);
-const onFileOpenMock = mock(
-  (_handler: (filePath: string) => void) => stopFileOpenMock,
-);
-const appOnceMock = mock((_event: string, _handler: () => void) => undefined);
-const resolveInvocationMock = mock(async () => ({
-  command: "vellum.exe",
-  baseArgs: [] as string[],
-}));
-const getGuardianAccessTokenMock = mock(async () => ({
-  ok: true as const,
-  accessToken: "guardian-token",
-}));
-
-mock.module("electron", () => ({
-  app: {
-    getPath: () => "C:\\Vellum",
-    isPackaged: true,
-    once: appOnceMock,
-  },
-  BrowserWindow: class {},
-  session: { defaultSession: {} },
-  shell: {},
-}));
-
-mock.module("@vellumai/electron-desktop/bundle-flow", () => ({
-  installBundleFlow: installBundleFlowMock,
-  handleBundleFile: handleBundleFileMock,
-}));
-
-mock.module("@vellumai/electron-desktop/file-open", () => ({
-  onFileOpen: onFileOpenMock,
-}));
-
-const localMode = await import("@vellumai/local-mode");
-mock.module("@vellumai/local-mode", () => ({
-  ...localMode,
-  getGuardianAccessToken: getGuardianAccessTokenMock,
-  getLockfileData: () => ({ ok: false, error: "missing" }),
-  resolveConfigDir: () => "C:\\Vellum\\config",
-  resolveLockfilePaths: () => ["C:\\Vellum\\lockfile.json"],
-}));
+import { mock } from "bun:test";
+import { runBundleFeatureSuite } from "@vellumai/electron-desktop/testing/bundle-feature-suite";
 
 mock.module("./ipc.client", () => ({
   handle: () => undefined,
   on: () => undefined,
 }));
 
-const {
-  bundleFileHandlerToken,
-  getBundlePlatform,
-  resetBundlePlatformForTest,
-} = await import("@vellumai/electron-desktop/bundle-platform");
-const { DesktopCapabilityRegistry } =
-  await import("@vellumai/electron-desktop/capability-registry");
-const { LOCAL_MODE_CLI } =
-  await import("@vellumai/electron-desktop/local-mode");
-const { default: bundles } = await import("./features/bundles");
-
-beforeEach(() => {
-  resetBundlePlatformForTest();
-  installBundleFlowMock.mockClear();
-  handleBundleFileMock.mockClear();
-  onFileOpenMock.mockClear();
-  stopFileOpenMock.mockClear();
-  appOnceMock.mockClear();
-  resolveInvocationMock.mockClear();
-  getGuardianAccessTokenMock.mockClear();
-});
-
-describe("Windows bundle workflow", () => {
-  test("installs the bundle flow and file-open handler", () => {
-    const registry = new DesktopCapabilityRegistry();
-    bundles.install(registry);
-
-    expect(registry.get(bundleFileHandlerToken)).toBe(handleBundleFileMock);
-    expect(installBundleFlowMock).toHaveBeenCalledTimes(1);
-    expect(onFileOpenMock).toHaveBeenCalledTimes(1);
-    onFileOpenMock.mock.calls[0]![0]("C:\\bundle.vellum");
-    expect(handleBundleFileMock).toHaveBeenCalledWith("C:\\bundle.vellum");
-    expect(appOnceMock).toHaveBeenCalledWith("before-quit", stopFileOpenMock);
-    expect(getBundlePlatform().bundlesRoot()).toBe("C:\\Vellum/bundles");
-  });
-
-  test("mints gateway tokens through the CLI provider installed later", async () => {
-    const registry = new DesktopCapabilityRegistry();
-    bundles.install(registry);
-
-    // Without the provider, the token request degrades to null.
-    await expect(
-      getBundlePlatform().acquireGatewayToken("assistant-1"),
-    ).resolves.toBeNull();
-
-    // A cold launch from a `.vellum` file asks for the token in the same
-    // tick that installs the remaining modules, including the CLI provider.
-    const pending = getBundlePlatform().acquireGatewayToken("assistant-1");
-    registry.provide(LOCAL_MODE_CLI, {
-      resolveInvocation: resolveInvocationMock,
-    });
-    await expect(pending).resolves.toBe("guardian-token");
-    expect(getGuardianAccessTokenMock).toHaveBeenCalledWith(
-      "assistant-1",
-      "C:\\Vellum\\config",
-      { command: "vellum.exe", baseArgs: [] },
-      true,
-    );
-  });
+await runBundleFeatureSuite("Windows", () => import("./features/bundles"), {
+  appData: "C:\\Vellum",
+  config: "C:\\Vellum\\config",
+  bundleFile: "C:\\bundle.vellum",
+  command: "vellum.exe",
 });

--- a/packages/electron-desktop/package.json
+++ b/packages/electron-desktop/package.json
@@ -76,6 +76,7 @@
     "./session-token-store": "./src/session-token-store.ts",
     "./status": "./src/status.ts",
     "./status-icon": "./src/status-icon.ts",
+    "./testing/bundle-feature-suite": "./src/testing/bundle-feature-suite.ts",
     "./text-context-menu": "./src/text-context-menu.ts",
     "./tray-model": "./src/tray-model.ts",
     "./vellumapp-protocol": "./src/vellumapp-protocol.ts",

--- a/packages/electron-desktop/src/testing/bundle-feature-suite.ts
+++ b/packages/electron-desktop/src/testing/bundle-feature-suite.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { join } from "node:path";
+import type {
+  CapabilityModule,
+  DesktopCapabilityRegistry as Registry,
+} from "../capability-registry";
+
+export async function runBundleFeatureSuite(
+  platform: string,
+  loadFeature: () => Promise<{ default: CapabilityModule<Registry> }>,
+  paths: {
+    appData: string;
+    config: string;
+    bundleFile: string;
+    command: string;
+  },
+) {
+  const installBundleFlowMock = mock(() => undefined);
+  const handleBundleFileMock = mock(async (_filePath: string) => undefined);
+  const stopFileOpenMock = mock(() => undefined);
+  const onFileOpenMock = mock(
+    (_handler: (filePath: string) => void) => stopFileOpenMock,
+  );
+  const appOnceMock = mock((_event: string, _handler: () => void) => undefined);
+  const resolveInvocationMock = mock(async () => ({
+    command: paths.command,
+    baseArgs: [] as string[],
+  }));
+  const getGuardianAccessTokenMock = mock(async () => ({
+    ok: true as const,
+    accessToken: "guardian-token",
+  }));
+
+  mock.module("electron", () => ({
+    app: {
+      getPath: () => paths.appData,
+      isPackaged: true,
+      once: appOnceMock,
+    },
+    BrowserWindow: class {},
+    session: { defaultSession: {} },
+    shell: {},
+  }));
+
+  mock.module("@vellumai/electron-desktop/bundle-flow", () => ({
+    installBundleFlow: installBundleFlowMock,
+    handleBundleFile: handleBundleFileMock,
+  }));
+
+  mock.module("@vellumai/electron-desktop/file-open", () => ({
+    onFileOpen: onFileOpenMock,
+  }));
+
+  const localMode = await import("@vellumai/local-mode");
+  mock.module("@vellumai/local-mode", () => ({
+    ...localMode,
+    getGuardianAccessToken: getGuardianAccessTokenMock,
+    getLockfileData: () => ({ ok: false, error: "missing" }),
+    resolveConfigDir: () => paths.config,
+    resolveLockfilePaths: () => [join(paths.config, "lockfile.json")],
+  }));
+
+  const {
+    bundleFileHandlerToken,
+    getBundlePlatform,
+    resetBundlePlatformForTest,
+  } = await import("@vellumai/electron-desktop/bundle-platform");
+  const { DesktopCapabilityRegistry } =
+    await import("@vellumai/electron-desktop/capability-registry");
+  const { LOCAL_MODE_CLI } =
+    await import("@vellumai/electron-desktop/local-mode");
+  const { default: bundles } = await loadFeature();
+
+  beforeEach(() => {
+    resetBundlePlatformForTest();
+    installBundleFlowMock.mockClear();
+    handleBundleFileMock.mockClear();
+    onFileOpenMock.mockClear();
+    stopFileOpenMock.mockClear();
+    appOnceMock.mockClear();
+    resolveInvocationMock.mockClear();
+    getGuardianAccessTokenMock.mockClear();
+  });
+
+  describe(`${platform} bundle workflow`, () => {
+    test("installs the bundle flow and file-open handler", () => {
+      const registry = new DesktopCapabilityRegistry();
+      bundles.install(registry);
+
+      expect(registry.get(bundleFileHandlerToken)).toBe(handleBundleFileMock);
+      expect(installBundleFlowMock).toHaveBeenCalledTimes(1);
+      expect(onFileOpenMock).toHaveBeenCalledTimes(1);
+      onFileOpenMock.mock.calls[0]![0](paths.bundleFile);
+      expect(handleBundleFileMock).toHaveBeenCalledWith(paths.bundleFile);
+      expect(appOnceMock).toHaveBeenCalledWith("before-quit", stopFileOpenMock);
+      expect(getBundlePlatform().bundlesRoot()).toBe(
+        join(paths.appData, "bundles"),
+      );
+    });
+
+    test("mints gateway tokens through the CLI provider installed later", async () => {
+      const registry = new DesktopCapabilityRegistry();
+      bundles.install(registry);
+
+      // Without the provider, the token request degrades to null.
+      await expect(
+        getBundlePlatform().acquireGatewayToken("assistant-1"),
+      ).resolves.toBeNull();
+
+      // A cold launch from a `.vellum` file asks for the token in the same
+      // tick that installs the remaining modules, including the CLI provider.
+      const pending = getBundlePlatform().acquireGatewayToken("assistant-1");
+      registry.provide(LOCAL_MODE_CLI, {
+        resolveInvocation: resolveInvocationMock,
+      });
+      await expect(pending).resolves.toBe("guardian-token");
+      expect(getGuardianAccessTokenMock).toHaveBeenCalledWith(
+        "assistant-1",
+        paths.config,
+        { command: paths.command, baseArgs: [] },
+        true,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds Linux behavior coverage for main-window activation, file-open handling, local mode, CLI provisioning, host proxy composition, bundles, auxiliary windows, notifications/share, and permissions. Linux and Windows run the same bundle workflow suite with platform-specific paths instead of copying the behavior tests.

The host-proxy test proves an empty registry supplies no computer-use executor; it does not prove that a present helper is feature-ready. Main-window fixtures support the startup activation introduced by the autostart PR. All control-flow bodies use braces.

Validation: all 9 Linux feature test files and both platforms' bundle suites pass. Combined Wave 1 testing also covers the autostart/startup/environment tests and the shared companion/login-item suites. Linux and shared desktop typechecks pass.

These are mocked wiring and behavior tests. Packaged GNOME/KDE Wayland and X11 checks remain required before claiming desktop parity. The PR remains above the plan's original 999-line guideline because it retains the nine feature suites; sharing the bundle harness removes one duplicated behavior suite without opening replacement PRs.

Part of Linux parity Wave 1 (PR 11).
