### PR TITLE
feat(web): render tool-gated replies inline and retire the Earlier activity collapse under send-user-message

### DIFF
--- a/clients/web/src/domains/chat/acp-connect-prompt.test.ts
+++ b/clients/web/src/domains/chat/acp-connect-prompt.test.ts
@@ -20,7 +20,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { handleToolResult } from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
 import { appendEventToMessages } from "@/domains/chat/transcript/rolling-snapshot";
-import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
+import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { AssistantEvent } from "@/types/event-types";
 import type { ToolResultEvent } from "@vellumai/assistant-api";
@@ -39,16 +39,6 @@ function missingTokenToolResult(
     errorCode: MISSING_TOKEN,
     ...overrides,
   } as ToolResultEvent;
-}
-
-/** Minimal stream-handler context — `handleToolResult` only touches turnActions. */
-function stubCtx(): StreamHandlerContext {
-  return {
-    turnActions: {
-      onToolResult: () => {},
-      onToolActivityMetadata: () => {},
-    },
-  } as unknown as StreamHandlerContext;
 }
 
 afterEach(() => {
@@ -143,7 +133,7 @@ describe("acp connect prompt — store lifecycle", () => {
 
 describe("acp connect prompt — raised live, never by reseed", () => {
   test("the live tool_result handler raises the prompt anchored to the tool call", () => {
-    handleToolResult(missingTokenToolResult(), stubCtx());
+    handleToolResult(missingTokenToolResult(), makeCtx());
     expect(useInteractionStore.getState().pendingAcpConnect).toEqual({
       toolUseId: "tc-1",
     });
@@ -154,7 +144,7 @@ describe("acp connect prompt — raised live, never by reseed", () => {
     // so the reason must survive into the store.
     handleToolResult(
       missingTokenToolResult({ errorCode: "acp_claude_auth_required" }),
-      stubCtx(),
+      makeCtx(),
     );
     expect(useInteractionStore.getState().pendingAcpConnect).toEqual({
       toolUseId: "tc-1",
@@ -165,14 +155,14 @@ describe("acp connect prompt — raised live, never by reseed", () => {
   test("a non-missing-token failure does not raise the prompt", () => {
     handleToolResult(
       missingTokenToolResult({ errorCode: "some_other_error" }),
-      stubCtx(),
+      makeCtx(),
     );
     expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();
   });
 
   test("the reseed reducer never touches the store, so a live prompt survives reseed", () => {
     // Live failure raises the prompt.
-    handleToolResult(missingTokenToolResult(), stubCtx());
+    handleToolResult(missingTokenToolResult(), makeCtx());
     expect(useInteractionStore.getState().pendingAcpConnect).not.toBeNull();
 
     // A `/messages` reseed replays the event tail through the reducer. Folding

--- a/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
+++ b/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
@@ -47,6 +47,8 @@ const { MultiActivityGroup } =
 const { useViewerStore } = await import("@/stores/viewer-store");
 const { useChatSessionStore } =
   await import("@/domains/chat/chat-session-store");
+const { useAssistantFeatureFlagStore } =
+  await import("@/stores/assistant-feature-flag-store");
 
 afterEach(() => {
   cleanup();
@@ -61,6 +63,7 @@ afterEach(() => {
     expandedCardIds: new Map(),
     expandedToolCallIds: new Set(),
   });
+  useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
 });
 
 function makeToolCall(
@@ -628,5 +631,44 @@ describe("MultiActivityGroup — header reflects the latest step", () => {
     // The leading thinking text is NOT promoted into the header (it's a
     // panel step only).
     expect(queryByText("Let me check the directory first.")).toBeNull();
+  });
+});
+
+describe("MultiActivityGroup - a web_fetch under the thinking gate", () => {
+  /**
+   * A fetch is projected as a synthesized reasoning step, so its header title
+   * is the word "Thinking" paired with the page read: "Thinking | Hacker
+   * News". With the transcript's thinking surface gone that is the last
+   * "Thinking" left on screen, and it never named a thought in the first
+   * place.
+   */
+  const fetchCall = (status: "running" | "completed") =>
+    makeToolCall({
+      id: "tc-fetch",
+      name: "web_fetch",
+      status,
+      input: { url: "https://news.ycombinator.com" },
+    });
+
+  test("says what it read, not that it thought", () => {
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    const { getByTestId, queryByText, getByText } = renderCard([
+      fetchCall("completed"),
+    ]);
+    expect(getByTestId("tool-progress-card-shell")).toBeTruthy();
+    expect(getByText("Read the web")).toBeTruthy();
+    expect(queryByText("Thinking")).toBeNull();
+  });
+
+  test("keeps the present tense while the page is still loading", () => {
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    const { getByText, queryByText } = renderCard([fetchCall("running")]);
+    expect(getByText("Reading the web")).toBeTruthy();
+    expect(queryByText("Thinking")).toBeNull();
+  });
+
+  test("is unchanged with the gate off", () => {
+    const { getByText } = renderCard([fetchCall("completed")]);
+    expect(getByText("Thinking")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
+++ b/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { deriveStepLabel } from "@/domains/chat/components/tool-progress-card/derive-step-label";
+import {
+  deriveStepLabel,
+  type IconName,
+} from "@/domains/chat/components/tool-progress-card/derive-step-label";
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 
@@ -268,5 +271,44 @@ describe("deriveStepLabel", () => {
     expect(result.info).toBe("echo hi");
     expect(result.iconName).toBe("terminal");
     expect(result.activity).toBe("outer activity wins");
+  });
+  test("the file tools name the act, not the tool", () => {
+    // Left to the generic default these read "Running File Write", which is
+    // the wire name showing through rather than a description of the work.
+    const cases: [string, string, IconName][] = [
+      ["file_read", "Reading", "file"],
+      ["host_file_read", "Reading", "file"],
+      ["file_write", "Writing", "pen"],
+      ["host_file_write", "Writing", "pen"],
+      ["file_edit", "Editing", "pen"],
+      ["host_file_edit", "Editing", "pen"],
+      ["file_list", "Listing", "file"],
+    ];
+    for (const [name, title, iconName] of cases) {
+      const result = deriveStepLabel(
+        buildToolCall({ name, input: { path: "/tmp/notes/draft.md" } }),
+      );
+      expect(result.title).toBe(title);
+      // The basename alone: the full path is noise beside the verb.
+      expect(result.info).toBe("draft.md");
+      expect(result.iconName).toBe(iconName);
+    }
+  });
+
+  test("a file tool sharing a title with text_editor groups as one phase", () => {
+    // `title` is the phase-grouping key, so an edit made through either tool
+    // has to read as the same phase.
+    expect(
+      deriveStepLabel(
+        buildToolCall({ name: "file_edit", input: { path: "/a/b.ts" } }),
+      ).title,
+    ).toBe(
+      deriveStepLabel(
+        buildToolCall({
+          name: "text_editor",
+          input: { command: "str_replace", path: "/a/b.ts" },
+        }),
+      ).title,
+    );
   });
 });

--- a/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -155,6 +155,50 @@ export function deriveStepLabelFromName(
       return { title: "Editing", info: file, activity, iconName: "pen" };
     }
 
+    // The daemon's own file tools, each paired with its host-side twin the way
+    // `bash` is paired with `host_bash`. They reuse the `text_editor` titles
+    // rather than reading "Writing a file" beside its "Editing", because
+    // `title` is the phase-grouping key: a run touching files through both
+    // tools has to read as one phase, not two.
+    case "file_read":
+    case "host_file_read": {
+      return {
+        title: "Reading",
+        info: basename(readToolInputString(inputBag, ...FILE_PATH_KEYS)),
+        activity,
+        iconName: "file",
+      };
+    }
+
+    case "file_write":
+    case "host_file_write": {
+      return {
+        title: "Writing",
+        info: basename(readToolInputString(inputBag, ...FILE_PATH_KEYS)),
+        activity,
+        iconName: "pen",
+      };
+    }
+
+    case "file_edit":
+    case "host_file_edit": {
+      return {
+        title: "Editing",
+        info: basename(readToolInputString(inputBag, ...FILE_PATH_KEYS)),
+        activity,
+        iconName: "pen",
+      };
+    }
+
+    case "file_list": {
+      return {
+        title: "Listing",
+        info: basename(readToolInputString(inputBag, ...FILE_PATH_KEYS)),
+        activity,
+        iconName: "file",
+      };
+    }
+
     case "computer": {
       const action = readToolInputString(inputBag, "action");
       return {

--- a/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
@@ -26,7 +26,10 @@ import {
   hasPendingAssistantResponse,
 } from "@/domains/chat/utils/chat";
 import { useHideThinkingUi } from "@/domains/chat/hooks/use-hide-thinking-ui";
-import { hasRenderedThinking } from "@/domains/chat/transcript/message-content";
+import {
+  hasRenderedStepStack,
+  hasRenderedThinking,
+} from "@/domains/chat/transcript/message-content";
 import { liveAssistantRowId } from "@/domains/chat/utils/stream-updaters/shared";
 import { useActiveConversationIsProcessing } from "@/lib/backwards-compat/conversation-processing-state";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -133,6 +136,17 @@ export function useChatUIState(): ChatUIState {
     return hasRenderedThinking(live, hideThinkingUi);
   }, [transcript, liveAssistantMessageId, hideThinkingUi]);
 
+  // Under `send-user-message` the step stack is the turn's one progress
+  // label, so the standalone row stands down once the live message renders a
+  // step. Flag off, the row keeps its own between-tools label.
+  const hasLiveStepStack = useMemo(() => {
+    if (!hideThinkingUi || liveAssistantMessageId == null) {
+      return false;
+    }
+    const live = transcript.find((m) => m.id === liveAssistantMessageId);
+    return live != null && hasRenderedStepStack(live);
+  }, [transcript, liveAssistantMessageId, hideThinkingUi]);
+
   const hasUncompletedVisibleSurface = useMemo(
     () => hasAnyInteractiveSurface(transcript),
     [transcript],
@@ -142,6 +156,7 @@ export function useChatUIState(): ChatUIState {
     () => ({
       hasStreamingAssistantMessage,
       hasStreamingAssistantThinking,
+      hasLiveStepStack,
       hasPendingSecret: !!pendingSecret,
       hasPendingConfirmation: !!pendingConfirmation,
       hasPendingQuestion: !!pendingQuestion,
@@ -155,6 +170,7 @@ export function useChatUIState(): ChatUIState {
     [
       hasStreamingAssistantMessage,
       hasStreamingAssistantThinking,
+      hasLiveStepStack,
       pendingSecret,
       pendingConfirmation,
       pendingQuestion,

--- a/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
@@ -25,6 +25,7 @@ import {
   hasAnyInteractiveSurface,
   hasPendingAssistantResponse,
 } from "@/domains/chat/utils/chat";
+import { hasRenderedThinking } from "@/domains/chat/transcript/message-content";
 import { liveAssistantRowId } from "@/domains/chat/utils/stream-updaters/shared";
 import { useActiveConversationIsProcessing } from "@/lib/backwards-compat/conversation-processing-state";
 import { useConversationStore } from "@/stores/conversation-store";
@@ -127,10 +128,7 @@ export function useChatUIState(): ChatUIState {
     if (!live) {
       return false;
     }
-    return (
-      (live.thinkingSegments?.length ?? 0) > 0 ||
-      !!live.contentBlocks?.some((b) => b.type === "thinking")
-    );
+    return hasRenderedThinking(live);
   }, [transcript, liveAssistantMessageId]);
 
   const hasUncompletedVisibleSurface = useMemo(

--- a/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-ui-state.ts
@@ -25,6 +25,7 @@ import {
   hasAnyInteractiveSurface,
   hasPendingAssistantResponse,
 } from "@/domains/chat/utils/chat";
+import { useHideThinkingUi } from "@/domains/chat/hooks/use-hide-thinking-ui";
 import { hasRenderedThinking } from "@/domains/chat/transcript/message-content";
 import { liveAssistantRowId } from "@/domains/chat/utils/stream-updaters/shared";
 import { useActiveConversationIsProcessing } from "@/lib/backwards-compat/conversation-processing-state";
@@ -101,6 +102,7 @@ export function useChatUIState(): ChatUIState {
   // source of truth on 0.8.8+; older daemons fall back to the client
   // optimistic mirror. See `lib/backwards-compat/conversation-processing-state`.
   const activeConversationIsProcessing = useActiveConversationIsProcessing();
+  const hideThinkingUi = useHideThinkingUi();
 
   const activeConversationHasPendingAssistantResponse = useMemo(
     () => hasPendingAssistantResponse(transcript),
@@ -128,8 +130,8 @@ export function useChatUIState(): ChatUIState {
     if (!live) {
       return false;
     }
-    return hasRenderedThinking(live);
-  }, [transcript, liveAssistantMessageId]);
+    return hasRenderedThinking(live, hideThinkingUi);
+  }, [transcript, liveAssistantMessageId, hideThinkingUi]);
 
   const hasUncompletedVisibleSurface = useMemo(
     () => hasAnyInteractiveSurface(transcript),

--- a/clients/web/src/domains/chat/hooks/use-hide-thinking-ui.ts
+++ b/clients/web/src/domains/chat/hooks/use-hide-thinking-ui.ts
@@ -1,0 +1,18 @@
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+/**
+ * Whether the transcript shows the assistant's reasoning at all.
+ *
+ * Under `send-user-message` the assistant speaks through a tool call, which
+ * makes every word it writes outside that call a working note. Reasoning is
+ * then not a second view of the answer but the raw draft behind it, so the
+ * transcript drops the whole thinking surface: the rows, the "Thinking" label
+ * (on its own and paired with a tool's), the drawer, and the shimmer's word
+ * for the wait. Tool rows, surfaces, and the delivered text are untouched.
+ *
+ * A blunt gate on top of the per-row `assistantTextVisibility` marker, which
+ * says the same thing about one row rather than the whole transcript.
+ */
+export function useHideThinkingUi(): boolean {
+  return useAssistantFeatureFlagStore.use.sendUserMessage();
+}

--- a/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
@@ -15,6 +15,7 @@ import {
   workflowRunIdForCall,
   type WorkflowCardBackingState,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
+import { useHideThinkingUi } from "@/domains/chat/hooks/use-hide-thinking-ui";
 import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
@@ -92,6 +93,7 @@ export function useLiveActivityGroup(
   groupIndex: number | undefined,
 ): { items: ToolCallCardItem[]; toolCalls: ChatMessageToolCall[] } | null {
   const message = useTranscriptMessageById(messageId);
+  const hideThinkingUi = useHideThinkingUi();
   // Card-backed process suppression reads the same store slices the
   // transcript subscribes to, so a card's backing flipping (an entry
   // appearing) drops the raw step from an open panel in the same render.
@@ -110,7 +112,7 @@ export function useLiveActivityGroup(
     }
     const groups = groupContentBlocks(
       message.contentBlocks ?? [],
-      groupOptionsForMessage(message),
+      groupOptionsForMessage(message, hideThinkingUi),
     );
     const group = groups[groupIndex];
     if (!group || group.type !== "activity") {
@@ -131,6 +133,7 @@ export function useLiveActivityGroup(
   }, [
     message,
     groupIndex,
+    hideThinkingUi,
     workflowById,
     workflowByToolUseId,
     workflowNotFoundRunIds,

--- a/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-activity-group.ts
@@ -6,6 +6,7 @@ import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import {
   activityItemsToCardData,
   groupContentBlocks,
+  groupOptionsForMessage,
 } from "@/domains/chat/transcript/message-content";
 import {
   acpRunIdForCall,
@@ -107,9 +108,10 @@ export function useLiveActivityGroup(
     if (!message || groupIndex == null) {
       return null;
     }
-    const groups = groupContentBlocks(message.contentBlocks ?? [], {
-      splitInlineThinking: message.role !== "user",
-    });
+    const groups = groupContentBlocks(
+      message.contentBlocks ?? [],
+      groupOptionsForMessage(message),
+    );
     const group = groups[groupIndex];
     if (!group || group.type !== "activity") {
       return null;

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
@@ -4,6 +4,7 @@ import {
   groupContentBlocks,
   groupOptionsForMessage,
 } from "@/domains/chat/transcript/message-content";
+import { useHideThinkingUi } from "@/domains/chat/hooks/use-hide-thinking-ui";
 import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 
 /**
@@ -37,13 +38,14 @@ export function useLiveThinkingText(
   thinkingItemIndex?: number,
 ): string | null {
   const message = useTranscriptMessageById(messageId);
+  const hideThinkingUi = useHideThinkingUi();
   return useMemo(() => {
     if (!message || groupIndex == null) {
       return null;
     }
     const groups = groupContentBlocks(
       message.contentBlocks ?? [],
-      groupOptionsForMessage(message),
+      groupOptionsForMessage(message, hideThinkingUi),
     );
     const group = groups[groupIndex];
     if (!group || group.type !== "activity") {
@@ -56,5 +58,5 @@ export function useLiveThinkingText(
       return segments.join("\n");
     }
     return segments[thinkingItemIndex] ?? null;
-  }, [message, groupIndex, thinkingItemIndex]);
+  }, [message, groupIndex, thinkingItemIndex, hideThinkingUi]);
 }

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 
-import { groupContentBlocks } from "@/domains/chat/transcript/message-content";
+import {
+  groupContentBlocks,
+  groupOptionsForMessage,
+} from "@/domains/chat/transcript/message-content";
 import { useTranscriptMessageById } from "@/domains/chat/hooks/use-transcript-message-by-id";
 
 /**
@@ -38,9 +41,10 @@ export function useLiveThinkingText(
     if (!message || groupIndex == null) {
       return null;
     }
-    const groups = groupContentBlocks(message.contentBlocks ?? [], {
-      splitInlineThinking: message.role !== "user",
-    });
+    const groups = groupContentBlocks(
+      message.contentBlocks ?? [],
+      groupOptionsForMessage(message),
+    );
     const group = groups[groupIndex];
     if (!group || group.type !== "activity") {
       return null;

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -153,6 +153,7 @@ export function useStreamEventHandler(
   // --- Refs owned by this hook (only used inside handleStreamEvent) ---
   const lastActivityVersionRef = useRef<Map<string, number>>(new Map());
   const currentAssistantMessageIdRef = useRef<string | undefined>(undefined);
+  const lastCompletedToolNameRef = useRef<string | undefined>(undefined);
 
   // --- Main event handler ---
 
@@ -264,6 +265,7 @@ export function useStreamEventHandler(
         consumePendingLocalDeletion: store.consumePendingLocalDeletion,
         lastActivityVersionRef,
         currentAssistantMessageIdRef,
+        lastCompletedToolNameRef,
       };
 
       switch (event.type) {

--- a/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-subagent-card-data.test.ts
@@ -218,8 +218,8 @@ describe("computeSubagentCardData — step mapping", () => {
         events: [
           makeEvent({
             type: "tool_call",
-            toolName: "file_read",
-            toolUseId: "tu-file-1",
+            toolName: "some_unknown_tool",
+            toolUseId: "tu-tool-1",
             content: "src/foo.ts",
           }),
         ],
@@ -229,13 +229,13 @@ describe("computeSubagentCardData — step mapping", () => {
     const step = data.steps[0]!;
     expect(step.kind).toBe("tool");
     if (step.kind === "tool") {
-      // `file_read` isn't a known branch in `deriveStepLabelFromName`, so
-      // it falls through to the default "Running <Name>" path with the
-      // bolt icon.
-      expect(step.title).toBe("Running File Read");
+      // A tool with no branch in `deriveStepLabelFromName` falls through to
+      // the default "Running <Name>" path with the bolt icon, and the empty
+      // derived `info` falls back to the event's summary content.
+      expect(step.title).toBe("Running Some Unknown Tool");
       expect(step.info).toBe("src/foo.ts");
       expect(step.status).toBe("running");
-      expect(step.toolCallId).toBe("tu-file-1");
+      expect(step.toolCallId).toBe("tu-tool-1");
       expect(step.iconName).toBe("bolt");
     }
   });

--- a/clients/web/src/domains/chat/hooks/use-tool-call-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-tool-call-card-data.ts
@@ -7,6 +7,7 @@
 import { useEffect, useState } from "react";
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import { useHideThinkingUi } from "@/domains/chat/hooks/use-hide-thinking-ui";
 import { useTurnStore } from "@/domains/chat/turn-store";
 
 import {
@@ -47,10 +48,13 @@ export function useToolCallCardData(
   toolCalls: ChatMessageToolCall[],
 ): ToolCallCardData {
   const liveWebActivity = useTurnStore.use.liveWebActivity();
+  const hideThinkingUi = useHideThinkingUi();
   const now = useNow(
     hasRunningItem(toolCalls.map((tc) => ({ kind: "toolCall", toolCall: tc }))),
   );
-  return computeToolCallCardData(toolCalls, liveWebActivity, now);
+  return computeToolCallCardData(toolCalls, liveWebActivity, now, {
+    hideThinkingUi,
+  });
 }
 
 /**
@@ -62,6 +66,9 @@ export function useToolCallCardDataFromItems(
   items: ToolCallCardItem[],
 ): ToolCallCardData {
   const liveWebActivity = useTurnStore.use.liveWebActivity();
+  const hideThinkingUi = useHideThinkingUi();
   const now = useNow(hasRunningItem(items));
-  return computeToolCallCardDataFromItems(items, liveWebActivity, now);
+  return computeToolCallCardDataFromItems(items, liveWebActivity, now, {
+    hideThinkingUi,
+  });
 }

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -9,6 +9,8 @@ import {
   type ContentBlockGroup,
   finalResponseStartIndex,
   groupContentBlocks,
+  groupOptionsForMessage,
+  hasRenderedThinking,
   isBackgroundBashCall,
   isRunWorkflowCall,
   isSubagentSpawnCall,
@@ -548,20 +550,9 @@ describe("finalResponseStartIndex", () => {
   });
 
   test("returns -1 for a response carrying no text", () => {
-    expect(finalResponseStartIndex([activityGroup()], drawsVisibleOutput())).toBe(
-      -1,
-    );
-  });
-});
-
-describe("isSendUserMessageCall", () => {
-  test("matches the reply tool only", () => {
     expect(
-      isSendUserMessageCall(toolCall({ id: "x", name: "send_user_message" })),
-    ).toBe(true);
-    expect(isSendUserMessageCall(toolCall({ id: "x", name: "bash" }))).toBe(
-      false,
-    );
+      finalResponseStartIndex([activityGroup()], drawsVisibleOutput()),
+    ).toBe(-1);
   });
 });
 
@@ -689,5 +680,87 @@ describe("send_user_message in the transcript projection", () => {
     expect(cardItems).toEqual([
       { kind: "toolCall", toolCall: toolCall({ id: "call-a" }) },
     ]);
+  });
+});
+
+describe("a private row's reasoning", () => {
+  const blocks: ConversationContentBlock[] = [
+    { type: "thinking", thinking: "let me look that up" },
+    { type: "tool_use", toolCall: toolCall({ id: "call-a", name: "bash" }) },
+    { type: "text", text: "Here you go." },
+  ];
+
+  test("is dropped from the projection, leaving the work it did", () => {
+    const groups = groupContentBlocks(
+      blocks,
+      groupOptionsForMessage({
+        role: "assistant",
+        assistantTextVisibility: "private",
+      }),
+    );
+    expect(groups).toEqual([
+      {
+        type: "activity",
+        items: [
+          {
+            type: "tool_use",
+            toolCall: toolCall({ id: "call-a", name: "bash" }),
+          },
+        ],
+      },
+      { type: "text", text: "Here you go." },
+    ]);
+  });
+
+  test("survives on a row carrying no marker", () => {
+    const groups = groupContentBlocks(
+      blocks,
+      groupOptionsForMessage({ role: "assistant" }),
+    );
+    expect(groups[0]).toEqual({
+      type: "activity",
+      items: [
+        {
+          type: "thinking",
+          thinking: "let me look that up",
+          startedAt: undefined,
+          completedAt: undefined,
+        },
+        {
+          type: "tool_use",
+          toolCall: toolCall({ id: "call-a", name: "bash" }),
+        },
+      ],
+    });
+  });
+
+  test("leaves the thinking dots owning the wait", () => {
+    // The inline link defers the dots row only when it actually renders.
+    expect(
+      hasRenderedThinking({
+        role: "assistant",
+        assistantTextVisibility: "private",
+        contentBlocks: [{ type: "thinking", thinking: "let me look that up" }],
+      }),
+    ).toBe(false);
+    expect(
+      hasRenderedThinking({
+        role: "assistant",
+        contentBlocks: [{ type: "thinking", thinking: "let me look that up" }],
+      }),
+    ).toBe(true);
+    expect(
+      hasRenderedThinking({
+        role: "assistant",
+        assistantTextVisibility: "private",
+        thinkingSegments: ["let me look that up"],
+      }),
+    ).toBe(false);
+  });
+
+  test("a user row never splits its own inline tags", () => {
+    expect(groupOptionsForMessage({ role: "user" }).splitInlineThinking).toBe(
+      false,
+    );
   });
 });

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -788,3 +788,122 @@ describe("a private row's reasoning", () => {
     );
   });
 });
+
+describe("silent tools in the transcript projection", () => {
+  /** The options a transcript rendered with the flag on projects a row with. */
+  const flagOn = groupOptionsForMessage({ role: "assistant" }, true);
+
+  test("a bookkeeping call after the reply opens no activity group", () => {
+    // GIVEN a delivered reply followed by the memory write the assistant made
+    // once it had answered
+    const blocks: ConversationContentBlock[] = [
+      { type: "text", text: "Here you go." },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-remember", name: "remember" }),
+      },
+    ];
+
+    // WHEN grouped with the flag on
+    // THEN only the prose survives. A trailing activity run would draw a
+    // "Noting dropped essay request" row under a finished answer.
+    expect(groupContentBlocks(blocks, flagOn)).toEqual([
+      { type: "text", text: "Here you go." },
+    ]);
+  });
+
+  test("does not split the activity run around one", () => {
+    // GIVEN real work either side of a memory write
+    const blocks: ConversationContentBlock[] = [
+      { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-remember", name: "remember" }),
+      },
+      { type: "tool_use", toolCall: toolCall({ id: "call-b" }) },
+    ];
+
+    // WHEN grouped with the flag on
+    // THEN the two real steps merge into one run, so the step count reads 2
+    const groups = groupContentBlocks(blocks, flagOn);
+    expect(groups).toEqual([
+      {
+        type: "activity",
+        items: [
+          { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+          { type: "tool_use", toolCall: toolCall({ id: "call-b" }) },
+        ],
+      },
+    ]);
+    const group = groups[0];
+    expect(group?.type === "activity" ? group.items : []).toHaveLength(2);
+    expect(
+      activityItemsToCardData(
+        group?.type === "activity" ? group.items : [],
+      ).toolCalls.map((tc) => tc.id),
+    ).toEqual(["call-a", "call-b"]);
+  });
+
+  test("keeps drawing every step with the flag off", () => {
+    // The flag-off transcript is untouched: the same blocks still group into
+    // one run of three steps.
+    const blocks: ConversationContentBlock[] = [
+      { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-remember", name: "remember" }),
+      },
+      { type: "tool_use", toolCall: toolCall({ id: "call-b" }) },
+    ];
+
+    const group = groupContentBlocks(
+      blocks,
+      groupOptionsForMessage({ role: "assistant" }),
+    )[0];
+    expect(group?.type === "activity" ? group.items : []).toHaveLength(3);
+  });
+
+  test("keeps a surface tool carrying a pending confirmation", () => {
+    // The chip is where the inline confirmation card renders, so dropping the
+    // call would leave the user nothing to answer.
+    const blocks: ConversationContentBlock[] = [
+      {
+        type: "tool_use",
+        toolCall: toolCall({
+          id: "call-ui",
+          name: "ui_show",
+          pendingConfirmation: { requestId: "req-1" },
+        }),
+      },
+    ];
+
+    expect(groupContentBlocks(blocks, flagOn)).toEqual([
+      {
+        type: "activity",
+        items: [
+          {
+            type: "tool_use",
+            toolCall: toolCall({
+              id: "call-ui",
+              name: "ui_show",
+              pendingConfirmation: { requestId: "req-1" },
+            }),
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("keeps the work the user asked for", () => {
+    const blocks: ConversationContentBlock[] = [
+      { type: "tool_use", toolCall: toolCall({ id: "call-bash", name: "bash" }) },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-ask", name: "ask_question" }),
+      },
+    ];
+
+    const group = groupContentBlocks(blocks, flagOn)[0];
+    expect(group?.type === "activity" ? group.items : []).toHaveLength(2);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -758,6 +758,30 @@ describe("a private row's reasoning", () => {
     ).toBe(false);
   });
 
+  test("goes the same way for an unmarked row under the transcript-wide gate", () => {
+    expect(
+      groupOptionsForMessage({ role: "assistant" }, true).dropThinking,
+    ).toBe(true);
+    expect(hasRenderedThinking({ role: "assistant" }, true)).toBe(false);
+    expect(
+      groupContentBlocks(
+        blocks,
+        groupOptionsForMessage({ role: "assistant" }, true),
+      ),
+    ).toEqual([
+      {
+        type: "activity",
+        items: [
+          {
+            type: "tool_use",
+            toolCall: toolCall({ id: "call-a", name: "bash" }),
+          },
+        ],
+      },
+      { type: "text", text: "Here you go." },
+    ]);
+  });
+
   test("a user row never splits its own inline tags", () => {
     expect(groupOptionsForMessage({ role: "user" }).splitInlineThinking).toBe(
       false,

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -10,6 +10,7 @@ import {
   finalResponseStartIndex,
   groupContentBlocks,
   groupOptionsForMessage,
+  hasRenderedStepStack,
   hasRenderedThinking,
   isBackgroundBashCall,
   isRunWorkflowCall,
@@ -734,6 +735,20 @@ describe("a private row's reasoning", () => {
     });
   });
 
+  test("counts only tool calls the projection renders as steps", () => {
+    expect(hasRenderedStepStack({ toolCalls: [] })).toBe(false);
+    expect(
+      hasRenderedStepStack({
+        toolCalls: [{ name: "send_user_message" }, { name: "remember" }],
+      }),
+    ).toBe(false);
+    expect(
+      hasRenderedStepStack({
+        toolCalls: [{ name: "remember" }, { name: "file_write" }],
+      }),
+    ).toBe(true);
+  });
+
   test("leaves the thinking dots owning the wait", () => {
     // The inline link defers the dots row only when it actually renders.
     expect(
@@ -896,7 +911,10 @@ describe("silent tools in the transcript projection", () => {
 
   test("keeps the work the user asked for", () => {
     const blocks: ConversationContentBlock[] = [
-      { type: "tool_use", toolCall: toolCall({ id: "call-bash", name: "bash" }) },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-bash", name: "bash" }),
+      },
       {
         type: "tool_use",
         toolCall: toolCall({ id: "call-ask", name: "ask_question" }),

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -11,7 +11,6 @@ import {
   groupContentBlocks,
   isBackgroundBashCall,
   isRunWorkflowCall,
-  isSendUserMessageCall,
   isSubagentSpawnCall,
   isSuppressedUiTool,
   isTaskProgressSurface,

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -5,11 +5,13 @@ import type { Surface } from "@/domains/chat/types/types";
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 import {
   activityHasDedicatedCard,
+  activityItemsToCardData,
   type ContentBlockGroup,
   finalResponseStartIndex,
   groupContentBlocks,
   isBackgroundBashCall,
   isRunWorkflowCall,
+  isSendUserMessageCall,
   isSubagentSpawnCall,
   isSuppressedUiTool,
   isTaskProgressSurface,
@@ -384,6 +386,23 @@ describe("isSuppressedUiTool", () => {
     );
   });
 
+  test("suppresses send_user_message, which renders as the prose it carries", () => {
+    expect(
+      isSuppressedUiTool(toolCall({ id: "x", name: "send_user_message" })),
+    ).toBe(true);
+    // Suppressed even carrying a confirmation: the tool has no confirmation
+    // policy, so a chip for it would only ever duplicate the reply.
+    expect(
+      isSuppressedUiTool(
+        toolCall({
+          id: "x",
+          name: "send_user_message",
+          pendingConfirmation: { requestId: "req-1" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
   test("does not suppress ui_* with a pending confirmation, or non-ui tools", () => {
     expect(
       isSuppressedUiTool(
@@ -536,6 +555,17 @@ describe("finalResponseStartIndex", () => {
   });
 });
 
+describe("isSendUserMessageCall", () => {
+  test("matches the reply tool only", () => {
+    expect(
+      isSendUserMessageCall(toolCall({ id: "x", name: "send_user_message" })),
+    ).toBe(true);
+    expect(isSendUserMessageCall(toolCall({ id: "x", name: "bash" }))).toBe(
+      false,
+    );
+  });
+});
+
 describe("activityHasDedicatedCard", () => {
   test("matches a subagent spawn even when nothing is marked card-backed", () => {
     expect(
@@ -599,5 +629,66 @@ describe("activityHasDedicatedCard", () => {
         () => true,
       ),
     ).toBe(false);
+  });
+});
+
+describe("send_user_message in the transcript projection", () => {
+  test("opens no activity group of its own", () => {
+    // GIVEN the live block order of a tool-gated turn: the reply arrives as a
+    // text delta, then the call that carried it
+    const blocks: ConversationContentBlock[] = [
+      { type: "text", text: "Here you go." },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-send", name: "send_user_message" }),
+      },
+    ];
+
+    // WHEN grouped
+    // THEN only the prose survives. A trailing activity run would draw a
+    // shimmering "Thinking" row under the reply while streaming.
+    expect(groupContentBlocks(blocks)).toEqual([
+      { type: "text", text: "Here you go." },
+    ]);
+  });
+
+  test("does not split the activity run around it", () => {
+    // GIVEN work either side of a reply the model sent mid-turn
+    const blocks: ConversationContentBlock[] = [
+      { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-send", name: "send_user_message" }),
+      },
+      { type: "tool_use", toolCall: toolCall({ id: "call-b" }) },
+    ];
+
+    // WHEN grouped
+    // THEN the two real steps merge into one run, as they would had the reply
+    // never been sent
+    expect(groupContentBlocks(blocks)).toEqual([
+      {
+        type: "activity",
+        items: [
+          { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+          { type: "tool_use", toolCall: toolCall({ id: "call-b" }) },
+        ],
+      },
+    ]);
+  });
+
+  test("counts no step and draws no chip when it reaches the card data", () => {
+    const { cardItems, toolCalls } = activityItemsToCardData([
+      { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+      {
+        type: "tool_use",
+        toolCall: toolCall({ id: "call-send", name: "send_user_message" }),
+      },
+    ]);
+
+    expect(toolCalls.map((tc) => tc.id)).toEqual(["call-a"]);
+    expect(cardItems).toEqual([
+      { kind: "toolCall", toolCall: toolCall({ id: "call-a" }) },
+    ]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -17,6 +17,7 @@ import type {
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { Surface } from "@/domains/chat/types/types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
+import { isSendUserMessageCall } from "@/domains/chat/utils/assistant-text-visibility";
 import { isArtifactPointerSurface } from "@/domains/chat/transcript/response-artifacts";
 import {
   containsInlineThinkingTag,
@@ -61,24 +62,6 @@ function hasToolCallId(
   toolCall: ConversationMessageToolCall,
 ): toolCall is ChatMessageToolCall {
   return typeof toolCall.id === "string" && toolCall.id.length > 0;
-}
-
-/**
- * The tool a tool-gated turn calls to say something to the user. Its argument
- * is the reply itself, which the daemon also streams as ordinary assistant
- * text and projects into a `text` block on the persisted row, so the call is
- * never a step the transcript has anything to draw.
- */
-export const SEND_USER_MESSAGE_TOOL_NAME = "send_user_message";
-
-/**
- * Whether a tool call is the user-facing reply channel rather than a step of
- * the assistant's work. The reply reaches the transcript as text, so drawing
- * the call as well would show the same sentence twice, once as prose and once
- * as a chip naming the tool that carried it.
- */
-export function isSendUserMessageCall(tc: ChatMessageToolCall): boolean {
-  return tc.name === SEND_USER_MESSAGE_TOOL_NAME;
 }
 
 export interface GroupContentBlocksOptions {

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -21,6 +21,10 @@ import {
   type AssistantTextVisibility,
   isSendUserMessageCall,
 } from "@/domains/chat/utils/assistant-text-visibility";
+import {
+  isSilentToolCall,
+  isUiSurfaceToolCall,
+} from "@/domains/chat/utils/silent-tool-calls";
 import { isArtifactPointerSurface } from "@/domains/chat/transcript/response-artifacts";
 import {
   containsInlineThinkingTag,
@@ -85,6 +89,16 @@ export interface GroupContentBlocksOptions {
    * timeline, and the detail drawer reading one projection.
    */
   dropThinking?: boolean;
+  /**
+   * Drop bookkeeping and surface tool calls (see `isSilentToolCall`) instead of
+   * grouping them, the way a `send_user_message` call is dropped. Pass under
+   * the `send-user-message` flag, where the assistant's own filing away, a
+   * memory write landing after the answer, a skill body load, a follow-up it
+   * left for itself, is not a step of the work the user asked for. Dropping
+   * rather than suppressing later leaves the surrounding run open, so the tool
+   * calls either side merge as they would had the call never been made.
+   */
+  dropSilentTools?: boolean;
 }
 
 /**
@@ -94,7 +108,9 @@ export interface GroupContentBlocksOptions {
  *
  * `hideThinkingUi` is the transcript-wide gate (see `useHideThinkingUi`); the
  * row's own `private` marker says the same thing about this row alone. Either
- * is enough to drop the reasoning.
+ * is enough to drop the reasoning. Only the transcript-wide gate drops the
+ * silent tools, so a transcript rendered with the flag off keeps every step it
+ * has always drawn.
  */
 export function groupOptionsForMessage(
   message: {
@@ -107,6 +123,7 @@ export function groupOptionsForMessage(
     splitInlineThinking: message.role !== "user",
     dropThinking:
       hideThinkingUi || message.assistantTextVisibility === "private",
+    dropSilentTools: hideThinkingUi,
   };
 }
 
@@ -242,6 +259,12 @@ export function groupContentBlocks(
       if (isSendUserMessageCall(block.toolCall)) {
         continue;
       }
+      // Every other silent tool is dropped the same way, and for the same
+      // reason: it draws nothing, so grouping it only opens a run with nothing
+      // renderable in it and adds a step no card can show.
+      if (options?.dropSilentTools && isSilentToolCall(block.toolCall)) {
+        continue;
+      }
       openActivity().items.push({
         type: "tool_use",
         toolCall: block.toolCall,
@@ -371,15 +394,7 @@ export function activityItemsToCardData(items: ContentBlockActivityItem[]): {
  * confirmation policy, so it is suppressed unconditionally.
  */
 export function isSuppressedUiTool(tc: ChatMessageToolCall): boolean {
-  if (isSendUserMessageCall(tc)) {
-    return true;
-  }
-  return (
-    !tc.pendingConfirmation &&
-    (tc.name === "ui_show" ||
-      tc.name === "ui_update" ||
-      tc.name === "ui_dismiss")
-  );
+  return isSendUserMessageCall(tc) || isUiSurfaceToolCall(tc);
 }
 
 /**

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -17,7 +17,10 @@ import type {
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { Surface } from "@/domains/chat/types/types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
-import { isSendUserMessageCall } from "@/domains/chat/utils/assistant-text-visibility";
+import {
+  type AssistantTextVisibility,
+  isSendUserMessageCall,
+} from "@/domains/chat/utils/assistant-text-visibility";
 import { isArtifactPointerSurface } from "@/domains/chat/transcript/response-artifacts";
 import {
   containsInlineThinkingTag,
@@ -73,6 +76,51 @@ export interface GroupContentBlocksOptions {
    * render verbatim.
    */
   splitInlineThinking?: boolean;
+  /**
+   * Drop `thinking` blocks instead of grouping them. Pass for a row whose
+   * prose is a scratchpad: its reasoning is the same working text the reply
+   * tool already spoke around, so a "Thinking" row over the delivered message
+   * shows the user their assistant talking to itself. Dropping the blocks
+   * here, rather than at each render site, keeps the inline view, the steps
+   * timeline, and the detail drawer reading one projection.
+   */
+  dropThinking?: boolean;
+}
+
+/**
+ * The grouping options a message row implies. One place decides both, so the
+ * render body, the live activity group, and the thinking drawer project the
+ * same row the same way.
+ */
+export function groupOptionsForMessage(message: {
+  role?: string;
+  assistantTextVisibility?: AssistantTextVisibility;
+}): GroupContentBlocksOptions {
+  return {
+    splitInlineThinking: message.role !== "user",
+    dropThinking: message.assistantTextVisibility === "private",
+  };
+}
+
+/**
+ * Whether a row shows reasoning the user can open. The inline thinking link
+ * owns the streaming loading state whenever it renders, so the standalone
+ * thinking-dots row reads this to know when to defer to it; a row whose
+ * reasoning the projection drops has no such link, and the dots keep the wait.
+ */
+export function hasRenderedThinking(message: {
+  role?: string;
+  assistantTextVisibility?: AssistantTextVisibility;
+  thinkingSegments?: string[];
+  contentBlocks?: ConversationContentBlock[];
+}): boolean {
+  if (groupOptionsForMessage(message).dropThinking) {
+    return false;
+  }
+  return (
+    (message.thinkingSegments?.length ?? 0) > 0 ||
+    !!message.contentBlocks?.some((block) => block.type === "thinking")
+  );
 }
 
 /**
@@ -138,6 +186,9 @@ export function groupContentBlocks(
 
   for (const block of walked) {
     if (block.type === "thinking") {
+      if (options?.dropThinking) {
+        continue;
+      }
       const activity = openActivity();
       const lastItem = activity.items[activity.items.length - 1];
       if (lastItem?.type === "thinking") {

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -91,14 +91,22 @@ export interface GroupContentBlocksOptions {
  * The grouping options a message row implies. One place decides both, so the
  * render body, the live activity group, and the thinking drawer project the
  * same row the same way.
+ *
+ * `hideThinkingUi` is the transcript-wide gate (see `useHideThinkingUi`); the
+ * row's own `private` marker says the same thing about this row alone. Either
+ * is enough to drop the reasoning.
  */
-export function groupOptionsForMessage(message: {
-  role?: string;
-  assistantTextVisibility?: AssistantTextVisibility;
-}): GroupContentBlocksOptions {
+export function groupOptionsForMessage(
+  message: {
+    role?: string;
+    assistantTextVisibility?: AssistantTextVisibility;
+  },
+  hideThinkingUi = false,
+): GroupContentBlocksOptions {
   return {
     splitInlineThinking: message.role !== "user",
-    dropThinking: message.assistantTextVisibility === "private",
+    dropThinking:
+      hideThinkingUi || message.assistantTextVisibility === "private",
   };
 }
 
@@ -108,13 +116,16 @@ export function groupOptionsForMessage(message: {
  * thinking-dots row reads this to know when to defer to it; a row whose
  * reasoning the projection drops has no such link, and the dots keep the wait.
  */
-export function hasRenderedThinking(message: {
-  role?: string;
-  assistantTextVisibility?: AssistantTextVisibility;
-  thinkingSegments?: string[];
-  contentBlocks?: ConversationContentBlock[];
-}): boolean {
-  if (groupOptionsForMessage(message).dropThinking) {
+export function hasRenderedThinking(
+  message: {
+    role?: string;
+    assistantTextVisibility?: AssistantTextVisibility;
+    thinkingSegments?: string[];
+    contentBlocks?: ConversationContentBlock[];
+  },
+  hideThinkingUi = false,
+): boolean {
+  if (groupOptionsForMessage(message, hideThinkingUi).dropThinking) {
     return false;
   }
   return (

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -63,6 +63,24 @@ function hasToolCallId(
   return typeof toolCall.id === "string" && toolCall.id.length > 0;
 }
 
+/**
+ * The tool a tool-gated turn calls to say something to the user. Its argument
+ * is the reply itself, which the daemon also streams as ordinary assistant
+ * text and projects into a `text` block on the persisted row, so the call is
+ * never a step the transcript has anything to draw.
+ */
+export const SEND_USER_MESSAGE_TOOL_NAME = "send_user_message";
+
+/**
+ * Whether a tool call is the user-facing reply channel rather than a step of
+ * the assistant's work. The reply reaches the transcript as text, so drawing
+ * the call as well would show the same sentence twice, once as prose and once
+ * as a chip naming the tool that carried it.
+ */
+export function isSendUserMessageCall(tc: ChatMessageToolCall): boolean {
+  return tc.name === SEND_USER_MESSAGE_TOOL_NAME;
+}
+
 export interface GroupContentBlocksOptions {
   /**
    * Split inline `<thinking>`/`<think>` tags out of text blocks into
@@ -167,6 +185,16 @@ export function groupContentBlocks(
       }
     } else if (block.type === "tool_use") {
       if (!hasToolCallId(block.toolCall)) {
+        continue;
+      }
+      // A `send_user_message` call is dropped rather than grouped, the way a
+      // pointer surface is: its message is already a text block beside it, and
+      // grouping it would open an activity run holding nothing renderable,
+      // which draws a shimmering "Thinking" row under the reply for the rest of
+      // a streaming turn and counts a step no card has anything to show.
+      // Leaving the open run open lets the tool calls either side of it merge
+      // into one run, the way they would had the call never been made.
+      if (isSendUserMessageCall(block.toolCall)) {
         continue;
       }
       openActivity().items.push({
@@ -291,11 +319,16 @@ export function activityItemsToCardData(items: ContentBlockActivityItem[]): {
 }
 
 /**
- * UI surface tools are rendered by the inline surface widget, not as tool-call
- * chips — unless they carry a pending confirmation, in which case the chip must
- * render so the inline confirmation card is visible.
+ * Tool calls that draw no chip of their own. UI surface tools are rendered by
+ * the inline surface widget, unless they carry a pending confirmation, in
+ * which case the chip must render so the inline confirmation card is visible.
+ * `send_user_message` is rendered as the prose it carries, and has no
+ * confirmation policy, so it is suppressed unconditionally.
  */
 export function isSuppressedUiTool(tc: ChatMessageToolCall): boolean {
+  if (isSendUserMessageCall(tc)) {
+    return true;
+  }
   return (
     !tc.pendingConfirmation &&
     (tc.name === "ui_show" ||

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -152,6 +152,22 @@ export function hasRenderedThinking(
 }
 
 /**
+ * Whether a row already shows a step stack: at least one tool call the
+ * projection renders as a step. Under `send-user-message` the step stack is
+ * the turn's one progress label, so the standalone thinking row reads this to
+ * stand down once a step exists. A bookkeeping call the projection drops does
+ * not count, and the flag-off path never asks.
+ */
+export function hasRenderedStepStack(message: {
+  toolCalls?: { name: string; pendingConfirmation?: unknown }[];
+}): boolean {
+  return !!message.toolCalls?.some(
+    (toolCall) =>
+      !isSendUserMessageCall(toolCall) && !isSilentToolCall(toolCall),
+  );
+}
+
+/**
  * Expand text blocks containing inline `<thinking>`/`<think>` tags into
  * interleaved thinking + text blocks. Returns the input array untouched when
  * no text block carries a tag (the common case).

--- a/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
+++ b/clients/web/src/domains/chat/transcript/rolling-snapshot.test.ts
@@ -82,6 +82,18 @@ const toolUseStart = (
     toolName: name,
     input: {},
   } as AssistantEvent);
+const toolUsePreviewStart = (
+  seq: number,
+  id: string,
+  toolUseId: string,
+  name: string,
+) =>
+  env(seq, {
+    type: "tool_use_preview_start",
+    messageId: id,
+    toolUseId,
+    toolName: name,
+  } as AssistantEvent);
 const surfacePending = (seq: number, id: string, toolUseId: string) =>
   env(seq, {
     type: "ui_surface_pending",
@@ -710,5 +722,55 @@ describe("visual placeholder markers", () => {
         cleanHistory,
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A turn that speaks through send_user_message more than once
+// ---------------------------------------------------------------------------
+
+describe("a turn that sends more than one reply", () => {
+  /**
+   * The daemon announces a tool call while its input is still streaming, so
+   * `tool_use_preview_start` for `send_user_message` reaches the client before
+   * the reply text it carries and before the `message_complete` that stamps
+   * the authoritative marker. The row has to know it is private by then: an
+   * unmarked row whose first reply is followed by more work would fold that
+   * reply into "Earlier activity" the moment a later text group appears.
+   */
+  const firstReply = [
+    thinkingDelta(1, "a1", "planning"),
+    toolUseStart(2, "a1", "t-fetch", "web_fetch"),
+    toolUsePreviewStart(3, "a1", "t-send-1", "send_user_message"),
+  ];
+
+  test("marks the row private before the first reply text lands", () => {
+    const history = applyEventsToHistory(SEED, firstReply);
+
+    expect(history.messages[0]?.assistantTextVisibility).toBe("private");
+  });
+
+  test("stays private across both replies and the work between them", () => {
+    const history = applyEventsToHistory(SEED, [
+      ...firstReply,
+      textDelta(4, "a1", "Found it."),
+      complete(5, "a1"),
+      toolUseStart(6, "a1", "t-send-1", "send_user_message"),
+      // The turn keeps working after its first reply.
+      toolUseStart(7, "a1", "t-bash", "bash"),
+      toolUsePreviewStart(8, "a1", "t-send-2", "send_user_message"),
+      textDelta(9, "a1", "All done."),
+    ]);
+
+    const row = history.messages[0];
+    expect(row?.assistantTextVisibility).toBe("private");
+    // Both replies are on the one row, with the work between them, which is
+    // the shape that would otherwise fold the first reply out of sight.
+    expect(
+      row?.contentBlocks?.filter((block) => block.type === "text"),
+    ).toEqual([
+      { type: "text", text: "Found it." },
+      { type: "text", text: "All done." },
+    ]);
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -880,6 +880,46 @@ describe("TranscriptMessageBody", () => {
     expect(getByRole("button", { name: "Earlier activity" })).not.toBeNull();
   });
 
+  test("keeps an already-sent reply visible while the turn keeps working", () => {
+    // A turn can speak, keep working, and speak again. Once the second reply
+    // opens a later text group, the first sits before the final one and would
+    // fold into "Earlier activity" if the row were not already marked private,
+    // hiding a reply the user has read.
+    const { queryByRole, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "two-reply-row",
+          role: "assistant",
+          assistantTextVisibility: "private",
+          contentBlocks: [
+            thinkingBlock("planning"),
+            toolUseBlock({
+              id: "tc-fetch",
+              name: "web_fetch",
+              input: {},
+              completedAt: 1,
+            }),
+            textBlock("Found it."),
+            toolUseBlock({
+              id: "tc-bash",
+              name: "bash",
+              input: {},
+              completedAt: 2,
+            }),
+            textBlock("All done."),
+          ],
+        }}
+        isStreaming
+        isLatestMessage
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+    expect(queryByText("Found it.")).not.toBeNull();
+    expect(queryByText("All done.")).not.toBeNull();
+  });
+
   test("renders a projected private row through the thinking UI", () => {
     // The server projects such a row before it ships: the raw prose arrives as
     // thinking, each `send_user_message` call as its own text block. Nothing

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -333,7 +333,6 @@ import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-mess
 import { MIN_VERSION as REDACTED_CHIPS_MIN_VERSION } from "@/lib/backwards-compat/use-supports-redacted-credential-chips";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 const noop = () => {};
 
@@ -797,71 +796,118 @@ describe("TranscriptMessageBody", () => {
     }
   });
 
-  test("renders all activity inline when the assistant is tool-gated", () => {
-    // A tool-gated assistant's prose is reasoning, and its reply is a
-    // deliberate `send_user_message`, so there is no "earlier" prose to fold.
-    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
-    try {
-      const { queryByRole, queryByText } = render(
-        <TranscriptMessageBody
-          message={{
-            id: "tool-gated-response",
-            role: "assistant",
-            contentBlocks: [
-              textBlock("I will check that."),
-              toolUseBlock({
-                id: "tc-check",
-                name: "bash",
-                input: {},
-                completedAt: 1,
-              }),
-              textBlock("Here is the final answer."),
-            ],
-          }}
-          onSurfaceAction={noop}
-        />,
-      );
+  test("renders all activity inline for a row marked private", () => {
+    // The row's prose is a scratchpad and its reply was a deliberate
+    // `send_user_message`, so there is no "earlier" prose to fold.
+    const { queryByRole, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "private-response",
+          role: "assistant",
+          assistantTextVisibility: "private",
+          contentBlocks: [
+            textBlock("I will check that."),
+            toolUseBlock({
+              id: "tc-check",
+              name: "bash",
+              input: {},
+              completedAt: 1,
+            }),
+            textBlock("Here is the final answer."),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
 
-      expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
-      expect(queryByText("I will check that.")).not.toBeNull();
-      expect(queryByText("Here is the final answer.")).not.toBeNull();
-    } finally {
-      useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
-    }
+    expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+    expect(queryByText("I will check that.")).not.toBeNull();
+    expect(queryByText("Here is the final answer.")).not.toBeNull();
   });
 
-  test("renders a projected tool-gated history row through the thinking UI", () => {
-    // The server projects a tool-gated row before it ships: the raw prose
-    // arrives as thinking, each `send_user_message` call as its own text
-    // block. Nothing new renders it; it reads as an ordinary reasoning row
-    // above the reply.
-    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
-    try {
-      const { container, queryByRole, queryByText } = render(
-        <TranscriptMessageBody
-          message={{
-            id: "tool-gated-history",
-            role: "assistant",
-            contentBlocks: [
-              thinkingBlock("private working notes"),
-              textBlock("Found it."),
-              textBlock("Sending now."),
-            ],
-          }}
-          onSurfaceAction={noop}
-        />,
-      );
+  test("still collapses a row carrying no visibility marker", () => {
+    // A row written before the gate, or by a daemon that predates the marker,
+    // sits beside private rows in the same conversation and keeps the shipped
+    // rendering. The decision is the row's, so nothing about the assistant's
+    // current settings reaches it.
+    const { getByRole, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "legacy-response",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("I will check that."),
+            toolUseBlock({
+              id: "tc-check",
+              name: "bash",
+              input: {},
+              completedAt: 1,
+            }),
+            textBlock("Here is the final answer."),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
 
-      expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
-      expect(
-        container.querySelectorAll("[data-testid='thought-process-link']")
-          .length,
-      ).toBe(1);
-      expect(queryByText("Found it.")).not.toBeNull();
-      expect(queryByText("Sending now.")).not.toBeNull();
-    } finally {
-      useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
-    }
+    expect(getByRole("button", { name: "Earlier activity" })).not.toBeNull();
+    expect(queryByText("I will check that.")).toBeNull();
+  });
+
+  test("still collapses a fallback row marked visible", () => {
+    // A tool-gated turn that ended without ever calling the tool surfaced its
+    // raw text as the reply, so that text is prose the user read and the
+    // shipped folding applies to it unchanged.
+    const { getByRole } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "fallback-response",
+          role: "assistant",
+          assistantTextVisibility: "visible",
+          contentBlocks: [
+            textBlock("I will check that."),
+            toolUseBlock({
+              id: "tc-check",
+              name: "bash",
+              input: {},
+              completedAt: 1,
+            }),
+            textBlock("Here is the final answer."),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(getByRole("button", { name: "Earlier activity" })).not.toBeNull();
+  });
+
+  test("renders a projected private row through the thinking UI", () => {
+    // The server projects such a row before it ships: the raw prose arrives as
+    // thinking, each `send_user_message` call as its own text block. Nothing
+    // new renders it; it reads as an ordinary reasoning row above the reply.
+    const { container, queryByRole, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "private-history",
+          role: "assistant",
+          assistantTextVisibility: "private",
+          contentBlocks: [
+            thinkingBlock("private working notes"),
+            textBlock("Found it."),
+            textBlock("Sending now."),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+    expect(
+      container.querySelectorAll("[data-testid='thought-process-link']").length,
+    ).toBe(1);
+    expect(queryByText("Found it.")).not.toBeNull();
+    expect(queryByText("Sending now.")).not.toBeNull();
   });
 
   test("draws no chip and no trailing thinking row for a send_user_message call", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -797,8 +797,8 @@ describe("TranscriptMessageBody", () => {
   });
 
   test("renders all activity inline for a row marked private", () => {
-    // The row's prose is a scratchpad and its reply was a deliberate
-    // `send_user_message`, so there is no "earlier" prose to fold.
+    // The row's prose is a scratchpad and its reply is a deliberate
+    // `send_user_message` call, so there is no "earlier" prose to fold.
     const { queryByRole, queryByText } = render(
       <TranscriptMessageBody
         message={{
@@ -826,10 +826,9 @@ describe("TranscriptMessageBody", () => {
   });
 
   test("still collapses a row carrying no visibility marker", () => {
-    // A row written before the gate, or by a daemon that predates the marker,
-    // sits beside private rows in the same conversation and keeps the shipped
-    // rendering. The decision is the row's, so nothing about the assistant's
-    // current settings reaches it.
+    // An unmarked row sits beside private rows in the same conversation and
+    // keeps the standard rendering. The decision is the row's, so nothing
+    // about the assistant's current settings reaches it.
     const { getByRole, queryByText } = render(
       <TranscriptMessageBody
         message={{
@@ -855,9 +854,8 @@ describe("TranscriptMessageBody", () => {
   });
 
   test("still collapses a fallback row marked visible", () => {
-    // A tool-gated turn that ended without ever calling the tool surfaced its
-    // raw text as the reply, so that text is prose the user read and the
-    // shipped folding applies to it unchanged.
+    // A row marked visible carries its own plain text as the reply, so that
+    // text is prose the user reads and the standard folding applies to it.
     const { getByRole } = render(
       <TranscriptMessageBody
         message={{

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -827,6 +827,39 @@ describe("TranscriptMessageBody", () => {
     expect(queryByText("Here is the final answer.")).not.toBeNull();
   });
 
+  test("renders all activity inline under the flag, marker or not", () => {
+    // Under `send-user-message` every text block is a message the assistant
+    // chose to send. A row that reached the client without its marker (an
+    // older wire, a reload) must not fold the earlier sends away.
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    try {
+      const { queryByRole, queryByText } = render(
+        <TranscriptMessageBody
+          message={{
+            id: "flag-on-response",
+            role: "assistant",
+            contentBlocks: [
+              textBlock("First message sent."),
+              toolUseBlock({
+                id: "tc-send",
+                name: "bash",
+                input: {},
+                completedAt: 1,
+              }),
+              textBlock("Second message sent."),
+            ],
+          }}
+          onSurfaceAction={noop}
+        />,
+      );
+      expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+      expect(queryByText("First message sent.")).not.toBeNull();
+      expect(queryByText("Second message sent.")).not.toBeNull();
+    } finally {
+      useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
+    }
+  });
+
   test("still collapses a row carrying no visibility marker", () => {
     // An unmarked row sits beside private rows in the same conversation and
     // keeps the standard rendering. The decision is the row's, so nothing

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -920,10 +920,11 @@ describe("TranscriptMessageBody", () => {
     expect(queryByText("All done.")).not.toBeNull();
   });
 
-  test("renders a projected private row through the thinking UI", () => {
+  test("renders a projected private row's reply and none of its scratchpad", () => {
     // The server projects such a row before it ships: the raw prose arrives as
-    // thinking, each `send_user_message` call as its own text block. Nothing
-    // new renders it; it reads as an ordinary reasoning row above the reply.
+    // thinking, each `send_user_message` call as its own text block. The
+    // scratchpad is the assistant talking to itself, so the row is its reply
+    // and nothing else.
     const { container, queryByRole, queryByText } = render(
       <TranscriptMessageBody
         message={{
@@ -943,7 +944,9 @@ describe("TranscriptMessageBody", () => {
     expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
     expect(
       container.querySelectorAll("[data-testid='thought-process-link']").length,
-    ).toBe(1);
+    ).toBe(0);
+    expect(queryByText("Thinking")).toBeNull();
+    expect(queryByText("private working notes")).toBeNull();
     expect(queryByText("Found it.")).not.toBeNull();
     expect(queryByText("Sending now.")).not.toBeNull();
   });
@@ -973,6 +976,34 @@ describe("TranscriptMessageBody", () => {
 
     expect(queryByText("Here you go.")).not.toBeNull();
     expect(container.textContent).not.toContain("send_user_message");
+    expect(container.textContent).not.toContain("Thinking");
+  });
+
+  test("holds the thinking row off a streaming private row", () => {
+    // The row's only step draws its own inline card, so the run falls through
+    // to the thinking branch. An unmarked row shimmers "Thinking" there while
+    // the turn streams; a private row has no reasoning the user reads, so the
+    // dots row under the transcript owns the wait instead.
+    const { container } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "private-streaming",
+          role: "assistant",
+          assistantTextVisibility: "private",
+          contentBlocks: [
+            toolUseBlock({
+              id: "tc-spawn",
+              name: "subagent_spawn",
+              input: {},
+            }),
+          ],
+        }}
+        isStreaming
+        isLatestMessage
+        onSurfaceAction={noop}
+      />,
+    );
+
     expect(container.textContent).not.toContain("Thinking");
   });
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -332,6 +332,7 @@ import type { ResponseArtifact } from "@/domains/chat/transcript/response-artifa
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
 import { MIN_VERSION as REDACTED_CHIPS_MIN_VERSION } from "@/lib/backwards-compat/use-supports-redacted-credential-chips";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 const noop = () => {};
@@ -390,6 +391,7 @@ afterAll(() => {
 });
 afterEach(() => {
   cleanup();
+  useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
 });
 
 function renderMessage(
@@ -1005,6 +1007,63 @@ describe("TranscriptMessageBody", () => {
     );
 
     expect(container.textContent).not.toContain("Thinking");
+  });
+
+  test("hides every thinking affordance when the transcript-wide gate is on", () => {
+    // A mixed history row: reasoning, a tool run, then the answer.
+    const mixedRow: DisplayMessage = {
+      id: "mixed-history",
+      role: "assistant",
+      contentBlocks: [
+        thinkingBlock("weighing the options"),
+        toolUseBlock({
+          id: "tc-bash",
+          name: "bash",
+          input: { command: "ls" },
+          completedAt: 1,
+        }),
+        textBlock("Here you go."),
+      ],
+    };
+
+    // The per-user opt-out renders every group inline, so the assertions read
+    // the thinking affordances themselves rather than the collapse around them.
+    useClientFeatureFlagStore.setState({ inlineAssistantIntermediates: true });
+    try {
+      useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+      const gated = render(
+        <TranscriptMessageBody message={mixedRow} onSurfaceAction={noop} />,
+      );
+      // The reasoning reaches neither the rendered text nor the steps the
+      // activity card would draw, and the tool run it sat beside is untouched.
+      expect(gated.container.textContent).not.toContain("Thinking");
+      expect(gated.container.textContent).not.toContain("weighing the options");
+      // The run is down to its one tool, so it renders as a lone tool row
+      // rather than the combined activity card.
+      expect(
+        gated.container.querySelector("[data-testid='inline-tool-link']"),
+      ).not.toBeNull();
+      expect(gated.queryByText("Here you go.")).not.toBeNull();
+      cleanup();
+
+      useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
+      const ungated = render(
+        <TranscriptMessageBody message={mixedRow} onSurfaceAction={noop} />,
+      );
+      const ungatedCard = ungated.container.querySelector(
+        "[data-testid='tool-progress-card']",
+      );
+      expect(ungatedCard?.getAttribute("data-item-kinds")).toBe(
+        "thinking,toolCall",
+      );
+      expect(ungatedCard?.getAttribute("data-item-thinking")).toBe(
+        "weighing the options",
+      );
+    } finally {
+      useClientFeatureFlagStore.setState({
+        inlineAssistantIntermediates: false,
+      });
+    }
   });
 
   test("renders the answered question card for a settled ask_question", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -333,6 +333,7 @@ import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-mess
 import { MIN_VERSION as REDACTED_CHIPS_MIN_VERSION } from "@/lib/backwards-compat/use-supports-redacted-credential-chips";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 const noop = () => {};
 
@@ -794,6 +795,101 @@ describe("TranscriptMessageBody", () => {
         inlineAssistantIntermediates: false,
       });
     }
+  });
+
+  test("renders all activity inline when the assistant is tool-gated", () => {
+    // A tool-gated assistant's prose is reasoning, and its reply is a
+    // deliberate `send_user_message`, so there is no "earlier" prose to fold.
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    try {
+      const { queryByRole, queryByText } = render(
+        <TranscriptMessageBody
+          message={{
+            id: "tool-gated-response",
+            role: "assistant",
+            contentBlocks: [
+              textBlock("I will check that."),
+              toolUseBlock({
+                id: "tc-check",
+                name: "bash",
+                input: {},
+                completedAt: 1,
+              }),
+              textBlock("Here is the final answer."),
+            ],
+          }}
+          onSurfaceAction={noop}
+        />,
+      );
+
+      expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+      expect(queryByText("I will check that.")).not.toBeNull();
+      expect(queryByText("Here is the final answer.")).not.toBeNull();
+    } finally {
+      useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
+    }
+  });
+
+  test("renders a projected tool-gated history row through the thinking UI", () => {
+    // The server projects a tool-gated row before it ships: the raw prose
+    // arrives as thinking, each `send_user_message` call as its own text
+    // block. Nothing new renders it; it reads as an ordinary reasoning row
+    // above the reply.
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    try {
+      const { container, queryByRole, queryByText } = render(
+        <TranscriptMessageBody
+          message={{
+            id: "tool-gated-history",
+            role: "assistant",
+            contentBlocks: [
+              thinkingBlock("private working notes"),
+              textBlock("Found it."),
+              textBlock("Sending now."),
+            ],
+          }}
+          onSurfaceAction={noop}
+        />,
+      );
+
+      expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+      expect(
+        container.querySelectorAll("[data-testid='thought-process-link']")
+          .length,
+      ).toBe(1);
+      expect(queryByText("Found it.")).not.toBeNull();
+      expect(queryByText("Sending now.")).not.toBeNull();
+    } finally {
+      useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
+    }
+  });
+
+  test("draws no chip and no trailing thinking row for a send_user_message call", () => {
+    // The live block order of a tool-gated turn: the daemon streams the reply
+    // as text just before the call that carried it lands.
+    const { container, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "tool-gated-live",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Here you go."),
+            toolUseBlock({
+              id: "tc-send",
+              name: "send_user_message",
+              input: { message: "Here you go." },
+            }),
+          ],
+        }}
+        isStreaming
+        isLatestMessage
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(queryByText("Here you go.")).not.toBeNull();
+    expect(container.textContent).not.toContain("send_user_message");
+    expect(container.textContent).not.toContain("Thinking");
   });
 
   test("renders the answered question card for a settled ask_question", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -50,6 +50,7 @@ import {
   type ContentBlockActivityItem,
   finalResponseStartIndex,
   groupContentBlocks,
+  groupOptionsForMessage,
   isSubagentSpawnCall,
   isTaskProgressSurface,
 } from "@/domains/chat/transcript/message-content";
@@ -174,6 +175,11 @@ export function TranscriptMessageBody({
   const isSlackMessage = Boolean(message.slackMessage);
   const isSlackReaction = message.slackMessage?.eventKind === "reaction";
   const isUser = message.role === "user";
+  // A row the daemon marks private speaks through the reply tool, so its
+  // reasoning is a scratchpad. `groupOptionsForMessage` drops the settled
+  // blocks; this is what keeps the live row from shimmering a "Thinking" label
+  // over the reply while the turn is still running.
+  const hidesThinking = message.assistantTextVisibility === "private";
   const hasAttachments = Boolean(message.attachments?.length);
   // Gated on the transcript owner: an older daemon neutralizes nothing, so
   // sentinel-shaped text in its transcripts must never chip-ify, and only the
@@ -181,10 +187,12 @@ export function TranscriptMessageBody({
   const supportsRedactedCredentialChips =
     useSupportsRedactedCredentialChips(assistantId);
 
-  // User-typed thinking tags must render verbatim; only assistant text splits.
-  const groups = groupContentBlocks(message.contentBlocks ?? [], {
-    splitInlineThinking: !isUser,
-  });
+  // User-typed thinking tags must render verbatim, and a row marked private
+  // carries no reasoning the user reads.
+  const groups = groupContentBlocks(
+    message.contentBlocks ?? [],
+    groupOptionsForMessage(message),
+  );
 
   // Only the trailing text group of a streaming assistant message is still
   // growing, so only it gets the typewriter re-pacing; earlier groups (and
@@ -913,7 +921,8 @@ export function TranscriptMessageBody({
     // inline thinking `SingleActivity`, plus any spawn cards. A trailing run
     // reads as still-streaming only while the row is live.
     const combinedThinking = thinkingContents.join("\n");
-    const showThinking = combinedThinking || (isStreaming && isLastGroup);
+    const showThinking =
+      !hidesThinking && (combinedThinking || (isStreaming && isLastGroup));
     return (
       <Fragment key={key}>
         {showThinking && (

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -79,6 +79,7 @@ import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ConversationMessageSurface } from "@vellumai/assistant-api";
@@ -171,6 +172,9 @@ export function TranscriptMessageBody({
   const { t } = useTranslation("chat");
   const inlineAssistantIntermediates =
     useClientFeatureFlagStore.use.inlineAssistantIntermediates();
+  // Assistant-scoped, because it describes what the daemon this transcript
+  // came from does with a turn, not a preference of the device reading it.
+  const sendUserMessage = useAssistantFeatureFlagStore.use.sendUserMessage();
   const isSlackMessage = Boolean(message.slackMessage);
   const isSlackReaction = message.slackMessage?.eventKind === "reaction";
   const isUser = message.role === "user";
@@ -1201,11 +1205,13 @@ export function TranscriptMessageBody({
     groups,
     groupDrawsVisibleOutput,
   );
-  // Per-user opt-out of the "Earlier activity" disclosure: with the flag on,
-  // no group is collapsible, so the whole response renders inline at full
-  // size and none of the collapsed styling applies.
+  // Two reasons no group is collapsible, after which the whole response
+  // renders inline at full size and none of the collapsed styling applies: the
+  // per-user opt-out, and a tool-gated assistant, whose reply is a deliberate
+  // `send_user_message` and whose prose is reasoning the transcript already
+  // shows as thinking, so there is no "earlier" prose left to fold away.
   const collapsibleGroupIndexes = groups.flatMap((group, groupIndex) => {
-    if (inlineAssistantIntermediates) {
+    if (inlineAssistantIntermediates || sendUserMessage) {
       return [];
     }
     if (groupIndex >= finalResponseGroupIndex) {

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1213,15 +1213,18 @@ export function TranscriptMessageBody({
     groups,
     groupDrawsVisibleOutput,
   );
-  // Two reasons no group is collapsible, after which the whole response
+  // Three reasons no group is collapsible, after which the whole response
   // renders inline at full size and none of the collapsed styling applies: the
-  // per-user opt-out, and a row the daemon marks private, whose prose arrives
-  // projected into thinking blocks with the reply as its own text, leaving no
-  // "earlier" prose to fold away. The second reason is the row's own marker,
-  // so each row in a conversation stands on its own.
+  // per-user opt-out; the `send-user-message` flag, under which every text
+  // block is a message the assistant chose to send and none is "earlier"
+  // prose to fold away; and a row the daemon marks private, whose prose
+  // arrives projected into thinking blocks with the reply as its own text.
+  // The third reason is the row's own marker, so a row sent under the flag
+  // stays inline after the flag is turned off.
   const collapsibleGroupIndexes = groups.flatMap((group, groupIndex) => {
     if (
       inlineAssistantIntermediates ||
+      hideThinkingUi ||
       message.assistantTextVisibility === "private"
     ) {
       return [];

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1203,11 +1203,10 @@ export function TranscriptMessageBody({
   );
   // Two reasons no group is collapsible, after which the whole response
   // renders inline at full size and none of the collapsed styling applies: the
-  // per-user opt-out, and a row whose prose the daemon marked private, which
-  // reaches here already projected into thinking blocks with the reply as its
-  // own text, leaving no "earlier" prose to fold away. Read off the row rather
-  // than off a current setting, so every row in a conversation renders the way
-  // the turn that wrote it was run.
+  // per-user opt-out, and a row the daemon marks private, whose prose arrives
+  // projected into thinking blocks with the reply as its own text, leaving no
+  // "earlier" prose to fold away. The second reason is the row's own marker,
+  // so each row in a conversation stands on its own.
   const collapsibleGroupIndexes = groups.flatMap((group, groupIndex) => {
     if (
       inlineAssistantIntermediates ||

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -61,6 +61,7 @@ import { AnsweredQuestionCard } from "@/domains/chat/components/answered-questio
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
 import { AssistantContentDisclosure } from "@/domains/chat/transcript/assistant-content-disclosure";
 import { parseInlineSurfaces } from "@/domains/chat/utils/parse-inline-surfaces";
+import { useHideThinkingUi } from "@/domains/chat/hooks/use-hide-thinking-ui";
 import { useSmoothStreamText } from "@/domains/chat/hooks/use-smooth-stream-text";
 import { useTranslation } from "@/i18n";
 import { useSupportsRedactedCredentialChips } from "@/lib/backwards-compat/use-supports-redacted-credential-chips";
@@ -175,11 +176,13 @@ export function TranscriptMessageBody({
   const isSlackMessage = Boolean(message.slackMessage);
   const isSlackReaction = message.slackMessage?.eventKind === "reaction";
   const isUser = message.role === "user";
-  // A row the daemon marks private speaks through the reply tool, so its
-  // reasoning is a scratchpad. `groupOptionsForMessage` drops the settled
-  // blocks; this is what keeps the live row from shimmering a "Thinking" label
-  // over the reply while the turn is still running.
-  const hidesThinking = message.assistantTextVisibility === "private";
+  // Two reasons this row shows no reasoning: the transcript-wide gate, and the
+  // row's own private marker. `groupOptionsForMessage` drops the settled blocks
+  // for either; this is what keeps the live row from shimmering a "Thinking"
+  // label over the reply while the turn is still running.
+  const hideThinkingUi = useHideThinkingUi();
+  const hidesThinking =
+    hideThinkingUi || message.assistantTextVisibility === "private";
   const hasAttachments = Boolean(message.attachments?.length);
   // Gated on the transcript owner: an older daemon neutralizes nothing, so
   // sentinel-shaped text in its transcripts must never chip-ify, and only the
@@ -191,7 +194,7 @@ export function TranscriptMessageBody({
   // carries no reasoning the user reads.
   const groups = groupContentBlocks(
     message.contentBlocks ?? [],
-    groupOptionsForMessage(message),
+    groupOptionsForMessage(message, hideThinkingUi),
   );
 
   // Only the trailing text group of a streaming assistant message is still

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -79,7 +79,6 @@ import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
-import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ConversationMessageSurface } from "@vellumai/assistant-api";
@@ -172,9 +171,6 @@ export function TranscriptMessageBody({
   const { t } = useTranslation("chat");
   const inlineAssistantIntermediates =
     useClientFeatureFlagStore.use.inlineAssistantIntermediates();
-  // Assistant-scoped, because it describes what the daemon this transcript
-  // came from does with a turn, not a preference of the device reading it.
-  const sendUserMessage = useAssistantFeatureFlagStore.use.sendUserMessage();
   const isSlackMessage = Boolean(message.slackMessage);
   const isSlackReaction = message.slackMessage?.eventKind === "reaction";
   const isUser = message.role === "user";
@@ -1207,11 +1203,16 @@ export function TranscriptMessageBody({
   );
   // Two reasons no group is collapsible, after which the whole response
   // renders inline at full size and none of the collapsed styling applies: the
-  // per-user opt-out, and a tool-gated assistant, whose reply is a deliberate
-  // `send_user_message` and whose prose is reasoning the transcript already
-  // shows as thinking, so there is no "earlier" prose left to fold away.
+  // per-user opt-out, and a row whose prose the daemon marked private, which
+  // reaches here already projected into thinking blocks with the reply as its
+  // own text, leaving no "earlier" prose to fold away. Read off the row rather
+  // than off a current setting, so every row in a conversation renders the way
+  // the turn that wrote it was run.
   const collapsibleGroupIndexes = groups.flatMap((group, groupIndex) => {
-    if (inlineAssistantIntermediates || sendUserMessage) {
+    if (
+      inlineAssistantIntermediates ||
+      message.assistantTextVisibility === "private"
+    ) {
       return [];
     }
     if (groupIndex >= finalResponseGroupIndex) {

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -381,16 +381,28 @@ describe("the turn-status slot's own word for the wait", () => {
     expect(getByTestId("transcript-thinking-row").textContent).toBe("Working");
   });
 
-  test("keeps a daemon-supplied label either way", () => {
-    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
-    const { getByTestId } = render(
+  function renderLabelled() {
+    return render(
       <TranscriptRow
         item={{ ...thinkingItem, label: "Processing bash results" }}
         onSurfaceAction={() => {}}
       />,
     );
+  }
+
+  test("keeps a daemon-supplied label by default", () => {
+    const { getByTestId } = renderLabelled();
     expect(getByTestId("transcript-thinking-row").textContent).toBe(
       "Processing bash results",
     );
+  });
+
+  test("drops the daemon's status line once the step stack is the live label", () => {
+    // Two labels stacked under one reply, the step stack's "Writing · 5 steps"
+    // over the daemon's own sentence, read as the assistant narrating itself
+    // twice. "Working" still covers the gap before the first tool starts.
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    const { getByTestId } = renderLabelled();
+    expect(getByTestId("transcript-thinking-row").textContent).toBe("Working");
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -18,9 +18,11 @@ import { TranscriptRow } from "@/domains/chat/transcript/transcript-row";
 import type { CreditsUpsellItem } from "@/domains/chat/transcript/types";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 afterEach(() => {
   cleanup();
+  useAssistantFeatureFlagStore.setState({ sendUserMessage: false });
 });
 
 function makeErrorRow(id: string): DisplayMessage {
@@ -352,5 +354,43 @@ describe("TranscriptRow creditsUpsell dispatch", () => {
 
     fireEvent.click(getByTestId("credits-upsell-card-stub"));
     expect(wrapper.getAttribute("data-revealed")).toBe("false");
+  });
+});
+
+describe("the turn-status slot's own word for the wait", () => {
+  const thinkingItem = {
+    kind: "thinking" as const,
+    key: "thinking",
+    active: true,
+  };
+
+  function renderSlot() {
+    return render(
+      <TranscriptRow item={thinkingItem} onSurfaceAction={() => {}} />,
+    );
+  }
+
+  test("says Thinking by default", () => {
+    const { getByTestId } = renderSlot();
+    expect(getByTestId("transcript-thinking-row").textContent).toBe("Thinking");
+  });
+
+  test("says Working once the transcript hides its reasoning", () => {
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    const { getByTestId } = renderSlot();
+    expect(getByTestId("transcript-thinking-row").textContent).toBe("Working");
+  });
+
+  test("keeps a daemon-supplied label either way", () => {
+    useAssistantFeatureFlagStore.setState({ sendUserMessage: true });
+    const { getByTestId } = render(
+      <TranscriptRow
+        item={{ ...thinkingItem, label: "Processing bash results" }}
+        onSurfaceAction={() => {}}
+      />,
+    );
+    expect(getByTestId("transcript-thinking-row").textContent).toBe(
+      "Processing bash results",
+    );
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -342,13 +342,19 @@ export const TranscriptRow = memo(function TranscriptRow({
             item.active ? "h-7 opacity-100" : "h-0 opacity-0"
           }`}
         >
+          {/*
+            The daemon's own status line ("Processing command results") shows
+            only where it is the transcript's one live label. Under
+            `send-user-message` the step stack above already names the work in
+            the user's terms, and a second label under it reads as the
+            assistant reporting on itself twice. "Working" still covers the gap
+            before the first tool starts, which is the only stretch of a turn
+            the step stack cannot narrate.
+          */}
           <StreamingShimmerText>
-            {item.label ??
-              t(
-                hideThinkingUi
-                  ? "transcriptRow.working"
-                  : "transcriptRow.thinking",
-              )}
+            {hideThinkingUi
+              ? t("transcriptRow.working")
+              : (item.label ?? t("transcriptRow.thinking"))}
           </StreamingShimmerText>
         </div>
       );

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -22,6 +22,7 @@ import { ReactionLineRow } from "@/domains/chat/transcript/reaction-line-row";
 import { SystemCardRow } from "@/domains/chat/transcript/system-card-row";
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
 import { isInteractiveClickTarget } from "@/domains/chat/transcript/transcript-message-body-shared";
+import { useHideThinkingUi } from "@/domains/chat/hooks/use-hide-thinking-ui";
 import { useCoarsePointerReveal } from "@/domains/chat/transcript/use-coarse-pointer-reveal";
 import { isChannelDeleted } from "@/domains/chat/utils/is-channel-deleted";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -225,6 +226,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   isLatestMessage,
 }: TranscriptRowProps) {
   const { t } = useTranslation("chat");
+  const hideThinkingUi = useHideThinkingUi();
   switch (item.kind) {
     case "message": {
       // A row deleted on its channel renders as a tombstone whatever else it
@@ -341,7 +343,12 @@ export const TranscriptRow = memo(function TranscriptRow({
           }`}
         >
           <StreamingShimmerText>
-            {item.label ?? t("transcriptRow.thinking")}
+            {item.label ??
+              t(
+                hideThinkingUi
+                  ? "transcriptRow.working"
+                  : "transcriptRow.thinking",
+              )}
           </StreamingShimmerText>
         </div>
       );

--- a/clients/web/src/domains/chat/transcript/transcript-thinking-shimmer.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-thinking-shimmer.test.tsx
@@ -73,14 +73,28 @@ function assistantThinkingItem(id: string, reasoning: string): MessageItem {
   return { kind: "message", key: id, message: msg };
 }
 
+/** The same row, marked the way a reply carried by `send_user_message` is. */
+function privateThinkingItem(id: string, reasoning: string): MessageItem {
+  const item = assistantThinkingItem(id, reasoning);
+  return {
+    ...item,
+    message: { ...item.message, assistantTextVisibility: "private" },
+  };
+}
+
 const noop = () => {};
 const sharedProps = { onSurfaceAction: noop };
 
-function renderTurn() {
+function renderTurn(
+  responseItem: MessageItem = assistantThinkingItem(
+    "a1",
+    "live reasoning so far",
+  ),
+) {
   return render(
     <LatestTurnRow
       anchorMessage={userItem("u1", "do the thing")}
-      responseItems={[assistantThinkingItem("a1", "live reasoning so far")]}
+      responseItems={[responseItem]}
       {...sharedProps}
     />,
   );
@@ -112,5 +126,26 @@ describe("streaming thinking shimmer wiring", () => {
     expect(getByTestId("thought-process-link")).toBeTruthy();
     expect(queryByTestId("thought-process-loading")).toBeNull();
     expect(getByText("Thinking")).toBeTruthy();
+  });
+});
+
+describe("a row whose prose is a scratchpad", () => {
+  test("streaming turn → no thinking row, shimmering or otherwise", () => {
+    useTurnStore.setState({ phase: "thinking" });
+    const { queryByTestId, queryByText } = renderTurn(
+      privateThinkingItem("a1", "let me look that up"),
+    );
+    expect(queryByTestId("thought-process-link")).toBeNull();
+    expect(queryByTestId("thought-process-loading")).toBeNull();
+    expect(queryByText("Thinking")).toBeNull();
+  });
+
+  test("settled turn → the reasoning it carries stays unrendered", () => {
+    useTurnStore.setState({ phase: "idle" });
+    const { queryByTestId, queryByText } = renderTurn(
+      privateThinkingItem("a1", "let me look that up"),
+    );
+    expect(queryByTestId("thought-process-link")).toBeNull();
+    expect(queryByText("let me look that up")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/turn-selectors.test.ts
+++ b/clients/web/src/domains/chat/turn-selectors.test.ts
@@ -67,6 +67,30 @@ describe("shouldShowThinkingIndicator — authoritative processing close-gate", 
   });
 });
 
+describe("shouldShowThinkingIndicator — step stack handoff", () => {
+  test("stands down once the live message renders a step stack", () => {
+    // Under send-user-message the step stack is the turn's one progress
+    // label; the standalone row would read as a second status under it.
+    expect(
+      shouldShowThinkingIndicator(
+        "thinking",
+        0,
+        ctx({ hasLiveStepStack: true }),
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps the gap before the first step", () => {
+    expect(
+      shouldShowThinkingIndicator(
+        "thinking",
+        0,
+        ctx({ hasLiveStepStack: false }),
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("isAssistantBusy — authoritative processing close-gate", () => {
   test("cannot stop once the server reports the turn idle", () => {
     expect(

--- a/clients/web/src/domains/chat/turn-selectors.ts
+++ b/clients/web/src/domains/chat/turn-selectors.ts
@@ -23,6 +23,11 @@ export interface UIContext {
    * streaming "Thinking" state). Gates off the standalone thinking-dots row so
    * the two don't both render; the dots stay only for the pre-message window. */
   hasStreamingAssistantThinking: boolean;
+  /** True when the live assistant message already renders a step stack under
+   * `send-user-message`, which is then the turn's one progress label. Gates
+   * off the standalone thinking row for the rest of the turn. Always false
+   * with the flag off. */
+  hasLiveStepStack?: boolean;
   hasPendingSecret: boolean;
   hasPendingConfirmation: boolean;
   hasPendingQuestion: boolean;
@@ -113,6 +118,8 @@ export function shouldShowThinkingIndicator(
       !ctx.hasStreamingAssistantMessage) &&
     // Inline SingleActivity owns the loading state once reasoning is present.
     !ctx.hasStreamingAssistantThinking &&
+    // The step stack owns it once a step exists (send-user-message only).
+    !ctx.hasLiveStepStack &&
     activeToolCallCount === 0
   );
 }

--- a/clients/web/src/domains/chat/turn-store.test.ts
+++ b/clients/web/src/domains/chat/turn-store.test.ts
@@ -1746,3 +1746,84 @@ describe("recoverFromAwaitingUserInput", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tool-gated turn (send_user_message)
+// ---------------------------------------------------------------------------
+
+describe("a tool-gated turn", () => {
+  /**
+   * With `send-user-message` on, the daemon streams no raw assistant text: the
+   * first text delta is the message a `send_user_message` call carries, and it
+   * arrives after the turn's real tool work. The stop button and the spinner
+   * are driven off the phase and the in-flight tool count, so both must hold
+   * through that longer silence and clear at `message_complete`.
+   */
+  const events: DomainEvent[] = [
+    { type: "USER_SEND_REQUESTED", turnId: "turn-1" },
+    { type: "USER_SEND_ACCEPTED", turnId: "turn-1" },
+    // web_fetch
+    { type: "TOOL_USE_START" },
+    { type: "TOOL_RESULT" },
+    // the reply, streamed from the tool's argument
+    { type: "ASSISTANT_TEXT_DELTA" },
+    // send_user_message
+    { type: "TOOL_USE_START" },
+    { type: "TOOL_RESULT" },
+    { type: "MESSAGE_COMPLETE" },
+  ];
+
+  test("stays busy through the whole turn and clears at message_complete", () => {
+    let state = INITIAL_TURN_STATE;
+    const busyAlong: boolean[] = [];
+    for (const event of events.slice(0, -1)) {
+      state = turnReducer(state, event);
+      busyAlong.push(
+        isAssistantBusy(state.phase, {
+          ...defaultCtx,
+          // The bubble exists from the first delta onward; before it, only the
+          // phase says a turn is running.
+          hasStreamingAssistantMessage: state.phase === "streaming",
+        }),
+      );
+    }
+    expect(busyAlong.every(Boolean)).toBe(true);
+
+    state = turnReducer(state, { type: "MESSAGE_COMPLETE" });
+    expect(state.phase).toBe("idle");
+    expect(state.activeToolCallCount).toBe(0);
+    expect(isAssistantBusy(state.phase, defaultCtx)).toBe(false);
+  });
+
+  test("shows the thinking indicator in the silence before the reply", () => {
+    // After the tool work settles and before the tool-carried text arrives,
+    // nothing is streaming and no tool is in flight, so the dots are the only
+    // sign the turn is alive and must show.
+    const beforeReply = applyEvents(INITIAL_TURN_STATE, events.slice(0, 4));
+    expect(beforeReply.activeToolCallCount).toBe(0);
+    expect(shouldShowThinkingIndicator(beforeReply.phase, 0, defaultCtx)).toBe(
+      true,
+    );
+
+    // Once the reply streams, the bubble owns the indicator.
+    const afterReply = applyEvents(INITIAL_TURN_STATE, events.slice(0, 5));
+    expect(afterReply.phase).toBe("streaming");
+    expect(
+      shouldShowThinkingIndicator(afterReply.phase, 0, {
+        ...defaultCtx,
+        hasStreamingAssistantMessage: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("the send_user_message call itself does not end the turn", () => {
+    const afterSendCall = applyEvents(INITIAL_TURN_STATE, events.slice(0, 7));
+    expect(afterSendCall.phase).toBe("streaming");
+    expect(
+      isAssistantBusy(afterSendCall.phase, {
+        ...defaultCtx,
+        hasStreamingAssistantMessage: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -8,6 +8,7 @@ import type {
   ConversationMessageSurface,
 } from "@vellumai/assistant-api";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
+import type { AssistantTextVisibility } from "@/domains/chat/utils/assistant-text-visibility";
 import { isToolCallCompleted } from "@/domains/chat/utils/tool-call-status";
 import type { DisplayAttachment } from "@/types/attachment-types";
 import type { ExternalSourceLink } from "@/utils/external-source-link";
@@ -165,6 +166,12 @@ export interface DisplayMessage {
    *  Mirrors `ConversationMessage["noResponse"]`; renders as a quiet marker
    *  and counts as the turn's reply. */
   isNoResponse?: boolean;
+  /** What this row's plain text was to the user who saw the turn. Mirrors
+   *  `ConversationMessage["assistantTextVisibility"]` and the same field on
+   *  `message_complete`; `"private"` marks a row whose prose is a scratchpad
+   *  the daemon already projected into thinking blocks. A property of the row,
+   *  not of any current setting, so history renders the way it was written. */
+  assistantTextVisibility?: AssistantTextVisibility;
   /** Reaction row, either direction; renders as a reaction line, never the
    *  stored sentinel text. */
   reaction?: ConversationMessage["reaction"];

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -166,11 +166,11 @@ export interface DisplayMessage {
    *  Mirrors `ConversationMessage["noResponse"]`; renders as a quiet marker
    *  and counts as the turn's reply. */
   isNoResponse?: boolean;
-  /** What this row's plain text was to the user who saw the turn. Mirrors
+  /** Whether this row's plain text is something the user reads. Mirrors
    *  `ConversationMessage["assistantTextVisibility"]` and the same field on
    *  `message_complete`; `"private"` marks a row whose prose is a scratchpad
-   *  the daemon already projected into thinking blocks. A property of the row,
-   *  not of any current setting, so history renders the way it was written. */
+   *  the daemon projects into thinking blocks. A property of the row, so each
+   *  row renders by its own marker rather than by any current setting. */
   assistantTextVisibility?: AssistantTextVisibility;
   /** Reaction row, either direction; renders as a reaction line, never the
    *  stored sentinel text. */

--- a/clients/web/src/domains/chat/utils/assistant-text-visibility.test.ts
+++ b/clients/web/src/domains/chat/utils/assistant-text-visibility.test.ts
@@ -13,9 +13,9 @@ describe("readAssistantTextVisibility", () => {
   });
 
   test("answers undefined for anything else", () => {
-    // An unmarked row, a daemon that predates the marker, a value this client
-    // does not recognize, and a malformed payload all degrade to the shipped
-    // rendering rather than hiding or restyling a reply.
+    // An unmarked row, a value this client does not recognize, and a malformed
+    // payload all read as no marker, which is the standard rendering rather
+    // than a hidden or restyled reply.
     expect(readAssistantTextVisibility({})).toBeUndefined();
     expect(
       readAssistantTextVisibility({ assistantTextVisibility: "later" }),

--- a/clients/web/src/domains/chat/utils/assistant-text-visibility.test.ts
+++ b/clients/web/src/domains/chat/utils/assistant-text-visibility.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { readAssistantTextVisibility } from "@/domains/chat/utils/assistant-text-visibility";
+
+describe("readAssistantTextVisibility", () => {
+  test("reads the two known markers", () => {
+    expect(
+      readAssistantTextVisibility({ assistantTextVisibility: "private" }),
+    ).toBe("private");
+    expect(
+      readAssistantTextVisibility({ assistantTextVisibility: "visible" }),
+    ).toBe("visible");
+  });
+
+  test("answers undefined for anything else", () => {
+    // An unmarked row, a daemon that predates the marker, a value this client
+    // does not recognize, and a malformed payload all degrade to the shipped
+    // rendering rather than hiding or restyling a reply.
+    expect(readAssistantTextVisibility({})).toBeUndefined();
+    expect(
+      readAssistantTextVisibility({ assistantTextVisibility: "later" }),
+    ).toBeUndefined();
+    expect(
+      readAssistantTextVisibility({ assistantTextVisibility: true }),
+    ).toBeUndefined();
+    expect(readAssistantTextVisibility(undefined)).toBeUndefined();
+    expect(readAssistantTextVisibility(null)).toBeUndefined();
+    expect(readAssistantTextVisibility("private")).toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/chat/utils/assistant-text-visibility.test.ts
+++ b/clients/web/src/domains/chat/utils/assistant-text-visibility.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { readAssistantTextVisibility } from "@/domains/chat/utils/assistant-text-visibility";
+import {
+  isSendUserMessageCall,
+  readAssistantTextVisibility,
+} from "@/domains/chat/utils/assistant-text-visibility";
 
 describe("readAssistantTextVisibility", () => {
   test("reads the two known markers", () => {
@@ -26,5 +29,12 @@ describe("readAssistantTextVisibility", () => {
     expect(readAssistantTextVisibility(undefined)).toBeUndefined();
     expect(readAssistantTextVisibility(null)).toBeUndefined();
     expect(readAssistantTextVisibility("private")).toBeUndefined();
+  });
+});
+
+describe("isSendUserMessageCall", () => {
+  test("matches the reply tool only", () => {
+    expect(isSendUserMessageCall({ name: "send_user_message" })).toBe(true);
+    expect(isSendUserMessageCall({ name: "bash" })).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/utils/assistant-text-visibility.ts
+++ b/clients/web/src/domains/chat/utils/assistant-text-visibility.ts
@@ -1,0 +1,37 @@
+/**
+ * What an assistant row's plain text was to the user who saw the turn.
+ *
+ * - `"private"`: the turn routed its reply through `send_user_message`, so the
+ *   prose is a working scratchpad the user never read. The daemon projects such
+ *   a row before it ships it: raw text arrives as `thinking` blocks and each
+ *   `send_user_message` call as the `text` block carrying its message.
+ * - `"visible"`: the turn ran under the tool gate but ended without ever
+ *   calling the tool, so its raw text was surfaced as the fallback reply.
+ *
+ * Absent on every other row, which is every row today: a call, a subagent leg,
+ * a turn written before the gate, or a turn from a daemon that predates the
+ * marker. Absent means "shipped behavior", so nothing has to know why.
+ */
+export type AssistantTextVisibility = "private" | "visible";
+
+/**
+ * Read the marker off a wire payload that may carry it: a history
+ * `ConversationMessage` or a `message_complete` event. Anything but the two
+ * known values answers `undefined`, so an unmarked row, an older daemon, and a
+ * value this client does not recognize all degrade to the shipped rendering
+ * rather than hiding or restyling a reply.
+ *
+ * The read goes through the payload's runtime shape because the field is the
+ * daemon's to declare, and this client must render correctly against daemons
+ * on either side of it.
+ */
+export function readAssistantTextVisibility(
+  payload: unknown,
+): AssistantTextVisibility | undefined {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined;
+  }
+  const value = (payload as { assistantTextVisibility?: unknown })
+    .assistantTextVisibility;
+  return value === "private" || value === "visible" ? value : undefined;
+}

--- a/clients/web/src/domains/chat/utils/assistant-text-visibility.ts
+++ b/clients/web/src/domains/chat/utils/assistant-text-visibility.ts
@@ -33,3 +33,24 @@ export function readAssistantTextVisibility(
     .assistantTextVisibility;
   return value === "private" || value === "visible" ? value : undefined;
 }
+
+/**
+ * The tool a row's reply travels through when its prose is a scratchpad. Its
+ * argument is the reply itself, which the daemon also streams as ordinary
+ * assistant text and projects into a `text` block on the persisted row, so the
+ * call is never a step the transcript has anything to draw.
+ *
+ * A call to it is also the earliest proof a row is private: the daemon
+ * announces the call while its input is still streaming, before the reply text
+ * and before `message_complete` carries the authoritative marker.
+ */
+export const SEND_USER_MESSAGE_TOOL_NAME = "send_user_message";
+
+/**
+ * Whether a tool call is the user-facing reply channel rather than a step of
+ * the assistant's work. Structural in its argument so both the render path and
+ * the stream fold can ask, without either owning the answer.
+ */
+export function isSendUserMessageCall(toolCall: { name: string }): boolean {
+  return toolCall.name === SEND_USER_MESSAGE_TOOL_NAME;
+}

--- a/clients/web/src/domains/chat/utils/assistant-text-visibility.ts
+++ b/clients/web/src/domains/chat/utils/assistant-text-visibility.ts
@@ -1,29 +1,27 @@
 /**
- * What an assistant row's plain text was to the user who saw the turn.
+ * Whether an assistant row's plain text is something the user reads.
  *
- * - `"private"`: the turn routed its reply through `send_user_message`, so the
- *   prose is a working scratchpad the user never read. The daemon projects such
- *   a row before it ships it: raw text arrives as `thinking` blocks and each
+ * - `"private"`: the row's reply travels through `send_user_message`, so its
+ *   prose is a working scratchpad. The daemon projects such a row before it
+ *   ships it: the prose arrives as `thinking` blocks and each
  *   `send_user_message` call as the `text` block carrying its message.
- * - `"visible"`: the turn ran under the tool gate but ended without ever
- *   calling the tool, so its raw text was surfaced as the fallback reply.
+ * - `"visible"`: the row's own plain text is its reply.
  *
- * Absent on every other row, which is every row today: a call, a subagent leg,
- * a turn written before the gate, or a turn from a daemon that predates the
- * marker. Absent means "shipped behavior", so nothing has to know why.
+ * No marker means the standard transcript rendering, which is what a row
+ * without one gets.
  */
 export type AssistantTextVisibility = "private" | "visible";
 
 /**
- * Read the marker off a wire payload that may carry it: a history
+ * Read the marker off a wire payload that carries one: a history
  * `ConversationMessage` or a `message_complete` event. Anything but the two
- * known values answers `undefined`, so an unmarked row, an older daemon, and a
- * value this client does not recognize all degrade to the shipped rendering
- * rather than hiding or restyling a reply.
+ * known values answers `undefined`, so an unmarked row and a value this client
+ * does not recognize both render the standard way rather than hiding or
+ * restyling a reply.
  *
  * The read goes through the payload's runtime shape because the field is the
- * daemon's to declare, and this client must render correctly against daemons
- * on either side of it.
+ * daemon's to declare, and this client renders correctly whether or not a
+ * given daemon sends it.
  */
 export function readAssistantTextVisibility(
   payload: unknown,

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -185,10 +185,9 @@ describe("mapRuntimeToDisplayMessage", () => {
   });
 
   test("carries the assistant-text visibility marker onto the display message", () => {
-    // The marker is the row's own, so every row in a conversation renders the
-    // way the turn that wrote it was run. An unmarked row (written before the
-    // gate, or by a daemon that predates the marker) stays unmarked, and an
-    // unrecognized value is read as no marker rather than guessed at.
+    // The marker is the row's own, so each row in a conversation renders by
+    // its own value. An unmarked row stays unmarked, and an unrecognized value
+    // reads as no marker rather than being guessed at.
     const plain = makeMessage({ id: "m-plain", role: "assistant" });
     expect(
       mapRuntimeToDisplayMessage(plain).assistantTextVisibility,

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -184,6 +184,37 @@ describe("mapRuntimeToDisplayMessage", () => {
     expect(mapRuntimeToDisplayMessage(m).isNoResponse).toBe(true);
   });
 
+  test("carries the assistant-text visibility marker onto the display message", () => {
+    // The marker is the row's own, so every row in a conversation renders the
+    // way the turn that wrote it was run. An unmarked row (written before the
+    // gate, or by a daemon that predates the marker) stays unmarked, and an
+    // unrecognized value is read as no marker rather than guessed at.
+    const plain = makeMessage({ id: "m-plain", role: "assistant" });
+    expect(
+      mapRuntimeToDisplayMessage(plain).assistantTextVisibility,
+    ).toBeUndefined();
+
+    for (const marker of ["private", "visible"] as const) {
+      const m = makeMessage({
+        id: `m-${marker}`,
+        role: "assistant",
+        assistantTextVisibility: marker,
+      } as Partial<ConversationMessage>);
+      expect(mapRuntimeToDisplayMessage(m).assistantTextVisibility).toBe(
+        marker,
+      );
+    }
+
+    const unknown = makeMessage({
+      id: "m-unknown",
+      role: "assistant",
+      assistantTextVisibility: "later",
+    } as Partial<ConversationMessage>);
+    expect(
+      mapRuntimeToDisplayMessage(unknown).assistantTextVisibility,
+    ).toBeUndefined();
+  });
+
   test("carries deletedAt onto the display message", () => {
     const plain = makeMessage({ id: "m-plain", role: "user" });
     expect(mapRuntimeToDisplayMessage(plain).deletedAt).toBeUndefined();

--- a/clients/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.ts
@@ -2,6 +2,7 @@ import type {
   ConversationMessage,
   ConversationMessageSurface,
 } from "@vellumai/assistant-api";
+import { readAssistantTextVisibility } from "@/domains/chat/utils/assistant-text-visibility";
 import { runtimeAttachmentsToDisplay } from "@/domains/chat/utils/attachment-mapping";
 import { parseAttachmentSummariesFromContent } from "@/domains/chat/utils/parse-attachment-summaries";
 import type {
@@ -188,6 +189,10 @@ export function mapRuntimeToDisplayMessage(
   }
   if (m.noResponse) {
     msg.isNoResponse = true;
+  }
+  const assistantTextVisibility = readAssistantTextVisibility(m);
+  if (assistantTextVisibility) {
+    msg.assistantTextVisibility = assistantTextVisibility;
   }
   if (m.reaction) {
     msg.reaction = m.reaction;

--- a/clients/web/src/domains/chat/utils/message-plain-text.test.ts
+++ b/clients/web/src/domains/chat/utils/message-plain-text.test.ts
@@ -85,6 +85,72 @@ describe("messagePlainText", () => {
   });
 });
 
+describe("a tool-gated turn's plain text", () => {
+  /**
+   * A `send_user_message` turn reaches the two views by different routes: live,
+   * the daemon streams one delta per model call carrying that call's messages
+   * already joined, and the fold lands it as one text block; from history, the
+   * server projects each call into its own text block. Copy, the Copy button,
+   * and the stall watchdog all read this one function, so the two routes must
+   * agree byte for byte or a settled turn reads as server progress forever.
+   */
+  it("folds the same whether the messages arrive joined or as separate blocks", () => {
+    const live: Pick<DisplayMessage, "contentBlocks"> = {
+      // One delta, joined by the daemon before it left.
+      contentBlocks: [{ type: "text", text: "Found it. Sending now." }],
+    };
+    const fromHistory: Pick<DisplayMessage, "contentBlocks"> = {
+      contentBlocks: [
+        { type: "text", text: "Found it." },
+        { type: "text", text: "Sending now." },
+      ],
+    };
+
+    expect(messagePlainText(live)).toBe(messagePlainText(fromHistory));
+    expect(messagePlainText(live)).toBe("Found it. Sending now.");
+  });
+
+  it("agrees across a turn split by tool work between two replies", () => {
+    // Live: a delta, the tool run, then a second delta, so two text blocks.
+    const live: Pick<DisplayMessage, "contentBlocks"> = {
+      contentBlocks: [
+        { type: "text", text: "Checking." },
+        {
+          type: "tool_use",
+          toolCall: { id: "tc-1", name: "web_fetch", input: {} },
+        },
+        { type: "text", text: "All set." },
+      ],
+    };
+    // History: the scratchpad projects to thinking, each call to its text.
+    const fromHistory: Pick<DisplayMessage, "contentBlocks"> = {
+      contentBlocks: [
+        { type: "thinking", thinking: "private working notes" },
+        { type: "text", text: "Checking." },
+        {
+          type: "tool_use",
+          toolCall: { id: "tc-1", name: "web_fetch", input: {} },
+        },
+        { type: "text", text: "All set." },
+      ],
+    };
+
+    expect(messagePlainText(live)).toBe(messagePlainText(fromHistory));
+    expect(messagePlainText(live)).toBe("Checking. All set.");
+  });
+
+  it("is copyable when the tool carried the only user-visible text", () => {
+    expect(
+      messageCopyText({
+        contentBlocks: [
+          { type: "thinking", thinking: "private working notes" },
+          { type: "text", text: "Here you go." },
+        ],
+      }),
+    ).toBe("Here you go.");
+  });
+});
+
 describe("messageCopyText", () => {
   it("offers nothing for a row deleted on its channel", () => {
     expect(

--- a/clients/web/src/domains/chat/utils/reconcile-detection.test.ts
+++ b/clients/web/src/domains/chat/utils/reconcile-detection.test.ts
@@ -127,3 +127,52 @@ describe("serverHasAssistantProgress", () => {
     ).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// A settled tool-gated turn must read as settled.
+// ---------------------------------------------------------------------------
+
+describe("a tool-gated turn", () => {
+  /**
+   * Live, the reply arrives as one delta per model call carrying that call's
+   * `send_user_message` messages already joined; from the server, the row
+   * projects each call into its own text block and the raw prose into
+   * thinking. Both halves of the rescue gate compare the two through
+   * `messagePlainText`, so an unequal fold would make every settled tool-gated
+   * turn look like missed server progress and re-trigger the watchdog forever.
+   */
+  const localRow: DisplayMessage = {
+    id: "a1",
+    role: "assistant",
+    ...textBody("Found it. Sending now."),
+  } as DisplayMessage;
+
+  const serverRow: DisplayMessage = {
+    id: "a1",
+    role: "assistant",
+    contentBlocks: [
+      { type: "thinking", thinking: "private working notes" },
+      { type: "text", text: "Found it." },
+      { type: "text", text: "Sending now." },
+    ],
+  } as DisplayMessage;
+
+  test("the projected server row carries nothing the local view lacks", () => {
+    expect(
+      serverSnapshotHasNewContent(
+        [userRow("u1", "q"), serverRow],
+        [userRow("u1", "q"), localRow],
+      ),
+    ).toBe(false);
+  });
+
+  test("reports no assistant progress once the turn has settled", () => {
+    expect(
+      serverHasAssistantProgress(
+        [userRow("u1", "q"), localRow],
+        [userRow("u1", "q"), serverRow],
+        false,
+      ),
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/utils/silent-tool-calls.test.ts
+++ b/clients/web/src/domains/chat/utils/silent-tool-calls.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isSilentToolCall,
+  isUiSurfaceToolCall,
+} from "@/domains/chat/utils/silent-tool-calls";
+
+describe("isSilentToolCall", () => {
+  test("matches the bookkeeping tools", () => {
+    for (const name of [
+      "send_user_message",
+      "remember",
+      "recall",
+      "delete_memory_page",
+      "notify_parent",
+      "subagent_message",
+      "skill_load",
+      "followup_create",
+      "followup_resolve",
+    ]) {
+      expect(isSilentToolCall({ name })).toBe(true);
+    }
+  });
+
+  test("matches the surface tools, unless one is awaiting a confirmation", () => {
+    for (const name of ["ui_show", "ui_update", "ui_dismiss"]) {
+      expect(isSilentToolCall({ name })).toBe(true);
+      expect(
+        isSilentToolCall({ name, pendingConfirmation: { requestId: "req-1" } }),
+      ).toBe(false);
+    }
+  });
+
+  test("leaves work the user asked for visible", () => {
+    // Side effects, waits, and spawns all draw a step of their own. A pending
+    // confirmation never rescues a bookkeeping tool, which has no chip to hang
+    // one on.
+    for (const name of [
+      "bash",
+      "web_fetch",
+      "file_write",
+      "messaging_send",
+      "subagent_spawn",
+      "schedule_create",
+      "ask_question",
+    ]) {
+      expect(isSilentToolCall({ name })).toBe(false);
+    }
+    expect(
+      isSilentToolCall({
+        name: "remember",
+        pendingConfirmation: { requestId: "req-1" },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isUiSurfaceToolCall", () => {
+  test("covers only the three surface tools", () => {
+    expect(isUiSurfaceToolCall({ name: "ui_show" })).toBe(true);
+    expect(isUiSurfaceToolCall({ name: "remember" })).toBe(false);
+    expect(isUiSurfaceToolCall({ name: "bash" })).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/utils/silent-tool-calls.ts
+++ b/clients/web/src/domains/chat/utils/silent-tool-calls.ts
@@ -1,0 +1,77 @@
+/**
+ * The tool calls the transcript draws nothing for.
+ *
+ * Two kinds live here:
+ *
+ * - **Bookkeeping.** Tools the assistant runs on its own behalf, whose whole
+ *   effect is inside the assistant: writing a memory, reading one back, loading
+ *   a skill body, messaging its own parent, filing a follow-up for itself.
+ *   Nothing the user asked for happened, and nothing they can act on came back,
+ *   so a step row for one reads as the assistant narrating its filing system.
+ *   A `remember` that lands after a delivered reply is the sharpest case: the
+ *   row appears under a finished answer and adds a step to the count.
+ * - **Surface tools.** `ui_show` / `ui_update` / `ui_dismiss` draw through the
+ *   inline surface widget instead of a chip, so a chip beside the surface is a
+ *   second drawing of one action. A call holding a pending confirmation is the
+ *   exception: the chip is what carries the inline confirmation card.
+ *
+ * Anything with a real side effect or a real wait stays visible: web fetches,
+ * bash, file writes, `messaging_send`, `subagent_spawn`, the schedule tools,
+ * and `ask_question` (which renders its own answered card, and whose chip is
+ * the only trace of a question that was never answered).
+ */
+
+import { SEND_USER_MESSAGE_TOOL_NAME } from "@/domains/chat/utils/assistant-text-visibility";
+
+/** A tool call as this module reads it: the name, and any pending confirmation. */
+export interface SilentToolCandidate {
+  name: string;
+  pendingConfirmation?: unknown;
+}
+
+/**
+ * The surface tools, whose output the inline surface widget owns. Named here so
+ * the transcript's own suppression and the silent-tool drop read one list.
+ */
+const UI_SURFACE_TOOL_NAMES = new Set(["ui_show", "ui_update", "ui_dismiss"]);
+
+/**
+ * The bookkeeping tools. Verified against `assistant/src/tools` and
+ * `assistant/src/plugins/defaults`, so a name here is a tool the daemon can
+ * actually emit rather than one this client hopes exists.
+ */
+const BOOKKEEPING_TOOL_NAMES = new Set([
+  SEND_USER_MESSAGE_TOOL_NAME,
+  // Memory plugin (`plugins/defaults/memory/tools.ts`).
+  "remember",
+  "recall",
+  "delete_memory_page",
+  // Subagent chatter (`tools/subagent/`).
+  "notify_parent",
+  "subagent_message",
+  // Skill body loads (`tools/workspace-tools/loader.ts`).
+  "skill_load",
+  // Follow-ups the assistant files for itself (`tools/followups/`).
+  "followup_create",
+  "followup_resolve",
+]);
+
+/**
+ * Whether a call is a surface tool the inline widget already draws. A pending
+ * confirmation keeps it visible, because the chip is where that confirmation
+ * renders.
+ */
+export function isUiSurfaceToolCall(toolCall: SilentToolCandidate): boolean {
+  return !toolCall.pendingConfirmation && UI_SURFACE_TOOL_NAMES.has(toolCall.name);
+}
+
+/**
+ * Whether a tool call is one the transcript draws nothing for. Structural in
+ * its argument so the render path, the projection, and the activity drawer can
+ * all ask without any of them owning the answer.
+ */
+export function isSilentToolCall(toolCall: SilentToolCandidate): boolean {
+  return (
+    BOOKKEEPING_TOOL_NAMES.has(toolCall.name) || isUiSurfaceToolCall(toolCall)
+  );
+}

--- a/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -19,6 +19,7 @@ import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { hasAnyInteractiveSurface } from "@/domains/chat/utils/chat";
+import { isSendUserMessageCall } from "@/domains/chat/utils/assistant-text-visibility";
 
 /**
  * Resolve the conversation id for SSE handlers — events that carry it on
@@ -220,9 +221,19 @@ export function handleAssistantActivityState(
     // this tab's indicator.
     const activeConversationId =
       useConversationStore.getState().activeConversationId;
-    ctx.turnActions.onActivityThinking(event.statusText, {
-      canStartFromIdle: convId != null && convId === activeConversationId,
+    // The daemon names the last completed tool in its label ("Processing
+    // <tool> results"). When that tool is the reply channel, the label
+    // describes a step the transcript suppresses everywhere else, so the turn
+    // reports activity with no label rather than one naming the tool.
+    const describesReplyTool = isSendUserMessageCall({
+      name: ctx.lastCompletedToolNameRef.current ?? "",
     });
+    ctx.turnActions.onActivityThinking(
+      describesReplyTool ? undefined : event.statusText,
+      {
+        canStartFromIdle: convId != null && convId === activeConversationId,
+      },
+    );
     recordDiagnostic("sse_activity_state_thinking_handled", {
       convId,
       reason: event.reason,

--- a/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -116,6 +116,7 @@ export function makeCtx(
       return true;
     }),
     lastActivityVersionRef: { current: new Map() },
+    lastCompletedToolNameRef: { current: undefined },
     currentAssistantMessageIdRef: { current: undefined },
     ...restOverrides,
   };

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { handleAssistantActivityState } from "@/domains/chat/utils/stream-handlers/message-handlers";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import {
   handleToolResult,
@@ -206,5 +207,92 @@ describe("handleToolResult", () => {
         "req-2",
       );
     });
+  });
+});
+
+describe("the reply tool in the live turn", () => {
+  /** The daemon's own label for a turn whose last completed tool was the
+   *  reply channel: the tool name, humanised. */
+  const REPLY_TOOL_STATUS = "Processing send user message results";
+
+  function replyToolTurn(ctx: ReturnType<typeof makeCtx>): void {
+    handleToolUseStart(
+      {
+        type: "tool_use_start",
+        toolName: "send_user_message",
+        input: { message: "on it" },
+        toolUseId: "tc-send",
+      },
+      ctx,
+    );
+    handleToolResult(
+      {
+        type: "tool_result",
+        toolName: "send_user_message",
+        toolUseId: "tc-send",
+        result: "delivered",
+      },
+      ctx,
+    );
+  }
+
+  it("claims no slot in the in-flight tool count", () => {
+    const ctx = makeCtx();
+    replyToolTurn(ctx);
+    expect(ctx.turnActions.onToolUseStart).not.toHaveBeenCalled();
+    expect(ctx.turnActions.onToolResult).not.toHaveBeenCalled();
+  });
+
+  it("never names itself in the live status label", () => {
+    const ctx = makeCtx();
+    replyToolTurn(ctx);
+    handleAssistantActivityState(
+      {
+        type: "assistant_activity_state",
+        activityVersion: 1,
+        phase: "thinking",
+        anchor: "assistant_turn",
+        reason: "tool_result_received",
+        statusText: REPLY_TOOL_STATUS,
+        conversationId: "conv-1",
+      },
+      ctx,
+    );
+    const labels = (
+      ctx.turnActions.onActivityThinking as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls.map((call) => call[0]);
+    expect(labels).toEqual([undefined]);
+  });
+
+  it("leaves a real tool's status label alone", () => {
+    const ctx = makeCtx();
+    replyToolTurn(ctx);
+    handleToolResult(
+      {
+        type: "tool_result",
+        toolName: "bash",
+        toolUseId: "tc-bash",
+        result: "ok",
+      },
+      ctx,
+    );
+    handleAssistantActivityState(
+      {
+        type: "assistant_activity_state",
+        activityVersion: 1,
+        phase: "thinking",
+        anchor: "assistant_turn",
+        reason: "tool_result_received",
+        statusText: "Processing bash results",
+        conversationId: "conv-1",
+      },
+      ctx,
+    );
+    expect(ctx.turnActions.onActivityThinking).toHaveBeenCalledWith(
+      "Processing bash results",
+      { canStartFromIdle: false },
+    );
   });
 });

--- a/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
@@ -1,4 +1,5 @@
 import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { isSendUserMessageCall } from "@/domains/chat/utils/assistant-text-visibility";
 import {
   ACP_CLAUDE_AUTH_REQUIRED_CODE,
   ACP_CLAUDE_OAUTH_MISSING_CODE,
@@ -30,7 +31,12 @@ export function handleToolUseStart(
   ctx: StreamHandlerContext,
 ): void {
   ctx.cancelReconciliation();
-  ctx.turnActions.onToolUseStart();
+  // The reply tool is the turn speaking, not a step of its work: it claims no
+  // slot in the in-flight tool count, which is what the thinking indicator
+  // reads to decide a tool is running.
+  if (!isSendUserMessageCall({ name: event.toolName })) {
+    ctx.turnActions.onToolUseStart();
+  }
   // The reducer folds the tool call onto the assistant row in the snapshot;
   // the handler owns the turn-state transition and the anchor stamp.
   if (event.messageId) {
@@ -42,7 +48,13 @@ export function handleToolResult(
   event: ToolResultEvent,
   ctx: StreamHandlerContext,
 ): void {
-  ctx.turnActions.onToolResult();
+  // Recorded for every tool, including the suppressed reply tool: the activity
+  // state that follows names this tool in its status label, so the label can
+  // only be read once the tool behind it is known.
+  ctx.lastCompletedToolNameRef.current = event.toolName;
+  if (!isSendUserMessageCall({ name: event.toolName })) {
+    ctx.turnActions.onToolResult();
+  }
   // Forward structured tool activity metadata (web_search / web_fetch) onto
   // the turn store so the web-search inline link can render during the
   // active turn. Metadata is live-only — the store clears it on idle

--- a/clients/web/src/domains/chat/utils/stream-handlers/types.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/types.ts
@@ -106,4 +106,9 @@ export interface StreamHandlerContext {
    *  bubble, and by `message_complete` to re-anchor onto the durable server id.
    *  Mirrors macOS `currentAssistantMessageId`. */
   currentAssistantMessageIdRef: MutableRefObject<string | undefined>;
+  /** Name of the tool whose `tool_result` landed most recently. The daemon
+   *  builds its thinking status label out of the same tool ("Processing <tool>
+   *  results"), so this is how `assistant_activity_state` is read for which
+   *  tool the label it carries describes. */
+  lastCompletedToolNameRef: MutableRefObject<string | undefined>;
 }

--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -376,9 +376,9 @@ export function finalizeMessageComplete(
 ): DisplayMessage[] {
   const last = prev[prev.length - 1];
   const attachments = toDisplayAttachments(event.attachments);
-  // What the turn did with its plain text, stamped on the live row from the
-  // same event so it renders the way its persisted twin will, with no refetch
-  // in between.
+  // Whether the row's plain text is something the user reads, stamped on the
+  // live row from the same event that finalizes it, so it renders the way its
+  // persisted twin does with no refetch in between.
   const assistantTextVisibility = readAssistantTextVisibility(event);
   const visibility = assistantTextVisibility ? { assistantTextVisibility } : {};
 

--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -12,6 +12,7 @@
 import { isNoResponseOnlyText } from "@vellumai/service-contracts/no-response";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import { readAssistantTextVisibility } from "@/domains/chat/utils/assistant-text-visibility";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import { toDisplayAttachments } from "@/utils/display-attachments";
 import type {
@@ -375,6 +376,11 @@ export function finalizeMessageComplete(
 ): DisplayMessage[] {
   const last = prev[prev.length - 1];
   const attachments = toDisplayAttachments(event.attachments);
+  // What the turn did with its plain text, stamped on the live row from the
+  // same event so it renders the way its persisted twin will, with no refetch
+  // in between.
+  const assistantTextVisibility = readAssistantTextVisibility(event);
+  const visibility = assistantTextVisibility ? { assistantTextVisibility } : {};
 
   if (last?.role !== "assistant") {
     if (!attachments) {
@@ -388,6 +394,7 @@ export function finalizeMessageComplete(
         role: "assistant" as const,
         timestamp: at,
         attachments,
+        ...visibility,
       },
     ];
   }
@@ -401,6 +408,7 @@ export function finalizeMessageComplete(
       ...(adoptServerId ? { id: event.messageId!, isOptimistic: false } : {}),
       ...(attachments ? { attachments } : {}),
       ...(finalized ?? {}),
+      ...visibility,
       // Deliberate silence, derived at fold time from the shared sentinel
       // contract: the daemon stamps the durable row after the turn, but the
       // live bubble would otherwise render the raw sentinel until a refetch.

--- a/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -396,6 +396,34 @@ describe("finalizeMessageComplete", () => {
     expect(text(result[1]!)).toBe("hello world");
   });
 
+  it("keeps a tool-gated reply, whose only text came from send_user_message", () => {
+    // The daemon streams the tool's `message` as an ordinary text delta just
+    // before `message_complete`, so the row reaching here looks like any other
+    // reply. It must not be read as deliberate silence.
+    const msg = makeAssistantMsg({
+      id: "tool-gated",
+      ...seg("Here you go."),
+      toolCalls: [
+        {
+          id: "tc-send",
+          name: "send_user_message",
+          input: { message: "Here you go." },
+          completedAt: 1,
+        },
+      ],
+    });
+
+    const result = finalizeMessageComplete([userMsg, msg], {
+      type: "message_complete",
+      conversationId: "c-1",
+      messageId: "row-A",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(text(result[1]!)).toBe("Here you go.");
+    expect(result[1]!.isNoResponse).toBeUndefined();
+  });
+
   it("finalizes running tool calls when finalizing", () => {
     const toolCall: ChatMessageToolCall = {
       id: "t-1",

--- a/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -21,6 +21,7 @@ import {
   applyToolResult,
   upsertToolCall,
 } from "@/domains/chat/utils/stream-updaters/tool-call-updaters";
+import type { MessageCompleteEvent } from "@vellumai/assistant-api";
 import type { ToolActivityMetadata } from "@/assistant/web-activity-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import {
@@ -394,6 +395,33 @@ describe("finalizeMessageComplete", () => {
     // Bubble content stays whatever the text-delta accumulator left it as —
     // message_complete no longer carries body content on the wire.
     expect(text(result[1]!)).toBe("hello world");
+  });
+
+  it("stamps the assistant-text visibility marker onto the live row", () => {
+    // The live row carries the same marker its persisted twin will, so the
+    // transcript renders it the same way with no refetch in between.
+    const msg = makeAssistantMsg({ id: "live-row", ...seg("Here you go.") });
+
+    const result = finalizeMessageComplete([userMsg, msg], {
+      type: "message_complete",
+      conversationId: "c-1",
+      messageId: "row-A",
+      assistantTextVisibility: "private",
+    } as MessageCompleteEvent);
+
+    expect(result[1]!.assistantTextVisibility).toBe("private");
+  });
+
+  it("leaves the row unmarked when the event carries no marker", () => {
+    const msg = makeAssistantMsg({ id: "live-row", ...seg("Here you go.") });
+
+    const result = finalizeMessageComplete([userMsg, msg], {
+      type: "message_complete",
+      conversationId: "c-1",
+      messageId: "row-A",
+    });
+
+    expect(result[1]!.assistantTextVisibility).toBeUndefined();
   });
 
   it("keeps a tool-gated reply, whose only text came from send_user_message", () => {

--- a/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -570,6 +570,62 @@ describe("handleConversationError", () => {
 });
 
 // ---------------------------------------------------------------------------
+// upsertToolCall: the assistant-text visibility a send_user_message implies
+// ---------------------------------------------------------------------------
+
+describe("upsertToolCall and the visibility marker", () => {
+  const sendCall = (id: string): ChatMessageToolCall => ({
+    id,
+    name: "send_user_message",
+    input: { message: "Here you go." },
+  });
+
+  it("marks the row private the moment the reply tool is announced", () => {
+    // The daemon announces the call while its input is still streaming, so the
+    // row knows it is private before its first reply delta and long before
+    // `message_complete` carries the authoritative marker.
+    const msg = makeAssistantMsg({ id: "live-row", ...seg("") });
+
+    const result = upsertToolCall([userMsg, msg], sendCall("tc-send"));
+
+    expect(result[1]!.assistantTextVisibility).toBe("private");
+  });
+
+  it("leaves the row unmarked for an ordinary tool call", () => {
+    const msg = makeAssistantMsg({ id: "live-row", ...seg("") });
+
+    const result = upsertToolCall([userMsg, msg], {
+      id: "tc-fetch",
+      name: "web_fetch",
+      input: {},
+    });
+
+    expect(result[1]!.assistantTextVisibility).toBeUndefined();
+  });
+
+  it("does not overwrite a marker message_complete already set", () => {
+    // `message_complete` is authoritative in both directions: a row it marks
+    // visible carries its own text as the reply and keeps the standard
+    // rendering, whatever tool calls follow.
+    const msg = makeAssistantMsg({
+      id: "fallback-row",
+      ...seg("Here you go."),
+      assistantTextVisibility: "visible",
+    });
+
+    const result = upsertToolCall([userMsg, msg], sendCall("tc-send"));
+
+    expect(result[1]!.assistantTextVisibility).toBe("visible");
+  });
+
+  it("marks a bubble it opens for the reply tool", () => {
+    const result = upsertToolCall([userMsg], sendCall("tc-send"), "row-A");
+
+    expect(result[1]!.assistantTextVisibility).toBe("private");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // upsertToolCall
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -398,7 +398,7 @@ describe("finalizeMessageComplete", () => {
   });
 
   it("stamps the assistant-text visibility marker onto the live row", () => {
-    // The live row carries the same marker its persisted twin will, so the
+    // The live row carries the same marker its persisted twin does, so the
     // transcript renders it the same way with no refetch in between.
     const msg = makeAssistantMsg({ id: "live-row", ...seg("Here you go.") });
 

--- a/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/tool-call-updaters.ts
@@ -8,6 +8,7 @@
  */
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import { isSendUserMessageCall } from "@/domains/chat/utils/assistant-text-visibility";
 import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
 import type {
   AnsweredQuestion,
@@ -52,6 +53,29 @@ function upsertToolUseBlock(
 }
 
 /**
+ * The visibility a `send_user_message` call implies for the row carrying it: a
+ * turn that speaks through the tool keeps its prose private.
+ *
+ * The daemon announces the call while its input is still streaming, well
+ * before `message_complete` carries the authoritative marker, and a turn can
+ * send one reply and go on working. Marking the row here is what keeps an
+ * already-sent reply reading as the reply for the rest of the turn instead of
+ * being folded into "Earlier activity" the moment a later one starts.
+ *
+ * Only an unmarked row is stamped, so `message_complete` still decides: a row
+ * it marks `"visible"` (the turn's own text was the reply) stays visible.
+ */
+function impliedVisibility(
+  row: DisplayMessage,
+  toolCall: ChatMessageToolCall,
+): Pick<DisplayMessage, "assistantTextVisibility"> | undefined {
+  if (row.assistantTextVisibility || !isSendUserMessageCall(toolCall)) {
+    return undefined;
+  }
+  return { assistantTextVisibility: "private" };
+}
+
+/**
  * Fold a tool call into the assistant row at `idx`, either updating the
  * existing entry (same `toolCall.id`) or appending a new one with a
  * matching `contentOrder` entry. The `contentBlocks` `tool_use` entry is
@@ -67,6 +91,7 @@ function upsertToolCallIntoRow(
   const existingIdx =
     row.toolCalls?.findIndex((tc) => tc.id === toolCall.id) ?? -1;
   const updated = [...prev];
+  const visibility = impliedVisibility(row, toolCall);
 
   if (existingIdx !== -1) {
     const updatedToolCalls = [...(row.toolCalls ?? [])];
@@ -74,6 +99,7 @@ function upsertToolCallIntoRow(
     updatedToolCalls[existingIdx] = merged;
     updated[idx] = {
       ...row,
+      ...visibility,
       toolCalls: updatedToolCalls,
       contentBlocks: upsertToolUseBlock(row.contentBlocks, merged),
     };
@@ -82,6 +108,7 @@ function upsertToolCallIntoRow(
 
   updated[idx] = {
     ...row,
+    ...visibility,
     toolCalls: [...(row.toolCalls ?? []), toolCall],
     contentOrder: [
       ...(row.contentOrder ?? []),
@@ -131,6 +158,9 @@ export function upsertToolCall(
       id: messageId ?? crypto.randomUUID(),
       ...(messageId ? {} : { isOptimistic: true }),
       role: "assistant" as const,
+      ...(isSendUserMessageCall(toolCall)
+        ? { assistantTextVisibility: "private" as const }
+        : {}),
       toolCalls: [toolCall],
       contentOrder: [{ type: "toolCall", id: toolCall.id }],
       contentBlocks: [{ type: "tool_use", toolCall }],

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -245,6 +245,18 @@ function webSearchStepTitle(terminal: boolean): string {
   return terminal ? "Searched the web" : "Searching the web";
 }
 
+/**
+ * Header title for a `web_fetch` run once the transcript hides its reasoning.
+ * The default title for one is "Thinking", because a fetch is projected as a
+ * synthesized reasoning step ("Reading <page>"). With the thinking surface
+ * gone that word is the last thing standing, and it named a page read rather
+ * than a thought, so the run says what it did in the tense of its sibling
+ * `webSearchStepTitle`.
+ */
+function webFetchStepTitle(terminal: boolean): string {
+  return terminal ? "Read the web" : "Reading the web";
+}
+
 function clampResults(results: WebSearchResultItem[]): {
   visible: WebSearchResultItem[];
   overflowResults: WebSearchResultItem[];
@@ -585,6 +597,7 @@ function buildToolStep(tc: ChatMessageToolCall): ToolCallCardStep {
 function deriveCurrentStepTitle(
   toolCalls: ChatMessageToolCall[],
   liveWebActivity: Record<string, ToolActivityMetadata>,
+  hideThinkingUi: boolean,
 ): string {
   for (let i = toolCalls.length - 1; i >= 0; i--) {
     const tc = toolCalls[i]!;
@@ -601,7 +614,7 @@ function deriveCurrentStepTitle(
         return webSearchStepTitle(terminal);
       }
       if (tc.name === "web_fetch") {
-        return "Thinking";
+        return hideThinkingUi ? webFetchStepTitle(terminal) : "Thinking";
       }
     } else {
       return deriveStepLabel(tc).title;
@@ -765,6 +778,16 @@ function deriveCardState(
  * between tool steps (e.g. `thinking → tool → thinking`) rather than only
  * prepending a single leading-thinking step ahead of all tools.
  */
+/** Render-time choices the projection cannot read for itself. */
+export interface ToolCallCardDataOptions {
+  /**
+   * Whether the transcript hides the assistant's reasoning (see
+   * `useHideThinkingUi`). The card carries no reasoning of its own, but one
+   * header title stands in for it, and that title has to change with the rest.
+   */
+  hideThinkingUi?: boolean;
+}
+
 export type ToolCallCardItem =
   | {
       kind: "thinking";
@@ -828,6 +851,7 @@ export function computeToolCallCardDataFromItems(
   items: ToolCallCardItem[],
   liveWebActivity: Record<string, ToolActivityMetadata>,
   nowMs?: number,
+  options: ToolCallCardDataOptions = {},
 ): ToolCallCardData {
   const toolCalls = items
     .filter(
@@ -895,6 +919,7 @@ export function computeToolCallCardDataFromItems(
     currentStepTitle = deriveCurrentStepTitle(
       renderableToolCalls,
       liveWebActivity,
+      options.hideThinkingUi ?? false,
     );
     currentStepInfo = deriveCurrentStepInfo(
       renderableToolCalls,
@@ -939,10 +964,16 @@ export function computeToolCallCardData(
   toolCalls: ChatMessageToolCall[],
   liveWebActivity: Record<string, ToolActivityMetadata>,
   nowMs?: number,
+  options: ToolCallCardDataOptions = {},
 ): ToolCallCardData {
   const items: ToolCallCardItem[] = toolCalls.map((tc) => ({
     kind: "toolCall",
     toolCall: tc,
   }));
-  return computeToolCallCardDataFromItems(items, liveWebActivity, nowMs);
+  return computeToolCallCardDataFromItems(
+    items,
+    liveWebActivity,
+    nowMs,
+    options,
+  );
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1717,7 +1717,8 @@
     "stopWorkflow": "Stop workflow"
   },
   "transcriptRow": {
-    "thinking": "Thinking"
+    "thinking": "Thinking",
+    "working": "Working"
   },
   "useConversationLoader": {
     "authFailed": "Failed to authenticate user."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1672,7 +1672,8 @@
     "stopWorkflow": "Detener flujo de trabajo"
   },
   "transcriptRow": {
-    "thinking": "Pensando"
+    "thinking": "Pensando",
+    "working": "Trabajando"
   },
   "useConversationLoader": {
     "authFailed": "No se pudo autenticar al usuario."

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1708,7 +1708,8 @@
     "stopWorkflow": "停止工作流程"
   },
   "transcriptRow": {
-    "thinking": "思考中"
+    "thinking": "思考中",
+    "working": "處理中"
   },
   "useConversationLoader": {
     "authFailed": "使用者驗證失敗。"

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1708,7 +1708,8 @@
     "stopWorkflow": "停止工作流"
   },
   "transcriptRow": {
-    "thinking": "思考中"
+    "thinking": "思考中",
+    "working": "处理中"
   },
   "useConversationLoader": {
     "authFailed": "用户身份验证失败。"

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -29,6 +29,11 @@ describe("feature flag catalog", () => {
     expect("vellumHostedInference" in CLIENT_FLAG_DEFAULTS).toBe(false);
   });
 
+  test("exposes the send-user-message tool gate to both flag stores", () => {
+    expect(CLIENT_FLAG_DEFAULTS.sendUserMessage).toBe(false);
+    expect(ASSISTANT_FLAG_DEFAULTS.sendUserMessage).toBe(false);
+  });
+
   test("does not expose GA collapsed assistant intermediates as a feature flag", () => {
     expect("collapseAssistantIntermediates" in CLIENT_FLAG_DEFAULTS).toBe(
       false,

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -494,6 +494,14 @@
       "label": "Velay Webhooks",
       "description": "Platform pods resolve webhook callback URLs from the Velay-published ingress URL instead of registering platform callback routes. Falls back to platform callback registration while no tunnel URL is published.",
       "defaultEnabled": false
+    },
+    {
+      "id": "send-user-message",
+      "scope": "both",
+      "key": "send-user-message",
+      "label": "Send User Message Tool",
+      "description": "Route all user-facing assistant text through the send_user_message tool instead of streamed assistant text",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -494,6 +494,14 @@
       "label": "Velay Webhooks",
       "description": "Platform pods resolve webhook callback URLs from the Velay-published ingress URL instead of registering platform callback routes. Falls back to platform callback registration while no tunnel URL is published.",
       "defaultEnabled": false
+    },
+    {
+      "id": "send-user-message",
+      "scope": "both",
+      "key": "send-user-message",
+      "label": "Send User Message Tool",
+      "description": "Route all user-facing assistant text through the send_user_message tool instead of streamed assistant text",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## What

The web half of the `send-user-message` tool gate. When a turn routes its reply through `send_user_message`, its plain text is a private scratchpad and the daemon projects the row before it ships it: raw prose becomes `thinking` blocks, each call becomes the `text` block carrying its message. This PR stops the transcript drawing what that swap makes redundant.

1. **A row marked private collapses nothing into "Earlier activity".** Its prose reaches the client already projected into thinking blocks, with the reply as its own text, so there is no "earlier" prose left to fold away. The gate ORs into the same early return as the existing per-user `inline-assistant-intermediates` opt-out, which is unchanged.
2. **A `send_user_message` call draws no chip.** It is dropped in `groupContentBlocks` rather than grouped, the way a pointer surface is. It therefore opens no activity run of its own (which showed a shimmering "Thinking" row under the reply for the rest of a streaming turn), does not split the run of real tool work around it, and counts no step in a `MultiActivityGroup` header or the steps panel. `isSuppressedUiTool` covers it as well, for the projection's documented edge case where a call carrying no usable message is left in place rather than silently dropped.

**The decision is the row's, not a setting's.** `DisplayMessage` carries `assistantTextVisibility`, read off the wire in the three places a row learns it: `mapRuntimeToDisplayMessage` for history, `finalizeMessageComplete` for the live row, and `upsertToolCall` the moment a `send_user_message` call is announced. Only `"private"` disables the collapse. A `"visible"` row (a turn that ended without ever calling the tool, so its own text was the reply) folds like any other, and so does an unmarked row. Nothing on the web reads a feature flag.

The third read is what makes a multi-reply turn hold together. A turn can speak, keep working, and speak again; waiting for `message_complete` would leave the first reply unmarked while a later text group opened above it, folding a reply the user has already read into "Earlier activity" until the turn finished. The daemon announces a tool call while its input is still streaming, so `tool_use_preview_start` for `send_user_message` arrives before the reply text it carries. `upsertToolCall` stamps there, covering the live stream and the `rolling-snapshot.ts` rebuild through one path, and only ever stamps a row with no marker yet, so `message_complete` stays authoritative in both directions.

## Why

With the gate on, the web already receives the reply as ordinary `assistant_text_delta` events and already receives projected history rows, so replies render correctly today. What is left is chrome that no longer fits: a disclosure that folds reasoning the user is now meant to see as reasoning, and a chip naming the tool that carried a sentence the transcript prints two lines above it.

## Dependency and merge order

**This must merge after #42183**, which owns the daemon side of the contract and the `send-user-message` flag registry entry.

**The wire field.** This PR reads `assistantTextVisibility` off the history `ConversationMessage` and off the `message_complete` event. As of writing, #42183 carries the marker only as server-side row metadata; the optional wire field is being added to `ConversationMessageSchema` and `MessageCompleteEventSchema` on that branch now. The web therefore reads the value through the payload's runtime shape rather than the declared type, in one shared reader (`assistant-text-visibility.ts`) that validates it. That read is correct either way: it is what lets this client render against daemons on both sides of the field, and it needs no change when the schemas land.

`clients/web/openapi-schemas/daemon.json` needs nothing: it is gitignored, generated from `assistant/openapi.yaml` by `scripts/transform-daemon-spec.ts`, and the field is not consumed through the generated SDK.

## The three couplings: verified, no production change

Each got a test rather than a fix, because each already holds.

**Local vs server text (`reconcile-detection.ts`).** The stall watchdog compares both halves of its rescue gate through `messagePlainText`, so an unequal fold would make every settled tool-gated turn look like missed server progress forever. Live, the daemon joins one model call's messages into a single delta and the fold lands one text block; from history, each call is its own text block. `joinWithSpacing` groups associatively (a space is inserted only when the accumulated left and the next right both end and start non-whitespace, and an empty part joins verbatim), so `join([join([a,b]), c]) === join([a,b,c])`. The two routes agree byte for byte. Pinned by `message-plain-text.test.ts` ("folds the same whether the messages arrive joined or as separate blocks", "agrees across a turn split by tool work between two replies") and `reconcile-detection.test.ts` ("the projected server row carries nothing the local view lacks", "reports no assistant progress once the turn has settled").

**Stop button and spinner (`turn-selectors.ts`, `turn-store.ts`).** The first text delta now arrives after the turn's real tool work, so the busy window has a longer silence in it. Both are driven off `phase` and `activeToolCallCount`, neither of which needs a text delta to stay open. `turn-store.test.ts` "a tool-gated turn" feeds the new event order (`USER_SEND_REQUESTED`, `USER_SEND_ACCEPTED`, `TOOL_USE_START`/`TOOL_RESULT` for `web_fetch`, `ASSISTANT_TEXT_DELTA` from the tool, `TOOL_USE_START`/`TOOL_RESULT` for `send_user_message`, `MESSAGE_COMPLETE`) and asserts busy at every step, the thinking dots in the pre-reply gap, that the `send_user_message` call does not end the turn, and that everything clears at `message_complete`.

**Copy and the no-response derivation (`message-plain-text.ts`, `stream-updaters/message-updaters.ts`).** A turn whose only user-visible text came from the tool reaches `finalizeMessageComplete` looking like any other reply, because the delta lands before `message_complete`. Copy reads the same text blocks. Pinned by `message-plain-text.test.ts` ("is copyable when the tool carried the only user-visible text") and `stream-updaters.test.ts` ("keeps a tool-gated reply, whose only text came from send_user_message").

## Thinking display for projected history

No new UI. A projected row's `thinking` blocks group and render through the existing thinking activity path: one collapsed row, expandable into the drawer. `transcript-message-body.test.tsx` "renders a projected private row through the thinking UI" pins one `thought-process-link` above the reply prose, with no disclosure.

## Verification

- `cd clients/web && bunx tsc --noEmit` clean.
- `bunx eslint` clean on every changed file (also run by the pre-commit hook).
- `prettier --check` clean on every changed file.
- Scoped tests, all green: `message-content.test.ts`, `transcript-message-body.test.tsx` (83), `rolling-snapshot.test.ts`, `turn-store.test.ts` (131), `turn-selectors.test.ts`, `message-plain-text.test.ts`, `reconcile-detection.test.ts`, `assistant-text-visibility.test.ts`, `map-runtime-message.test.ts`, `stream-updaters.test.ts`, `feature-flag-catalog.test.ts` (459 across 11 files), plus the consumers of the changed grouping: `use-live-activity-group.test.ts`, `use-live-thinking-text.test.tsx`, `single-activity.test.tsx`, `multi-activity-group.test.tsx`, `transcript-row.test.tsx` (82 across 5).

Row-marker coverage specifically: a private row does not collapse, an unmarked row in the same conversation still collapses, a `"visible"` fallback row still collapses, the marker maps from history, from `message_complete`, and from the announcement of a `send_user_message` call, an unrecognized value reads as no marker, and a two-reply turn folded from real events keeps both replies visible mid-turn.

## Notes for review

- `SEND_USER_MESSAGE_TOOL_NAME` and `isSendUserMessageCall` live in `utils/assistant-text-visibility.ts` rather than in `transcript/message-content.ts`, so the stream fold does not import from the render layer. The predicate is structural in its argument, so neither side needs the other's tool-call type.
- `groupContentBlocks` dropping a block shifts group indices, which the activity drawer resolves by. Every consumer derives its indices from that same function, so they shift together; this is the mechanism the pointer-surface drop already uses.
- Prettier reformatted two pre-existing unformatted lines it found in files touched here (one in `message-content.ts`, one in `transcript-message-body.test.tsx`). Unrelated to the change, kept rather than reverted.
- No Storybook story was added: an `assistant-content-disclosure` "marked private" variant would render nothing, since the effect is that the disclosure does not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oPSTYuVjkzuXHZskHfpTm
