### PR TITLE
feat(prompt): delegate independent parallel requests to subagents

### DIFF
--- a/assistant/src/__tests__/agent-wake-delegation-prompt.test.ts
+++ b/assistant/src/__tests__/agent-wake-delegation-prompt.test.ts
@@ -156,6 +156,37 @@ describe("the delegation section on a direct wake", () => {
     expect(promptDuringRun).toContain(DELEGATION_SECTION);
   });
 
+  test("the restored prompt is built without the wake's persona", async () => {
+    // `wakePersonaOverride` feeds `buildCurrentSystemPrompt`, so a rebuild
+    // that ran before the clear would leave the loop holding the wake's
+    // persona: the next wake's pre-run compaction gate reads that prompt and
+    // would size against a turn that already ended.
+    const personaSeen: Array<unknown> = [];
+    const { target, loopPrompt } = makeTarget(() => {});
+    const buildUnderPersona = () => {
+      personaSeen.push(target.wakePersonaOverride);
+      return target.wakePersonaOverride
+        ? "base [wake persona]"
+        : "base [delegation section]";
+    };
+    (target as unknown as Record<string, unknown>).buildCurrentSystemPrompt =
+      buildUnderPersona;
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "test hint",
+        source: "scheduler",
+        personaOverride: { userSlug: "someone" },
+      },
+      { resolveTarget: async () => target },
+    );
+
+    // The last build saw no override, and that is the prompt the loop keeps.
+    expect(personaSeen.at(-1)).toBeUndefined();
+    expect(loopPrompt()).toBe("base [delegation section]");
+  });
+
   test("the prompt is restored once the wake's scope comes off", async () => {
     const { target, loopPrompt } = makeTarget(() => {});
 

--- a/assistant/src/__tests__/agent-wake-delegation-prompt.test.ts
+++ b/assistant/src/__tests__/agent-wake-delegation-prompt.test.ts
@@ -1,0 +1,175 @@
+/**
+ * A direct wake runs under its own prompt, not the last app turn's.
+ *
+ * `wakeAgentForOpportunity` drives `agentLoop.run` itself, so the loop holds
+ * whatever prompt the conversation last synced. The parallel-delegation
+ * section is gated on the turn's resolved tool surface, so without a re-sync a
+ * restricted wake would inherit an app turn's instruction to hand independent
+ * work to subagents it cannot spawn, and an unrestricted wake following a
+ * restricted turn would be told not to. The wake syncs under its own scope and
+ * restores the prompt with the rest of what it scoped.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  getConversationOverrideProfile: () => undefined,
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+import type { AgentLoopRunOptions } from "../agent/loop.js";
+import type { Conversation } from "../daemon/conversation.js";
+import { canSpawnSubagentsForTurn } from "../daemon/conversation-tool-setup.js";
+import type { Message } from "../providers/types.js";
+import {
+  __resetWakeChainForTests,
+  wakeAgentForOpportunity,
+} from "../runtime/agent-wake.js";
+
+/** Stands in for the `01-parallel-tasks` section's rendered body. */
+const DELEGATION_SECTION = "[delegation section]";
+
+function makeTarget(onRun: (conv: Conversation) => void): {
+  target: Conversation;
+  loopPrompt: () => string;
+} {
+  const messages: Message[] = [
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+  ];
+  let processing = false;
+  let loopPrompt = "";
+
+  const target = {
+    conversationId: "conv-wake-delegation",
+    currentCallSite: "mainAgent",
+    toolsDisabledDepth: 0,
+    hasNoClient: false,
+    agentLoop: {
+      run: async (options: AgentLoopRunOptions) => {
+        onRun(target as unknown as Conversation);
+        return { history: options.messages, exitReason: null };
+      },
+      setSystemPrompt: (prompt: string) => {
+        loopPrompt = prompt;
+      },
+    },
+    messages,
+    trimAgedSightFrames: (msgs: Message[]) => msgs,
+    getMessages: () => messages,
+    isProcessing: () => processing,
+    waitForIdle: async () => !processing,
+    setProcessing: (on: boolean) => {
+      processing = on;
+    },
+    setTrustContext: () => {},
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+    drainQueue: async () => {},
+    kickDrainQueue: async () => {},
+    maybeCompact: async () => null,
+    // The wake scope the allowlist is applied through, which is what the
+    // delegation gate reads.
+    subagentAllowedTools: undefined as ReadonlySet<string> | undefined,
+    subagentToolGateMode: undefined as string | undefined,
+    toolContextPin: undefined,
+    preactivatedSkillIds: undefined as readonly string[] | undefined,
+    setSubagentAllowedTools: (tools?: ReadonlySet<string>) => {
+      target.subagentAllowedTools = tools;
+    },
+    setPreactivatedSkillIds: (ids?: readonly string[]) => {
+      target.preactivatedSkillIds = ids;
+    },
+    // The section's gate, rendered as a marker so the assertions turn on the
+    // real predicate rather than on a stubbed answer.
+    buildCurrentSystemPrompt: () =>
+      canSpawnSubagentsForTurn(target as unknown as Conversation)
+        ? `base ${DELEGATION_SECTION}`
+        : "base",
+    // Mirrors `Conversation.syncLoopSystemPrompt`.
+    syncLoopSystemPrompt: () => {
+      const next = (
+        target as unknown as Conversation
+      ).buildCurrentSystemPrompt();
+      if (next === target.systemPrompt) {
+        return;
+      }
+      target.systemPrompt = next;
+      target.agentLoop.setSystemPrompt(next);
+    },
+    systemPrompt: "",
+    modelOverride: undefined,
+  };
+  return {
+    target: target as unknown as Conversation,
+    loopPrompt: () => loopPrompt,
+  };
+}
+
+beforeEach(() => {
+  __resetWakeChainForTests();
+});
+
+describe("the delegation section on a direct wake", () => {
+  test("a restricted wake drops the section an app turn left behind", async () => {
+    let promptDuringRun = "";
+    const { target, loopPrompt } = makeTarget(() => {
+      promptDuringRun = loopPrompt();
+    });
+
+    // An unrestricted app turn ran first and synced the section into the loop,
+    // which holds it until something else syncs.
+    target.syncLoopSystemPrompt();
+    expect(loopPrompt()).toContain(DELEGATION_SECTION);
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "test hint",
+        source: "scheduler",
+        // A background run scoped to tools that carry no path to a subagent.
+        allowedTools: ["file_read", "web_search"],
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(promptDuringRun).not.toContain(DELEGATION_SECTION);
+    expect(promptDuringRun.length).toBeGreaterThan(0);
+  });
+
+  test("an unrestricted wake keeps the section", async () => {
+    let promptDuringRun = "";
+    const { target, loopPrompt } = makeTarget(() => {
+      promptDuringRun = loopPrompt();
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "test hint",
+        source: "scheduler",
+      },
+      { resolveTarget: async () => target },
+    );
+
+    expect(promptDuringRun).toContain(DELEGATION_SECTION);
+  });
+
+  test("the prompt is restored once the wake's scope comes off", async () => {
+    const { target, loopPrompt } = makeTarget(() => {});
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: target.conversationId,
+        hint: "test hint",
+        source: "scheduler",
+        allowedTools: ["file_read", "web_search"],
+      },
+      { resolveTarget: async () => target },
+    );
+
+    // Whatever runs next must not inherit the wake's narrowed prompt.
+    expect(loopPrompt()).toContain(DELEGATION_SECTION);
+  });
+});

--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -329,6 +329,9 @@ describe("POST /v1/btw", () => {
     expect(mockBuildSystemPrompt).toHaveBeenCalledWith({
       excludeBootstrap: true,
       excludeCustomPrefix: true,
+      // The side-chain forces `tool_choice: none`, so the prompt must not
+      // carry guidance about handing work to subagents it cannot spawn.
+      canSpawnSubagents: false,
     });
     expect(options!.config!.tool_choice).toEqual({ type: "none" });
     expect(options!.config!.callSite).toBe("identityIntro");

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1434,6 +1434,43 @@ describe("session-agent-loop", () => {
       expect(cleanupFlagDuringInjection()).toEqual([true]);
     });
 
+    test("re-syncs the system prompt once the cleanup-mode policy is known", async () => {
+      // Sections gated on the turn's resolved tool surface (the
+      // parallel-delegation guidance, which needs the skill dispatcher that
+      // cleanup mode withholds) are built by the first sync, which runs before
+      // the disk-pressure decision. A cleanup-mode turn therefore syncs a
+      // second time, with the flag already set.
+      mockDiskPressureDecision = {
+        action: "allow-cleanup-mode",
+        reason: "local-owner",
+      };
+      const observed: Array<boolean | undefined> = [];
+      const ctx = makeCtx();
+      ctx.syncLoopSystemPrompt = () => {
+        observed.push(ctx.diskPressureCleanupModeActive);
+      };
+
+      await runAgentLoopImpl(ctx, "free up space", "msg-1", () => {});
+
+      expect(observed).toEqual([undefined, true]);
+    });
+
+    test("does not re-sync the system prompt on an ordinary turn", async () => {
+      // The mode is cleared at the end of every turn, so the first sync
+      // already ran under the answer the turn keeps. A second rebuild would
+      // cost every turn a prompt render for nothing.
+      mockDiskPressureDecision = { action: "allow-normal" };
+      const observed: Array<boolean | undefined> = [];
+      const ctx = makeCtx();
+      ctx.syncLoopSystemPrompt = () => {
+        observed.push(ctx.diskPressureCleanupModeActive);
+      };
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      expect(observed).toEqual([undefined]);
+    });
+
     test("keeps the cleanup-mode flag set across overflow recovery reinjection", async () => {
       mockDiskPressureDecision = {
         action: "allow-cleanup-mode",

--- a/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
+++ b/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
@@ -1,0 +1,76 @@
+/**
+ * `canSpawnSubagentsForTurn` reads the turn's resolved tool surface, which is
+ * what gates the parallel-delegation system-prompt section. A turn that cannot
+ * reach the spawn tool must not be told to hand work to subagents.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import * as configLoader from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/schema.js";
+import type { Conversation } from "../conversation.js";
+import { canSpawnSubagentsForTurn } from "../conversation-tool-setup.js";
+
+let getConfigSpy: ReturnType<typeof spyOn> | undefined;
+
+function withExclude(exclude: string[]): void {
+  const stub: Partial<AssistantConfig> = { tools: { exclude } };
+  getConfigSpy = spyOn(configLoader, "getConfig").mockReturnValue(
+    stub as AssistantConfig,
+  );
+}
+
+function ctx(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    toolsDisabledDepth: 0,
+    hasNoClient: false,
+    ...overrides,
+  } as unknown as Conversation;
+}
+
+afterEach(() => {
+  getConfigSpy?.mockRestore();
+  getConfigSpy = undefined;
+});
+
+describe("canSpawnSubagentsForTurn", () => {
+  test("an ordinary turn can spawn", () => {
+    withExclude([]);
+    expect(canSpawnSubagentsForTurn(ctx())).toBe(true);
+  });
+
+  test("a workspace tools.exclude entry for the spawn tool answers no", () => {
+    withExclude(["subagent_spawn"]);
+    expect(canSpawnSubagentsForTurn(ctx())).toBe(false);
+  });
+
+  test("excluding the skill loader alone still leaves the spawn tool reachable", () => {
+    withExclude(["skill_load"]);
+    expect(canSpawnSubagentsForTurn(ctx())).toBe(true);
+  });
+
+  test("a turn with tools disabled answers no", () => {
+    withExclude([]);
+    expect(canSpawnSubagentsForTurn(ctx({ toolsDisabledDepth: 1 }))).toBe(
+      false,
+    );
+  });
+
+  test("a wire-scoped background run whose allowlist omits both answers no", () => {
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(
+        ctx({ subagentAllowedTools: new Set(["file_read", "web_search"]) }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a background run that allowlists the spawn tool can spawn", () => {
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(
+        ctx({ subagentAllowedTools: new Set(["subagent_spawn"]) }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
+++ b/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
@@ -58,6 +58,15 @@ describe("canSpawnSubagentsForTurn", () => {
     );
   });
 
+  test("a disk-pressure cleanup turn answers no", () => {
+    // Cleanup mode narrows the surface to `DISK_PRESSURE_CLEANUP_TOOL_NAMES`,
+    // which carries `skill_load` but neither the dispatcher nor the spawn tool.
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(ctx({ diskPressureCleanupModeActive: true })),
+    ).toBe(false);
+  });
+
   test("a wire-scoped background run whose allowlist omits the path answers no", () => {
     withExclude([]);
     expect(

--- a/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
+++ b/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
@@ -1,7 +1,10 @@
 /**
  * `canSpawnSubagentsForTurn` reads the turn's resolved tool surface, which is
- * what gates the parallel-delegation system-prompt section. A turn that cannot
- * reach the spawn tool must not be told to hand work to subagents.
+ * one of the two inputs gating the parallel-delegation system-prompt section.
+ * A turn that cannot reach the spawn tool must not be told to hand work to
+ * subagents, and reaching it means the whole dispatch path: `skill_load`
+ * activates the bundled `subagent` skill and `skill_execute` dispatches to
+ * `subagent_spawn` inside it, so the bare spawn name alone is not a path.
  */
 
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
@@ -39,14 +42,13 @@ describe("canSpawnSubagentsForTurn", () => {
     expect(canSpawnSubagentsForTurn(ctx())).toBe(true);
   });
 
-  test("a workspace tools.exclude entry for the spawn tool answers no", () => {
-    withExclude(["subagent_spawn"]);
-    expect(canSpawnSubagentsForTurn(ctx())).toBe(false);
-  });
-
-  test("excluding the skill loader alone still leaves the spawn tool reachable", () => {
-    withExclude(["skill_load"]);
-    expect(canSpawnSubagentsForTurn(ctx())).toBe(true);
+  test("a workspace tools.exclude entry on any step of the path answers no", () => {
+    for (const name of ["subagent_spawn", "skill_execute", "skill_load"]) {
+      withExclude([name]);
+      expect(canSpawnSubagentsForTurn(ctx())).toBe(false);
+      getConfigSpy?.mockRestore();
+      getConfigSpy = undefined;
+    }
   });
 
   test("a turn with tools disabled answers no", () => {
@@ -56,7 +58,7 @@ describe("canSpawnSubagentsForTurn", () => {
     );
   });
 
-  test("a wire-scoped background run whose allowlist omits both answers no", () => {
+  test("a wire-scoped background run whose allowlist omits the path answers no", () => {
     withExclude([]);
     expect(
       canSpawnSubagentsForTurn(
@@ -65,11 +67,37 @@ describe("canSpawnSubagentsForTurn", () => {
     ).toBe(false);
   });
 
-  test("a background run that allowlists the spawn tool can spawn", () => {
+  test("an allowlist naming only the spawn tool answers no", () => {
+    // The spawn tool is never called by name: without the dispatcher there is
+    // no callable path to it, so the turn must not be told to delegate.
     withExclude([]);
     expect(
       canSpawnSubagentsForTurn(
         ctx({ subagentAllowedTools: new Set(["subagent_spawn"]) }),
+      ),
+    ).toBe(false);
+  });
+
+  test("an allowlist naming only the skill loader answers no", () => {
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(
+        ctx({ subagentAllowedTools: new Set(["skill_load"]) }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a background run that allowlists the whole path can spawn", () => {
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(
+        ctx({
+          subagentAllowedTools: new Set([
+            "skill_load",
+            "skill_execute",
+            "subagent_spawn",
+          ]),
+        }),
       ),
     ).toBe(true);
   });

--- a/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
+++ b/assistant/src/daemon/__tests__/can-spawn-subagents.test.ts
@@ -111,3 +111,58 @@ describe("canSpawnSubagentsForTurn", () => {
     ).toBe(true);
   });
 });
+
+describe("an execution-gated wake's allowlist", () => {
+  /**
+   * `isToolActiveForContext` skips the allowlist in execution mode by design:
+   * that mode keeps the full surface on the wire for provider-cache parity and
+   * rejects the call in the executor instead. The delegation gate is asking a
+   * different question, so it checks the allowlist itself.
+   */
+  test("the memory retrospective's shape cannot spawn", () => {
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(
+        ctx({
+          subagentToolGateMode: "execution",
+          // The wake's real list: `skill_load` is on it, the dispatcher and the
+          // spawn tool are not, so a spawn is denied at execution.
+          subagentAllowedTools: new Set([
+            "remember",
+            "scaffold_managed_skill",
+            "skill_load",
+            "find_similar_skills",
+          ]),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a remember-only execution-mode wake cannot spawn", () => {
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(
+        ctx({
+          subagentToolGateMode: "execution",
+          subagentAllowedTools: new Set(["remember"]),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("an execution-mode allowlist naming the whole path can spawn", () => {
+    withExclude([]);
+    expect(
+      canSpawnSubagentsForTurn(
+        ctx({
+          subagentToolGateMode: "execution",
+          subagentAllowedTools: new Set([
+            "skill_load",
+            "skill_execute",
+            "subagent_spawn",
+          ]),
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -722,6 +722,16 @@ export async function runAgentLoopImpl(
   );
   ctx.diskPressureCleanupModeActive =
     diskPressureDecision.action === "allow-cleanup-mode";
+  if (ctx.diskPressureCleanupModeActive) {
+    // The prompt synced above was built before this turn's disk-pressure
+    // policy was known. Cleanup mode narrows the turn to
+    // `DISK_PRESSURE_CLEANUP_TOOL_NAMES`, so sections gated on the resolved
+    // tool surface (the parallel-delegation guidance, which needs the skill
+    // dispatcher cleanup mode withholds) must be re-derived against it.
+    // Skipped otherwise: the mode is cleared at the end of every turn, so an
+    // ordinary turn already synced under the same answer.
+    ctx.syncLoopSystemPrompt();
+  }
   const toolsDisabledForTurn = ctx.toolsDisabledDepth > 0;
 
   ctx.lastAssistantAttachments = [];

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -924,6 +924,41 @@ export function isToolActiveForContext(
   return true;
 }
 
+/** The spawn tool, carried by the bundled `subagent` skill. */
+const SUBAGENT_SPAWN_TOOL_NAME = "subagent_spawn";
+/** The tool that activates a skill, and so the route to the spawn tool. */
+const SKILL_LOAD_TOOL_NAME = "skill_load";
+
+/**
+ * Whether this turn could actually spawn a subagent, read off the resolved
+ * tool surface rather than assumed.
+ *
+ * The spawn tool ships inside the bundled `subagent` skill, so on an ordinary
+ * turn it is reachable rather than already present: the answer is yes when the
+ * spawn tool is not excluded and the turn can still reach it, either because it
+ * is on the surface already or because `skill_load` is. Both names run through
+ * {@link isToolActiveForContext}, so a turn with tools disabled, a read-only
+ * subagent pass, or a wire-scoped background run whose `allowedTools` omits
+ * them all answer no, as does a workspace `tools.exclude` entry.
+ *
+ * The system prompt's delegation guidance gates on this: telling a turn to hand
+ * work to subagents it cannot spawn invites it to defer work it must do inline.
+ */
+export function canSpawnSubagentsForTurn(ctx: Conversation): boolean {
+  let excluded: ReadonlySet<string>;
+  try {
+    excluded = new Set(getConfig().tools.exclude);
+  } catch {
+    excluded = new Set<string>();
+  }
+  if (excluded.has(SUBAGENT_SPAWN_TOOL_NAME)) {
+    return false;
+  }
+  const canReach = (name: string): boolean =>
+    !excluded.has(name) && isToolActiveForContext(name, ctx);
+  return canReach(SUBAGENT_SPAWN_TOOL_NAME) || canReach(SKILL_LOAD_TOOL_NAME);
+}
+
 /**
  * Build a resolveTools callback that merges base tool definitions with
  * dynamically projected skill tools on each agent turn. Also updates

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -959,8 +959,21 @@ export function canSpawnSubagentsForTurn(ctx: Conversation): boolean {
   } catch {
     excluded = new Set<string>();
   }
+  // A run carrying an allowlist is checked against it here whatever its gate
+  // mode. `isToolActiveForContext` skips the allowlist under
+  // `subagentToolGateMode === "execution"` by design, because that mode keeps
+  // the full surface on the wire for cache parity and rejects the call in the
+  // executor instead. That is the right answer to "is this tool on the wire"
+  // and the wrong one to "could this turn actually spawn": the memory
+  // retrospective wake runs in execution mode with an allowlist that names
+  // `skill_load` but neither the dispatcher nor the spawn tool, so the spawn
+  // is denied after the prompt has already told the model to delegate.
+  const allowlist = ctx.subagentAllowedTools;
   return SUBAGENT_SPAWN_PATH_TOOL_NAMES.every(
-    (name) => !excluded.has(name) && isToolActiveForContext(name, ctx),
+    (name) =>
+      !excluded.has(name) &&
+      (allowlist === undefined || allowlist.has(name)) &&
+      isToolActiveForContext(name, ctx),
   );
 }
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -930,7 +930,7 @@ export function isToolActiveForContext(
  * The spawn tool ships inside the bundled `subagent` skill, so it is never
  * called by name: `skill_load` activates the skill and `skill_execute`
  * dispatches to `subagent_spawn` inside it, which the executor gates as the
- * resolved inner tool. All three are therefore required — any one of them
+ * resolved inner tool. All three are therefore required: any one of them
  * missing leaves no callable path to a subagent.
  */
 const SUBAGENT_SPAWN_PATH_TOOL_NAMES = [

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -924,22 +924,30 @@ export function isToolActiveForContext(
   return true;
 }
 
-/** The spawn tool, carried by the bundled `subagent` skill. */
-const SUBAGENT_SPAWN_TOOL_NAME = "subagent_spawn";
-/** The tool that activates a skill, and so the route to the spawn tool. */
-const SKILL_LOAD_TOOL_NAME = "skill_load";
+/**
+ * Every name a turn has to reach before it can spawn a subagent.
+ *
+ * The spawn tool ships inside the bundled `subagent` skill, so it is never
+ * called by name: `skill_load` activates the skill and `skill_execute`
+ * dispatches to `subagent_spawn` inside it, which the executor gates as the
+ * resolved inner tool. All three are therefore required — any one of them
+ * missing leaves no callable path to a subagent.
+ */
+const SUBAGENT_SPAWN_PATH_TOOL_NAMES = [
+  "skill_load",
+  "skill_execute",
+  "subagent_spawn",
+] as const;
 
 /**
  * Whether this turn could actually spawn a subagent, read off the resolved
  * tool surface rather than assumed.
  *
- * The spawn tool ships inside the bundled `subagent` skill, so on an ordinary
- * turn it is reachable rather than already present: the answer is yes when the
- * spawn tool is not excluded and the turn can still reach it, either because it
- * is on the surface already or because `skill_load` is. Both names run through
- * {@link isToolActiveForContext}, so a turn with tools disabled, a read-only
- * subagent pass, or a wire-scoped background run whose `allowedTools` omits
- * them all answer no, as does a workspace `tools.exclude` entry.
+ * Answers yes only when the whole dispatch path is callable: the skill loader,
+ * the dispatcher, and the spawn tool the dispatcher resolves to. Each name runs
+ * through {@link isToolActiveForContext}, so a turn with tools disabled, a
+ * read-only subagent pass, or a wire-scoped background run whose `allowedTools`
+ * omits one of them all answer no, as does a workspace `tools.exclude` entry.
  *
  * The system prompt's delegation guidance gates on this: telling a turn to hand
  * work to subagents it cannot spawn invites it to defer work it must do inline.
@@ -951,12 +959,9 @@ export function canSpawnSubagentsForTurn(ctx: Conversation): boolean {
   } catch {
     excluded = new Set<string>();
   }
-  if (excluded.has(SUBAGENT_SPAWN_TOOL_NAME)) {
-    return false;
-  }
-  const canReach = (name: string): boolean =>
-    !excluded.has(name) && isToolActiveForContext(name, ctx);
-  return canReach(SUBAGENT_SPAWN_TOOL_NAME) || canReach(SKILL_LOAD_TOOL_NAME);
+  return SUBAGENT_SPAWN_PATH_TOOL_NAMES.every(
+    (name) => !excluded.has(name) && isToolActiveForContext(name, ctx),
+  );
 }
 
 /**

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -175,6 +175,7 @@ import type {
   WakeToolContextPin,
 } from "./conversation-tool-setup.js";
 import {
+  canSpawnSubagentsForTurn,
   createResolveToolsCallback,
   createToolExecutor,
 } from "./conversation-tool-setup.js";
@@ -1064,6 +1065,12 @@ export class Conversation {
           personaOverride: this.wakePersonaOverride,
           onboardingContext: this.getOnboardingContext(),
           conversationId: this.conversationId,
+          // Read off this turn's resolved tool surface: a workspace
+          // `tools.exclude` entry, a background run's `allowedTools` scope, a
+          // read-only subagent pass, or tools disabled all answer no, and the
+          // delegation section renders off rather than pointing at a tool the
+          // turn cannot call.
+          canSpawnSubagents: canSpawnSubagentsForTurn(this),
         });
   }
 

--- a/assistant/src/home/home-greeting.ts
+++ b/assistant/src/home/home-greeting.ts
@@ -61,6 +61,8 @@ export async function refreshPersonalizedGreeting(): Promise<boolean> {
     const systemPrompt = buildSystemPrompt({
       excludeBootstrap: true,
       excludeCustomPrefix: true,
+      // One-shot generation through the tool-disabled side-chain.
+      canSpawnSubagents: false,
     });
 
     const result = await runBtwSidechain({

--- a/assistant/src/home/suggested-prompts.ts
+++ b/assistant/src/home/suggested-prompts.ts
@@ -94,6 +94,8 @@ async function generateAssistantPrompts(): Promise<SuggestedPrompt[]> {
   const systemPrompt = buildSystemPrompt({
     excludeBootstrap: true,
     excludeCustomPrefix: true,
+    // One-shot generation through the tool-disabled side-chain.
+    canSpawnSubagents: false,
   });
 
   let integrationContext = "";

--- a/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
+++ b/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
@@ -48,9 +48,23 @@ describe("parallel-tasks system prompt section", () => {
     expect(sortedIds[index + 1]).toBe("01-parallel-tool-calls");
   });
 
-  test("renders unconditionally, with no options required", () => {
+  test("renders by default, with no options required", () => {
     expect(buildSystemPrompt()).toContain(HEADING);
     expect(buildSystemPrompt({ hasNoClient: true })).toContain(HEADING);
+    expect(buildSystemPrompt({ canSpawnSubagents: true })).toContain(HEADING);
+  });
+
+  test("renders off for a turn that cannot spawn subagents", () => {
+    // The shape a tool-disabled `/v1/btw` side-chain and a restricted-tool
+    // workflow leaf build: telling them to delegate would make them defer work
+    // they can only do inline.
+    expect(buildSystemPrompt({ canSpawnSubagents: false })).not.toContain(
+      HEADING,
+    );
+    // The rest of the prompt is untouched by the opt-out.
+    expect(buildSystemPrompt({ canSpawnSubagents: false })).toContain(
+      "<use_parallel_tool_calls>",
+    );
   });
 
   test("delegates only independent tasks and keeps small requests inline", () => {

--- a/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
+++ b/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
@@ -37,10 +37,15 @@ describe("parallel-tasks system prompt section", () => {
     ensurePromptFiles();
   });
 
-  test("is in the bundled section list next to the parallel-tool-calls section", () => {
-    const ids = BUNDLED_SYSTEM_SECTIONS.map((section) => section.id);
-    expect(ids).toContain("01-parallel-tasks");
-    expect(ids).toContain("01-parallel-tool-calls");
+  test("renders immediately before the parallel-tool-calls section", () => {
+    // The renderer sorts section ids, so adjacency in the rendered prompt is
+    // adjacency in the sorted id list, not in the declaration order.
+    const sortedIds = BUNDLED_SYSTEM_SECTIONS.map((section) => section.id)
+      .slice()
+      .sort();
+    const index = sortedIds.indexOf("01-parallel-tasks");
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(sortedIds[index + 1]).toBe("01-parallel-tool-calls");
   });
 
   test("renders unconditionally, with no options required", () => {
@@ -53,5 +58,12 @@ describe("parallel-tasks system prompt section", () => {
     expect(prompt).toContain("several independent things at once");
     expect(prompt).toContain("subagent");
     expect(prompt).toContain("Keep small, quick requests inline");
+  });
+
+  test("keeps approval-gated work on the assistant's own turn", () => {
+    // A subagent runs non-interactive, so an operation that needs the user's
+    // approval is denied there rather than prompting.
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain("may need the user's approval on your own turn");
   });
 });

--- a/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
+++ b/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
@@ -48,27 +48,30 @@ describe("parallel-tasks system prompt section", () => {
     expect(sortedIds[index + 1]).toBe("01-parallel-tool-calls");
   });
 
-  test("renders by default, with no options required", () => {
-    expect(buildSystemPrompt()).toContain(HEADING);
-    expect(buildSystemPrompt({ hasNoClient: true })).toContain(HEADING);
+  test("renders for a turn that can spawn subagents", () => {
     expect(buildSystemPrompt({ canSpawnSubagents: true })).toContain(HEADING);
+    expect(
+      buildSystemPrompt({ canSpawnSubagents: true, hasNoClient: true }),
+    ).toContain(HEADING);
   });
 
-  test("renders off for a turn that cannot spawn subagents", () => {
-    // The shape a tool-disabled `/v1/btw` side-chain and a restricted-tool
-    // workflow leaf build: telling them to delegate would make them defer work
-    // they can only do inline.
-    expect(buildSystemPrompt({ canSpawnSubagents: false })).not.toContain(
-      HEADING,
-    );
-    // The rest of the prompt is untouched by the opt-out.
-    expect(buildSystemPrompt({ canSpawnSubagents: false })).toContain(
-      "<use_parallel_tool_calls>",
-    );
+  test("renders off unless the turn states it can spawn", () => {
+    // Absent means no: a prompt built outside a turn (a tool-disabled
+    // side-chain, a one-shot generator) never carries guidance it cannot act
+    // on. The live turn answers from its resolved tool surface.
+    for (const options of [
+      undefined,
+      { hasNoClient: true },
+      { canSpawnSubagents: false },
+    ]) {
+      expect(buildSystemPrompt(options)).not.toContain(HEADING);
+      // The rest of the prompt is untouched either way.
+      expect(buildSystemPrompt(options)).toContain("<use_parallel_tool_calls>");
+    }
   });
 
   test("delegates only independent tasks and keeps small requests inline", () => {
-    const prompt = buildSystemPrompt();
+    const prompt = buildSystemPrompt({ canSpawnSubagents: true });
     expect(prompt).toContain("several independent things at once");
     expect(prompt).toContain("subagent");
     expect(prompt).toContain("Keep small, quick requests inline");
@@ -77,7 +80,7 @@ describe("parallel-tasks system prompt section", () => {
   test("keeps approval-gated work on the assistant's own turn", () => {
     // A subagent runs non-interactive, so an operation that needs the user's
     // approval is denied there rather than prompting.
-    const prompt = buildSystemPrompt();
+    const prompt = buildSystemPrompt({ canSpawnSubagents: true });
     expect(prompt).toContain("may need the user's approval on your own turn");
   });
 });

--- a/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
+++ b/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for the `01-parallel-tasks` system prompt section: it renders
+ * unconditionally (no flag, no options dependency), sits beside
+ * `01-parallel-tool-calls`, and scopes the guidance to independent tasks so a
+ * single small request stays inline.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const noopLogger: Record<string, unknown> = new Proxy(
+  {} as Record<string, unknown>,
+  {
+    get: (_target, prop) => (prop === "child" ? () => noopLogger : () => {}),
+  },
+);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realLogger = require("../../util/logger.js");
+mock.module("../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => noopLogger,
+  getCliLogger: () => noopLogger,
+  truncateForLog: (v: string) => v,
+  initLogger: () => {},
+  pruneOldLogFiles: () => 0,
+}));
+
+const { buildSystemPrompt, ensurePromptFiles } =
+  await import("../system-prompt.js");
+const { BUNDLED_SYSTEM_SECTIONS } =
+  await import("../templates/system-sections.js");
+
+const HEADING = "Run Independent Tasks in Parallel";
+
+describe("parallel-tasks system prompt section", () => {
+  beforeEach(() => {
+    ensurePromptFiles();
+  });
+
+  test("is in the bundled section list next to the parallel-tool-calls section", () => {
+    const ids = BUNDLED_SYSTEM_SECTIONS.map((section) => section.id);
+    expect(ids).toContain("01-parallel-tasks");
+    expect(ids).toContain("01-parallel-tool-calls");
+  });
+
+  test("renders unconditionally, with no options required", () => {
+    expect(buildSystemPrompt()).toContain(HEADING);
+    expect(buildSystemPrompt({ hasNoClient: true })).toContain(HEADING);
+  });
+
+  test("delegates only independent tasks and keeps small requests inline", () => {
+    const prompt = buildSystemPrompt();
+    expect(prompt).toContain("several independent things at once");
+    expect(prompt).toContain("subagent");
+    expect(prompt).toContain("Keep small, quick requests inline");
+  });
+});

--- a/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
+++ b/assistant/src/prompts/__tests__/parallel-tasks-section.test.ts
@@ -1,8 +1,9 @@
 /**
- * Tests for the `01-parallel-tasks` system prompt section: it renders
- * unconditionally (no flag, no options dependency), sits beside
- * `01-parallel-tool-calls`, and scopes the guidance to independent tasks so a
- * single small request stays inline.
+ * Tests for the `01-parallel-tasks` system prompt section: it sits beside
+ * `01-parallel-tool-calls`, scopes the guidance to independent tasks so a
+ * single small request stays inline, and renders only for a turn that can act
+ * on it - one that can spawn subagents AND whose reply is not delivered to an
+ * external channel.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -29,8 +30,19 @@ const { buildSystemPrompt, ensurePromptFiles } =
   await import("../system-prompt.js");
 const { BUNDLED_SYSTEM_SECTIONS } =
   await import("../templates/system-sections.js");
+type ChannelCapabilities =
+  import("../../daemon/conversation-runtime-assembly.js").ChannelCapabilities;
 
 const HEADING = "Run Independent Tasks in Parallel";
+
+function channel(id: string): ChannelCapabilities {
+  return {
+    channel: id,
+    dashboardCapable: false,
+    supportsDynamicUi: false,
+    supportsVoiceInput: false,
+  };
+}
 
 describe("parallel-tasks system prompt section", () => {
   beforeEach(() => {
@@ -53,6 +65,27 @@ describe("parallel-tasks system prompt section", () => {
     expect(
       buildSystemPrompt({ canSpawnSubagents: true, hasNoClient: true }),
     ).toContain(HEADING);
+    // Every first-party client folds onto the `vellum` channel.
+    expect(
+      buildSystemPrompt({
+        canSpawnSubagents: true,
+        channelCapabilities: channel("vellum"),
+      }),
+    ).toContain(HEADING);
+  });
+
+  test("renders off for a channel-delivered turn", () => {
+    // A subagent's terminal summary is injected through the conversation's
+    // event sink, which app clients read and a channel does not, so a
+    // delegated answer would never reach the person who asked for it.
+    for (const id of ["slack", "telegram", "email", "plugin"]) {
+      const prompt = buildSystemPrompt({
+        canSpawnSubagents: true,
+        channelCapabilities: channel(id),
+      });
+      expect(prompt).not.toContain(HEADING);
+      expect(prompt).toContain("<use_parallel_tool_calls>");
+    }
   });
 
   test("renders off unless the turn states it can spawn", () => {

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -420,13 +420,15 @@ export interface BuildSystemPromptOptions {
    */
   conversationId?: string;
   /**
-   * Whether the turn this prompt serves can actually spawn subagents. Defaults
-   * to true, which is every ordinary turn. A caller that disables or restricts
-   * tools passes `false` so the parallel-delegation section renders off:
-   * telling a model to hand work to subagents it cannot spawn makes it defer
-   * or refuse work it should have done inline. Current opt-outs are the
-   * tool-disabled `/v1/btw` side-chain, the home-content generators, and a
-   * persona workflow leaf running its caller's restricted tool set.
+   * Whether the turn this prompt serves can actually spawn subagents, which
+   * gates the parallel-delegation section. Absent means no, so a prompt built
+   * outside a turn (a side-chain, a one-shot generator) never carries guidance
+   * it cannot act on.
+   *
+   * The live turn answers it from its resolved tool surface via
+   * `canSpawnSubagentsForTurn` (workspace `tools.exclude`, a wire-scoped
+   * background run's `allowedTools`, tools disabled, a read-only subagent
+   * pass), rather than from a caller's assumption.
    */
   canSpawnSubagents?: boolean;
 }
@@ -497,10 +499,12 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const ctx = {
     ...options,
     hasNoClient,
-    // Defaults true: an ordinary turn carries the full tool surface. A caller
-    // whose turn cannot spawn (a tool-disabled side-chain, a restricted-tool
-    // workflow leaf) passes `false` and the delegation section renders off.
-    canSpawnSubagents: options?.canSpawnSubagents !== false,
+    // Off unless a caller states otherwise, and the caller that states it
+    // derives the answer from the turn's resolved tool surface rather than
+    // assuming (`canSpawnSubagentsForTurn`). Guidance about handing work to
+    // subagents is worth nothing to a turn that cannot spawn, and worse than
+    // nothing when it makes that turn defer work it has to do inline.
+    canSpawnSubagents: options?.canSpawnSubagents === true,
     isContainerized: getIsContainerized(),
     workspaceDir: getWorkspaceDir(),
     userSlug,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -419,6 +419,16 @@ export interface BuildSystemPromptOptions {
    * is selected, the conversation is marked as an activation session.
    */
   conversationId?: string;
+  /**
+   * Whether the turn this prompt serves can actually spawn subagents. Defaults
+   * to true, which is every ordinary turn. A caller that disables or restricts
+   * tools passes `false` so the parallel-delegation section renders off:
+   * telling a model to hand work to subagents it cannot spawn makes it defer
+   * or refuse work it should have done inline. Current opt-outs are the
+   * tool-disabled `/v1/btw` side-chain, the home-content generators, and a
+   * persona workflow leaf running its caller's restricted tool set.
+   */
+  canSpawnSubagents?: boolean;
 }
 
 /**
@@ -487,6 +497,10 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const ctx = {
     ...options,
     hasNoClient,
+    // Defaults true: an ordinary turn carries the full tool surface. A caller
+    // whose turn cannot spawn (a tool-disabled side-chain, a restricted-tool
+    // workflow leaf) passes `false` and the delegation section renders off.
+    canSpawnSubagents: options?.canSpawnSubagents !== false,
     isContainerized: getIsContainerized(),
     workspaceDir: getWorkspaceDir(),
     userSlug,

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -420,10 +420,11 @@ export interface BuildSystemPromptOptions {
    */
   conversationId?: string;
   /**
-   * Whether the turn this prompt serves can actually spawn subagents, which
-   * gates the parallel-delegation section. Absent means no, so a prompt built
-   * outside a turn (a side-chain, a one-shot generator) never carries guidance
-   * it cannot act on.
+   * Whether the turn this prompt serves can actually spawn subagents, one of
+   * the two inputs to the parallel-delegation section's gate (the other is
+   * whether the turn is channel-delivered, read from `channelCapabilities`).
+   * Absent means no, so a prompt built outside a turn (a side-chain, a
+   * one-shot generator) never carries guidance it cannot act on.
    *
    * The live turn answers it from its resolved tool surface via
    * `canSpawnSubagentsForTurn` (workspace `tools.exclude`, a wire-scoped
@@ -431,6 +432,23 @@ export interface BuildSystemPromptOptions {
    * pass), rather than from a caller's assumption.
    */
   canSpawnSubagents?: boolean;
+}
+
+/**
+ * Whether this turn arrived on an external messaging surface (Slack, Telegram,
+ * email, a plugin channel) rather than the app itself.
+ *
+ * `resolveChannelCapabilities` folds every first-party client (macOS, web,
+ * iOS, CLI, the HTTP API) onto the `vellum` channel, and a prompt built
+ * outside a turn carries no capabilities at all, so those two cases are the
+ * app and everything else is a channel the gateway delivers to over a reply
+ * callback.
+ */
+function isExternalChannelTurn(
+  capabilities: ChannelCapabilities | undefined,
+): boolean {
+  const channel = capabilities?.channel;
+  return channel !== undefined && channel !== "vellum";
 }
 
 /**
@@ -499,12 +517,22 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   const ctx = {
     ...options,
     hasNoClient,
-    // Off unless a caller states otherwise, and the caller that states it
+    // The delegation section's gate: the turn can spawn AND a subagent's
+    // answer would reach whoever asked.
+    //
+    // Off unless a caller states it can spawn, and the caller that states it
     // derives the answer from the turn's resolved tool surface rather than
     // assuming (`canSpawnSubagentsForTurn`). Guidance about handing work to
     // subagents is worth nothing to a turn that cannot spawn, and worse than
     // nothing when it makes that turn defer work it has to do inline.
-    canSpawnSubagents: options?.canSpawnSubagents === true,
+    //
+    // Off on an external channel for the second reason: a subagent's terminal
+    // summary reaches the parent through the conversation's event sink, which
+    // an app client reads and a channel does not, so a delegated answer would
+    // never be delivered to the person who asked for it.
+    delegateIndependentTasks:
+      options?.canSpawnSubagents === true &&
+      !isExternalChannelTurn(options?.channelCapabilities),
     isContainerized: getIsContainerized(),
     workspaceDir: getWorkspaceDir(),
     userSlug,

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -277,6 +277,13 @@ Before emitting a single tool call, ask whether your next turn would be another 
 `,
   },
   {
+    id: "01-parallel-tasks",
+    body: `## Run Independent Tasks in Parallel
+
+When the user asks for several independent things at once, or adds new tasks while you are still working on earlier ones, hand each independent task to a subagent so they run in parallel rather than one after another. Keep small, quick requests inline: a single task, or anything that is a handful of tool calls, is done faster yourself.
+`,
+  },
+  {
     id: "01-progress-surface",
     body: `## Show Progress on Long Turns
 

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -277,10 +277,20 @@ Before emitting a single tool call, ask whether your next turn would be another 
 `,
   },
   {
+    // Sorts immediately before `01-parallel-tool-calls`, which makes the same
+    // point one level down: batch independent tool calls within a response.
+    //
+    // Deliberately about the SHAPE of your user's request, not about the
+    // subagent capability. The subagent skill's `activation-hints` cover the
+    // routing decision once a turn already looks like subagent work, but they
+    // reach the model only when the memory-v3 selector picks that card (a
+    // semantic match on topic) or after `skill_load`. "Several independent
+    // asks arrived at once" is not a topic, so nothing surfaces it, and an
+    // install with memory off never sees the hints at all.
     id: "01-parallel-tasks",
     body: `## Run Independent Tasks in Parallel
 
-When the user asks for several independent things at once, or adds new tasks while you are still working on earlier ones, hand each independent task to a subagent so they run in parallel rather than one after another. Keep small, quick requests inline: a single task, or anything that is a handful of tool calls, is done faster yourself.
+When your user asks for several independent things at once, or adds new tasks while you are still working on earlier ones, hand each independent task to a subagent so they run in parallel rather than one after another. Keep small, quick requests inline, and keep anything that may need the user's approval on your own turn: a subagent runs unattended, so approval-gated work is denied there rather than prompted.
 `,
   },
   {

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -292,6 +292,10 @@ Before emitting a single tool call, ask whether your next turn would be another 
 
 When your user asks for several independent things at once, or adds new tasks while you are still working on earlier ones, hand each independent task to a subagent so they run in parallel rather than one after another. Keep small, quick requests inline, and keep anything that may need the user's approval on your own turn: a subagent runs unattended, so approval-gated work is denied there rather than prompted.
 `,
+    // Off for a turn that cannot spawn: a tool-disabled side-chain or a
+    // restricted-tool workflow leaf would otherwise be told to delegate work
+    // it can only do inline, and defer or refuse it instead.
+    enabled: "canSpawnSubagents",
   },
   {
     id: "01-progress-surface",

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -294,8 +294,11 @@ When your user asks for several independent things at once, or adds new tasks wh
 `,
     // Off for a turn that cannot spawn: a tool-disabled side-chain or a
     // restricted-tool workflow leaf would otherwise be told to delegate work
-    // it can only do inline, and defer or refuse it instead.
-    enabled: "canSpawnSubagents",
+    // it can only do inline, and defer or refuse it instead. Off on an
+    // external channel too, where a subagent's answer reaches app clients
+    // through the conversation's event sink and never the channel. The
+    // conjunction is derived in `buildSystemPrompt`, which owns both inputs.
+    enabled: "delegateIndependentTasks",
   },
   {
     id: "01-progress-surface",

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1390,10 +1390,23 @@ export async function wakeAgentForOpportunity(
           );
         }
       }
-      // The prompt is part of what the wake scoped, so it comes back with the
-      // rest rather than leaving the loop holding a wake-scoped prompt for
-      // whatever runs next. Runs even when no allowlist was applied, because
-      // the wake's per-turn stamps (call site, presence) move the gate too.
+    };
+
+    /**
+     * Undo everything the wake scoped onto the conversation, then rebuild the
+     * prompt once under what is left.
+     *
+     * The order is load-bearing. `wakePersonaOverride` is read by
+     * `buildCurrentSystemPrompt`, so a rebuild that runs before the clear
+     * leaves the loop holding the wake's persona: the next wake's pre-run
+     * compaction gate reads `conversation.systemPrompt` through the window
+     * manager and would size, and summarize, against a prompt belonging to a
+     * turn that already ended. Rebuilding after both restores is also why this
+     * is one function rather than a rebuild bolted onto either half.
+     */
+    const restoreWakeTurnScope = (): void => {
+      restoreWakeAllowedTools();
+      clearWakePersonaOverride();
       syncWakeLoopSystemPrompt();
     };
     const applyWakeAllowedTools = (): boolean => {
@@ -1745,8 +1758,7 @@ export async function wakeAgentForOpportunity(
       // accepts entries while processing === true, and drain expects
       // processing to already be false). The finally block handles the
       // error/early-return paths where no tail was produced.
-      restoreWakeAllowedTools();
-      clearWakePersonaOverride();
+      restoreWakeTurnScope();
       try {
         conversation.setProcessing(false);
       } catch (err) {
@@ -1771,8 +1783,7 @@ export async function wakeAgentForOpportunity(
       // the try body before reaching the drain block, so `drainedInTry` is
       // still false.
       if (!drainedInTry) {
-        restoreWakeAllowedTools();
-        clearWakePersonaOverride();
+        restoreWakeTurnScope();
         try {
           conversation.setProcessing(false);
         } catch (err) {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1348,6 +1348,31 @@ export async function wakeAgentForOpportunity(
       persistedTailIndex += newMessages.length;
     };
 
+    /**
+     * Rebuild the loop's system prompt under whatever tool scope and per-turn
+     * stamps are in effect right now.
+     *
+     * A wake drives `agentLoop.run` itself, so the loop holds whatever prompt
+     * the conversation last synced. Sections gated on the turn's resolved tool
+     * surface would otherwise be inherited from the last app turn: a wake whose
+     * allowlist omits the subagent dispatch path would still be told to hand
+     * independent work to subagents, and an unrestricted wake following a
+     * restricted turn would be told not to. A conversation carrying a
+     * system-prompt override (a subagent fork) resolves it verbatim, so this is
+     * a no-op there.
+     */
+    const syncWakeLoopSystemPrompt = (): void => {
+      try {
+        conversation.syncLoopSystemPrompt();
+      } catch (err) {
+        // A prompt rebuild is a refinement, never a reason to lose the wake.
+        log.warn(
+          { conversationId, source, err },
+          "agent-wake: failed to sync the loop system prompt; continuing",
+        );
+      }
+    };
+
     let wakeToolScopeRestored = false;
     let restoreWakeToolScope: (() => void) | null = null;
     const restoreWakeAllowedTools = (): void => {
@@ -1355,17 +1380,21 @@ export async function wakeAgentForOpportunity(
         return;
       }
       wakeToolScopeRestored = true;
-      if (!restoreWakeToolScope) {
-        return;
+      if (restoreWakeToolScope) {
+        try {
+          restoreWakeToolScope();
+        } catch (err) {
+          log.warn(
+            { conversationId, source, err },
+            "agent-wake: failed to restore tool allowlist; continuing",
+          );
+        }
       }
-      try {
-        restoreWakeToolScope();
-      } catch (err) {
-        log.warn(
-          { conversationId, source, err },
-          "agent-wake: failed to restore tool allowlist; continuing",
-        );
-      }
+      // The prompt is part of what the wake scoped, so it comes back with the
+      // rest rather than leaving the loop holding a wake-scoped prompt for
+      // whatever runs next. Runs even when no allowlist was applied, because
+      // the wake's per-turn stamps (call site, presence) move the gate too.
+      syncWakeLoopSystemPrompt();
     };
     const applyWakeAllowedTools = (): boolean => {
       if (!opts.allowedTools) {
@@ -1515,6 +1544,10 @@ export async function wakeAgentForOpportunity(
       if (opts.trustContext) {
         conversation.currentTurnTrustContext = opts.trustContext;
       }
+
+      // Rebuild the prompt under the allowlist and the stamps just applied,
+      // the way `runAgentLoopImpl` does for a normal turn.
+      syncWakeLoopSystemPrompt();
 
       let updatedHistory: Message[];
       try {

--- a/assistant/src/runtime/btw-sidechain.ts
+++ b/assistant/src/runtime/btw-sidechain.ts
@@ -75,6 +75,10 @@ export async function runBtwSidechain(
       : buildSystemPrompt({
           excludeBootstrap: true,
           excludeCustomPrefix: true,
+          // `tool_choice: { type: "none" }` below: this turn calls nothing, so
+          // guidance about handing work to subagents would only make it defer
+          // work it has to answer inline.
+          canSpawnSubagents: false,
         }));
 
   const { signal: timeoutSignal, cleanup } = createTimeout(

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -107,6 +107,9 @@ async function resolveLeafContext(
     // A persona leaf is not an onboarding turn, and it must not emit the
     // first-run bootstrap block: keep it to the assistant's stable identity.
     excludeBootstrap: true,
+    // A leaf runs the caller's restricted tool set, which carries no spawn
+    // surface, so the parallel-delegation guidance would misdirect it.
+    canSpawnSubagents: false,
   });
 
   const messages = await injectPersonaMemory(opts, userMessages);


### PR DESCRIPTION
## What

Two sentences in the always-on system prompt, as a new bundled section `01-parallel-tasks` beside `01-parallel-tool-calls`:

> **Run Independent Tasks in Parallel**
>
> When your user asks for several independent things at once, or adds new tasks while you are still working on earlier ones, hand each independent task to a subagent so they run in parallel rather than one after another. Keep small, quick requests inline, and keep anything that may need the user's approval on your own turn: a subagent runs unattended, so approval-gated work is denied there rather than prompted.

Ungated, no feature flag.

## Why

A user who assigns several independent things, or keeps adding tasks while earlier ones are still running, currently waits while they are worked one after another. Independent tasks handed to subagents finish in the time of the longest one instead of the sum.

## Why here and not the tool description

Per the System Prompt Minimalism rule I checked the tool surface first. The subagent capability is exposed through the **bundled `subagent` skill** (`assistant/src/config/bundled-skills/subagent/SKILL.md` + `TOOLS.json`), which is progressively disclosed: its guidance is only in context once the model has already decided to reach for subagents. That skill already covers tool routing well (types, when a task is too small, parallel research-then-implement patterns), and none of that changes here.

What is missing is upstream of routing: **recognizing the shape of the user's request** (several independent asks, or new asks arriving mid-work) as the trigger to delegate at all. That recognition has to be available before any subagent surface loads, which is why it belongs in the always-on section list next to `01-parallel-tool-calls`, the section that makes the same point one level down for tool calls within a single response.

### Are the skill's activation-hints already in the prompt every turn? No.

Review asked whether `subagent/SKILL.md`'s `activation-hints` / `avoid-when` already cover this, since the guard test directs routing cues there. They do not reach the model unconditionally: **there is no skill index in the system prompt.** Hints reach the model by two routes only, and both are downstream of the decision this section makes:

1. Seeded as capability memories and surfaced by the **memory-v3 selector**, a semantic match against the turn (`plugins/defaults/memory/substrate/skill-content.ts` renders the card; `v3/shadow-plugin.ts` selects and owns the `always-candidate` pinning lane). An install on an earlier memory tier, or with memory off, gets none of it.
2. The full SKILL.md after `skill_load`.

Retrieval matches on **topic**; this trigger is a **shape**. "Book the flight, draft the memo, and fix CI" retrieves cards about flights, documents and CI, and nothing in it is semantically about subagents, so the one card that would say "parallelize" is the one the selector has no reason to pick. Pinning it with `always-candidate: true` would fix retrieval at the cost of a ~900-char capability card in the pool every turn (`ALWAYS_CANDIDATE_CARD_CHARS`), more always-on text than these two sentences, and still only under memory v3. Everything genuinely about routing (which subagent type, when a task is too small, research-then-implement pairing) stays in the skill; this section names no tool and adds no capability.

### Subagents and forks

Ordinary subagents never receive this section: `setUpSubagent` builds their prompt with `buildSubagentSystemPrompt`, which carries the role preamble and none of the bundled sections. Forks copy the parent's prompt **verbatim by design**, for KV-cache parity with the parent prefix, and never re-render it, so an `enabled:` predicate cannot reach them either. The wording is scoped instead: it triggers on "your user" asking, which a fork (given an objective, not a conversation) does not have, on top of the fork task's explicit "Do NOT spawn sub-agents" and the manager's hard rejection of nested spawns.

### Turns that cannot spawn

The section's `enabled:` predicate is `delegateIndependentTasks`, a conjunction `buildSystemPrompt` derives from the two things that decide whether the guidance can be acted on: the turn can spawn, and a subagent's answer would reach whoever asked.

**Can it spawn?** The live turn **derives** it from its resolved tool surface rather than assuming. `subagent_spawn` is never called by name: `skill_load` activates the bundled `subagent` skill and `skill_execute` dispatches to the spawn tool inside it, which the executor gates as the resolved inner tool. `canSpawnSubagentsForTurn` (in `conversation-tool-setup.ts`) therefore requires all three to be callable, each through `isToolActiveForContext` plus the workspace `tools.exclude` check, so it answers no when any step is excluded, when the turn has tools disabled, when a wire-scoped background run's `allowedTools` omits one of them, or on a read-only subagent pass. An allowlist naming the bare spawn tool exposes no callable path and reads as no.

**Would the answer land?** Not on a channel. `subagent/notify.ts::deliverToParent` injects a subagent's terminal summary through the conversation's fixed event sink, which app clients read and a channel callback does not, so a Slack or Telegram user would get the acknowledgement and never the result. That is a pre-existing delivery gap, and this section must not amplify it, so the gate reads `channelCapabilities.channel`: `resolveChannelCapabilities` folds every first-party client (macOS, web, iOS, CLI, HTTP API) onto `vellum`, and every other id is an external surface the gateway delivers to over a reply callback.

The `buildSystemPrompt` option itself defaults **off**, so a prompt built outside a turn never renders the section by accident. The callers with no spawn surface keep an explicit `false` as documentation: `runBtwSidechain`, which forces `tool_choice: { type: "none" }`; the two home-content generators that run through it; and the persona workflow leaf, which runs its caller's restricted tool set. Telling those turns to delegate would invite them to defer or refuse work they can only do inline.

## Overuse guard

Subagent overuse has been a real cost problem, so the wording is deliberately narrow: independent tasks only, plural, an explicit instruction to keep small, quick requests inline, and a carve-out for anything that may need the user's approval (a subagent runs non-interactive, so approval-gated work is denied there rather than prompted, and the same operation would have completed on the parent turn). It adds no new capability and names no tool.

## Verification

- `bun run typecheck:fast` clean.
- `assistant/src/prompts/__tests__/parallel-tasks-section.test.ts` covers real adjacency (the sorted id list places `01-parallel-tasks` immediately before `01-parallel-tool-calls`, so a section introduced between them fails), the independent-only / keep-small-inline wording, the approval carve-out, and the gate in both directions: renders for `canSpawnSubagents: true` (with `hasNoClient`, and on the `vellum` channel); absent with no options, with `hasNoClient` alone, with an explicit false, and on a `slack` / `telegram` / `email` / `plugin` turn, while the rest of the prompt is intact.
- `assistant/src/daemon/__tests__/can-spawn-subagents.test.ts` covers the derivation: ordinary turn, a `tools.exclude` entry on any of the three path names, tools disabled, an allowlist omitting the path, an allowlist naming only the spawn tool, an allowlist naming only `skill_load`, and an allowlist naming the whole path. `btw-routes.test.ts` pins that the side-chain builds with the opt-out.
- `no-domain-routing-in-prompt-guard.test.ts` passes.
- Scoped prompt tests pass: `src/prompts/__tests__/`, `src/__tests__/system-prompt.test.ts`, `src/__tests__/workspace-policy.test.ts` (216 pass, 0 fail).
- `bun run lint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oPSTYuVjkzuXHZskHfpTm

