### PR TITLE
fix(companion): draw the resting pill in onto the creature, not out around it

### DIFF
--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -540,9 +540,17 @@ export function CompanionSurfacePage() {
     // Reading a box forces layout, and this runs on every pixel of every
     // mouse-move the host forwards, so each is read exactly once.
     const pillRect = pillRef.current?.getBoundingClientRect() ?? null;
-    // Whichever pill is drawn is the one the pointer can be on, and exactly
-    // one of them ever is: the pill that carries content has no width until
-    // there is content, and the resting pill fades out the moment there is.
+    // The pill that carries content takes precedence, and it has no width
+    // until there is content, so the resting one answers for every state that
+    // draws no row.
+    //
+    // **The resting rect is the marker's footprint, not the lit line inside
+    // it.** The line draws in onto the creature and goes out the moment a hand
+    // arrives; the footprint does not, precisely so that hand is still on the
+    // surface afterwards. A reach that shrank with the drawing would drop the
+    // pointer onto the desktop and flicker the creature in and out under a
+    // stationary hand.
+    //
     // The resting one is centred on the creature rather than beside it, so the
     // creature's rect falls inside it and the bridge between them comes out
     // degenerate, which is the right answer for two shapes with no gap.

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -218,8 +218,8 @@ const avatarOf = (container: HTMLElement): HTMLElement => {
 };
 
 /**
- * The pill the surface rests in: the lit outline the creature stands in, drawn
- * beside the avatar's box rather than inside it.
+ * The lit line the surface rests in, drawn beside the avatar's box rather than
+ * inside it: the marker, and the ring it draws in to on the creature's edge.
  *
  * Found by the shadow it is the only thing on the surface to carry, since it
  * has no fill and no class of its own to name it by.
@@ -230,6 +230,19 @@ const restingPillOf = (container: HTMLElement): HTMLElement => {
   );
   if (found === undefined) {
     throw new Error("Expected the resting pill to render");
+  }
+  return found;
+};
+
+/**
+ * The box that line is drawn in, which is what the pointer is hit-tested
+ * against and what takes the press: the marker's own footprint, whatever the
+ * line inside it is doing.
+ */
+const restingFootprintOf = (container: HTMLElement): HTMLElement => {
+  const found = restingPillOf(container).parentElement;
+  if (found === null) {
+    throw new Error("Expected the resting pill's footprint to render");
   }
   return found;
 };
@@ -1825,16 +1838,29 @@ describe("the pill the surface rests in", () => {
   });
 
   /**
-   * Hover is the shape answering the pointer: the marker grows into the frame
-   * the creature stands up in, and the growth and the standing are one
-   * gesture.
+   * Hover is the shape answering the pointer: the marker draws in onto the
+   * creature's own artwork and goes out as the creature stands up, so the two
+   * are one gesture and what is left is the creature.
+   *
+   * Inward rather than outward. The marker is wide and the creature is not, so
+   * a pill that grew into a frame read as the surface swelling and then a
+   * creature appearing inside it, which is two events.
    */
-  test("grows to hold the whole creature under the pointer", () => {
+  test("draws in onto the creature under the pointer", () => {
     const { container } = render(<CompanionSurface phase="hover" hovered />);
 
     const pill = restingPillOf(container);
-    expect(pill.style.width).toBe("150px");
-    expect(pill.style.height).toBe("35px");
+    // The creature's own artwork, squared, so the line lands as a ring on its
+    // edge. Narrower than the 64pt marker it came from, which is the point.
+    expect(pill.style.width).toBe("28px");
+    expect(pill.style.height).toBe("28px");
+  });
+
+  /** And it is gone by the time it gets there. */
+  test("goes out as the creature comes out", () => {
+    const { container } = render(<CompanionSurface phase="hover" hovered />);
+
+    expect(restingPillOf(container).style.opacity).toBe("0");
   });
 
   /**
@@ -1860,18 +1886,18 @@ describe("the pill the surface rests in", () => {
   test("centres itself on the creature", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const pill = restingPillOf(container);
-    expect(pill.style.left).toBe("50%");
-    expect(pill.style.transform).toBe("translate(-50%, -50%)");
-    expect(pill.style.top).toBe(avatarOf(container).style.top);
+    const footprint = restingFootprintOf(container);
+    expect(footprint.style.left).toBe("50%");
+    expect(footprint.style.transform).toBe("translate(-50%, -50%)");
+    expect(footprint.style.top).toBe(avatarOf(container).style.top);
   });
 
   /**
-   * The grown pill has to contain the creature, so it takes the avatar's box
-   * the way the creature does: one drawn at `ridiculous` standing in a 35pt
-   * frame would wear it as a belt.
+   * The ring lands on the creature, so it takes the avatar's box the way the
+   * creature does: one that stopped at the authored size would close inside a
+   * creature drawn at `ridiculous` rather than on its edge.
    */
-  test("scales the grown pill with the creature", () => {
+  test("scales the ring it closes on with the creature", () => {
     const { container } = render(
       <CompanionSurface
         phase="hover"
@@ -1881,8 +1907,8 @@ describe("the pill the surface rests in", () => {
     );
 
     const pill = restingPillOf(container);
-    expect(pill.style.width).toBe("300px");
-    expect(pill.style.height).toBe("70px");
+    expect(pill.style.width).toBe("56px");
+    expect(pill.style.height).toBe("56px");
   });
 
   /**
@@ -1918,6 +1944,28 @@ describe("the pill the surface rests in", () => {
   });
 
   /**
+   * **The reach is not the drawing.** The box the line is drawn in holds the
+   * marker's size for as long as the creature is out, so a hand that arrived
+   * on the marker's end is still on the surface once the line has drawn away
+   * from under it.
+   *
+   * Without this the surface flickers under a stationary pointer: the line
+   * leaves, the pointer lands on the desktop, the creature tucks back, and the
+   * marker returns under the same pointer to start again.
+   */
+  test("keeps the marker's reach in every phase", () => {
+    for (const phase of PHASES) {
+      const { container } = render(
+        <CompanionSurface phase={phase} hovered={phase !== "resting"} />,
+      );
+
+      const footprint = restingFootprintOf(container);
+      expect(footprint.style.width).toBe("64px");
+      expect(footprint.style.height).toBe("14px");
+    }
+  });
+
+  /**
    * Faded is not gone. Opacity leaves the box where it is, and this one is
    * drawn after the pill that carries content and centred on the same point
    * the call's bar stands on, so without this a live call hands its presses to
@@ -1928,21 +1976,20 @@ describe("the pill the surface rests in", () => {
       <CompanionSurface phase="call" call={LISTENING_CALL} />,
     );
 
-    expect(restingPillOf(container).style.pointerEvents).toBe("none");
+    expect(restingFootprintOf(container).style.pointerEvents).toBe("none");
   });
 
   test("takes the pointer while it is the shape on screen", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    expect(restingPillOf(container).style.pointerEvents).toBe("");
+    expect(restingFootprintOf(container).style.pointerEvents).toBe("");
   });
 
   /**
-   * A reader who asked for stillness keeps the cross-fade and loses the
-   * growth: the box going from a marker to a frame is travel across the
-   * screen, which is the thing they asked not to have.
+   * A reader who asked for stillness keeps the fade and loses the draw-in: the
+   * line travelling in across the screen is the thing they asked not to have.
    */
-  test("drops the growth for a reader who asked for stillness", () => {
+  test("drops the draw-in for a reader who asked for stillness", () => {
     reducedMotion = true;
 
     const { container } = render(<CompanionSurface phase="hover" hovered />);
@@ -1950,16 +1997,9 @@ describe("the pill the surface rests in", () => {
     expect(restingPillOf(container).style.transitionProperty).toBe("opacity");
   });
 
-  /** Hover opens no pill, so the resting one is still the shape on screen. */
-  test("stays drawn under the pointer", () => {
-    const { container } = render(<CompanionSurface phase="hover" hovered />);
-
-    expect(restingPillOf(container).style.opacity).toBe("1");
-  });
-
   /**
    * The largest thing on screen at rest is what a hand reaches for to move the
-   * surface, and a 150pt shape that ignored the press would read as broken.
+   * surface, and a marker that ignored the press would read as broken.
    */
   test("is a drag handle, as the creature and the pill both are", () => {
     const onSurfacePointerDown = mock(() => {});
@@ -1970,7 +2010,7 @@ describe("the pill the surface rests in", () => {
       />,
     );
 
-    fireEvent.pointerDown(restingPillOf(container));
+    fireEvent.pointerDown(restingFootprintOf(container));
     expect(onSurfacePointerDown).toHaveBeenCalled();
   });
 

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -29,7 +29,6 @@ import type {
 import {
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_BASE_AVATAR_IMAGE,
-  COMPANION_BASE_RESTING_PILL_HEIGHT,
 } from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
@@ -240,33 +239,37 @@ const AVATAR_IMAGE = COMPANION_BASE_AVATAR_IMAGE;
  * colour is not, and being hollow is what keeps it from taking the screen away
  * from whatever the user is actually working in.
  *
- * **Two sizes, because the shape answers the pointer.** `idle` is the marker:
- * the creature is tucked behind it and peeks out of it every few seconds.
- * `active` is what a hand arriving grows it into, big enough for the creature
- * to stand up in. That growth is the whole of what hover does here, and it is
- * why the creature coming out and the pill opening read as one gesture rather
- * than two.
+ * **Two sizes, because the shape gives way to the creature.** `idle` is the
+ * marker: the creature is tucked behind it and peeks out of it every few
+ * seconds. `closing` is where it ends when a hand arrives and the creature
+ * stands up, which is on the creature's own artwork: the marker draws in from
+ * both ends until it is a ring the size of the creature, and goes out as the
+ * creature reaches full size. One gesture, and the thing it hands the surface
+ * over to is the creature.
  *
- * **Only `active` scales with the creature.** It has to contain it, so at
- * `ridiculous` it is five times the pill it is at `small`. `idle` holds one
- * size on every setting: sizing the creature is a statement about the
- * creature, and someone who wants a big mascot when they look at it has not
- * asked for a big lozenge sitting over their work all day. The rim holds one
- * thickness for the same reason, so the line stays a line instead of
+ * **Inward, not outward.** The pill used to grow into a frame the creature
+ * stood inside. The marker is wide and the creature is not, so that read as
+ * the surface swelling under the pointer and then the creature appearing in
+ * the middle of it, which is two events; drawing in reads as one shape
+ * becoming the other. It also leaves nothing lit behind the standing creature,
+ * which is the state hover is actually for.
+ *
+ * **Only `closing` scales with the creature**, because it lands on it. `idle`
+ * holds one size on every setting: sizing the creature is a statement about
+ * the creature, and someone who wants a big mascot when they look at it has
+ * not asked for a big lozenge sitting over their work all day. The rim holds
+ * one thickness for the same reason, so the line stays a line instead of
  * thickening into a frame.
  */
 const RESTING_PILL = {
   /** The marker. Wider than the artwork it stands in for, and hollow. */
   idle: { width: 64, height: 14 },
   /**
-   * What a pointer grows it into: the frame the whole creature stands in.
-   *
-   * The height is the contract's, because main places the window by it: this
-   * shape reaches further below the avatar's centre than the creature does,
-   * and a placement that did not know how far would hang its lower rim off
-   * the bottom of the display.
+   * Where the line ends up: the creature's own artwork, squared, so a
+   * `rounded-full` shape drawn at it is a ring on the creature's edge. Scaled
+   * with the creature by the caller, since the creature is what it lands on.
    */
-  active: { width: 150, height: COMPANION_BASE_RESTING_PILL_HEIGHT },
+  closing: AVATAR_IMAGE,
   /** The lit line's thickness, at every size and every setting. */
   rim: 2.5,
   /** How far that line throws light, as the nearer of its two blooms. */
@@ -944,22 +947,23 @@ export function CompanionSurface({
   /**
    * The creature's box over the one this file's lengths are authored for.
    *
-   * The activated pill takes it, because it has to contain the creature; the
-   * idle marker and the rim do not. See {@link RESTING_PILL}.
+   * The closing ring takes it, because it lands on the creature; the idle
+   * marker and the rim do not. See {@link RESTING_PILL}.
    */
   const restingScale = avatarBox / COMPANION_BASE_AVATAR_BOX;
 
   /**
-   * The resting pill's box: the marker, or what a pointer has grown it into.
+   * The lit line's box: the marker, or the ring it draws in to on the
+   * creature's own edge as the creature stands up.
    *
    * Read off `creatureOut` rather than off `hovered`, so the one thing that
-   * decides whether the creature is standing decides whether there is
-   * anywhere for it to stand. The two are the same gesture.
+   * decides whether the creature is standing decides where the line goes. The
+   * two are the same gesture: the marker becomes the creature.
    */
   const restingBox = creatureOut
     ? {
-        width: RESTING_PILL.active.width * restingScale,
-        height: RESTING_PILL.active.height * restingScale,
+        width: RESTING_PILL.closing * restingScale,
+        height: RESTING_PILL.closing * restingScale,
       }
     : RESTING_PILL.idle;
 
@@ -1139,8 +1143,8 @@ export function CompanionSurface({
       </div>
       {/* The pill the surface rests in: the assistant's own colour as a lit
         edge and nothing inside it. A marker with the creature tucked behind
-        it until a pointer arrives, then grown to the size the creature stands
-        up in. See {@link RESTING_PILL}.
+        it until a pointer arrives, then drawn in onto the creature and out.
+        See {@link RESTING_PILL}.
 
         A sibling of the pill that carries content rather than the same
         element, and the two cross-fade. They are different shapes in different
@@ -1150,26 +1154,31 @@ export function CompanionSurface({
         the centre to an edge mid-transition, which reads as the surface
         flinching.
 
+        **The footprint and the line are two nodes, and only the line moves.**
+        This one is the marker's own box and never changes size, because it is
+        what the pointer is hit-tested against: a shape that drew in from under
+        the hand that arrived would take the surface out from under it, the
+        pointer would land on the desktop, the creature would tuck back, and
+        the marker would return under the same stationary pointer to start
+        again. So the reach stays the marker's for as long as the creature is
+        out, and staying anywhere the marker covered keeps it out.
+
         A drag handle, as the creature and the pill both are. It is the largest
         thing on screen at rest, so it is what a hand reaches for to move the
-        surface, and a 150pt shape that ignored the press would read as broken.
+        surface, and a shape that ignored the press would read as broken.
         `aria-hidden` because it says nothing the creature beside it does not
         already say: the creature carries the accessible name and the press. */}
       <div
-        className="absolute cursor-grab rounded-full transition-[width,height,opacity] duration-300 active:cursor-grabbing"
+        className="absolute cursor-grab active:cursor-grabbing"
         style={{
-          width: inUnits(restingBox.width),
-          height: inUnits(restingBox.height),
-          // **Faded is not gone.** Opacity leaves the box where it is, and
-          // this one is drawn after the pill that carries content and centred
-          // on the same point the call's bar stands on, so a live call would
-          // hand its presses to an invisible sheet instead of to mute and
-          // end. It takes the pointer only while it is the shape on screen.
-          pointerEvents: expanded ? "none" : undefined,
-          // A reader who asked for stillness keeps the cross-fade and loses
-          // the growth: the box going from a marker to a frame is travel
-          // across the screen, which is the thing they asked not to have.
-          transitionProperty: reduce ? "opacity" : undefined,
+          width: inUnits(RESTING_PILL.idle.width),
+          height: inUnits(RESTING_PILL.idle.height),
+          // **The reach is not the drawing.** This box outlives the line
+          // inside it, and it is drawn after the pill that carries content and
+          // centred on the same point the call's bar stands on, so a live call
+          // would hand its presses to an invisible sheet instead of to mute
+          // and end. It takes the pointer only while the creature is in it.
+          pointerEvents: creatureOut ? "none" : undefined,
           // Centred on the point the host put the window around, which is the
           // point the creature holds. The creature is a sibling drawn on that
           // same point, so centring the pill on it is what puts the creature
@@ -1178,21 +1187,40 @@ export function CompanionSurface({
           left: "50%",
           top: lineAt(cardGrowth, 0),
           transform: "translate(-50%, -50%)",
-          boxShadow: restingRim(
-            accentHex,
-            inUnits(RESTING_PILL.rim),
-            inUnits(RESTING_PILL.bloom),
-          ),
-          // Gone the moment there is a pill with something in it. Not
-          // unmounted: the fade is what makes the two read as one surface
-          // changing shape rather than one object replacing another.
-          opacity: expanded ? 0 : 1,
         }}
         onPointerDown={onSurfacePointerDown}
         onContextMenu={onSurfaceContextMenu}
         ref={restingPillRef}
         aria-hidden
-      />
+      >
+        {/* The lit line itself, centred in that footprint: the marker at rest,
+          and the ring on the creature's own edge once the creature is out.
+          Drawn in rather than grown, so the marker reads as becoming the
+          creature rather than as swelling around it. */}
+        <div
+          className="absolute top-1/2 left-1/2 rounded-full transition-[width,height,opacity] duration-300"
+          style={{
+            width: inUnits(restingBox.width),
+            height: inUnits(restingBox.height),
+            transform: "translate(-50%, -50%)",
+            transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
+            // A reader who asked for stillness keeps the fade and loses the
+            // draw-in: the line travelling in across the screen is the thing
+            // they asked not to have.
+            transitionProperty: reduce ? "opacity" : undefined,
+            boxShadow: restingRim(
+              accentHex,
+              inUnits(RESTING_PILL.rim),
+              inUnits(RESTING_PILL.bloom),
+            ),
+            // Gone the moment the creature is out, which is what the draw-in
+            // hands the surface over to. Not unmounted: the fade is what makes
+            // the two read as one surface changing shape rather than one
+            // object replacing another.
+            opacity: creatureOut ? 0 : 1,
+          }}
+        />
+      </div>
       {/* The creature's name for a press, the way the Dock names an icon: a
           small label centred above it rather than a control standing beside
           it.

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1100,15 +1100,21 @@ export const companionBaselineFor = (avatarBox: number): number =>
   (COMPANION_BASE_AVATAR_IMAGE / 2) * companionScaleFor(avatarBox);
 
 /**
- * The height of the pill the surface rests in once a pointer has grown it, at
- * the authored avatar box.
+ * The tallest the pill the surface rests in has ever been drawn, at the
+ * authored avatar box.
  *
  * Here rather than in the renderer alone because main places the window by it:
- * the grown pill is centred on the avatar and reaches further below that
- * centre than the creature does, so a placement that did not know this number
- * would rest the surface low enough to hang the pill's lower rim off the
- * bottom of the display. Two readings of it is a pill drawn somewhere main did
- * not leave room for.
+ * this shape is centred on the avatar, so a placement that did not know how
+ * far below that centre it reached would rest the surface low enough to hang
+ * its lower rim off the bottom of the display.
+ *
+ * **Now a floor rather than a measurement.** The pill no longer grows under
+ * the pointer: it draws in onto the creature and goes out, so nothing the
+ * surface draws is this tall any more and the renderer no longer reads this
+ * number. It stays because the room it reserves is room the surface already
+ * had, and giving it back would move every companion that rests near the
+ * bottom of a display up against the edge as a side effect of an animation
+ * change. Retiring it is its own change, and takes the term below with it.
  */
 export const COMPANION_BASE_RESTING_PILL_HEIGHT = 35;
 
@@ -1125,10 +1131,12 @@ export const COMPANION_BASE_CALL_RING = 2;
  * **The whole surface, not the state it happens to be in.** The window is
  * placed once and does not move when the pointer arrives or a call starts, so
  * the room kept under it has to answer for every state it can enter from
- * there. Three things are centred on that point and each is the lowest at some
- * size: the creature's own artwork, the pill a pointer grows around it, and
- * the call's bar, which stands on the centre rather than beside it and is
- * sized by the options box instead of the avatar's.
+ * there. Three things are centred on that point: the creature's own artwork,
+ * the resting pill, and the call's bar, which stands on the centre rather than
+ * beside it and is sized by the options box instead of the avatar's. The last
+ * two are the lowest at some size; the pill's term is now a floor over a shape
+ * that has stopped growing, and {@link COMPANION_BASE_RESTING_PILL_HEIGHT}
+ * says why it is still here.
  *
  * Whole points, as every distance the window is placed by is: the options
  * sizes are not whole multiples of the authored box, and a reach carrying a


### PR DESCRIPTION
Closes JARVIS-1749.

## What

On activation the resting marker grew into a 150pt frame the creature stood inside. The marker is wide and the creature is not, so that read as the surface swelling under the pointer and *then* a creature appearing in the middle of it: two events, with something lit still sitting behind the creature afterwards.

Now the lit line draws in from both ends onto the creature's own artwork and goes out as the creature reaches full size, on the same 300ms and `cubic-bezier(.2,.8,.2,1)` the creature stands up on. One gesture, and what activation leaves on screen is the creature.

`RESTING_PILL.active` (150 x 35) becomes `RESTING_PILL.closing` — the creature's artwork size, squared, so a `rounded-full` shape drawn at it lands as a ring on the creature's edge. It still scales with the creature, because that is what it lands on. The marker and the rim still hold one size on every setting.

The fade is now keyed to `creatureOut` rather than `expanded`, so hover clears the pill too. Before, hover left it lit at the grown size.

## The footprint and the line are two nodes

Only the line moves. The box the pointer is hit-tested against holds the marker's 64 x 14 in every phase.

This is load-bearing, not tidiness. The marker is wider than the creature's box (64pt against 44pt), so a hand arriving on the marker's *end* would have had the shape draw in out from under it: the pointer lands on the desktop, the window goes click-through, the creature tucks back, and the marker returns under the same stationary hand to start again — a flicker at frame rate. Keeping the reach at the marker's means staying anywhere the marker covered keeps the creature out.

`companion-surface-page.tsx` gets the same note where it picks which rect the pointer is tested against.

## COMPANION_BASE_RESTING_PILL_HEIGHT

It no longer measures anything the surface draws — nothing grows to 35pt any more, and the renderer stops reading it. Its term in `companionLowerReachFor` now over-reserves about 3.5pt under the creature.

Left in place, with a comment saying why: giving that room back would move every companion resting near the bottom of a display, which is not something an animation change should do as a side effect. Retiring it is its own change.

## Testing

- `clients/web`: 249 pass across the surface, its page, the peek, the layout and the intro.
- `clients/macos`: `companion-window.test.ts`, 181 pass.
- Typecheck and lint clean.
- Storybook endpoints screenshotted: at rest a lit marker with nothing in it, on hover the creature standing alone with no border behind it.

**Not verified:** the draw-in itself. A static screenshot cannot see a transition, and I did not record one — worth watching in the running app before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrS8oj6JPnVjpQGYuZLHsH