### PR TITLE
fix(tools): side-effecting tools observe the abort signal; unsettled cancels say so

### DIFF
--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -6,7 +6,7 @@ import type {
   CheckpointInfo,
 } from "../agent/loop.js";
 import { AgentLoop } from "../agent/loop.js";
-import type { StopContext } from "../plugin-api/types.js";
+import type { PostToolUseContext, StopContext } from "../plugin-api/types.js";
 import { REFUSAL_FALLBACK_TEXT } from "../plugins/defaults/empty-response/hooks/post-model-call.js";
 import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
 import { registerPlugin } from "../plugins/registry.js";
@@ -18,6 +18,10 @@ import type {
   ToolDefinition,
 } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
+import {
+  CANCELLED_TOOL_RESULT,
+  CANCELLED_UNSETTLED_TOOL_RESULT,
+} from "../tools/execution-timeout.js";
 import {
   createMockProvider,
   textResponse,
@@ -769,6 +773,8 @@ describe("AgentLoop", () => {
     expect(lastMsg.role).toBe("user");
     expect(lastMsg.content).toHaveLength(1);
     expect(lastMsg.content[0].type).toBe("tool_result");
+    // The tool ignores the signal, so it is abandoned mid-flight and the
+    // synthesized result says the work may still land.
     expect(
       (
         lastMsg.content[0] as {
@@ -778,7 +784,7 @@ describe("AgentLoop", () => {
           is_error: boolean;
         }
       ).content,
-    ).toBe("Cancelled by user");
+    ).toBe(CANCELLED_UNSETTLED_TOOL_RESULT);
     expect(
       (
         lastMsg.content[0] as {
@@ -789,6 +795,181 @@ describe("AgentLoop", () => {
         }
       ).is_error,
     ).toBe(true);
+  });
+
+  // 6c. A tool that finishes inside the post-abort grace keeps its real result
+  test("a tool that settles during the abort grace reports its real result", async () => {
+    const controller = new AbortController();
+
+    const { provider } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/slow.txt" }),
+      textResponse("Should not reach"),
+    ]);
+
+    // Abort lands while the tool is in flight; the tool finishes shortly
+    // after, inside the loop's settlement grace.
+    const toolExecutor = async () => {
+      setTimeout(() => controller.abort(), 5);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return {
+        content: "wrote the file",
+        isError: false,
+        status: "ok",
+        diff: {
+          filePath: "/slow.txt",
+          oldContent: "",
+          newContent: "x",
+          isNewFile: true,
+        },
+        contentBlocks: [
+          { type: "text" as const, text: "attachment" },
+        ] as ContentBlock[],
+        riskLevel: "low",
+      };
+    };
+
+    const loop = new AgentLoop({
+      provider: provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+      tools: dummyTools,
+      toolExecutor: toolExecutor,
+    });
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collectEvents(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      signal: controller.signal,
+    });
+
+    const resultEvent = events.find(
+      (e): e is Extract<AgentEvent, { type: "tool_result" }> =>
+        e.type === "tool_result",
+    );
+    expect(resultEvent).toBeDefined();
+    // It ran, so it is not a cancellation: the daemon must still do the
+    // bookkeeping the tool's side effects need.
+    expect(resultEvent!.cancelled).toBeUndefined();
+    expect(resultEvent!.content).toBe("wrote the file");
+    expect(resultEvent!.isError).toBe(false);
+    expect(resultEvent!.diff?.filePath).toBe("/slow.txt");
+    expect(resultEvent!.contentBlocks).toHaveLength(1);
+    expect(resultEvent!.status).toBe("ok");
+    expect(resultEvent!.riskLevel).toBe("low");
+
+    const lastMsg = history[history.length - 1];
+    const block = lastMsg.content.find((b) => b.type === "tool_result");
+    expect(block).toBeDefined();
+    expect((block as { content: string }).content).toBe("wrote the file");
+    expect((block as { is_error: boolean }).is_error).toBe(false);
+    expect(
+      (block as { contentBlocks?: ContentBlock[] }).contentBlocks,
+    ).toHaveLength(1);
+  });
+
+  // 6c-ii. Grace-settled output is truncated like any other tool result
+  test("an oversized result settling during the abort grace goes through the post-tool-use pipeline", async () => {
+    const controller = new AbortController();
+    const seen: number[] = [];
+
+    // Stand in for the truncate plugin: record what it was handed and shrink
+    // it, so the assertions prove the chain ran on the cancelled batch.
+    registerPlugin({
+      manifest: { name: "grace-truncate", version: "0.0.1" },
+      hooks: {
+        "post-tool-use": async (ctx: PostToolUseContext) => {
+          const block = ctx.toolResponse as { content: string };
+          seen.push(block.content.length);
+          return {
+            ...ctx,
+            toolResponse: { ...ctx.toolResponse, content: "truncated" },
+          };
+        },
+      },
+    });
+
+    const { provider } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/big.txt" }),
+      textResponse("Should not reach"),
+    ]);
+
+    const oversized = "x".repeat(50_000);
+    const toolExecutor = async () => {
+      setTimeout(() => controller.abort(), 5);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return { content: oversized, isError: false };
+    };
+
+    const loop = new AgentLoop({
+      provider: provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+      tools: dummyTools,
+      toolExecutor: toolExecutor,
+    });
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collectEvents(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      signal: controller.signal,
+    });
+
+    // The hook saw the full result and its rewrite reached both history and
+    // the client, so cancelling is not a way past the truncation pipeline.
+    expect(seen).toEqual([oversized.length]);
+    const resultEvent = events.find(
+      (e): e is Extract<AgentEvent, { type: "tool_result" }> =>
+        e.type === "tool_result",
+    );
+    expect(resultEvent!.content).toBe("truncated");
+
+    const lastMsg = history[history.length - 1];
+    const block = lastMsg.content.find((b) => b.type === "tool_result");
+    expect((block as { content: string }).content).toBe("truncated");
+  });
+
+  // 6d. A tool that ignores the signal is reported as possibly still running
+  test("an unsettled tool is flagged cancelled with the may-still-complete wording", async () => {
+    const controller = new AbortController();
+
+    const { provider } = createMockProvider([
+      toolUseResponse("t1", "read_file", { path: "/stuck.txt" }),
+      textResponse("Should not reach"),
+    ]);
+
+    const toolExecutor = async () => {
+      setTimeout(() => controller.abort(), 5);
+      await new Promise((resolve) => setTimeout(resolve, 10_000));
+      return { content: "should never return", isError: false };
+    };
+
+    const loop = new AgentLoop({
+      provider: provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+      tools: dummyTools,
+      toolExecutor: toolExecutor,
+    });
+    const events: AgentEvent[] = [];
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: collectEvents(events),
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      signal: controller.signal,
+    });
+
+    const resultEvent = events.find(
+      (e): e is Extract<AgentEvent, { type: "tool_result" }> =>
+        e.type === "tool_result",
+    );
+    expect(resultEvent).toBeDefined();
+    expect(resultEvent!.cancelled).toBe(true);
+    expect(resultEvent!.content).toBe(CANCELLED_UNSETTLED_TOOL_RESULT);
   });
 
   // 7. Events — verify text_delta and other events are emitted
@@ -1216,10 +1397,10 @@ describe("AgentLoop", () => {
     );
     expect(toolResultBlocks).toHaveLength(2);
     expect(toolResultBlocks[0].tool_use_id).toBe("t1");
-    expect(toolResultBlocks[0].content).toBe("Cancelled by user");
+    expect(toolResultBlocks[0].content).toBe(CANCELLED_TOOL_RESULT);
     expect(toolResultBlocks[0].is_error).toBe(true);
     expect(toolResultBlocks[1].tool_use_id).toBe("t2");
-    expect(toolResultBlocks[1].content).toBe("Cancelled by user");
+    expect(toolResultBlocks[1].content).toBe(CANCELLED_TOOL_RESULT);
     expect(toolResultBlocks[1].is_error).toBe(true);
   });
 

--- a/assistant/src/__tests__/call-domain.test.ts
+++ b/assistant/src/__tests__/call-domain.test.ts
@@ -51,8 +51,16 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async () => null,
 }));
 
+/**
+ * Fires on each callback-URL resolution. Lets a test land a cancel inside the
+ * async setup that runs after the call session and its lease already exist.
+ */
+let onResolveCallbackUrl: (() => void) | null = null;
 mock.module("../inbound/platform-callback-registration.js", () => ({
-  resolveCallbackUrl: async (fn: () => string) => fn(),
+  resolveCallbackUrl: async (fn: () => string) => {
+    onResolveCallbackUrl?.();
+    return fn();
+  },
 }));
 
 mock.module("../inbound/public-ingress-urls.js", () => ({
@@ -92,7 +100,7 @@ import type { AssistantConfig } from "../config/types.js";
 import { getMessages } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { conversations } from "../persistence/schema/index.js";
+import { callSessions, conversations } from "../persistence/schema/index.js";
 import { setConfig } from "./helpers/set-config.js";
 
 /** Seed the ingress block startCall's preflight reads for real. */
@@ -116,6 +124,7 @@ beforeEach(() => {
   twilioInitiateCallArgs = [];
   seedIngress(true);
   mockCredentialReadiness = { status: "ready" };
+  onResolveCallbackUrl = null;
 });
 
 let ensuredConvIds = new Set<string>();
@@ -143,6 +152,16 @@ function resetTables(): void {
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
   ensuredConvIds = new Set();
+}
+
+function listCallSessions(): Array<{ status: string; endedAt: number | null }> {
+  return getDb()
+    .select({
+      status: callSessions.status,
+      endedAt: callSessions.endedAt,
+    })
+    .from(callSessions)
+    .all();
 }
 
 function getLatestAssistantText(conversationId: string): string | null {
@@ -433,5 +452,57 @@ describe("startCall — pointer message regression", () => {
 
     expect(cancelResult.ok).toBe(true);
     expect(getActiveCallLease(startResult.session.id)).toBeNull();
+  });
+});
+
+describe("startCall: a stopped turn never dials", () => {
+  test("an already-cancelled turn creates no session and places no call", async () => {
+    const convId = "conv-domain-abort-before-setup";
+    ensureConversation(convId);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      startCall({
+        phoneNumber: "+12025550142",
+        task: "Test call",
+        conversationId: convId,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+
+    expect(twilioInitiateCallCount).toBe(0);
+    expect(listActiveCallLeases()).toHaveLength(0);
+    expect(listCallSessions()).toHaveLength(0);
+  });
+
+  test("a cancel during setup releases the session it already created", async () => {
+    const convId = "conv-domain-abort-during-setup";
+    ensureConversation(convId);
+    const controller = new AbortController();
+    // The callback-URL lookups run after the session, its voice conversation
+    // and its lease exist, so this is the window the late recheck guards.
+    onResolveCallbackUrl = () => controller.abort();
+
+    await expect(
+      startCall({
+        phoneNumber: "+12025550142",
+        task: "Test call",
+        conversationId: convId,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+
+    expect(twilioInitiateCallCount).toBe(0);
+    expect(listActiveCallLeases()).toHaveLength(0);
+
+    const sessions = listCallSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].status).toBe("cancelled");
+    expect(sessions[0].endedAt).toEqual(expect.any(Number));
+
+    // No failure pointer: the user stopped the turn, nothing went wrong.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getLatestAssistantText(convId)).toBeNull();
   });
 });

--- a/assistant/src/__tests__/contacts-tools.test.ts
+++ b/assistant/src/__tests__/contacts-tools.test.ts
@@ -28,8 +28,20 @@ let searchContactsOverride: unknown[] | null = null;
 // Mock the IPC client to dispatch contact reads to the real store (backed by
 // the test DB) and serve `merge_contacts` as a fake gateway relay, without
 // needing a running IPC server.
+/** Per-method record of the options `cliIpcCall` was handed, newest last. */
+const ipcCallOptions: Array<{
+  method: string;
+  options?: { signal?: AbortSignal };
+}> = [];
+
 mock.module("../ipc/cli-client.js", () => ({
-  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+  cliIpcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    options?: { signal?: AbortSignal },
+  ) => {
+    ipcCallOptions.push({ method, options });
+    options?.signal?.throwIfAborted();
     const store = await import("../contacts/contact-store.js");
     const body = (params?.body ?? params ?? {}) as Record<string, unknown>;
     const pathParams = (params?.pathParams ?? {}) as Record<string, string>;
@@ -387,5 +399,56 @@ describe("contact_merge tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("not found");
+  });
+
+  test("a cancelled turn stops before the merge", async () => {
+    const keepId = upsertFixture({ display_name: "Keep" }).id;
+    const mergeId = upsertFixture({ display_name: "Donor" }).id;
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      executeContactMerge({ keep_id: keepId, merge_id: mergeId }, {
+        ...ctx,
+        signal: controller.signal,
+      } as ToolContext),
+    ).rejects.toThrow();
+
+    // The donor survives: nothing was merged.
+    const count = getRawDb()
+      .query("SELECT COUNT(*) as c FROM contacts")
+      .get() as { c: number };
+    expect(count.c).toBe(2);
+  });
+
+  test("the merge request is not attached to the turn signal", async () => {
+    // `cliIpcCall` cancels only the client socket, so an abort after dispatch
+    // would resolve a quick "Request aborted" that settles inside the agent
+    // loop's grace and reports an ordinary failure for a merge the gateway
+    // finished anyway. Leaving the destructive call and its read-back detached
+    // keeps it unsettled instead, which is what makes the loop tell the model
+    // the work may still have completed.
+    const keepId = upsertFixture({ display_name: "Keep" }).id;
+    const mergeId = upsertFixture({ display_name: "Donor" }).id;
+    ipcCallOptions.length = 0;
+    const controller = new AbortController();
+
+    const result = await executeContactMerge(
+      { keep_id: keepId, merge_id: mergeId },
+      { ...ctx, signal: controller.signal } as ToolContext,
+    );
+    expect(result.isError).toBe(false);
+
+    const merge = ipcCallOptions.find((c) => c.method === "merge_contacts");
+    expect(merge).toBeDefined();
+    expect(merge!.options?.signal).toBeUndefined();
+
+    // The read-back after the merge is detached for the same reason; the
+    // existence checks before it still carry the signal.
+    const reads = ipcCallOptions.filter((c) => c.method === "getContact");
+    expect(reads).toHaveLength(3);
+    expect(reads[0].options?.signal).toBe(controller.signal);
+    expect(reads[1].options?.signal).toBe(controller.signal);
+    expect(reads[2].options?.signal).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -18,6 +18,7 @@ import {
   READ_CHAR_BUDGET,
 } from "../tools/shared/filesystem/file-ops-service.js";
 import { sandboxPolicy } from "../tools/shared/filesystem/path-policy.js";
+import { createAbortReason } from "../util/abort-reasons.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -629,5 +630,67 @@ describe("FileSystemOps.editFileSafe", () => {
       return;
     }
     expect(result.error.code).toBe("PATH_OUT_OF_BOUNDS");
+  });
+});
+
+describe("FileSystemOps.writeFileSafe cancellation", () => {
+  const REASON = createAbortReason("user_cancel", "file-ops-service.test");
+
+  function abortedSignal(): AbortSignal {
+    const controller = new AbortController();
+    controller.abort(REASON);
+    return controller.signal;
+  }
+
+  /**
+   * The guard sits before `ensureDir`, so a stopped turn leaves no directory
+   * tree behind for a file it never wrote.
+   */
+  test("a cancelled write creates no parent directories", async () => {
+    const dir = makeTempDir();
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    await expect(
+      ops.writeFileSafe({
+        path: "nested/deeper/new.txt",
+        content: "hello",
+        signal: abortedSignal(),
+      }),
+    ).rejects.toThrow();
+
+    expect(existsSync(join(dir, "nested"))).toBe(false);
+    expect(existsSync(join(dir, "nested/deeper/new.txt"))).toBe(false);
+  });
+
+  /**
+   * The write path turns thrown errors into an IO_ERROR result. A cancellation
+   * must escape that: reported as an IO failure, the model reads a stop as a
+   * disk problem and retries the write.
+   */
+  test("the abort escapes rather than becoming an IO error", async () => {
+    const dir = makeTempDir();
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+
+    await expect(
+      ops.writeFileSafe({
+        path: "new.txt",
+        content: "hello",
+        signal: abortedSignal(),
+      }),
+    ).rejects.toBe(REASON);
+  });
+
+  test("a live signal leaves a normal write alone", async () => {
+    const dir = makeTempDir();
+    const ops = new FileSystemOps(sandboxPolicyFor(dir));
+    const controller = new AbortController();
+
+    const result = await ops.writeFileSafe({
+      path: "nested/new.txt",
+      content: "hello",
+      signal: controller.signal,
+    });
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(dir, "nested/new.txt"))).toBe(true);
   });
 });

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -29,6 +29,9 @@ let mockGenerateResult = {
 let mockGenerateError: Error | null = null;
 let lastGenerateProvider: unknown = null;
 let lastGenerateCredentials: unknown = null;
+let lastGenerateRequest: Record<string, unknown> | null = null;
+/** Holds the mocked generation in flight so a test can cancel mid-request. */
+let mockGenerateDelayMs = 0;
 
 /**
  * Seed the image-generation service entry in the real workspace config.
@@ -69,10 +72,14 @@ mock.module("../media/image-service.js", () => ({
   generateImage: async (
     provider: unknown,
     credentials: unknown,
-    _request: Record<string, unknown>,
+    request: Record<string, unknown>,
   ) => {
     lastGenerateProvider = provider;
     lastGenerateCredentials = credentials;
+    lastGenerateRequest = request;
+    if (mockGenerateDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, mockGenerateDelayMs));
+    }
     if (mockGenerateError) {
       throw mockGenerateError;
     }
@@ -145,6 +152,8 @@ beforeEach(() => {
   mockGenerateError = null;
   lastGenerateProvider = null;
   lastGenerateCredentials = null;
+  lastGenerateRequest = null;
+  mockGenerateDelayMs = 0;
   mockManagedBaseUrl = undefined;
   mockManagedProxyContext = {
     enabled: false,
@@ -593,6 +602,51 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("outside the working directory");
+  });
+});
+
+describe("image-studio cancellation", () => {
+  test("an already-cancelled turn never starts a generation", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const context = {
+      ...makeContext(),
+      signal: controller.signal,
+    } as ToolContext;
+
+    await expect(run({ prompt: "a cat" }, context)).rejects.toThrow();
+    expect(lastGenerateProvider).toBeNull();
+  });
+
+  test("passes the turn signal to the generation request", async () => {
+    const controller = new AbortController();
+    const context = {
+      ...makeContext(),
+      signal: controller.signal,
+    } as ToolContext;
+
+    await run({ prompt: "a cat" }, context);
+
+    expect(lastGenerateRequest?.signal).toBe(controller.signal);
+  });
+
+  test("keeps a generation that resolves after the abort", async () => {
+    // The user cancels while the request is in flight and the provider still
+    // returns. The generation was paid for, so its images reach the model
+    // rather than being discarded as a cancellation.
+    const controller = new AbortController();
+    const context = {
+      ...makeContext(),
+      signal: controller.signal,
+    } as ToolContext;
+    mockGenerateDelayMs = 20;
+    setTimeout(() => controller.abort(), 5);
+
+    const result = await run({ prompt: "a cat" }, context);
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Generated 1 image");
+    expect(result.contentBlocks).toHaveLength(1);
   });
 });
 

--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -57,8 +57,14 @@ let provider: MessagingProvider = phoneProvider;
 
 let connection: OAuthConnection | undefined = undefined;
 
+/** Fires during provider resolution, the first await after the entry guard. */
+let onResolveProvider: (() => void) | null = null;
+
 mock.module("../config/bundled-skills/messaging/tools/shared.js", () => ({
-  resolveProvider: () => provider,
+  resolveProvider: () => {
+    onResolveProvider?.();
+    return provider;
+  },
   getProviderConnection: () => connection,
   ok: (content: string) => ({ content, isError: false }),
   err: (content: string) => ({ content, isError: true }),
@@ -156,6 +162,7 @@ describe("messaging-send tool", () => {
     sendMessageMock.mockClear();
     mockOutlookCreateDraft.mockClear();
     mockOutlookCreateReplyDraft.mockClear();
+    onResolveProvider = null;
     getConversationMock.mockClear();
     syncMessageToDiskMock.mockClear();
     resolveProactiveHomeConversationMock.mockClear();
@@ -288,9 +295,7 @@ describe("messaging-send tool", () => {
         expect.objectContaining({
           subject: "Docs",
           body: { contentType: "text", content: "see attached" },
-          toRecipients: [
-            { emailAddress: { address: "user@example.com" } },
-          ],
+          toRecipients: [{ emailAddress: { address: "user@example.com" } }],
           attachments: [expect.objectContaining({ name: "report.pdf" })],
         }),
       );
@@ -644,5 +649,68 @@ describe("messaging-send tool", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Message sent");
+  });
+
+  /**
+   * Provider and connection resolution and the attachment reads all sit
+   * between the tool's entry guard and the Graph call, so a turn stopped
+   * during them must not leave a draft in the user's mailbox. The stop lands
+   * inside provider resolution rather than before the call, which is what
+   * makes these exercise the recheck instead of the entry guard.
+   */
+  describe("a cancelled turn creates no Outlook draft", () => {
+    function abortedContext() {
+      const controller = new AbortController();
+      onResolveProvider = () => controller.abort();
+      return {
+        workingDir: "/tmp",
+        conversationId: "conv-1",
+        assistantId: "ast-alpha",
+        trustClass: "guardian" as const,
+        signal: controller.signal,
+      };
+    }
+
+    test("new message", async () => {
+      provider = outlookProvider;
+      connection = {
+        id: "outlook-conn-1",
+        provider: "outlook",
+      } as OAuthConnection;
+
+      await expect(
+        run(
+          {
+            platform: "outlook",
+            conversation_id: "user@example.com",
+            text: "never sent",
+            subject: "Docs",
+          },
+          abortedContext(),
+        ),
+      ).rejects.toThrow();
+      expect(mockOutlookCreateDraft).not.toHaveBeenCalled();
+    });
+
+    test("reply", async () => {
+      provider = outlookProvider;
+      connection = {
+        id: "outlook-conn-1",
+        provider: "outlook",
+      } as OAuthConnection;
+
+      await expect(
+        run(
+          {
+            platform: "outlook",
+            conversation_id: "user@example.com",
+            text: "never sent",
+            in_reply_to: "msg-1",
+          },
+          abortedContext(),
+        ),
+      ).rejects.toThrow();
+      expect(mockOutlookCreateReplyDraft).not.toHaveBeenCalled();
+    });
   });
 });

--- a/assistant/src/__tests__/parallel-tool.benchmark.test.ts
+++ b/assistant/src/__tests__/parallel-tool.benchmark.test.ts
@@ -10,6 +10,7 @@ import type {
   SendMessageOptions,
   ToolDefinition,
 } from "../providers/types.js";
+import { CANCELLED_UNSETTLED_TOOL_RESULT } from "../tools/execution-timeout.js";
 
 // ---------------------------------------------------------------------------
 // Helpers (mirrors agent-loop.test.ts patterns)
@@ -345,9 +346,10 @@ describe("Parallel tool execution benchmarks", () => {
       );
       expect(toolResultBlocks).toHaveLength(toolCount);
 
-      // All results should be cancelled
+      // All results should be cancelled. These tools ignore the signal, so
+      // each is abandoned mid-flight and reported as possibly still running.
       for (const block of toolResultBlocks) {
-        expect(block.content).toBe("Cancelled by user");
+        expect(block.content).toBe(CANCELLED_UNSETTLED_TOOL_RESULT);
         expect(block.is_error).toBe(true);
       }
 

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -3285,21 +3285,22 @@ describe("Subagent advisor-role consult", () => {
 
   test("a spawn whose turn was stopped never reaches the manager", async () => {
     // The stop can land while the advisor's context pack is being assembled, so
-    // the tool checks before paying for that as well as after.
+    // the tool checks before paying for that as well as after. Like every
+    // side-effecting tool it hands the abort to the executor, which writes the
+    // cancelled result, rather than answering with a result of its own.
     const controller = new AbortController();
     controller.abort();
     const { captured, restore } = stubSpawn();
     try {
-      const result = await executeSubagentSpawn(
-        { label: "Consult", objective: "x", role: "advisor" },
-        makeContext("advisor-sess-cancelled", {
-          sendToClient: () => {},
-          signal: controller.signal,
-        }),
-      );
-      // Not an error: the user cancelled, and no child was started.
-      expect(result.isError).toBe(false);
-      expect(result.content).toContain("this turn was stopped");
+      await expect(
+        executeSubagentSpawn(
+          { label: "Consult", objective: "x", role: "advisor" },
+          makeContext("advisor-sess-cancelled", {
+            sendToClient: () => {},
+            signal: controller.signal,
+          }),
+        ),
+      ).rejects.toThrow();
       expect(captured.current).toBeUndefined();
     } finally {
       restore();

--- a/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
+++ b/assistant/src/__tests__/tool-execution-abort-cleanup.test.ts
@@ -251,24 +251,23 @@ describe("file tools — abort signal pre-check", () => {
     expect(result.content).toContain("readable");
   });
 
-  test("file_write tool: synchronous write completes regardless of pre-aborted signal (abort checked at executor level)", async () => {
-    // The tool implementations use synchronous Node.js I/O, so they complete
-    // regardless of the signal. The ToolExecutor.execute() wrapper is
-    // responsible for checking signal.aborted before dispatching; the tool
-    // itself is not expected to check it. This test documents that contract.
+  test("file_write tool: a pre-aborted signal stops the write", async () => {
+    // A side-effecting tool owns the cancellation check itself. The executor
+    // guards before dispatch, but the agent loop can abandon a batch while a
+    // call is already in flight, so the tool must refuse rather than write.
     const { fileWriteTool } = await import("../tools/filesystem/write.js");
 
     const dir = makeTempDir();
     const ac = new AbortController();
-    ac.abort(); // pre-aborted
+    ac.abort();
 
-    // When invoked directly (not through ToolExecutor), the sync write runs.
-    const result = await fileWriteTool.execute(
-      { path: "should-write.txt", content: "test", reason: "test" },
-      makeToolContext(dir, ac.signal),
-    );
-    // Should succeed — the tool's own execute() doesn't check the signal.
-    expect(result.isError).toBe(false);
+    await expect(
+      fileWriteTool.execute(
+        { path: "should-not-write.txt", content: "test", reason: "test" },
+        makeToolContext(dir, ac.signal),
+      ),
+    ).rejects.toThrow();
+    expect(existsSync(join(dir, "should-not-write.txt"))).toBe(false);
   });
 });
 

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -38,6 +38,7 @@ mock.module("./prepare-agent-env.js", () => ({
   },
 }));
 
+import { createAbortReason } from "../util/abort-reasons.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { AcpSessionManager } from "./session-manager.js";
 
@@ -610,5 +611,109 @@ describe("AcpSessionManager.spawn: a credential Claude refused at startup", () =
     }
 
     expect(refusedDigests).toContain("digest-refused-at-startup");
+  });
+});
+
+describe("AcpSessionManager.steer: a stopped turn hands the agent nothing", () => {
+  function abortedSignal(): AbortSignal {
+    const controller = new AbortController();
+    controller.abort(createAbortReason("user_cancel", "session-manager.test"));
+    return controller.signal;
+  }
+
+  test("an already-cancelled turn never fires the prompt", async () => {
+    const manager = new AcpSessionManager(1);
+    const prompt = mock(() => Promise.resolve({}));
+    injectSession(manager, "sess-abort-1", "conv-1", fakeProcess(prompt));
+
+    await expect(
+      manager.steer("sess-abort-1", "do it", { signal: abortedSignal() }),
+    ).rejects.toThrow();
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Cancelling the in-flight prompt is an await, so a stop landing inside it
+   * still reaches the new prompt unless the signal is read again afterwards.
+   */
+  test("a cancel during the in-flight cancel never fires the prompt", async () => {
+    const manager = new AcpSessionManager(1);
+    const controller = new AbortController();
+    const prompt = mock(() => Promise.resolve({}));
+    const entry = injectSession(
+      manager,
+      "sess-abort-2",
+      "conv-1",
+      fakeProcess(prompt),
+    );
+    entry.currentPrompt = Promise.resolve();
+    (entry.process as unknown as { cancel: () => Promise<void> }).cancel =
+      async () => {
+        controller.abort(
+          createAbortReason("user_cancel", "session-manager.test"),
+        );
+      };
+
+    await expect(
+      manager.steer("sess-abort-2", "do it", { signal: controller.signal }),
+    ).rejects.toThrow();
+    expect(prompt).not.toHaveBeenCalled();
+  });
+});
+
+describe("AcpSessionManager.spawn: a stopped turn leaves no agent running", () => {
+  const REASON = createAbortReason("user_cancel", "session-manager.test");
+
+  /**
+   * The protocol handshake and session creation are awaits, and the child
+   * process is already running by the time they finish. A stop landing there
+   * has to kill it: the spawned event would otherwise tell the client a
+   * session started, and the prompt would hand the agent the task.
+   */
+  test("a cancel during protocol setup tears the process down and fires nothing", async () => {
+    const manager = new AcpSessionManager(1);
+    const controller = new AbortController();
+    const prompt = mock(() => Promise.resolve({}));
+    const proc = {
+      ...fakeProcess(prompt),
+      spawn: () => {},
+      initialize: async () => {},
+      createSession: async () => {
+        // The user stops the turn while the protocol is coming up.
+        controller.abort(REASON);
+        return "proto-1";
+      },
+    };
+    const internals = manager as unknown as {
+      registerSession: (opts: {
+        acpSessionId: string;
+        parentConversationId: string;
+      }) => unknown;
+      sessions: Map<string, unknown>;
+    };
+    internals.registerSession = (opts) =>
+      injectSession(
+        manager,
+        opts.acpSessionId,
+        opts.parentConversationId,
+        proc as unknown as ReturnType<typeof fakeProcess>,
+      );
+
+    await expect(
+      manager.spawn(
+        "claude",
+        { command: "noop", args: [] } as never,
+        "do the task",
+        "/tmp",
+        "conv-1",
+        () => {},
+        undefined,
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow();
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(proc.kill).toHaveBeenCalled();
+    expect(internals.sessions.size).toBe(0);
   });
 });

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -15,6 +15,7 @@ import { SYNC_TAGS } from "../daemon/message-types/sync.js";
 import { getDb } from "../persistence/db-connection.js";
 import { acpSessionHistory } from "../persistence/schema/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { isAbortLikeError } from "../tools/shared/abort.js";
 import { getLogger } from "../util/logger.js";
 import {
   acpAuthMarkerStillCurrent,
@@ -135,6 +136,17 @@ type ResumableHistoryRow = typeof acpSessionHistory.$inferSelect & {
   cwd: string;
 };
 
+/**
+ * Cancellation for a call that puts an agent to work. Starting a child
+ * process, cancelling an in-flight prompt and restoring a session from history
+ * are all awaits, and what follows each of them hands a long-lived agent an
+ * instruction that outlives the turn, so the signal is rechecked at every one
+ * of those seams.
+ */
+export interface AcpCancellationOptions {
+  signal?: AbortSignal;
+}
+
 export class AcpSessionManager {
   private sessions = new Map<string, SessionEntry>();
   /**
@@ -240,8 +252,10 @@ export class AcpSessionManager {
     parentConversationId: string,
     sendToVellum: (msg: AssistantEvent) => void,
     parentToolUseId?: string,
+    opts?: AcpCancellationOptions,
   ): Promise<{ acpSessionId: string; protocolSessionId: string }> {
     this.assertCapacity();
+    opts?.signal?.throwIfAborted();
 
     const acpSessionId = randomUUID();
     log.info(
@@ -299,9 +313,22 @@ export class AcpSessionManager {
       throw err;
     }
 
+    // Recheck: the protocol handshake and session creation above are both
+    // awaits, and the child process is already running. A turn stopped in that
+    // window must not be told a session started, nor have the agent handed the
+    // task, so the process is torn down and the abort let out instead.
+    if (opts?.signal?.aborted) {
+      log.info(
+        { acpSessionId, agentId },
+        "ACP spawn cancelled during setup; tearing the session down",
+      );
+      this.teardownSession(acpSessionId, entry);
+      opts.signal.throwIfAborted();
+    }
+
     this.sendSpawnedEvent(acpSessionId, entry);
 
-    // Fire prompt in the background — don't await
+    // Fire prompt in the background, do not await
     entry.currentPrompt = this.firePromptInBackground(
       acpSessionId,
       entry,
@@ -650,7 +677,11 @@ export class AcpSessionManager {
    * Cancels any in-flight prompt first, then fires the new prompt in the
    * background with completion/error event handlers (matching spawn's pattern).
    */
-  async steer(acpSessionId: string, instruction: string): Promise<void> {
+  async steer(
+    acpSessionId: string,
+    instruction: string,
+    opts?: AcpCancellationOptions,
+  ): Promise<void> {
     const entry = this.sessions.get(acpSessionId);
     if (!entry) {
       throw new AcpSessionNotFoundError(acpSessionId);
@@ -676,6 +707,10 @@ export class AcpSessionManager {
         );
       }
     }
+
+    // Recheck: cancelling the in-flight prompt above is an await, and the
+    // call below hands a paid agent a new instruction that outlives this turn.
+    opts?.signal?.throwIfAborted();
 
     // Fire new prompt in the background with event handlers
     entry.currentPrompt = this.firePromptInBackground(
@@ -711,11 +746,17 @@ export class AcpSessionManager {
     acpSessionId: string,
     instruction: string,
     sendToVellum: (msg: AssistantEvent) => void,
+    opts?: AcpCancellationOptions,
   ): Promise<{ resumed: boolean }> {
     try {
-      await this.steer(acpSessionId, instruction);
+      await this.steer(acpSessionId, instruction, opts);
       return { resumed: false };
     } catch (err) {
+      // A cancelled turn is not a missing session: it must never fall through
+      // to the resume path and start an agent the user has stopped.
+      if (isAbortLikeError(err)) {
+        throw err;
+      }
       // Fall through to the in-flight-resume handling both when the session
       // is entirely unknown and when a concurrent resume has already
       // registered its entry but is still initializing: steer rejects with a
@@ -744,13 +785,22 @@ export class AcpSessionManager {
       // The resumed session is owned by the concurrent caller (its own
       // post-resume steer handles teardown on failure), so a failure here
       // propagates as a plain steer error without closing the session.
-      await this.steer(acpSessionId, instruction);
+      await this.steer(acpSessionId, instruction, opts);
       return { resumed: true };
     }
+
+    // Recheck: restoring a session from history spawns the agent process, so
+    // a turn stopped while getting here must not start one.
+    opts?.signal?.throwIfAborted();
 
     try {
       await this.resumeFromHistory(acpSessionId, sendToVellum);
     } catch (err) {
+      // An abort is not a resume failure; it must reach the caller intact
+      // rather than wrapped in AcpResumeError, which hides its abort shape.
+      if (isAbortLikeError(err)) {
+        throw err;
+      }
       // A missing history row keeps its not-found shape; everything else
       // (legacy row without cwd, resolver failure, capability missing)
       // is a resume failure with an actionable message.
@@ -761,10 +811,11 @@ export class AcpSessionManager {
     }
 
     try {
-      await this.steer(acpSessionId, instruction);
+      await this.steer(acpSessionId, instruction, opts);
     } catch (err) {
       // Tear down the just-resumed session rather than leaving it
-      // running-idle with no prompt handler to own its cleanup.
+      // running-idle with no prompt handler to own its cleanup. A cancelled
+      // turn needs the same teardown, and then its abort back unwrapped.
       try {
         this.close(acpSessionId);
       } catch (closeErr) {
@@ -772,6 +823,9 @@ export class AcpSessionManager {
           { acpSessionId, err: closeErr },
           "Failed to close ACP session after post-resume steer failure",
         );
+      }
+      if (isAbortLikeError(err)) {
+        throw err;
       }
       throw new AcpResumeError(err);
     }

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -47,6 +47,11 @@ import {
   isContextOverflowError,
   NATIVE_WEB_SEARCH_TOOL_NAME,
 } from "../providers/types.js";
+import {
+  ABORT_SETTLE_GRACE_MS,
+  CANCELLED_TOOL_RESULT,
+  CANCELLED_UNSETTLED_TOOL_RESULT,
+} from "../tools/execution-timeout.js";
 import { getTool } from "../tools/registry.js";
 import type { SensitiveOutputBinding } from "../tools/sensitive-output-placeholders.js";
 import {
@@ -739,6 +744,125 @@ export type LoopToolExecutor = (
 
 type ToolUseBlock = Extract<ContentBlock, { type: "tool_use" }>;
 
+type LoopToolResult = Awaited<ReturnType<LoopToolExecutor>>;
+
+/**
+ * One dispatched tool call of the current turn's batch, carrying whether it has
+ * reported back. The abort path reads this to tell a call whose tool finished
+ * from one abandoned while it was still running: only the latter can still be
+ * doing work after the model has been told the batch was cancelled.
+ */
+interface InFlightToolCall {
+  readonly toolUse: ToolUseBlock;
+  /** True once the executor promise fulfilled or rejected. */
+  settled: boolean;
+  /** The executor's result once the call fulfilled. */
+  result?: LoopToolResult;
+  /** The executor promise, awaited by the post-abort settlement grace. */
+  promise?: Promise<{ toolUse: ToolUseBlock; result: LoopToolResult }>;
+}
+
+/**
+ * Give tools that honour the abort signal a bounded moment to settle so their
+ * real outcome, not the "may still be running" hedge, reaches the model.
+ * Returns as soon as every call has settled.
+ */
+async function awaitAbortSettlementGrace(
+  calls: readonly InFlightToolCall[],
+): Promise<void> {
+  const pending = calls
+    .filter((call) => !call.settled && call.promise !== undefined)
+    .map((call) => call.promise!);
+  if (pending.length === 0) {
+    return;
+  }
+  let graceHandle: ReturnType<typeof setTimeout>;
+  const grace = new Promise<void>((resolve) => {
+    graceHandle = setTimeout(resolve, ABORT_SETTLE_GRACE_MS);
+  });
+  try {
+    await Promise.race([Promise.allSettled(pending), grace]);
+  } finally {
+    clearTimeout(graceHandle!);
+  }
+}
+
+/**
+ * What an aborted batch writes for one of its calls.
+ *
+ * A call whose tool reported back before the grace expired carries its real
+ * `result`: it ran, so it travels the same path a tool result always does,
+ * rich fields and all. A call with no `result` is synthetic, and the loop
+ * flags it `cancelled` so the daemon skips the side effects that assume the
+ * tool ran.
+ */
+interface CancelledToolOutcome {
+  toolUse: ToolUseBlock;
+  content: string;
+  isError: boolean;
+  /** The tool's own result, present only when the call actually finished. */
+  result?: LoopToolResult;
+}
+
+function cancelledToolOutcomeFor(
+  toolUse: ToolUseBlock,
+  calls: readonly InFlightToolCall[],
+): CancelledToolOutcome {
+  const synthetic = (content: string): CancelledToolOutcome => ({
+    toolUse,
+    content,
+    isError: true,
+  });
+  const call = calls.find((candidate) => candidate.toolUse === toolUse);
+  if (call === undefined) {
+    return synthetic(CANCELLED_TOOL_RESULT);
+  }
+  if (call.settled) {
+    if (call.result !== undefined) {
+      return {
+        toolUse,
+        content: call.result.content,
+        isError: call.result.isError,
+        result: call.result,
+      };
+    }
+    // The executor rejected, so the tool stopped rather than ran on.
+    return synthetic(CANCELLED_TOOL_RESULT);
+  }
+  return synthetic(CANCELLED_UNSETTLED_TOOL_RESULT);
+}
+
+/**
+ * The `tool_result` event fields a tool's own result contributes. Shared by
+ * the turn's normal emission and the abort path's settled calls so a result
+ * that survives a cancellation reaches the client with the same payload it
+ * would have had on an uninterrupted turn.
+ */
+function toolResultEventFields(
+  result: LoopToolResult,
+): Omit<Extract<AgentEvent, { type: "tool_result" }>, "type" | "toolUseId"> {
+  return {
+    content: result.content,
+    isError: result.isError,
+    diff: result.diff,
+    status: result.status,
+    contentBlocks: result.contentBlocks,
+    riskLevel: result.riskLevel,
+    riskReason: result.riskReason,
+    matchedTrustRuleId: result.matchedTrustRuleId,
+    isContainerized: result.isContainerized,
+    riskScopeOptions: result.riskScopeOptions,
+    riskAllowlistOptions: result.riskAllowlistOptions,
+    riskDirectoryScopeOptions: result.riskDirectoryScopeOptions,
+    approvalMode: result.approvalMode,
+    approvalReason: result.approvalReason,
+    riskThreshold: result.riskThreshold,
+    activityMetadata: result.activityMetadata,
+    answeredQuestion: result.answeredQuestion,
+    errorCode: result.errorCode,
+  };
+}
+
 interface NormalizedToolUse {
   /** Assistant content with at most one `tool_use` block per call id. */
   content: ContentBlock[];
@@ -1271,6 +1395,87 @@ export class AgentLoop {
       );
     }
 
+    /**
+     * Turn a batch's raw `tool_result` blocks into the ones that reach the
+     * provider-bound history and the client: oversized output is spooled to
+     * `.tool-results/` and swapped for its stub, then every block passes
+     * through the `post-tool-use` hook chain (whose default plugin tail-drops
+     * what is still too large for the context window).
+     *
+     * Spooling runs first so the file on disk holds the tool's full output
+     * rather than the truncate plugin's tail-dropped copy, and stubbing before
+     * the first send keeps the provider-bound history append-only.
+     *
+     * Both the turn's normal path and the abort path's grace-settled results
+     * run through here: a result must not reach history unbounded merely
+     * because the turn was cancelled while it was finishing.
+     */
+    const finalizeToolResultBlocks = async (
+      rawBlocks: ContentBlock[],
+      calls: readonly ToolUseBlock[],
+      messages: Message[],
+      model: string,
+      turn: number,
+    ): Promise<{
+      resultBlocks: ContentBlock[];
+      additionalContextBlocks: ContentBlock[];
+    }> => {
+      if (conversationDir) {
+        const toolCallByUseId = new Map(
+          calls.map((tu) => [tu.id, { name: tu.name, input: tu.input }]),
+        );
+        try {
+          spoolAndStubOversizedToolResults(rawBlocks, {
+            conversationDir,
+            toolCallById: (id) => toolCallByUseId.get(id),
+          });
+        } catch (err) {
+          rlog.warn(
+            { err, turn },
+            "Spooling oversized tool results to disk failed (non-fatal)",
+          );
+        }
+      }
+
+      const contextWindowTokens =
+        options.resolveContextWindow?.().maxInputTokens ??
+        this.config.maxInputTokens ??
+        180_000;
+
+      const resultBlocks: ContentBlock[] = [];
+      const additionalContextBlocks: ContentBlock[] = [];
+      for (const block of rawBlocks) {
+        if (block.type !== "tool_result") {
+          resultBlocks.push(block);
+          continue;
+        }
+        const postToolUseCtx: PostToolUseInputContext = {
+          conversationId: this.conversationId,
+          toolResponse: block as ToolResultContent,
+          messages,
+          additionalContext: null,
+          model,
+          maxInputTokens: contextWindowTokens,
+          callSite: callSite ?? null,
+          supportsDynamicUi,
+        };
+        const finalCtx = await runHook(HOOKS.POST_TOOL_USE, postToolUseCtx);
+        resultBlocks.push(finalCtx.toolResponse);
+        if (finalCtx.additionalContext !== null) {
+          additionalContextBlocks.push({
+            type: "text",
+            text: finalCtx.additionalContext,
+          });
+        }
+      }
+      return { resultBlocks, additionalContextBlocks };
+    };
+
+    // The model the most recent provider response reported. The abort path
+    // finalizes tool results outside the scope that holds the response, and
+    // the `post-tool-use` hook contract requires a model name.
+    let lastResponseModel = runModel ?? "";
+
     // Resolve the inference-profile override that applies right now. The
     // optional resolver lets a turn observe a confirmed mid-turn profile switch
     // before the next model call; absent a resolver the turn-start value holds.
@@ -1348,6 +1553,10 @@ export class AgentLoop {
       );
 
       let toolUseBlocks: ToolUseBlock[] = [];
+      // This iteration's dispatched tool calls, in `tool_use` order. Declared
+      // here so the outer catch, where an abort lands, can read each call's
+      // settlement state while synthesizing cancellation results.
+      let inFlightToolCalls: InFlightToolCall[] = [];
       // The provider rejection thrown by this iteration's call, if any. Set in
       // the inner provider catch and read by the outer catch to confine
       // error-stop recovery to genuine provider rejections — a throw from
@@ -1935,6 +2144,8 @@ export class AgentLoop {
         // serialized in `handleUsage` already sees it.
         latencyTracker?.mark("call_complete");
 
+        lastResponseModel = response.model;
+
         onEvent({
           type: "usage",
           inputTokens: response.usage.inputTokens,
@@ -2251,13 +2462,14 @@ export class AgentLoop {
           });
         }
 
-        // If already cancelled, synthesize cancelled results and stop
+        // If already cancelled, synthesize cancelled results and stop. No call
+        // was dispatched, so nothing can still be running.
         if (signal?.aborted) {
           const cancelledBlocks: ContentBlock[] = toolUseBlocks.map(
             (toolUse) => ({
               type: "tool_result" as const,
               tool_use_id: toolUse.id,
-              content: "Cancelled by user",
+              content: CANCELLED_TOOL_RESULT,
               is_error: true,
             }),
           );
@@ -2266,7 +2478,7 @@ export class AgentLoop {
             await onEvent({
               type: "tool_result",
               toolUseId: toolUse.id,
-              content: "Cancelled by user",
+              content: CANCELLED_TOOL_RESULT,
               isError: true,
               cancelled: true,
             });
@@ -2311,29 +2523,49 @@ export class AgentLoop {
           );
         }
 
-        const toolExecutionPromise = Promise.all(
-          toolUseBlocks.map(async (toolUse) => {
-            if (deferSiblings && toolUse !== exclusiveBlock) {
-              const result: Awaited<ReturnType<LoopToolExecutor>> = {
-                content: deferredForExclusiveMessage(exclusiveBlock!.name),
-                isError: false,
-              };
-              return { toolUse, result };
-            }
-            const result = await this.toolExecutor!(
-              toolUse.name,
-              toolUse.input,
-              (chunk) => {
-                onEvent({
-                  type: "tool_output_chunk",
-                  toolUseId: toolUse.id,
-                  chunk,
-                });
-              },
-              toolUse.id,
-            );
+        inFlightToolCalls = toolUseBlocks.map((toolUse) => ({
+          toolUse,
+          settled: false,
+        }));
 
-            return { toolUse, result };
+        const toolExecutionPromise = Promise.all(
+          inFlightToolCalls.map((call) => {
+            const { toolUse } = call;
+            const promise = (async () => {
+              if (deferSiblings && toolUse !== exclusiveBlock) {
+                const result: LoopToolResult = {
+                  content: deferredForExclusiveMessage(exclusiveBlock!.name),
+                  isError: false,
+                };
+                return { toolUse, result };
+              }
+              const result = await this.toolExecutor!(
+                toolUse.name,
+                toolUse.input,
+                (chunk) => {
+                  onEvent({
+                    type: "tool_output_chunk",
+                    toolUseId: toolUse.id,
+                    chunk,
+                  });
+                },
+                toolUse.id,
+              );
+
+              return { toolUse, result };
+            })().then(
+              (settled) => {
+                call.settled = true;
+                call.result = settled.result;
+                return settled;
+              },
+              (err) => {
+                call.settled = true;
+                throw err;
+              },
+            );
+            call.promise = promise;
+            return promise;
           }),
         );
 
@@ -2394,73 +2626,17 @@ export class AgentLoop {
           }),
         );
 
-        // Spool oversized results to `.tool-results/` and swap the inline
-        // copy for the post-turn pass's stub now — on the raw blocks, before
-        // the post-tool-use hooks, event emission, and history append. Running
-        // ahead of the hooks means the spooled file holds the tool's full
-        // output rather than the truncate plugin's tail-dropped copy, and the
-        // hooks then see the stub. Stubbing before the first send keeps the
-        // provider-bound history strictly append-only (rewriting an earlier
-        // message between calls would invalidate the prompt-cache prefix on
-        // every iteration).
-        if (conversationDir) {
-          const toolCallByUseId = new Map(
-            toolUseBlocks.map((tu) => [
-              tu.id,
-              { name: tu.name, input: tu.input },
-            ]),
+        // Spool oversized results and run the `post-tool-use` hook chain
+        // before the results join the provider-bound history or reach a
+        // client.
+        const { resultBlocks, additionalContextBlocks } =
+          await finalizeToolResultBlocks(
+            rawResultBlocks,
+            toolUseBlocks,
+            history,
+            response.model,
+            toolUseTurns,
           );
-          try {
-            spoolAndStubOversizedToolResults(rawResultBlocks, {
-              conversationDir,
-              toolCallById: (id) => toolCallByUseId.get(id),
-            });
-          } catch (err) {
-            rlog.warn(
-              { err, turn: toolUseTurns },
-              "Spooling oversized tool results to disk failed (non-fatal)",
-            );
-          }
-        }
-
-        // Run the `post-tool-use` hook once per tool result, after the tool
-        // returns and before the result joins the provider-bound history.
-        // The default tool-result-truncate plugin tail-drops oversized output
-        // to fit the context window (spool-stubbed results are already tiny;
-        // spool-exempt ones still rely on it); user hooks can swap in a
-        // smarter strategy (e.g. a summariser) or observe results for side
-        // effects.
-        const contextWindowTokens =
-          options.resolveContextWindow?.().maxInputTokens ??
-          this.config.maxInputTokens ??
-          180_000;
-
-        const resultBlocks: ContentBlock[] = [];
-        const additionalContextBlocks: ContentBlock[] = [];
-        for (const block of rawResultBlocks) {
-          if (block.type !== "tool_result") {
-            resultBlocks.push(block);
-            continue;
-          }
-          const postToolUseCtx: PostToolUseInputContext = {
-            conversationId: this.conversationId,
-            toolResponse: block as ToolResultContent,
-            messages: history,
-            additionalContext: null,
-            model: response.model,
-            maxInputTokens: contextWindowTokens,
-            callSite: callSite ?? null,
-            supportsDynamicUi,
-          };
-          const finalCtx = await runHook(HOOKS.POST_TOOL_USE, postToolUseCtx);
-          resultBlocks.push(finalCtx.toolResponse);
-          if (finalCtx.additionalContext !== null) {
-            additionalContextBlocks.push({
-              type: "text",
-              text: finalCtx.additionalContext,
-            });
-          }
-        }
 
         // Emit tool_result events AFTER truncation so downstream consumers
         // (e.g. session persistence) receive the truncated content.
@@ -2476,24 +2652,8 @@ export class AgentLoop {
           onEvent({
             type: "tool_result",
             toolUseId: toolUse.id,
+            ...toolResultEventFields(result),
             content: emitContent,
-            isError: result.isError,
-            diff: result.diff,
-            status: result.status,
-            contentBlocks: result.contentBlocks,
-            riskLevel: result.riskLevel,
-            riskReason: result.riskReason,
-            matchedTrustRuleId: result.matchedTrustRuleId,
-            isContainerized: result.isContainerized,
-            riskScopeOptions: result.riskScopeOptions,
-            riskAllowlistOptions: result.riskAllowlistOptions,
-            riskDirectoryScopeOptions: result.riskDirectoryScopeOptions,
-            approvalMode: result.approvalMode,
-            approvalReason: result.approvalReason,
-            riskThreshold: result.riskThreshold,
-            activityMetadata: result.activityMetadata,
-            answeredQuestion: result.answeredQuestion,
-            errorCode: result.errorCode,
           });
         }
 
@@ -2560,23 +2720,73 @@ export class AgentLoop {
         // Anthropic API (every tool_use must have a matching tool_result).
         if (signal?.aborted) {
           if (toolUseBlocks.length > 0) {
-            const cancelledBlocks: ContentBlock[] = toolUseBlocks.map(
-              (toolUse) => ({
+            // Tools that honour the signal settle on the abort; wait briefly so
+            // they report their real outcome instead of the hedge below.
+            await awaitAbortSettlementGrace(inFlightToolCalls);
+            const outcomes = toolUseBlocks.map((toolUse) =>
+              cancelledToolOutcomeFor(toolUse, inFlightToolCalls),
+            );
+            const rawCancelledBlocks: ContentBlock[] = outcomes.map(
+              ({ toolUse, content, isError, result }) => ({
                 type: "tool_result" as const,
                 tool_use_id: toolUse.id,
-                content: "Cancelled by user",
-                is_error: true,
+                content,
+                is_error: isError,
+                ...(result?.contentBlocks
+                  ? { contentBlocks: result.contentBlocks }
+                  : {}),
               }),
             );
+            // A tool that finished inside the grace produced real output, which
+            // can be arbitrarily large. Spool and truncate it the same way an
+            // uninterrupted turn does, so cancelling is not a way to put an
+            // unbounded result into history and onto a client.
+            let cancelledBlocks = rawCancelledBlocks;
+            try {
+              ({ resultBlocks: cancelledBlocks } =
+                await finalizeToolResultBlocks(
+                  rawCancelledBlocks,
+                  toolUseBlocks,
+                  history,
+                  lastResponseModel,
+                  toolUseTurns,
+                ));
+            } catch (finalizeErr) {
+              // Every tool_use still needs a tool_result for the history to
+              // stay well-formed, so a failing hook falls back to raw blocks.
+              rlog.warn(
+                { err: finalizeErr, turn: toolUseTurns },
+                "Finalizing cancelled tool results failed (non-fatal)",
+              );
+            }
             history.push({ role: "user", content: cancelledBlocks });
-            for (const toolUse of toolUseBlocks) {
-              await onEvent({
-                type: "tool_result",
-                toolUseId: toolUse.id,
-                content: "Cancelled by user",
-                isError: true,
-                cancelled: true,
-              });
+            for (const { toolUse, content, isError, result } of outcomes) {
+              const finalized = cancelledBlocks.find(
+                (b) => b.type === "tool_result" && b.tool_use_id === toolUse.id,
+              );
+              const emitContent =
+                finalized && finalized.type === "tool_result"
+                  ? finalized.content
+                  : content;
+              // A call that finished ran, so it is not a cancellation: sending
+              // it with `cancelled` set would tell the daemon to skip the
+              // bookkeeping its side effects need.
+              await onEvent(
+                result
+                  ? {
+                      type: "tool_result",
+                      toolUseId: toolUse.id,
+                      ...toolResultEventFields(result),
+                      content: emitContent,
+                    }
+                  : {
+                      type: "tool_result",
+                      toolUseId: toolUse.id,
+                      content: emitContent,
+                      isError,
+                      cancelled: true,
+                    },
+              );
             }
           }
           await stopTurn("aborted_via_error");

--- a/assistant/src/calls/call-domain.ts
+++ b/assistant/src/calls/call-domain.ts
@@ -22,8 +22,12 @@ import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { isGuardian } from "../runtime/channel-verification-service.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { isAbortLikeError } from "../tools/shared/abort.js";
 import { getLogger } from "../util/logger.js";
-import { upsertActiveCallLease } from "./active-call-lease.js";
+import {
+  syncActiveCallLeaseFromSession,
+  upsertActiveCallLease,
+} from "./active-call-lease.js";
 import { isDeniedNumber } from "./call-constants.js";
 import { postPointerMessageSafe } from "./call-pointer-messages.js";
 import { getCallController, unregisterCallController } from "./call-state.js";
@@ -71,6 +75,12 @@ type StartCallInput = {
   assistantId?: string;
   callerIdentityMode?: "assistant_number" | "user_number";
   skipDisclosure?: boolean;
+  /**
+   * Cancellation for the turn that asked for the call. Setup is asynchronous
+   * (caller-identity resolution, ingress preflight, callback-URL lookups), so
+   * this is what stops a stopped turn from still dialling a real number.
+   */
+  signal?: AbortSignal;
 };
 
 type CancelCallInput = {
@@ -352,6 +362,7 @@ export async function startCall(
     callerIdentityMode,
     skipDisclosure,
     assistantId = DAEMON_INTERNAL_ASSISTANT_ID,
+    signal,
   } = input;
 
   if (!phoneNumber || typeof phoneNumber !== "string") {
@@ -420,6 +431,11 @@ export async function startCall(
 
     const ingressConfig = preflightResult.ingressConfig;
     const provider = new TwilioVoiceProvider();
+
+    // Caller-identity resolution and the ingress preflight above are both
+    // awaits. Checking here means a turn stopped during them leaves nothing
+    // behind: no call session, no voice conversation, no lease.
+    signal?.throwIfAborted();
 
     const session = createCallSession({
       conversationId,
@@ -502,6 +518,24 @@ export async function startCall(
 
     upsertActiveCallLease({ callSessionId: session.id });
 
+    // The callback-URL lookups above are awaits too, and by now the session,
+    // its voice conversation and its lease exist. A cancel landing here must
+    // not still place a real outbound call, so the session is marked cancelled
+    // and its lease released before the abort is let out.
+    if (signal?.aborted) {
+      updateCallSession(session.id, {
+        status: "cancelled",
+        endedAt: Date.now(),
+        lastError: "Cancelled before the call was placed",
+      });
+      syncActiveCallLeaseFromSession({
+        id: session.id,
+        providerCallSid: null,
+        status: "cancelled",
+      });
+      signal.throwIfAborted();
+    }
+
     const { callSid } = await provider.initiateCall({
       from: fromNumber,
       to: phoneNumber,
@@ -526,6 +560,12 @@ export async function startCall(
       callerIdentityMode: identityResult.mode,
     };
   } catch (err) {
+    // A cancelled turn is not a call failure: the session and lease are already
+    // released above, so let the abort out rather than reporting a failure and
+    // posting a failure notice to the conversation.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     log.error({ err, phoneNumber }, "Failed to initiate call");
 

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -1,6 +1,7 @@
 import * as appStore from "../../../../apps/app-store.js";
 import type { AppCreateInput } from "../../../../tools/apps/executors.js";
 import { executeAppCreate } from "../../../../tools/apps/executors.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -10,6 +11,7 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  throwIfCancelled(context);
   const createInput: AppCreateInput = input as unknown as AppCreateInput;
   return executeAppCreate(
     createInput,

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-delete.ts
@@ -1,5 +1,6 @@
 import * as appStore from "../../../../apps/app-store.js";
 import { executeAppDelete } from "../../../../tools/apps/executors.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -7,7 +8,8 @@ import type {
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  throwIfCancelled(context);
   return executeAppDelete({ app_id: input.app_id as string }, appStore);
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
@@ -5,6 +5,7 @@ import {
   missingAppIdError,
   resolveAppId,
 } from "../../../../tools/apps/resolve-app-id.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -18,8 +19,10 @@ export async function run(
   if (!appId) {
     return missingAppIdError();
   }
+  throwIfCancelled(context);
   return executeAppGenerateIcon(
     { ...input, app_id: appId } as unknown as AppGenerateIconInput,
     appStore,
+    context.signal,
   );
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-open.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-open.ts
@@ -2,6 +2,7 @@ import {
   missingAppIdError,
   resolveAppId,
 } from "../../../../tools/apps/resolve-app-id.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -28,5 +29,6 @@ export async function run(
       isError: true,
     };
   }
+  throwIfCancelled(context);
   return context.proxyToolResolver("app_open", { ...input, app_id: appId });
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
@@ -4,6 +4,7 @@ import {
   missingAppIdError,
   resolveAppId,
 } from "../../../../tools/apps/resolve-app-id.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -17,5 +18,6 @@ export async function run(
   if (!appId) {
     return missingAppIdError();
   }
+  throwIfCancelled(context);
   return executeAppRefresh({ app_id: appId }, appStore);
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
@@ -5,6 +5,7 @@ import {
   missingAppIdError,
   resolveAppId,
 } from "../../../../tools/apps/resolve-app-id.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -18,6 +19,7 @@ export async function run(
   if (!appId) {
     return missingAppIdError();
   }
+  throwIfCancelled(context);
   return executeAppUpdate(
     { ...input, app_id: appId } as unknown as AppUpdateInput,
     appStore,

--- a/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
+++ b/assistant/src/config/bundled-skills/contacts/tools/contact-merge.ts
@@ -2,6 +2,7 @@ import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts
 
 import { cliIpcCall } from "../../../../ipc/cli-client.js";
 import { resolveGuardianName } from "../../../../prompts/user-reference.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -15,7 +16,7 @@ function guardianAwareName(contact: Pick<ContactRead, "role" | "displayName">) {
 
 export async function executeContactMerge(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const keepId = input.keep_id as string | undefined;
   const mergeId = input.merge_id as string | undefined;
@@ -26,15 +27,20 @@ export async function executeContactMerge(
   if (!mergeId || typeof mergeId !== "string") {
     return { content: "Error: merge_id is required", isError: true };
   }
+  throwIfCancelled(context);
 
   // Validate both contacts exist before merging
   const [keepRes, mergeRes] = await Promise.all([
-    cliIpcCall<{ contact: ContactRead }>("getContact", {
-      pathParams: { id: keepId },
-    }),
-    cliIpcCall<{ contact: ContactRead }>("getContact", {
-      pathParams: { id: mergeId },
-    }),
+    cliIpcCall<{ contact: ContactRead }>(
+      "getContact",
+      { pathParams: { id: keepId } },
+      { signal: context.signal },
+    ),
+    cliIpcCall<{ contact: ContactRead }>(
+      "getContact",
+      { pathParams: { id: mergeId } },
+      { signal: context.signal },
+    ),
   ]);
 
   if (!keepRes.ok) {
@@ -47,12 +53,21 @@ export async function executeContactMerge(
   const keepContact = keepRes.result!.contact;
   const mergeContact = mergeRes.result!.contact;
 
+  // Recheck: the two existence lookups above are awaits, so a cancel landing
+  // in either must not reach the merge.
+  throwIfCancelled(context);
+
+  // Deliberately detached from the turn signal. `cliIpcCall` cancels only the
+  // client socket, so an abort after the request is on the wire resolves
+  // "Request aborted" here while the route and the gateway finish the merge
+  // regardless. That quick resolution would settle inside the loop's abort
+  // grace and hand the model an ordinary failure for a merge that destroyed a
+  // contact. Staying attached leaves the call unsettled instead, which is what
+  // makes the loop say the work may still have completed.
   const mergeResult = await cliIpcCall<{
     ok: boolean;
     contact?: ContactRead;
-  }>("merge_contacts", {
-    body: { keepId, mergeId },
-  });
+  }>("merge_contacts", { body: { keepId, mergeId } });
 
   if (!mergeResult.ok) {
     return { content: `Error: ${mergeResult.error}`, isError: true };
@@ -63,7 +78,10 @@ export async function executeContactMerge(
   const mergedId = mergeResult.result?.contact?.id ?? keepId;
 
   // Re-read the surviving contact through the gateway-relayed read so role and
-  // interactionCount come from the gateway ContactRead.
+  // interactionCount come from the gateway ContactRead. Detached from the turn
+  // signal for the same reason as the merge above: the destructive step has
+  // already run, so aborting the read here would report a failure for work that
+  // succeeded.
   const mergedRes = await cliIpcCall<{ contact: ContactRead }>("getContact", {
     pathParams: { id: mergedId },
   });

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -15,6 +15,10 @@ import {
 } from "../../../../media/image-service.js";
 import { getFilePathBySourcePath } from "../../../../persistence/attachments-store.js";
 import type { ImageContent } from "../../../../providers/types.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import { sandboxPolicy } from "../../../../tools/shared/filesystem/path-policy.js";
 import type {
   ToolContext,
@@ -107,6 +111,7 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  throwIfCancelled(context);
   const config = getConfig();
   const svc = config.services["image-generation"];
   let modelOverride = input.model;
@@ -201,6 +206,12 @@ export async function run(
     sourceImages = validPathImages;
   }
 
+  // Recheck: credential resolution and the source-image reads above are all
+  // awaits, so a cancel landing during them must not still start a paid
+  // generation. Past this line the request is in flight and carries the turn's
+  // signal, so a cancel aborts it rather than being checked for.
+  throwIfCancelled(context);
+
   try {
     const result = await generateImage(provider, credentials, {
       prompt,
@@ -208,8 +219,11 @@ export async function run(
       sourceImages,
       model,
       variants,
+      ...(context.signal ? { signal: context.signal } : {}),
     });
 
+    // No cancellation check here on purpose. The generation resolved, so it was
+    // paid for; discarding it would charge the user and hand the model nothing.
     const imageCount = result.images.length;
     const { savedPaths, saveError } = saveGeneratedImages(
       result.images,
@@ -254,6 +268,11 @@ export async function run(
       contentBlocks,
     };
   } catch (error) {
+    // A cancelled turn is not a generation failure: let it reach the
+    // executor's abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(error)) {
+      throw error;
+    }
     // Echo the model that failed so callers (including the skill's retry
     // branch) can key off the error text instead of remembering their input.
     return {

--- a/assistant/src/config/bundled-skills/media-processing/__tests__/audio-transcribe.test.ts
+++ b/assistant/src/config/bundled-skills/media-processing/__tests__/audio-transcribe.test.ts
@@ -18,8 +18,18 @@ let spawnResult: { exitCode: number; stdout: string; stderr: string } = {
   stderr: "",
 };
 
+let spawnSignals: (AbortSignal | undefined)[] = [];
+
 mock.module("../../../../util/spawn.js", () => ({
-  spawnWithTimeout: async () => spawnResult,
+  spawnWithTimeout: async (
+    _cmd: string[],
+    _timeoutMs: number,
+    signal?: AbortSignal,
+  ) => {
+    spawnSignals.push(signal);
+    signal?.throwIfAborted();
+    return spawnResult;
+  },
 }));
 
 let mockFileContents: Buffer = Buffer.alloc(0);
@@ -33,6 +43,7 @@ mock.module("node:fs/promises", () => ({
 // Subject import (after mocks)
 // ---------------------------------------------------------------------------
 
+import { createAbortReason } from "../../../../util/abort-reasons.js";
 import { transcribeSegmentAudio } from "../services/audio-transcribe.js";
 
 // ---------------------------------------------------------------------------
@@ -121,5 +132,72 @@ describe("transcribeSegmentAudio", () => {
     const result = await transcribeSegmentAudio("/tmp/video.mp4", 0, 10);
 
     expect(result).toBe("");
+  });
+});
+
+describe("transcribeSegmentAudio cancellation", () => {
+  const REASON = createAbortReason("user_cancel", "audio-transcribe.test");
+
+  test("the ffmpeg extraction is handed the signal", async () => {
+    spawnSignals = [];
+    const controller = new AbortController();
+    mockTranscriber = makeMockTranscriber("hello");
+    spawnResult = { exitCode: 0, stdout: "", stderr: "" };
+
+    await transcribeSegmentAudio(
+      "/tmp/v.mp4",
+      0,
+      5,
+      mockTranscriber,
+      controller.signal,
+    );
+    expect(spawnSignals[0]).toBe(controller.signal);
+  });
+
+  test("the transcribe request runs under the turn signal too", async () => {
+    const controller = new AbortController();
+    let seen: AbortSignal | undefined;
+    mockTranscriber = {
+      ...makeMockTranscriber("hello"),
+      transcribe: async (req: { signal?: AbortSignal }) => {
+        seen = req.signal;
+        return { text: "hello" };
+      },
+    } as unknown as BatchTranscriber;
+    spawnResult = { exitCode: 0, stdout: "", stderr: "" };
+
+    await transcribeSegmentAudio(
+      "/tmp/v.mp4",
+      0,
+      5,
+      mockTranscriber,
+      controller.signal,
+    );
+    // Composed with the request's own timeout, so it is not the raw signal.
+    expect(seen).toBeDefined();
+    expect(seen!.aborted).toBe(false);
+    controller.abort(REASON);
+    expect(seen!.aborted).toBe(true);
+  });
+
+  /**
+   * Every other failure degrades to an empty transcript so one bad segment
+   * cannot kill the run. A cancellation must not: the caller has to stop
+   * rather than record a silent segment and move to the next one.
+   */
+  test("a cancelled turn raises instead of degrading to no transcript", async () => {
+    const controller = new AbortController();
+    controller.abort(REASON);
+    mockTranscriber = makeMockTranscriber("hello");
+
+    await expect(
+      transcribeSegmentAudio(
+        "/tmp/v.mp4",
+        0,
+        5,
+        mockTranscriber,
+        controller.signal,
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/audio-transcribe.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 
 import { resolveBatchTranscriber } from "../../../../providers/speech-to-text/resolve.js";
 import type { BatchTranscriber } from "../../../../stt/types.js";
+import { isAbortLikeError } from "../../../../tools/shared/abort.js";
 import { spawnWithTimeout } from "../../../../util/spawn.js";
 
 const FFMPEG_TIMEOUT_MS = 60_000;
@@ -26,13 +27,17 @@ const STT_REQUEST_TIMEOUT_MS = 120_000;
  * omitted, resolves the transcriber on demand via `resolveBatchTranscriber()`.
  *
  * Returns empty string when no provider is configured, the provider call
- * fails, or ffmpeg extraction fails — this preserves preprocess resilience.
+ * fails, or ffmpeg extraction fails, which preserves preprocess resilience.
+ * A cancelled turn is the exception: it is raised rather than degraded to an
+ * empty transcript, because the caller needs to stop the whole run instead of
+ * carrying on to the next segment.
  */
 export async function transcribeSegmentAudio(
   videoPath: string,
   startSeconds: number,
   durationSeconds: number,
   transcriber?: BatchTranscriber | null,
+  signal?: AbortSignal,
 ): Promise<string> {
   const tmpWav = join(tmpdir(), `vellum-seg-audio-${randomUUID()}.wav`);
 
@@ -68,6 +73,7 @@ export async function transcribeSegmentAudio(
         tmpWav,
       ],
       FFMPEG_TIMEOUT_MS,
+      signal,
     );
 
     if (extractResult.exitCode !== 0) {
@@ -76,14 +82,22 @@ export async function transcribeSegmentAudio(
 
     // Send extracted WAV through the provider-agnostic transcriber
     const audioBuffer = await readFile(tmpWav);
+    // The request's own ceiling composed with the turn's cancellation, so
+    // stopping the turn aborts the paid call instead of abandoning it.
+    const timeout = AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS);
     const result = await resolved.transcribe({
       audio: audioBuffer,
       mimeType: "audio/wav",
-      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+      signal: signal ? AbortSignal.any([timeout, signal]) : timeout,
     });
 
     return result.text?.trim() ?? "";
-  } catch {
+  } catch (err) {
+    // Degrading a cancellation to an empty transcript would have the caller
+    // record a segment with no audio and move on to the next one.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     return "";
   } finally {
     try {

--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-map.ts
@@ -30,6 +30,11 @@ export interface GeminiMapOptions {
   model?: string;
   concurrency?: number;
   maxRetries?: number;
+  /**
+   * Turn cancellation. Stops the fan-out between segments and aborts the paid
+   * generation calls instead of letting them run to completion.
+   */
+  signal?: AbortSignal;
 }
 
 export interface SegmentMapResult {
@@ -144,6 +149,7 @@ async function processSegment(
     model,
     contents: [{ role: "user" as const, parts: parts as never }],
     config: {
+      ...(options.signal ? { abortSignal: options.signal } : {}),
       systemInstruction: options.systemPrompt,
       responseMimeType: "application/json",
       responseSchema: options.outputSchema as never,
@@ -174,6 +180,7 @@ async function processSegmentWithRetry(
   onProgress?: (msg: string) => void,
 ): Promise<SegmentProcessingResult> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    options.signal?.throwIfAborted();
     try {
       const { result, model, inputTokens, outputTokens } = await processSegment(
         client,

--- a/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/gemini-video.ts
@@ -28,6 +28,11 @@ export interface GeminiVideoOptions {
   context?: Record<string, unknown>;
   model?: string;
   maxRetries?: number;
+  /**
+   * Turn cancellation. Stops the upload/poll loop and aborts the paid
+   * generation calls instead of letting them run for their full deadline.
+   */
+  signal?: AbortSignal;
 }
 
 // 2 GB file size limit for Gemini Files API
@@ -45,8 +50,10 @@ async function waitForFileActive(
   client: GoogleGenAI,
   fileName: string,
   onProgress?: (msg: string) => void,
+  signal?: AbortSignal,
 ): Promise<void> {
   for (let i = 0; i < FILE_POLL_MAX_ATTEMPTS; i++) {
+    signal?.throwIfAborted();
     const fileInfo = await client.files.get({ name: fileName });
     if (fileInfo.state === "ACTIVE") {
       return;
@@ -106,10 +113,16 @@ export async function analyzeVideoDirectly(
   let uploadedFileName: string | undefined;
 
   try {
-    // Upload the video file
+    // Upload the video file. The signal reaches the SDK, which stops pushing
+    // bytes on abort; the size check and the pipeline mkdir above are awaits,
+    // so it is also checked here before a multi-gigabyte upload starts.
+    options.signal?.throwIfAborted();
     const uploadResult = await client.files.upload({
       file: filePath,
-      config: { mimeType },
+      config: {
+        mimeType,
+        ...(options.signal ? { abortSignal: options.signal } : {}),
+      },
     });
 
     if (!uploadResult.name || !uploadResult.uri) {
@@ -122,12 +135,18 @@ export async function analyzeVideoDirectly(
     );
 
     // Wait for file to be processed
-    await waitForFileActive(client, uploadResult.name, onProgress);
+    await waitForFileActive(
+      client,
+      uploadResult.name,
+      onProgress,
+      options.signal,
+    );
     onProgress?.(`Video processed. Sending to ${model} for analysis...\n`);
 
     // Send to generateContent with retries
     let lastError: string | undefined;
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      options.signal?.throwIfAborted();
       try {
         let promptText = `Analyzing full video (${durationSeconds.toFixed(
           1,
@@ -157,6 +176,7 @@ export async function analyzeVideoDirectly(
             },
           ],
           config: {
+            ...(options.signal ? { abortSignal: options.signal } : {}),
             systemInstruction: options.systemPrompt,
             responseMimeType: "application/json",
             responseSchema: options.outputSchema as never,

--- a/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/preprocess.ts
@@ -304,8 +304,12 @@ export function sampleFrameIndices(
  * Extract dominant colors from a frame image using ffmpeg's thumbnail and showinfo filters.
  * Returns hex color strings.
  */
-async function extractDominantColors(framePath: string): Promise<string[]> {
+async function extractDominantColors(
+  framePath: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
   // Use ffmpeg to extract a palette from the frame
+  signal?.throwIfAborted();
   const result = await spawnWithTimeout(
     [
       "ffmpeg",
@@ -318,6 +322,7 @@ async function extractDominantColors(framePath: string): Promise<string[]> {
       "-",
     ],
     FFMPEG_PALETTE_TIMEOUT_MS,
+    signal,
   );
 
   // Fallback: return empty if analysis fails
@@ -339,6 +344,7 @@ async function extractDominantColors(framePath: string): Promise<string[]> {
  */
 async function buildSubjectRegistry(
   framePaths: string[],
+  signal?: AbortSignal,
 ): Promise<SubjectRegistry> {
   if (framePaths.length === 0) {
     return { groups: [] };
@@ -350,7 +356,7 @@ async function buildSubjectRegistry(
   // Collect all dominant colors across sampled frames
   const colorCounts = new Map<string, number>();
   for (const path of sampledPaths) {
-    const colors = await extractDominantColors(path);
+    const colors = await extractDominantColors(path, signal);
     for (const c of colors) {
       colorCounts.set(c, (colorCounts.get(c) || 0) + 1);
     }
@@ -378,7 +384,9 @@ export async function preprocessForAsset(
   assetId: string,
   options: PreprocessOptions = {},
   onProgress?: (msg: string) => void,
+  opts?: { signal?: AbortSignal },
 ): Promise<PreprocessManifest> {
+  const signal = opts?.signal;
   const config: PreprocessConfig = {
     intervalSeconds: options.intervalSeconds ?? 1,
     segmentDuration: options.segmentDuration ?? 15,
@@ -410,6 +418,10 @@ export async function preprocessForAsset(
   if (!stage) {
     stage = createProcessingStage({ assetId, stage: "preprocess" });
   }
+  // Recheck: the asset lookup and stage reads above are awaits, and this marks
+  // the asset as being processed by a run that is about to start spawning
+  // ffmpeg.
+  signal?.throwIfAborted();
   updateProcessingStage(stage.id, { status: "running", startedAt: Date.now() });
 
   const pipelineDir = join(dirname(asset.filePath), "pipeline", assetId);
@@ -423,6 +435,7 @@ export async function preprocessForAsset(
 
     if (detectDeadTime) {
       onProgress?.("Detecting dead time with mpdecimate filter...\n");
+      signal?.throwIfAborted();
       const mpdecimateResult = await spawnWithTimeout(
         [
           "ffmpeg",
@@ -437,6 +450,7 @@ export async function preprocessForAsset(
           "-",
         ],
         FFMPEG_PREPROCESS_TIMEOUT_MS,
+        signal,
       );
 
       const droppedTimestamps = parseDroppedFrameTimestamps(
@@ -465,6 +479,7 @@ export async function preprocessForAsset(
     // reason on the progress stream rather than killing the whole run.
     let transcriber: BatchTranscriber | null = null;
     if (options.includeAudio) {
+      signal?.throwIfAborted();
       try {
         transcriber = await resolveBatchTranscriber({ role: "batch" });
       } catch (err) {
@@ -477,6 +492,9 @@ export async function preprocessForAsset(
     const scaleFilter = `scale='if(gt(iw,ih),-1,${config.shortEdge})':'if(gt(iw,ih),${config.shortEdge},-1)'`;
 
     for (let i = 0; i < rawSegments.length; i++) {
+      // Each pass spawns ffmpeg and can transcribe audio, so a stop is
+      // honoured between segments as well as inside the spawn itself.
+      signal?.throwIfAborted();
       const seg = rawSegments[i];
       const segDuration = seg.endSeconds - seg.startSeconds;
       const effectiveInterval = computeEffectiveInterval(
@@ -511,6 +529,7 @@ export async function preprocessForAsset(
           join(segTempDir, "frame-%06d.jpg"),
         ],
         FFMPEG_PREPROCESS_TIMEOUT_MS,
+        signal,
       );
 
       if (result.exitCode !== 0) {
@@ -546,11 +565,14 @@ export async function preprocessForAsset(
       };
 
       if (options.includeAudio) {
+        // Transcription is a paid provider call per segment.
+        signal?.throwIfAborted();
         const transcript = await transcribeSegmentAudio(
           asset.filePath,
           seg.startSeconds,
           seg.endSeconds - seg.startSeconds,
           transcriber,
+          signal,
         );
         if (transcript) {
           segment.transcript = transcript;
@@ -576,15 +598,13 @@ export async function preprocessForAsset(
       `Extracted ${totalFrames} total frames across ${segments.length} segments.\n`,
     );
 
-    // Atomically swap temp dir to durable path
-    await rm(framesDir, { recursive: true, force: true });
-    await mkdir(dirname(framesDir), { recursive: true });
-    await rename(tempDir, framesDir);
-
     // Step 4: Subject registry
+    //
+    // Reads the frames where they still are, under the temp directory, so the
+    // destructive swap can wait for the commit step below. `segment.framePaths`
+    // are the durable paths those files acquire once the swap happens.
     onProgress?.("Building subject registry...\n");
-    const allExtractedPaths = segments.flatMap((s) => s.framePaths);
-    const subjectRegistry = await buildSubjectRegistry(allExtractedPaths);
+    const subjectRegistry = await buildSubjectRegistry(allFramePaths, signal);
     onProgress?.(
       `Identified ${subjectRegistry.groups.length} subject group(s).\n`,
     );
@@ -599,7 +619,21 @@ export async function preprocessForAsset(
       sectionBoundaries = createDefaultSections(durationSeconds);
     }
 
-    // Step 6: Register keyframes in DB
+    // Step 6: Commit
+    //
+    // Last checkpoint before the run becomes durable. Everything past here
+    // replaces the asset's frames on disk, replaces its keyframe rows, rewrites
+    // the manifest and marks the stage complete. Those have to move together:
+    // a cancel between the swap and the rows would leave new frames on disk
+    // described by the previous run's keyframes, and the asset looking
+    // preprocessed by a run the model was told never finished.
+    signal?.throwIfAborted();
+
+    // Atomically swap temp dir to durable path
+    await rm(framesDir, { recursive: true, force: true });
+    await mkdir(dirname(framesDir), { recursive: true });
+    await rename(tempDir, framesDir);
+
     onProgress?.("Registering keyframes in database...\n");
     deleteKeyframesForAsset(assetId);
 

--- a/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
+++ b/assistant/src/config/bundled-skills/media-processing/services/reduce.ts
@@ -34,6 +34,11 @@ export interface ReduceOptions {
   systemPrompt?: string;
   /** Model override. When omitted, the configured provider's default is used. */
   model?: string;
+  /**
+   * Turn cancellation. Composed with the reduce deadline so stopping the turn
+   * aborts the paid provider call instead of leaving it to time out.
+   */
+  signal?: AbortSignal;
 }
 
 export interface ReduceResult {
@@ -180,6 +185,7 @@ async function sendToClaude(
   systemPrompt?: string,
   model?: string,
   onProgress?: (msg: string) => void,
+  callerSignal?: AbortSignal,
 ): Promise<ReduceResult> {
   const provider = await getConfiguredProvider("mainAgent");
   if (!provider) {
@@ -194,7 +200,10 @@ async function sendToClaude(
 
   onProgress?.("Sending map output to Claude for analysis...\n");
 
-  const { signal, cleanup } = createTimeout(REDUCE_TIMEOUT_MS);
+  const { signal: timeoutSignal, cleanup } = createTimeout(REDUCE_TIMEOUT_MS);
+  const signal = callerSignal
+    ? AbortSignal.any([callerSignal, timeoutSignal])
+    : timeoutSignal;
 
   try {
     const response = await provider.sendMessage([userMessage(userContent)], {
@@ -251,6 +260,7 @@ export async function reduceForAsset(
     options.systemPrompt,
     options.model,
     onProgress,
+    options.signal,
   );
   try {
     await persistReduceCost(assetId, effectiveQuery, result);

--- a/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/analyze-keyframes.ts
@@ -3,6 +3,10 @@ import { dirname, join } from "node:path";
 
 import { getMediaAssetById } from "../../../../persistence/media-store.js";
 import { getProviderKeyAsync } from "../../../../security/secure-keys.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -22,6 +26,8 @@ export interface MapSegmentsOptions {
   model?: string;
   concurrency?: number;
   maxRetries?: number;
+  /** Turn cancellation, forwarded into the paid segment calls. */
+  signal?: AbortSignal;
 }
 
 export async function mapSegmentsForAsset(
@@ -36,6 +42,10 @@ export async function mapSegmentsForAsset(
       "No Gemini API key configured. Please set your Gemini API key to use keyframe analysis.",
     );
   }
+
+  // Credential and manifest loading are awaits, so recheck before committing
+  // to the fan-out of paid calls below.
+  options.signal?.throwIfAborted();
 
   const asset = getMediaAssetById(assetId);
   if (!asset) {
@@ -74,6 +84,7 @@ export async function mapSegmentsForAsset(
       model: options.model,
       concurrency: options.concurrency,
       maxRetries: options.maxRetries,
+      signal: options.signal,
     },
     onProgress,
   );
@@ -117,11 +128,16 @@ export async function run(
     return { content: "max_retries must be non-negative.", isError: true };
   }
 
+  throwIfCancelled(context);
+
   try {
     let output: MapOutput;
 
     if (mode === "direct_video") {
       const apiKey = await getProviderKeyAsync("gemini");
+      // The credential lookup is an await, so recheck before the upload,
+      // polling and paid generation this branch starts.
+      throwIfCancelled(context);
       if (!apiKey) {
         return {
           content:
@@ -153,6 +169,7 @@ export async function run(
           context: contextObj,
           model,
           maxRetries,
+          ...(context.signal ? { signal: context.signal } : {}),
         },
         asset.filePath,
         asset.durationSeconds ?? 0,
@@ -169,6 +186,7 @@ export async function run(
           model,
           concurrency,
           maxRetries,
+          ...(context.signal ? { signal: context.signal } : {}),
         },
         context.onOutput,
       );
@@ -195,6 +213,11 @@ export async function run(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not an analysis failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = (err as Error).message;
     return { content: msg, isError: true };
   }

--- a/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/extract-keyframes.ts
@@ -4,6 +4,10 @@ import {
   getKeyframesForAsset,
   getMediaAssetById,
 } from "../../../../persistence/media-store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -39,11 +43,16 @@ export async function run(
     includeAudio,
   };
 
+  throwIfCancelled(context);
+
   try {
     const manifest = await preprocessForAsset(
       assetId,
       options,
       context.onOutput,
+      // Segmentation spawns ffmpeg per segment and can transcribe each one, so
+      // the run is long enough that a stopped turn must not carry it on.
+      context.signal ? { signal: context.signal } : undefined,
     );
 
     const asset = getMediaAssetById(assetId);
@@ -68,6 +77,11 @@ export async function run(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a preprocess failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = (err as Error).message;
     if (
       msg.startsWith("Media asset not found:") ||

--- a/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/generate-clip.ts
@@ -13,6 +13,10 @@ import { dirname, join } from "node:path";
 
 import { uploadFileBackedAttachment } from "../../../../persistence/attachments-store.js";
 import { getMediaAssetById } from "../../../../persistence/media-store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -30,7 +34,10 @@ import {
 /**
  * Get the duration of a media file in seconds via ffprobe.
  */
-async function getMediaDuration(filePath: string): Promise<number> {
+async function getMediaDuration(
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<number> {
   const result = await spawnWithTimeout(
     [
       "ffprobe",
@@ -43,6 +50,7 @@ async function getMediaDuration(filePath: string): Promise<number> {
       filePath,
     ],
     FFPROBE_TIMEOUT_MS,
+    signal,
   );
   if (result.exitCode !== 0) {
     return 0;
@@ -121,6 +129,8 @@ export async function run(
   }
   const title = input.title as string | undefined;
 
+  throwIfCancelled(context);
+
   const asset = getMediaAssetById(assetId);
   if (!asset) {
     return { content: `Media asset not found: ${assetId}`, isError: true };
@@ -135,7 +145,8 @@ export async function run(
 
   // Get the file duration so we can clamp pre/post-roll to file boundaries
   const fileDuration =
-    asset.durationSeconds ?? (await getMediaDuration(asset.filePath));
+    asset.durationSeconds ??
+    (await getMediaDuration(asset.filePath, context.signal));
 
   // Calculate actual clip boundaries with pre/post-roll, clamped to file
   const clipStart = Math.max(0, startTime - preRoll);
@@ -174,6 +185,8 @@ export async function run(
     : `clip-${timestampSuffix}-${uniqueSuffix}.${outputFormat}`;
   const clipPath = join(clipDir, clipFilename);
 
+  throwIfCancelled(context);
+
   try {
     context.onOutput?.(
       `Extracting clip ${formatTimestamp(clipStart)} – ${formatTimestamp(
@@ -198,7 +211,11 @@ export async function run(
       clipPath,
     ];
 
-    const result = await spawnWithTimeout(ffmpegArgs, FFMPEG_CLIP_TIMEOUT_MS);
+    const result = await spawnWithTimeout(
+      ffmpegArgs,
+      FFMPEG_CLIP_TIMEOUT_MS,
+      context.signal,
+    );
 
     if (result.exitCode !== 0) {
       // Stream copy failed - fall back to re-encoding (handles high-bitrate
@@ -243,9 +260,11 @@ export async function run(
         "make_zero",
         clipPath,
       ];
+      throwIfCancelled(context);
       const reencodeResult = await spawnWithTimeout(
         reencodeArgs,
         FFMPEG_CLIP_TIMEOUT_MS,
+        context.signal,
       );
       if (reencodeResult.exitCode !== 0) {
         return {
@@ -269,6 +288,10 @@ export async function run(
         1,
       )} MB). Registering as attachment...\n`,
     );
+
+    // Recheck: the transcode and the stat above are awaits, and registering
+    // hands the conversation an attachment the model was told never appeared.
+    throwIfCancelled(context);
 
     // Register as file-backed attachment (no size limit, no base64 in-memory copy)
     const mimeType = MIME_BY_FORMAT[outputFormat] ?? "video/mp4";
@@ -307,6 +330,11 @@ export async function run(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a clip failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     return {
       content: `Clip generation failed: ${(err as Error).message}`,
       isError: true,

--- a/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/ingest-media.ts
@@ -13,6 +13,7 @@ import {
   registerMediaAsset,
   updateMediaAssetStatus,
 } from "../../../../persistence/media-store.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -83,7 +84,10 @@ function classifyMediaType(mimeType: string): MediaType | null {
 // ffprobe duration extraction
 // ---------------------------------------------------------------------------
 
-async function extractDuration(filePath: string): Promise<number | null> {
+async function extractDuration(
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<number | null> {
   try {
     const result = await spawnWithTimeout(
       [
@@ -97,6 +101,7 @@ async function extractDuration(filePath: string): Promise<number | null> {
         filePath,
       ],
       FFPROBE_TIMEOUT_MS,
+      signal,
     );
     if (result.exitCode !== 0) {
       return null;
@@ -125,6 +130,7 @@ export async function run(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   // Validate file exists
   try {
@@ -177,7 +183,7 @@ export async function run(
   let durationSeconds: number | null = null;
   if (mediaType === "video" || mediaType === "audio") {
     context.onOutput?.("Extracting duration via ffprobe...\n");
-    durationSeconds = await extractDuration(filePath);
+    durationSeconds = await extractDuration(filePath, context.signal);
   }
 
   // Determine title
@@ -188,6 +194,8 @@ export async function run(
   if (input.metadata && typeof input.metadata === "object") {
     metadata = input.metadata as Record<string, unknown>;
   }
+
+  throwIfCancelled(context);
 
   // Register the asset
   const asset = registerMediaAsset({

--- a/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
+++ b/assistant/src/config/bundled-skills/media-processing/tools/query-media-events.ts
@@ -7,6 +7,10 @@
  * video content.
  */
 
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -48,7 +52,12 @@ export async function run(
     query,
     systemPrompt,
     model,
+    // Composed with the reduce deadline inside the service, so stopping the
+    // turn aborts the paid provider call rather than abandoning it.
+    ...(context.signal ? { signal: context.signal } : {}),
   };
+
+  throwIfCancelled(context);
 
   try {
     const result: ReduceResult = await reduceForAsset(
@@ -74,6 +83,11 @@ export async function run(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a query failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = (err as Error).message;
     return { content: msg, isError: true };
   }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-analyze-style.ts
@@ -9,6 +9,10 @@ import {
 } from "../../../../persistence/jobs-store.js";
 import { memoryGraphNodes } from "../../../../persistence/schema/index.js";
 import { clampUnitInterval } from "../../../../plugins/defaults/memory/validation.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -95,7 +99,7 @@ function upsertMemoryItem(opts: {
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const maxMessages = Math.min(
@@ -103,6 +107,8 @@ export async function run(
     100,
   );
   const queryFilter = input.query_filter as string | undefined;
+
+  throwIfCancelled(context);
 
   try {
     const provider = await resolveProvider(platform);
@@ -121,11 +127,19 @@ export async function run(
       );
     }
 
-    const result = await extractStylePatterns(searchResult.messages);
+    const result = await extractStylePatterns(
+      searchResult.messages,
+      context.signal,
+    );
 
     if (result.stylePatterns.length === 0) {
       return err("No style patterns were extracted. Try with more messages.");
     }
+
+    // Recheck: provider resolution, the message search and the paid analysis
+    // are all awaits, so a cancel landing in any of them must not still write
+    // every extracted style and relationship memory.
+    throwIfCancelled(context);
 
     let savedCount = 0;
 
@@ -176,6 +190,11 @@ export async function run(
 
     return ok(summary);
   } catch (e) {
+    // A cancelled turn is not an analysis failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -1,4 +1,8 @@
 import { isArchiveBySenderAuthorized } from "../../../../runtime/effective-capabilities.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -28,6 +32,7 @@ export async function run(
   if (!query) {
     return err("query is required.");
   }
+  throwIfCancelled(context);
 
   try {
     const provider = await resolveProvider(platform);
@@ -40,6 +45,9 @@ export async function run(
 
     const account = input.account as string | undefined;
     const conn = await getProviderConnection(provider, account);
+    // Recheck: provider resolution and the connection lookup are awaits, and a
+    // cancel landing during either must not still archive up to 5000 messages.
+    throwIfCancelled(context);
     const result = await provider.archiveByQuery!(conn, query);
 
     if (result.archived === 0) {
@@ -54,6 +62,11 @@ export async function run(
     }
     return ok(summary);
   } catch (e) {
+    // A cancelled turn is not an archive failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-draft.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-draft.ts
@@ -3,6 +3,7 @@ import {
   deleteDraft,
   listDrafts,
 } from "../../../../messaging/draft-store.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -11,7 +12,7 @@ import { err, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const action = input.action as string;
 
@@ -31,6 +32,7 @@ export async function run(
         return err("text is required for creating a draft.");
       }
 
+      throwIfCancelled(context);
       const draft = createDraft({
         platform,
         conversationId,
@@ -62,6 +64,7 @@ export async function run(
       if (!platform) {
         return err("platform is required for deleting a draft.");
       }
+      throwIfCancelled(context);
       const deleted = deleteDraft(platform, draftId);
       if (!deleted) {
         return err("Draft not found.");

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-mark-read.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-mark-read.ts
@@ -1,3 +1,7 @@
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -6,7 +10,7 @@ import { err, getProviderConnection, ok, resolveProvider } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const platform = input.platform as string | undefined;
   const conversationId = input.conversation_id as string;
@@ -15,6 +19,7 @@ export async function run(
   if (!conversationId) {
     return err("conversation_id is required.");
   }
+  throwIfCancelled(context);
 
   try {
     const provider = await resolveProvider(platform);
@@ -25,9 +30,17 @@ export async function run(
     }
     const account = input.account as string | undefined;
     const conn = await getProviderConnection(provider, account);
+    // Recheck: provider resolution and the connection lookup are awaits, and a
+    // cancel landing in either must not still mutate the mailbox.
+    throwIfCancelled(context);
     await provider.markRead(conn, conversationId, messageId);
     return ok("Marked as read.");
   } catch (e) {
+    // A cancelled turn is not a mark-read failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -21,6 +21,10 @@ import { recordDeliveredChannelPost } from "../../../../notifications/delivered-
 import { getConversation } from "../../../../persistence/conversation-crud.js";
 import { syncMessageToDisk } from "../../../../persistence/conversation-disk-view.js";
 import { normalizeExternalThreadId } from "../../../../persistence/external-conversation-store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -186,6 +190,8 @@ export async function run(
     return err("text is required.");
   }
 
+  throwIfCancelled(context);
+
   try {
     const provider = await resolveProvider(platform);
 
@@ -276,6 +282,9 @@ export async function run(
             cc: ccList.length > 0 ? ccList.join(", ") : undefined,
             attachments,
           });
+          // Recheck: the thread lookups and the attachment reads above are
+          // awaits, and this creates a real mailbox draft.
+          throwIfCancelled(context);
           const draft = await createDraftRaw(gmailConn, raw, threadId);
 
           const filenames = attachments.map((a) => a.filename).join(", ");
@@ -288,6 +297,9 @@ export async function run(
           );
         }
 
+        // Recheck: the thread and profile lookups above are awaits, and this
+        // creates a real mailbox draft.
+        throwIfCancelled(context);
         const draft = await createDraft(
           gmailConn,
           toList.join(", "),
@@ -319,6 +331,9 @@ export async function run(
           inReplyTo,
           attachments,
         });
+        // Recheck: the attachment reads above are awaits, and this creates a
+        // real mailbox draft.
+        throwIfCancelled(context);
         const draft = await createDraftRaw(gmailConn, raw, threadId);
 
         const filenames = attachments.map((a) => a.filename).join(", ");
@@ -328,6 +343,9 @@ export async function run(
       }
 
       // Without attachments: use standard createDraft
+      // Recheck: provider and connection resolution above are awaits, and
+      // this creates a real mailbox draft.
+      throwIfCancelled(context);
       const draft = await createDraft(
         gmailConn,
         conversationId,
@@ -364,11 +382,10 @@ export async function run(
         : undefined;
 
       if (inReplyTo) {
-        const draft = await createOutlookReplyDraft(
-          conn,
-          inReplyTo,
-          text,
-        );
+        // Recheck: the attachment reads above are awaits, and this creates a
+        // real mailbox draft.
+        throwIfCancelled(context);
+        const draft = await createOutlookReplyDraft(conn, inReplyTo, text);
         const recipientSummary = toAddress ? `To: ${toAddress}` : undefined;
         return ok(
           formatOutlookDraftCreated({
@@ -389,6 +406,9 @@ export async function run(
           : {}),
         ...(graphAttachments ? { attachments: graphAttachments } : {}),
       };
+      // Recheck: the attachment reads above are awaits, and this creates a
+      // real mailbox draft.
+      throwIfCancelled(context);
       const draft = await createOutlookDraft(conn, draftBody);
       const recipientSummary = toAddress ? `To: ${toAddress}` : undefined;
       return ok(
@@ -406,6 +426,7 @@ export async function run(
     const attachments = attachmentPaths?.length
       ? await readAttachments(attachmentPaths)
       : undefined;
+    throwIfCancelled(context);
     const result = await provider.sendMessage(conn, conversationId, text, {
       subject,
       inReplyTo,
@@ -429,6 +450,11 @@ export async function run(
 
     return ok(`Message sent (ID: ${result.id}${threadSuffix}).`);
   } catch (e) {
+    // A cancelled turn is not a send failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-create.ts
@@ -15,6 +15,10 @@ import {
   updateNode,
 } from "../../../../plugins/defaults/memory/graph/store.js";
 import type { NewNode } from "../../../../plugins/defaults/memory/graph/types.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -24,7 +28,7 @@ const VALID_AUTONOMY_LEVELS = new Set<string>(["auto", "draft", "notify"]);
 
 export async function executePlaybookCreate(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const trigger = input.trigger as string;
   const action = input.action as string;
@@ -41,6 +45,8 @@ export async function executePlaybookCreate(
       isError: true,
     };
   }
+
+  throwIfCancelled(context);
 
   const channel = typeof input.channel === "string" ? input.channel : "*";
   const category =
@@ -147,6 +153,11 @@ export async function executePlaybookCreate(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a playbook failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error creating playbook: ${msg}`, isError: true };
   }

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-delete.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-delete.ts
@@ -3,6 +3,10 @@ import {
   getNode,
   updateNode,
 } from "../../../../plugins/defaults/memory/graph/store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -10,7 +14,7 @@ import type {
 
 export async function executePlaybookDelete(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const playbookId = input.playbook_id as string;
   if (!playbookId || typeof playbookId !== "string") {
@@ -19,6 +23,7 @@ export async function executePlaybookDelete(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   try {
     const existing = getNode(playbookId);
@@ -48,6 +53,11 @@ export async function executePlaybookDelete(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a playbook failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error deleting playbook: ${msg}`, isError: true };
   }

--- a/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
+++ b/assistant/src/config/bundled-skills/playbooks/tools/playbook-update.ts
@@ -15,6 +15,10 @@ import {
   getNode,
   updateNode,
 } from "../../../../plugins/defaults/memory/graph/store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -24,7 +28,7 @@ const VALID_AUTONOMY_LEVELS = new Set<string>(["auto", "draft", "notify"]);
 
 export async function executePlaybookUpdate(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const playbookId = input.playbook_id as string;
   if (!playbookId || typeof playbookId !== "string") {
@@ -33,6 +37,7 @@ export async function executePlaybookUpdate(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   try {
     const existing = getNode(playbookId);
@@ -153,6 +158,11 @@ export async function executePlaybookUpdate(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a playbook failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error updating playbook: ${msg}`, isError: true };
   }

--- a/assistant/src/config/bundled-skills/screen-annotation/tools/screen-annotation.test.ts
+++ b/assistant/src/config/bundled-skills/screen-annotation/tools/screen-annotation.test.ts
@@ -3,8 +3,15 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import type { ToolContext } from "../../../../tools/types.js";
+import { createAbortReason } from "../../../../util/abort-reasons.js";
 import { run as clearMarks } from "./screen-clear-marks.js";
 import { run as pointAt } from "./screen-point-at.js";
+
+function abortedSignal(): AbortSignal {
+  const controller = new AbortController();
+  controller.abort(createAbortReason("user_cancel", "screen-annotation.test"));
+  return controller.signal;
+}
 
 function recorder() {
   const calls: { toolName: string; input: Record<string, unknown> }[] = [];
@@ -48,6 +55,16 @@ describe("screen_point_at", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("connected desktop client");
   });
+
+  /** Drawing on the user's screen is a side effect a stopped turn must not have. */
+  test("a cancelled turn draws nothing", async () => {
+    const { calls, context } = recorder();
+
+    await expect(
+      pointAt({ marks: [MARK] }, { ...context, signal: abortedSignal() }),
+    ).rejects.toThrow();
+    expect(calls).toHaveLength(0);
+  });
 });
 
 describe("screen_clear_marks", () => {
@@ -72,6 +89,25 @@ describe("screen_clear_marks", () => {
       target_client_id: "client-9",
       marks: [],
     });
+  });
+
+  /**
+   * Teardown, so it runs on a cancelled turn. It shares a wire name with
+   * pointing, which the guard does stop, so the exemption is stated by the
+   * caller rather than read off the name.
+   */
+  test("a cancelled turn still takes the marks down", async () => {
+    const { calls, context } = recorder();
+
+    const result = await clearMarks({}, {
+      ...context,
+      signal: abortedSignal(),
+    } as ToolContext);
+
+    expect(result.isError).toBe(false);
+    expect(calls).toEqual([
+      { toolName: "computer_use_point_at", input: { marks: [] } },
+    ]);
   });
 });
 

--- a/assistant/src/config/bundled-skills/screen-annotation/tools/screen-clear-marks.ts
+++ b/assistant/src/config/bundled-skills/screen-annotation/tools/screen-clear-marks.ts
@@ -29,5 +29,9 @@ export async function run(
       marks: [],
     },
     context,
+    // Teardown: it takes marks down. Refusing it on a cancelled turn would
+    // leave arrows drawn on the screen the user is sharing, with nothing left
+    // to remove them.
+    { teardown: true },
   );
 }

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-create.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-create.ts
@@ -1,5 +1,9 @@
 import { createSequence } from "../../../../sequence/store.js";
 import type { SequenceStep } from "../../../../sequence/types.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -8,7 +12,7 @@ import { err, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const name = input.name as string;
   const channel = input.channel as string;
@@ -25,6 +29,8 @@ export async function run(
   if (!stepsRaw || stepsRaw.length === 0) {
     return err("steps array is required and must have at least one step.");
   }
+
+  throwIfCancelled(context);
 
   try {
     const steps: SequenceStep[] = stepsRaw.map((s, i) => ({
@@ -48,6 +54,11 @@ export async function run(
       `Sequence created (ID: ${sequence.id}).\n\nName: ${sequence.name}\nChannel: ${sequence.channel}\nSteps: ${steps.length}\nExit on reply: ${sequence.exitOnReply}\nStatus: ${sequence.status}`,
     );
   } catch (e) {
+    // A cancelled turn is not a sequence failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-delete.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-delete.ts
@@ -1,4 +1,8 @@
 import { deleteSequence, getSequence } from "../../../../sequence/store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -7,12 +11,14 @@ import { err, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const id = input.id as string;
   if (!id) {
     return err("id is required.");
   }
+
+  throwIfCancelled(context);
 
   try {
     const seq = getSequence(id);
@@ -25,6 +31,11 @@ export async function run(
       `Sequence "${seq.name}" deleted. All active enrollments have been cancelled.`,
     );
   } catch (e) {
+    // A cancelled turn is not a sequence failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-enroll.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-enroll.ts
@@ -1,4 +1,8 @@
 import { enrollContact, getSequence } from "../../../../sequence/store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -7,7 +11,7 @@ import { err, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  toolContext: ToolContext,
 ): Promise<ToolExecutionResult> {
   const sequenceId = input.sequence_id as string;
   const emails = input.emails as string | string[];
@@ -19,6 +23,7 @@ export async function run(
   if (!emails) {
     return err("emails is required (string or array).");
   }
+  throwIfCancelled(toolContext);
 
   try {
     const seq = getSequence(sequenceId);
@@ -50,6 +55,11 @@ export async function run(
         results.push(`  ${email} - enrolled (ID: ${enrollment.id})`);
         successCount++;
       } catch (e) {
+        // A cancelled turn is not an enrollment failure: let it reach the executor's
+        // abort handling instead of being rendered as a tool error.
+        if (isAbortLikeError(e)) {
+          throw e;
+        }
         results.push(
           `  ${email} - failed: ${e instanceof Error ? e.message : String(e)}`,
         );
@@ -62,6 +72,11 @@ export async function run(
       }":\n${results.join("\n")}`,
     );
   } catch (e) {
+    // A cancelled turn is not an enrollment failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-import.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-import.ts
@@ -1,5 +1,9 @@
 import { bulkEnroll, parseContactFile } from "../../../../sequence/importer.js";
 import { getSequence } from "../../../../sequence/store.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -8,7 +12,7 @@ import { err, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const filePath = input.file_path as string;
   const sequenceId = input.sequence_id as string;
@@ -19,6 +23,10 @@ export async function run(
   }
   if (!sequenceId) {
     return err("sequence_id is required.");
+  }
+  // Only the auto-enroll branch mutates; the default preview branch reads.
+  if (autoEnroll) {
+    throwIfCancelled(context);
   }
 
   try {
@@ -101,6 +109,11 @@ export async function run(
 
     return ok(lines.join("\n"));
   } catch (e) {
+    // A cancelled turn is not an import failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
+++ b/assistant/src/config/bundled-skills/sequences/tools/sequence-update.ts
@@ -10,6 +10,10 @@ import type {
   SequenceStatus,
   SequenceStep,
 } from "../../../../sequence/types.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -18,11 +22,13 @@ import { err, ok } from "./shared.js";
 
 export async function run(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const id = input.id as string | undefined;
   const enrollmentId = input.enrollment_id as string | undefined;
   const enrollmentAction = input.enrollment_action as string | undefined;
+
+  throwIfCancelled(context);
 
   // ── Enrollment-level lifecycle actions ──────────────────────────────
   if (enrollmentId) {
@@ -87,6 +93,11 @@ export async function run(
           );
       }
     } catch (e) {
+      // A cancelled turn is not an enrollment failure: let it reach the executor's
+      // abort handling instead of being rendered as a tool error.
+      if (isAbortLikeError(e)) {
+        throw e;
+      }
       return err(e instanceof Error ? e.message : String(e));
     }
   }
@@ -134,6 +145,11 @@ export async function run(
 
     return ok(`Sequence updated: ${updated.name} (${updated.status})`);
   } catch (e) {
+    // A cancelled turn is not a sequence failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(e)) {
+      throw e;
+    }
     return err(e instanceof Error ? e.message : String(e));
   }
 }

--- a/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/navigate-settings-tab.ts
@@ -1,3 +1,4 @@
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -42,6 +43,8 @@ export async function run(
       isError: true,
     };
   }
+
+  throwIfCancelled(context);
 
   if (context.sendToClient) {
     context.sendToClient({

--- a/assistant/src/config/bundled-skills/settings/tools/open-system-settings.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/open-system-settings.ts
@@ -1,3 +1,4 @@
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -60,6 +61,8 @@ export async function run(
     (requestedPlatform as SettingsPlatform | undefined) ??
     (isWindows() ? "windows" : "macos");
   const meta = PANES[pane as PaneName];
+
+  throwIfCancelled(context);
 
   if (context.sendToClient) {
     context.sendToClient({

--- a/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
+++ b/assistant/src/config/bundled-skills/settings/tools/voice-config-update.ts
@@ -9,6 +9,7 @@ import {
   listProviderModelFamilies,
 } from "../../../../providers/speech-to-text/provider-catalog.js";
 import type { SttProviderId } from "../../../../stt/types.js";
+import { throwIfCancelled } from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -426,6 +427,7 @@ export async function run(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   // A tts_voice_id change targets the *active* TTS provider's voice field, so
   // validation and the write below both need to know which provider is live.
@@ -465,6 +467,10 @@ export async function run(
       isError: true,
     };
   }
+
+  // Recheck: the managed-speech reachability probe above is an await, and the
+  // client broadcast and config write below are what the user would notice.
+  throwIfCancelled(context);
 
   const meta: VoiceSettingMeta = VOICE_SETTINGS[setting as VoiceSettingName];
   const friendlyName =

--- a/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
+++ b/assistant/src/config/bundled-skills/transcribe/tools/transcribe-media.ts
@@ -5,6 +5,10 @@ import { extname, join } from "node:path";
 
 import { resolveBatchTranscriber } from "../../../../providers/speech-to-text/resolve.js";
 import type { BatchTranscriber } from "../../../../stt/types.js";
+import {
+  isAbortLikeError,
+  throwIfCancelled,
+} from "../../../../tools/shared/abort.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -50,7 +54,10 @@ const STT_REQUEST_TIMEOUT_MS = 300_000;
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function getAudioDuration(audioPath: string): Promise<number> {
+async function getAudioDuration(
+  audioPath: string,
+  signal?: AbortSignal,
+): Promise<number> {
   const result = await spawnWithTimeout(
     [
       "ffprobe",
@@ -63,6 +70,7 @@ async function getAudioDuration(audioPath: string): Promise<number> {
       audioPath,
     ],
     FFPROBE_TIMEOUT_MS,
+    signal,
   );
   if (result.exitCode !== 0) {
     return 0;
@@ -74,6 +82,7 @@ async function splitAudio(
   audioPath: string,
   chunkDir: string,
   chunkDurationSecs: number,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   const chunkPattern = join(chunkDir, "chunk-%03d.wav");
   const result = await spawnWithTimeout(
@@ -95,6 +104,7 @@ async function splitAudio(
       chunkPattern,
     ],
     FFMPEG_TRANSCODE_TIMEOUT_MS,
+    signal,
   );
   if (result.exitCode !== 0) {
     throw new Error(`Failed to split audio: ${result.stderr.slice(0, 300)}`);
@@ -140,14 +150,22 @@ async function resolveSource(
 }
 
 /** Convert source to 16kHz mono WAV for consistent processing. */
-async function toWav(inputPath: string, isVideo: boolean): Promise<string> {
+async function toWav(
+  inputPath: string,
+  isVideo: boolean,
+  signal?: AbortSignal,
+): Promise<string> {
   const wavPath = join(tmpdir(), `vellum-transcribe-${randomUUID()}.wav`);
   const args = ["ffmpeg", "-y", "-i", inputPath];
   if (isVideo) {
     args.push("-vn");
   }
   args.push("-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", wavPath);
-  const result = await spawnWithTimeout(args, FFMPEG_TRANSCODE_TIMEOUT_MS);
+  const result = await spawnWithTimeout(
+    args,
+    FFMPEG_TRANSCODE_TIMEOUT_MS,
+    signal,
+  );
   if (result.exitCode !== 0) {
     throw new Error(`ffmpeg failed: ${result.stderr.slice(0, 500)}`);
   }
@@ -158,21 +176,32 @@ async function toWav(inputPath: string, isVideo: boolean): Promise<string> {
 // Transcription via resolved STT provider
 // ---------------------------------------------------------------------------
 
+/**
+ * The signal a single STT request runs under: the provider's own deadline, and
+ * the turn's cancellation when there is one. Without the turn's signal a paid
+ * request outlives a stopped turn until its five-minute timeout.
+ */
+function sttRequestSignal(context: ToolContext): AbortSignal {
+  const timeout = AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS);
+  return context.signal ? AbortSignal.any([context.signal, timeout]) : timeout;
+}
+
 async function transcribeWithProvider(
   audioPath: string,
   transcriber: BatchTranscriber,
   context: ToolContext,
 ): Promise<string> {
-  const duration = await getAudioDuration(audioPath);
+  const duration = await getAudioDuration(audioPath, context.signal);
   const fileSize = Bun.file(audioPath).size;
 
   // If small enough, send directly
   if (fileSize <= STT_CHUNK_MAX_BYTES) {
+    throwIfCancelled(context);
     const audioBuffer = await readFile(audioPath);
     const result = await transcriber.transcribe({
       audio: audioBuffer,
       mimeType: "audio/wav",
-      signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+      signal: sttRequestSignal(context),
     });
     return result.text;
   }
@@ -187,19 +216,22 @@ async function transcribeWithProvider(
         duration / 60,
       )}min) - splitting into chunks...\n`,
     );
-    const chunks = await splitAudio(audioPath, chunkDir, CHUNK_DURATION_SECS);
+    const chunks = await splitAudio(
+      audioPath,
+      chunkDir,
+      CHUNK_DURATION_SECS,
+      context.signal,
+    );
     const parts: string[] = [];
 
     for (let i = 0; i < chunks.length; i++) {
-      if (context.signal?.aborted) {
-        throw new Error("Cancelled");
-      }
+      throwIfCancelled(context);
       context.onOutput?.(`  Transcribing chunk ${i + 1}/${chunks.length}...\n`);
       const audioBuffer = await readFile(chunks[i]);
       const result = await transcriber.transcribe({
         audio: audioBuffer,
         mimeType: "audio/wav",
-        signal: AbortSignal.timeout(STT_REQUEST_TIMEOUT_MS),
+        signal: sttRequestSignal(context),
       });
       if (result.text) {
         parts.push(result.text);
@@ -233,6 +265,7 @@ export async function run(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   // Resolve the configured STT provider. A typed resolver error already names
   // the mismatch (e.g. a streaming-only provider) and its fix, so it reaches
@@ -261,7 +294,7 @@ export async function run(
 
   try {
     // Convert to WAV
-    wavPath = await toWav(inputPath, isVideo);
+    wavPath = await toWav(inputPath, isVideo, context.signal);
 
     const text = await transcribeWithProvider(wavPath, transcriber, context);
 
@@ -271,6 +304,11 @@ export async function run(
 
     return { content: text, isError: false };
   } catch (err) {
+    // A cancelled turn is not a transcription failure: let it reach the
+    // executor's abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     return {
       content: `Transcription failed: ${(err as Error).message}`,
       isError: true,

--- a/assistant/src/media/app-icon-generator.ts
+++ b/assistant/src/media/app-icon-generator.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 
 import { getAppDirPath } from "../apps/app-store.js";
 import { getConfig } from "../config/loader.js";
+import { isAbortLikeError } from "../tools/shared/abort.js";
 import { getLogger } from "../util/logger.js";
 import {
   resolveImageGenCredentials,
@@ -24,13 +25,15 @@ const log = getLogger("app-icon-generator");
  * Generate an app icon and save it to `~/.vellum/apps/{appId}/icon.png`.
  *
  * Uses the configured image-generation provider when credentials are
- * available. Silently no-ops if no credentials are configured or
- * generation fails.
+ * available. No-ops quietly when no credentials are configured or generation
+ * fails; a cancelled turn is raised rather than swallowed, so the caller can
+ * tell "stopped" apart from "could not be made".
  */
 export async function generateAppIcon(
   appId: string,
   appName: string,
   appDescription?: string,
+  opts?: { signal?: AbortSignal },
 ): Promise<void> {
   const config = getConfig();
   const svc = config.services["image-generation"];
@@ -39,6 +42,9 @@ export async function generateAppIcon(
     provider: backendProvider,
     managed,
   });
+  // Recheck: credential resolution is an await, and what follows pays a
+  // provider for an image.
+  opts?.signal?.throwIfAborted();
   if (!credentials) {
     log.debug(
       `${errorHint ?? "Image generation is not configured"} — skipping app icon generation`,
@@ -77,6 +83,7 @@ export async function generateAppIcon(
       prompt,
       mode: "generate",
       model: svc.model,
+      ...(opts?.signal ? { signal: opts.signal } : {}),
     });
 
     if (result.images.length === 0) {
@@ -95,10 +102,15 @@ export async function generateAppIcon(
 
     log.info({ appId, iconPath }, "App icon saved");
   } catch (error) {
+    // A cancelled turn is not a generation failure: skipping quietly would
+    // tell the caller the icon simply could not be made.
+    if (isAbortLikeError(error)) {
+      throw error;
+    }
     const message = mapImageGenError(backendProvider, error);
     log.warn(
       { appId, provider: backendProvider, error: message },
-      "App icon generation failed — skipping",
+      "App icon generation failed, skipping",
     );
   }
 }

--- a/assistant/src/media/gemini-image-service.ts
+++ b/assistant/src/media/gemini-image-service.ts
@@ -71,6 +71,7 @@ async function generateImageViaProxy(
   model: string,
   contents: unknown[],
   config: Record<string, unknown>,
+  signal: AbortSignal | undefined,
 ): Promise<{
   images: GeneratedImage[];
   text?: string;
@@ -87,6 +88,7 @@ async function generateImageViaProxy(
       contents,
       generationConfig: config,
     }),
+    ...(signal ? { signal } : {}),
   });
 
   if (!response.ok) {
@@ -165,7 +167,13 @@ export async function generateImage(
   // the managed proxy translating to Vertex internally.
   if (credentials.type === "managed-proxy") {
     const makeSingleCall = () =>
-      generateImageViaProxy(credentials, model, contents, config);
+      generateImageViaProxy(
+        credentials,
+        model,
+        contents,
+        config,
+        request.signal,
+      );
 
     if (variants === 1) {
       const result = await makeSingleCall();
@@ -215,7 +223,9 @@ export async function generateImage(
     const response = await client.models.generateContent({
       model,
       contents,
-      config,
+      config: request.signal
+        ? { ...config, abortSignal: request.signal }
+        : config,
     });
 
     const images: GeneratedImage[] = [];

--- a/assistant/src/media/openai-image-service.ts
+++ b/assistant/src/media/openai-image-service.ts
@@ -118,18 +118,24 @@ export async function generateImageOpenAI(
         }),
       ),
     );
-    response = (await client.images.edit({
-      model,
-      prompt: request.prompt,
-      image: files,
-      n: variants,
-    })) as { data?: Array<{ b64_json?: string }> };
+    response = (await client.images.edit(
+      {
+        model,
+        prompt: request.prompt,
+        image: files,
+        n: variants,
+      },
+      request.signal ? { signal: request.signal } : undefined,
+    )) as { data?: Array<{ b64_json?: string }> };
   } else {
-    response = (await client.images.generate({
-      model,
-      prompt: request.prompt,
-      n: variants,
-    })) as { data?: Array<{ b64_json?: string }> };
+    response = (await client.images.generate(
+      {
+        model,
+        prompt: request.prompt,
+        n: variants,
+      },
+      request.signal ? { signal: request.signal } : undefined,
+    )) as { data?: Array<{ b64_json?: string }> };
   }
 
   const images: GeneratedImage[] = [];

--- a/assistant/src/media/types.ts
+++ b/assistant/src/media/types.ts
@@ -17,6 +17,12 @@ export interface ImageGenerationRequest {
   sourceImages?: Array<{ mimeType: string; dataBase64: string }>;
   model?: string;
   variants?: number;
+  /**
+   * Cancellation for the provider request itself. A generation is paid, so a
+   * caller that can be cancelled mid-flight (a tool on an aborted turn) passes
+   * the turn's signal here rather than letting the request run to completion.
+   */
+  signal?: AbortSignal;
 }
 
 export interface GeneratedImage {

--- a/assistant/src/messaging/style-analyzer.ts
+++ b/assistant/src/messaging/style-analyzer.ts
@@ -119,6 +119,7 @@ function buildCorpus(messages: ProviderMessage[]): string[] {
  */
 export async function extractStylePatterns(
   messages: ProviderMessage[],
+  callerSignal?: AbortSignal,
 ): Promise<StyleAnalysisResult> {
   const corpusEntries = buildCorpus(messages);
   if (corpusEntries.length === 0) {
@@ -145,10 +146,13 @@ export async function extractStylePatterns(
     },
   ];
 
+  // The analysis deadline, plus the caller's cancellation when it has one, so
+  // stopping the turn aborts the paid call instead of leaving it to time out.
+  const deadline = AbortSignal.timeout(30_000);
   const response = await provider.sendMessage(promptMessages, {
     tools: [storeStyleAnalysisTool],
     systemPrompt: STYLE_EXTRACTION_SYSTEM_PROMPT,
-    signal: AbortSignal.timeout(30_000),
+    signal: callerSignal ? AbortSignal.any([callerSignal, deadline]) : deadline,
     config: { callSite: "styleAnalyzer" },
   });
 

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -385,6 +385,12 @@ export {
 // sent). Persisted and pushed to clients; not seated in the turn's working
 // history.
 export { persistSystemCard } from "./system-card.js";
+// Turn cancellation: the guard a side-effecting tool calls immediately before
+// it acts, so a tool does not land work on a turn the user already stopped.
+// The agent loop tells the model an aborted batch was cancelled, and this is
+// what makes that true. Host tools and plugin tools share this one guard.
+export type { CancellableToolContext } from "./tool-cancellation.js";
+export { throwIfCancelled } from "./tool-cancellation.js";
 // Synthesize text to speech through the assistant's globally configured TTS
 // provider (ElevenLabs, Fish Audio, etc.). Plugins that need voice output —
 // e.g. a meeting bot speaking into a live call — use this instead of managing

--- a/assistant/src/plugin-api/tool-cancellation.ts
+++ b/assistant/src/plugin-api/tool-cancellation.ts
@@ -1,0 +1,30 @@
+/**
+ * The turn-cancellation guard every side-effecting tool calls, host tools and
+ * plugin tools alike. It lives on the plugin API surface because that is the
+ * only module a plugin may import from, and the guard must be one
+ * implementation rather than a copy per side of the boundary.
+ */
+
+/** The slice of a tool's context this guard reads. */
+export interface CancellableToolContext {
+  /** Cooperative cancellation signal for the turn, when the caller supplies one. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Stop a side-effecting tool whose turn was cancelled before it acted.
+ *
+ * Call this immediately before the step that changes something the user would
+ * notice: a write, a create/update/delete, a message send, a process spawn, a
+ * paid provider call. The agent loop tells the model an aborted batch was
+ * cancelled, so anything that lands after the abort is work the model believes
+ * never happened.
+ *
+ * Throws the signal's own reason, which is the daemon's tagged abort reason
+ * for a conversation abort and a `DOMException` named `AbortError` for a plain
+ * one. The tool executor recognizes both and reports the call as an expected
+ * cancellation rather than a tool failure.
+ */
+export function throwIfCancelled(context: CancellableToolContext): void {
+  context.signal?.throwIfAborted();
+}

--- a/assistant/src/plugins/defaults/memory/tools.ts
+++ b/assistant/src/plugins/defaults/memory/tools.ts
@@ -7,6 +7,8 @@
  * memory feature (`src/memory/*`).
  */
 
+import { throwIfCancelled } from "@vellumai/plugin-api";
+
 import { getConfig, getConfigReadOnly } from "../../../config/loader.js";
 import { usesConceptPageMemory } from "../../../config/memory-v3-gate.js";
 import { RiskLevel } from "../../../permissions/types.js";
@@ -51,6 +53,8 @@ export const rememberTool = {
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
     const typedInput = input as unknown as RememberInput;
+    // The append below writes the memory buffer, so a cancelled turn stops here.
+    throwIfCancelled(context);
     const result = handleRemember(
       typedInput,
       context.conversationId,
@@ -164,10 +168,17 @@ export const deleteMemoryPageTool = {
       };
     }
 
+    throwIfCancelled(context);
+
     try {
       await deletePage(getWorkspaceDir(), slug);
       return { content: `Deleted memory page "${slug}".`, isError: false };
     } catch (err) {
+      // A cancelled turn is not a delete failure: let it reach the executor's
+      // abort handling instead of being rendered as a tool error.
+      if (context.signal?.aborted) {
+        throw err;
+      }
       return {
         content: `Error deleting memory page "${slug}": ${
           err instanceof Error ? err.message : String(err)

--- a/assistant/src/plugins/defaults/memory/v3/candidate-match.ts
+++ b/assistant/src/plugins/defaults/memory/v3/candidate-match.ts
@@ -79,6 +79,7 @@ export interface SkillShortlistHit {
 export type ScoreSlugsFn = (
   goal: string,
   restrictToSlugs: readonly string[],
+  signal?: AbortSignal,
 ) => Promise<ScoredSlug[]>;
 
 export interface NearestExistingSkillsOptions {
@@ -90,6 +91,12 @@ export interface NearestExistingSkillsOptions {
   loadCatalog?: () => { id: string }[] | Promise<{ id: string }[]>;
   /** Max shortlist entries. Defaults to {@link DEFAULT_SHORTLIST_LIMIT}. */
   limit?: number;
+  /**
+   * Cancellation for the work this shortlist serves. Reaches the embedding
+   * request and its retry backoff, so a stopped caller stops paying for
+   * embeddings instead of finishing the round-trip nobody will read.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -105,7 +112,8 @@ export async function nearestExistingSkills(
 ): Promise<SkillShortlistHit[]> {
   const config = opts.config ?? getConfig();
   const scoreSlugs =
-    opts.scoreSlugs ?? ((g, slugs) => scoreSlugsWithSimBatch(config, g, slugs));
+    opts.scoreSlugs ??
+    ((g, slugs, signal) => scoreSlugsWithSimBatch(config, g, slugs, signal));
   const loadCatalog = opts.loadCatalog ?? (() => listInstalledSkills());
   const limit = opts.limit ?? DEFAULT_SHORTLIST_LIMIT;
 
@@ -120,7 +128,7 @@ export async function nearestExistingSkills(
     return [];
   }
 
-  const scored = await scoreSlugs(goal, slugs);
+  const scored = await scoreSlugs(goal, slugs, opts.signal);
   const hits: SkillShortlistHit[] = [];
   for (const { slug, score } of scored) {
     if (score < SHORTLIST_THRESHOLD) {
@@ -156,11 +164,23 @@ async function scoreSlugsWithSimBatch(
   config: AssistantConfig,
   goal: string,
   restrictToSlugs: readonly string[],
+  signal?: AbortSignal,
 ): Promise<ScoredSlug[]> {
   try {
-    const scores = await simBatchWithRetry(config, goal, restrictToSlugs);
+    const scores = await simBatchWithRetry(
+      config,
+      goal,
+      restrictToSlugs,
+      signal,
+    );
     return [...scores].map(([slug, score]) => ({ slug, score }));
   } catch (err) {
+    // A cancelled caller is not a scorer outage: degrading to an empty
+    // shortlist here would report "no similar skills" for a search that never
+    // ran.
+    if (isAbortError(err)) {
+      throw err;
+    }
     log.warn(
       { err },
       "nearest-existing-skills scorer failed after retries; degrading to empty shortlist",
@@ -181,11 +201,13 @@ async function simBatchWithRetry(
   config: AssistantConfig,
   goal: string,
   restrictToSlugs: readonly string[],
+  signal?: AbortSignal,
 ): Promise<Map<string, number>> {
   let lastError: unknown;
   for (let attempt = 0; attempt <= EMBED_MAX_RETRIES; attempt++) {
+    signal?.throwIfAborted();
     try {
-      return await simBatch(goal, restrictToSlugs, config);
+      return await simBatch(goal, restrictToSlugs, config, { signal });
     } catch (err) {
       lastError = err;
       if (isAbortError(err)) {
@@ -199,7 +221,7 @@ async function simBatchWithRetry(
         { err, attempt: attempt + 1, delayMs: Math.round(delay) },
         "transient nearest-existing-skills embedding failure, retrying",
       );
-      await abortableSleep(delay);
+      await abortableSleep(delay, signal);
     }
   }
   throw lastError;

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -214,6 +214,16 @@ export type OrdinaryScheduleCreator =
   | typeof LEGACY_DEFER_CREATED_BY;
 
 /**
+ * Cancellation for a schedule write, carried alongside the row rather than in
+ * it. The retry wrapper reads it between attempts, so a caller whose turn was
+ * stopped does not sleep through a backoff and then persist a schedule that
+ * would go on to run on its own.
+ */
+export interface ScheduleWriteOptions {
+  signal?: AbortSignal;
+}
+
+/**
  * Parameters for ordinary schedule creation. `sourceKey` and `definitionHash`
  * are excluded for the same structural reason `createdBy` is constrained:
  * plugin-declaration provenance is minted only by
@@ -245,6 +255,7 @@ function resolveStoredTimezone(
 
 async function insertSchedule(
   params: InsertScheduleParams,
+  opts?: ScheduleWriteOptions,
 ): Promise<ScheduleJob> {
   const expression = params.expression ?? params.cronExpression ?? null;
   const isOneShot = expression == null;
@@ -364,6 +375,7 @@ async function insertSchedule(
   await withSqliteRetry(() => db.insert(scheduleJobs).values(row).run(), {
     op: "createSchedule",
     context: { scheduleId: id },
+    ...(opts?.signal ? { signal: opts.signal } : {}),
   });
   notifySchedulesChanged();
   return parseJobRow(row);
@@ -381,13 +393,14 @@ async function insertSchedule(
  */
 export async function createSchedule(
   params: CreateScheduleParams,
+  opts?: ScheduleWriteOptions,
 ): Promise<ScheduleJob> {
   if (params.createdBy && hasOwnerDeferProvenance(params.createdBy)) {
     throw new Error(
       "Owner-defer provenance is issued only by createOwnerDeferredWake()",
     );
   }
-  return insertSchedule(params);
+  return insertSchedule(params, opts);
 }
 
 /**
@@ -563,6 +576,7 @@ export async function updateSchedule(
     // owner-defer provenance they are immutable, enforced at the top of the
     // function body rather than in the type, since the distinction is per-row.
   },
+  opts?: ScheduleWriteOptions,
 ): Promise<ScheduleJob | null> {
   const db = getDb();
   const existing = db
@@ -746,7 +760,11 @@ export async function updateSchedule(
 
   await withSqliteRetry(
     () => db.update(scheduleJobs).set(set).where(eq(scheduleJobs.id, id)).run(),
-    { op: "updateSchedule", context: { scheduleId: id } },
+    {
+      op: "updateSchedule",
+      context: { scheduleId: id },
+      ...(opts?.signal ? { signal: opts.signal } : {}),
+    },
   );
   notifySchedulesChanged();
 
@@ -763,7 +781,10 @@ function getRowSourceKey(id: string): string | null {
   return row?.sourceKey ?? null;
 }
 
-export async function deleteSchedule(id: string): Promise<boolean> {
+export async function deleteSchedule(
+  id: string,
+  opts?: ScheduleWriteOptions,
+): Promise<boolean> {
   const db = getDb();
   // Plugin-sourced rows keep their identity and run history: deleting one
   // would just have the reconciler recreate it from the declaration on its
@@ -781,7 +802,11 @@ export async function deleteSchedule(id: string): Promise<boolean> {
       db.delete(scheduleJobs).where(eq(scheduleJobs.id, id)).run();
       return rawChanges() > 0;
     },
-    { op: "deleteSchedule", context: { scheduleId: id } },
+    {
+      op: "deleteSchedule",
+      context: { scheduleId: id },
+      ...(opts?.signal ? { signal: opts.signal } : {}),
+    },
   );
   if (deleted) {
     notifySchedulesChanged();
@@ -1026,6 +1051,7 @@ export async function disarmDeclaredSchedule(id: string): Promise<boolean> {
 export async function setUserEnabled(
   id: string,
   value: boolean,
+  opts?: ScheduleWriteOptions,
 ): Promise<ScheduleJob | null> {
   const db = getDb();
   const existing = db
@@ -1077,7 +1103,11 @@ export async function setUserEnabled(
 
   await withSqliteRetry(
     () => db.update(scheduleJobs).set(set).where(eq(scheduleJobs.id, id)).run(),
-    { op: "setUserEnabled", context: { scheduleId: id } },
+    {
+      op: "setUserEnabled",
+      context: { scheduleId: id },
+      ...(opts?.signal ? { signal: opts.signal } : {}),
+    },
   );
   notifySchedulesChanged();
   return getSchedule(id);

--- a/assistant/src/tools/__tests__/side-effect-abort-guard.test.ts
+++ b/assistant/src/tools/__tests__/side-effect-abort-guard.test.ts
@@ -1,0 +1,354 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+import { createAbortReason } from "../../util/abort-reasons.js";
+import { explicitTools } from "../tool-manifest.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Side-effecting tools must observe the turn's abort signal.
+ *
+ * When a user cancels mid-turn the agent loop abandons the in-flight batch and
+ * tells the model the calls were cancelled. A tool that keeps going past that
+ * point lands work the model has been told never happened, so every tool that
+ * writes, sends, spawns, or pays must refuse to act on an already-aborted
+ * signal. The lists below are deliberately explicit: a new side-effecting tool
+ * has to be added here, and adding it fails until the tool honours the signal.
+ *
+ * Read-only tools are out of scope, and so are the teardown calls
+ * (`app_control_stop`, `computer_use_done`, `ui_dismiss`, `acp_abort`,
+ * `subagent_abort`, `call_end`, `screen_clear_marks`) whose whole purpose is
+ * to stop something: refusing those on a cancelled turn would strand the
+ * session they close, or the marks they take down.
+ */
+
+const ABORT_REASON = createAbortReason(
+  "user_cancel",
+  "side-effect-abort-guard.test",
+);
+
+const BUNDLED_SKILLS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../config/bundled-skills",
+);
+
+interface GuardedTool {
+  /** Tool name as the model sees it. */
+  name: string;
+  /** Input that reaches the tool's side-effecting path. */
+  input: Record<string, unknown>;
+  /** Context fields the path to the guard reads. */
+  context?: Partial<ToolContext>;
+}
+
+function abortedContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  const controller = new AbortController();
+  controller.abort(ABORT_REASON);
+  return {
+    conversationId: "conv-abort-guard",
+    workingDir: "/tmp/abort-guard",
+    signal: controller.signal,
+    ...overrides,
+  } as ToolContext;
+}
+
+/** Absolute path of the executor a bundled skill declares for one of its tools. */
+function resolveSkillExecutor(toolName: string): string {
+  const manifests = [
+    ...new Bun.Glob("*/TOOLS.json").scanSync({ cwd: BUNDLED_SKILLS_DIR }),
+  ];
+  for (const relative of manifests) {
+    const manifestPath = join(BUNDLED_SKILLS_DIR, relative);
+    const parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      tools?: Array<{ name?: string; executor?: string }>;
+    };
+    for (const tool of parsed.tools ?? []) {
+      if (tool.name === toolName && typeof tool.executor === "string") {
+        return join(dirname(manifestPath), tool.executor);
+      }
+    }
+  }
+  throw new Error(`No bundled skill declares a tool named "${toolName}"`);
+}
+
+async function invokeSkillTool(
+  guarded: GuardedTool,
+): Promise<ToolExecutionResult> {
+  const module = (await import(resolveSkillExecutor(guarded.name))) as {
+    run: (
+      input: Record<string, unknown>,
+      context: ToolContext,
+    ) => Promise<ToolExecutionResult> | ToolExecutionResult;
+  };
+  return module.run(guarded.input, abortedContext(guarded.context));
+}
+
+async function invokeRegisteredTool(
+  guarded: GuardedTool,
+): Promise<ToolExecutionResult> {
+  const tool = explicitTools.find(
+    (candidate) => candidate.name === guarded.name,
+  );
+  if (!tool?.execute) {
+    throw new Error(`No explicitly registered tool named "${guarded.name}"`);
+  }
+  return tool.execute(guarded.input, abortedContext(guarded.context));
+}
+
+/**
+ * Assert the call rejects with the signal's own reason. A tool that returns a
+ * validation error, a "not found", or a success instead has decided to act on
+ * a turn the user already cancelled, or has spent work getting there.
+ */
+async function expectRefusal(
+  invoke: () => Promise<ToolExecutionResult>,
+): Promise<void> {
+  await expect(Promise.resolve().then(invoke)).rejects.toBe(ABORT_REASON);
+}
+
+/** The trust class the memory and schedule tools require before they act. */
+const GUARDIAN: Partial<ToolContext> = { trustClass: "guardian" };
+
+/** A proxied host actuation: a keypress, a click, a drag, an app launch. */
+function proxied(name: string): GuardedTool {
+  return {
+    name,
+    input: {},
+    context: {
+      proxyToolResolver: async () => ({
+        content: "the proxy must not be reached",
+        isError: true,
+      }),
+    },
+  };
+}
+
+const SKILL_TOOLS: GuardedTool[] = [
+  { name: "acp_spawn", input: { agent: "claude", task: "do a thing" } },
+  {
+    name: "acp_steer",
+    input: { acp_session_id: "acp-1", instruction: "change course" },
+  },
+
+  { name: "app_create", input: { name: "App", description: "An app" } },
+  { name: "app_update", input: { app_id: "app-1", source_files: [] } },
+  { name: "app_delete", input: { app_id: "app-1" } },
+  { name: "app_refresh", input: { app_id: "app-1" } },
+  { name: "app_generate_icon", input: { app_id: "app-1" } },
+  {
+    name: "app_open",
+    input: { app_id: "app-1" },
+    context: proxied("app_open").context,
+  },
+
+  proxied("app_control_start"),
+  proxied("app_control_press"),
+  proxied("app_control_combo"),
+  proxied("app_control_sequence"),
+  proxied("app_control_type"),
+  proxied("app_control_click"),
+  proxied("app_control_drag"),
+
+  proxied("computer_use_click"),
+  proxied("computer_use_type_text"),
+  proxied("computer_use_key"),
+  proxied("computer_use_scroll"),
+  proxied("computer_use_drag"),
+  proxied("computer_use_open_app"),
+  proxied("computer_use_run_applescript"),
+  proxied("computer_use_respond"),
+
+  { name: "contact_merge", input: { keep_id: "c-1", merge_id: "c-2" } },
+
+  { name: "conversation_group_create", input: { name: "Group" } },
+  {
+    name: "conversation_move_to_group",
+    input: { group: "Group", conversation_id: "conv-1" },
+  },
+
+  { name: "document_create", input: { title: "Doc" } },
+  { name: "document_update", input: { surface_id: "doc-1", content: "text" } },
+  { name: "document_delete", input: { surface_id: "doc-1" } },
+  {
+    name: "document_replace_text",
+    input: { surface_id: "doc-1", find: "a", replace: "b" },
+  },
+  {
+    name: "comment_resolve",
+    input: { surface_id: "doc-1", comment_id: "cm-1" },
+  },
+  {
+    name: "comment_reply",
+    input: { surface_id: "doc-1", comment_id: "cm-1", content: "reply" },
+  },
+
+  {
+    name: "followup_create",
+    input: { channel: "slack", conversation_id: "c" },
+  },
+  { name: "followup_resolve", input: { id: "f-1" } },
+
+  { name: "media_generate_image", input: { prompt: "a cat" } },
+
+  { name: "ingest_media", input: { file_path: "clip.mp4" } },
+  { name: "extract_keyframes", input: { asset_id: "asset-1" } },
+  {
+    name: "analyze_keyframes",
+    input: {
+      asset_id: "asset-1",
+      system_prompt: "describe",
+      output_schema: { type: "object" },
+    },
+  },
+  { name: "query_media", input: { asset_id: "asset-1", query: "what?" } },
+  {
+    name: "generate_clip",
+    input: { asset_id: "asset-1", start_time: 0, end_time: 1 },
+  },
+
+  {
+    name: "messaging_send",
+    input: { conversation_id: "m-1", text: "hi", confidence: "high" },
+  },
+  { name: "messaging_mark_read", input: { conversation_id: "m-1" } },
+  { name: "messaging_analyze_style", input: {} },
+  {
+    name: "messaging_draft",
+    input: {
+      action: "create",
+      platform: "gmail",
+      conversation_id: "m-1",
+      text: "hi",
+    },
+  },
+  {
+    name: "messaging_archive_by_sender",
+    input: { query: "from:sender", confidence: "high" },
+    context: { triggeredBySurfaceAction: true },
+  },
+
+  {
+    name: "call_start",
+    input: { phone_number: "+15550100", task: "confirm the booking" },
+  },
+
+  { name: "playbook_create", input: { trigger: "t", action: "a" } },
+  { name: "playbook_update", input: { playbook_id: "pb-1", action: "a" } },
+  { name: "playbook_delete", input: { playbook_id: "pb-1" } },
+
+  {
+    name: "schedule_create",
+    input: {
+      name: "Nightly",
+      description: "Runs nightly",
+      syntax: "cron",
+      expression: "0 3 * * *",
+      message: "run",
+    },
+    context: GUARDIAN,
+  },
+  {
+    name: "schedule_update",
+    input: { job_id: "job-1", name: "Renamed" },
+    context: GUARDIAN,
+  },
+  { name: "schedule_delete", input: { job_id: "job-1" } },
+
+  {
+    name: "sequence_create",
+    input: {
+      name: "Seq",
+      channel: "email",
+      steps: [{ subject: "Hello", body_prompt: "Say hello" }],
+    },
+  },
+  { name: "sequence_update", input: { id: "seq-1", name: "Renamed" } },
+  { name: "sequence_delete", input: { id: "seq-1" } },
+  {
+    name: "sequence_enroll",
+    input: { sequence_id: "seq-1", emails: ["user@example.com"] },
+  },
+  {
+    name: "sequence_import",
+    input: {
+      file_path: "contacts.csv",
+      sequence_id: "seq-1",
+      auto_enroll: true,
+    },
+  },
+
+  {
+    name: "voice_config_update",
+    input: { setting: "voice", value: "alloy" },
+  },
+  {
+    name: "open_system_settings",
+    input: { pane: "microphone", platform: "macos" },
+  },
+  { name: "navigate_settings_tab", input: { tab: "General" } },
+
+  proxied("screen_point_at"),
+
+  {
+    name: "scaffold_managed_skill",
+    input: {
+      skill_id: "guard-skill",
+      name: "Guard Skill",
+      description: "A skill",
+      body_markdown: "# Guard Skill",
+      activation_hints: ["guard"],
+    },
+  },
+  { name: "delete_managed_skill", input: { skill_id: "guard-skill" } },
+  { name: "find_similar_skills", input: { goal: "do a thing" } },
+
+  {
+    name: "subagent_spawn",
+    input: { label: "worker", objective: "do a thing" },
+  },
+  {
+    name: "subagent_message",
+    input: { subagent_id: "sub-1", content: "carry on" },
+  },
+
+  { name: "run_workflow", input: { script: "export default () => {};" } },
+  { name: "manage_workflows", input: { action: "resume", run_id: "run-1" } },
+
+  { name: "transcribe_media", input: { file_path: "clip.m4a" } },
+];
+
+const REGISTERED_TOOLS: GuardedTool[] = [
+  { name: "file_write", input: { path: "guard.txt", content: "text" } },
+  {
+    name: "file_edit",
+    input: { path: "guard.txt", old_string: "a", new_string: "b" },
+  },
+  { name: "notify_parent", input: { message: "an update" } },
+  { name: "react_to_message", input: { emoji: "eyes" } },
+  { name: "ui_show", input: { surface_type: "card", data: { title: "T" } } },
+  { name: "ui_update", input: { surface_id: "s-1", data: { title: "T" } } },
+  { name: "remember", input: { content: "a fact" }, context: GUARDIAN },
+  {
+    name: "delete_memory_page",
+    input: { slug: "a-page" },
+    context: GUARDIAN,
+  },
+];
+
+describe("side-effecting skill tools refuse an aborted turn", () => {
+  for (const guarded of SKILL_TOOLS) {
+    test(guarded.name, async () => {
+      await expectRefusal(() => invokeSkillTool(guarded));
+    });
+  }
+});
+
+describe("side-effecting registered tools refuse an aborted turn", () => {
+  for (const guarded of REGISTERED_TOOLS) {
+    test(guarded.name, async () => {
+      await expectRefusal(() => invokeRegisteredTool(guarded));
+    });
+  }
+});

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -18,6 +18,7 @@ import {
 import { formatResolveFailure } from "../../acp/resolve-agent.js";
 import { claudeResumeHint } from "../../acp/resume-hint.js";
 import { FailedDependencyError } from "../../runtime/routes/errors.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -69,6 +70,7 @@ export async function executeAcpSpawn(
   if (!task) {
     return { content: '"task" is required.', isError: true };
   }
+  throwIfCancelled(context);
 
   // Pure precondition: the session streams its results through the
   // conversation's event sink, so a context with no sink at all (a tool run
@@ -119,6 +121,9 @@ export async function executeAcpSpawn(
   try {
     const manager = getAcpSessionManager();
     const cwd = parsedInput.data.cwd || context.workingDir;
+    // Recheck: the auto-install and the agent-env preparation above are both
+    // awaits, and this is the point a long-lived subprocess starts.
+    throwIfCancelled(context);
     const { acpSessionId, protocolSessionId } = await manager.spawn(
       agent,
       agentConfig,
@@ -127,6 +132,10 @@ export async function executeAcpSpawn(
       context.conversationId,
       sendToClient,
       context.toolUseId,
+      // The manager rechecks after its own protocol handshake and session
+      // creation, so a turn stopped in that window tears the child process
+      // down instead of handing it the task.
+      context.signal ? { signal: context.signal } : undefined,
     );
 
     // Claude Code-only resume hint; empty for other adapters. Keyed off the
@@ -155,6 +164,12 @@ export async function executeAcpSpawn(
 
     return { content: payload, isError: false };
   } catch (err) {
+    // A cancelled turn is not a spawn failure: the manager already tore the
+    // child process down, so let the abort reach the executor rather than
+    // rendering it as an error the model should recover from.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     // A pre-spawn rejection of the stored Claude credential (the adapter
     // raises auth_required during session creation) gets the same recovery
     // surface as the missing-token preflight: the errorCode raises the inline

--- a/assistant/src/tools/acp/steer.ts
+++ b/assistant/src/tools/acp/steer.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { getAcpSessionManager } from "../../acp/index.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -36,6 +37,7 @@ export async function executeAcpSteer(
   if (!instruction) {
     return { content: '"instruction" is required.', isError: true };
   }
+  throwIfCancelled(context);
 
   const manager = getAcpSessionManager();
   const sendToClient = getSendToClient(context);
@@ -45,7 +47,9 @@ export async function executeAcpSteer(
       // Without a connected client there is no one to receive a resumed
       // session's events, so skip the transparent resume fallback and
       // steer the in-memory session only.
-      await manager.steer(acpSessionId, instruction);
+      await manager.steer(acpSessionId, instruction, {
+        ...(context.signal ? { signal: context.signal } : {}),
+      });
       return steeredResult(acpSessionId, { resumed: false });
     }
     // Sessions no longer in memory (completed, or lost to a daemon
@@ -57,9 +61,15 @@ export async function executeAcpSteer(
       acpSessionId,
       instruction,
       sendToClient,
+      { ...(context.signal ? { signal: context.signal } : {}) },
     );
     return steeredResult(acpSessionId, { resumed });
   } catch (err) {
+    // A cancelled turn is not a steer failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return steerError(acpSessionId, msg);
   }

--- a/assistant/src/tools/app-control/skill-proxy-bridge.ts
+++ b/assistant/src/tools/app-control/skill-proxy-bridge.ts
@@ -5,7 +5,15 @@
  * the proxy resolver, which forwards the call to the connected client.
  */
 
+import { throwIfCancelled } from "../shared/abort.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+/**
+ * Session teardown, which runs even on a cancelled turn: refusing it would
+ * leave the app-control session the model opened running with nothing left to
+ * close it.
+ */
+const TEARDOWN_TOOLS: ReadonlySet<string> = new Set(["app_control_stop"]);
 
 /**
  * Forward an app-control proxy tool call through the context's proxyToolResolver.
@@ -18,6 +26,10 @@ export function forwardAppControlProxyTool(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
+  // Every non-teardown call actuates the host: a keypress, a click, a drag.
+  if (!TEARDOWN_TOOLS.has(toolName)) {
+    throwIfCancelled(context);
+  }
   if (!context.proxyToolResolver) {
     return Promise.resolve({
       content: `Cannot execute ${toolName}: no proxy resolver available. This tool requires a connected client.`,

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -514,6 +514,8 @@ export interface AppGenerateIconInput {
 export async function executeAppGenerateIcon(
   input: AppGenerateIconInput,
   store: AppStoreReader,
+  /** Turn cancellation, checked before the rename and the paid generation. */
+  signal?: AbortSignal,
 ): Promise<ExecutorResult> {
   const app = store.getApp(input.app_id);
   if (!app) {
@@ -530,16 +532,31 @@ export async function executeAppGenerateIcon(
   const iconPath = join(getAppDirPath(input.app_id), "icon.png");
   const tempPath = join(getAppDirPath(input.app_id), "icon.tmp.png");
 
+  // The dynamic imports above yield, so recheck before moving the user's
+  // existing icon aside and paying for a replacement.
+  signal?.throwIfAborted();
+
   // Temporarily move existing icon aside so generateAppIcon doesn't skip
   if (existsSync(iconPath)) {
     renameSync(iconPath, tempPath);
   }
 
-  await generateAppIcon(
-    input.app_id,
-    app.name,
-    input.description ?? app.description,
-  );
+  try {
+    await generateAppIcon(
+      input.app_id,
+      app.name,
+      input.description ?? app.description,
+      signal ? { signal } : undefined,
+    );
+  } catch (err) {
+    // The existing icon is sitting at the temp path. Put it back before the
+    // cancellation leaves, or a stopped turn costs the user the icon it was
+    // only meant to replace.
+    if (existsSync(tempPath) && !existsSync(iconPath)) {
+      renameSync(tempPath, iconPath);
+    }
+    throw err;
+  }
 
   if (existsSync(iconPath)) {
     // Success - clean up the old icon backup

--- a/assistant/src/tools/calls/call-start.ts
+++ b/assistant/src/tools/calls/call-start.ts
@@ -4,6 +4,7 @@ import { startCall } from "../../calls/call-domain.js";
 import { findActiveSession } from "../../channels/gateway-verification-sessions.js";
 import { getConfig } from "../../config/loader.js";
 import { normalizePhoneNumber } from "../../util/phone.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -66,6 +67,7 @@ export async function executeCallStart(
     }
   }
 
+  throwIfCancelled(context);
   const result = await startCall({
     phoneNumber: parsed.phone_number,
     task: parsed.task,
@@ -74,6 +76,9 @@ export async function executeCallStart(
     assistantId: context.assistantId,
     callerIdentityMode: parsed.caller_identity_mode,
     skipDisclosure: input.skip_disclosure === true,
+    // Setup is asynchronous, and the domain rechecks immediately before it
+    // dials, so a turn stopped during setup never places the call.
+    ...(context.signal ? { signal: context.signal } : {}),
   });
 
   if (!result.ok) {

--- a/assistant/src/tools/channel/react-to-message.ts
+++ b/assistant/src/tools/channel/react-to-message.ts
@@ -23,6 +23,7 @@ import {
   supportsChannelReaction,
 } from "../../messaging/providers/index.js";
 import { RiskLevel } from "../../permissions/types.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   toToolInputSchema,
@@ -81,6 +82,7 @@ export const reactToMessageTool = {
     if (!parsed.success) {
       return invalidToolInputResult("react_to_message", parsed.error);
     }
+    throwIfCancelled(context);
 
     const channel = context.executionChannel;
     const chatId = context.requesterChatId;

--- a/assistant/src/tools/computer-use/skill-proxy-bridge.ts
+++ b/assistant/src/tools/computer-use/skill-proxy-bridge.ts
@@ -5,6 +5,7 @@
  * the proxy resolver, which forwards the call to the connected desktop client.
  */
 
+import { throwIfCancelled } from "../shared/abort.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
@@ -18,6 +19,14 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
 export const POINT_AT_PROXY_TOOL = "computer_use_point_at";
 
 /**
+ * Session teardown, which runs even on a cancelled turn: refusing it would
+ * leave the computer-use session the model opened running with nothing left to
+ * close it. Keyed on the wire name, so a caller whose wire name it shares with
+ * an actuating tool says so with `opts.teardown` instead.
+ */
+const TEARDOWN_TOOLS: ReadonlySet<string> = new Set(["computer_use_done"]);
+
+/**
  * Forward a computer-use proxy tool call through the context's proxyToolResolver.
  *
  * Returns a clear error result if the resolver is missing (e.g. when the tool
@@ -27,7 +36,13 @@ export function forwardComputerUseProxyTool(
   toolName: string,
   input: Record<string, unknown>,
   context: ToolContext,
+  opts?: { teardown?: boolean },
 ): Promise<ToolExecutionResult> {
+  // Every non-teardown call actuates the user's desktop: a click, a keystroke,
+  // an app launch, an AppleScript run.
+  if (!opts?.teardown && !TEARDOWN_TOOLS.has(toolName)) {
+    throwIfCancelled(context);
+  }
   if (!context.proxyToolResolver) {
     return Promise.resolve({
       content: `Cannot execute ${toolName}: no proxy resolver available. This tool requires a connected desktop client.`,

--- a/assistant/src/tools/conversation-groups/group_create.ts
+++ b/assistant/src/tools/conversation-groups/group_create.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { createGroup, listGroups } from "../../persistence/group-crud.js";
 import { publishConversationListChanged } from "../../runtime/sync/resource-sync-events.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -20,7 +21,7 @@ export const conversationGroupCreateInputSchema = z.looseObject({
 
 export async function executeConversationGroupCreate(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const parsedInput = conversationGroupCreateInputSchema.safeParse(input);
   if (!parsedInput.success) {
@@ -37,6 +38,7 @@ export async function executeConversationGroupCreate(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   const existing = listGroups().find(
     (g) => g.name.trim().toLowerCase() === name.toLowerCase(),

--- a/assistant/src/tools/conversation-groups/move_to_group.ts
+++ b/assistant/src/tools/conversation-groups/move_to_group.ts
@@ -6,6 +6,7 @@ import {
   getDisplayMetaForConversations,
 } from "../../persistence/conversation-crud.js";
 import { publishConversationListAndMetadataChanged } from "../../runtime/sync/resource-sync-events.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -42,6 +43,7 @@ export async function executeConversationMoveToGroup(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   const resolved = resolveGroupReference(groupRef);
   if ("error" in resolved) {

--- a/assistant/src/tools/document/document-comment-tool.ts
+++ b/assistant/src/tools/document/document-comment-tool.ts
@@ -6,6 +6,7 @@ import {
   listComments,
   resolveComment,
 } from "../../documents/document-comments-store.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import { invalidToolInputResult } from "../shared/zod-tool-schema.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { canAccessDocument, documentNotFound } from "./document-tool.js";
@@ -80,6 +81,7 @@ export function executeCommentResolve(
   if (!parsedInput.success) {
     return invalidToolInputResult("comment_resolve", parsedInput.error);
   }
+  throwIfCancelled(context);
   const { surface_id: surfaceId, comment_id: commentId } = parsedInput.data;
 
   if (!canAccessDocument(surfaceId, context)) {
@@ -128,6 +130,7 @@ export function executeCommentReply(
   if (!parsedInput.success) {
     return invalidToolInputResult("comment_reply", parsedInput.error);
   }
+  throwIfCancelled(context);
   const {
     surface_id: surfaceId,
     comment_id: commentId,

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -16,6 +16,7 @@ import {
   updateDocumentContent,
 } from "../../documents/document-store.js";
 import { canActOnPrivilegedDocuments } from "../../runtime/effective-capabilities.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -285,6 +286,7 @@ export function executeDocumentCreate(
   if (!parsedInput.success) {
     return invalidToolInputResult("document_create", parsedInput.error);
   }
+  throwIfCancelled(context);
   const title = parsedInput.data.title || "Untitled Document";
   const initialContent = parsedInput.data.initial_content || "";
 
@@ -389,6 +391,7 @@ export function executeDocumentUpdate(
   if (!parsedInput.success) {
     return invalidToolInputResult("document_update", parsedInput.error);
   }
+  throwIfCancelled(context);
   if (typeof input.content !== "string") {
     return invalidInput("content is required and must be a string");
   }
@@ -547,6 +550,7 @@ export function executeDocumentDelete(
   if (!parsedInput.success) {
     return invalidToolInputResult("document_delete", parsedInput.error);
   }
+  throwIfCancelled(context);
   const surfaceIdOrError = validateSurfaceId(input);
   if (typeof surfaceIdOrError !== "string") {
     return surfaceIdOrError;
@@ -637,6 +641,7 @@ export function executeDocumentReplaceText(
   if (!parsedInput.success) {
     return invalidToolInputResult("document_replace_text", parsedInput.error);
   }
+  throwIfCancelled(context);
   const surfaceIdOrError = validateSurfaceId(input);
   if (typeof surfaceIdOrError !== "string") {
     return surfaceIdOrError;

--- a/assistant/src/tools/execution-timeout.ts
+++ b/assistant/src/tools/execution-timeout.ts
@@ -4,6 +4,29 @@ import type { ToolExecutionResult } from "./types.js";
 const TIMEOUT_SENTINEL = Symbol("tool-timeout");
 
 /**
+ * Content of the synthetic `tool_result` written for a tool call the user
+ * cancelled before the call was ever dispatched to its tool.
+ */
+export const CANCELLED_TOOL_RESULT = "Cancelled by user";
+
+/**
+ * Content of the synthetic `tool_result` written for a tool call that was
+ * still in flight when the user cancelled and did not settle. A tool that
+ * does not read `context.signal` keeps running after the caller abandons it,
+ * so the model is told the work may have landed rather than that it did not.
+ */
+export const CANCELLED_UNSETTLED_TOOL_RESULT =
+  "Cancelled by user before the tool finished; it may still have completed, check before repeating it.";
+
+/**
+ * Upper bound on how long a caller waits after an abort for in-flight tool
+ * calls to settle. A tool that honours the signal settles as soon as the
+ * signal fires and so reports its real outcome; one that ignores the signal is
+ * abandoned at this bound and reported as unsettled.
+ */
+export const ABORT_SETTLE_GRACE_MS = 50;
+
+/**
  * Convert a config-provided seconds value to a safe milliseconds value,
  * falling back to the default if the input is NaN, non-finite, zero, or negative.
  *
@@ -20,6 +43,43 @@ export function safeTimeoutMs(
     return fallbackMs;
   }
   return n * 1000;
+}
+
+/** Settlement state of a promise a caller may abandon before it finishes. */
+export interface SettlementTracker<T> {
+  /** The tracked promise. Awaiting it is equivalent to awaiting the original. */
+  readonly promise: Promise<T>;
+  /** True once the tracked promise has fulfilled or rejected. */
+  isSettled(): boolean;
+  /** The value when the tracked promise fulfilled, otherwise undefined. */
+  fulfilledValue(): T | undefined;
+}
+
+/**
+ * Observe whether a promise has settled without changing what awaiting it
+ * does. Callers that race a promise against a timeout or an abort signal use
+ * this to tell a call whose work actually finished from one they walked away
+ * from while it was still running.
+ */
+export function trackSettlement<T>(promise: Promise<T>): SettlementTracker<T> {
+  let settled = false;
+  let value: T | undefined;
+  const tracked = promise.then(
+    (result) => {
+      settled = true;
+      value = result;
+      return result;
+    },
+    (err) => {
+      settled = true;
+      throw err;
+    },
+  );
+  return {
+    promise: tracked,
+    isSettled: () => settled,
+    fulfilledValue: () => value,
+  };
 }
 
 /**
@@ -40,9 +100,16 @@ export async function executeWithTimeout(
   const timeoutPromise = new Promise<typeof TIMEOUT_SENTINEL>((resolve) => {
     timeoutHandle = setTimeout(() => resolve(TIMEOUT_SENTINEL), safeMs);
   });
+  const tracked = trackSettlement(promise);
   try {
-    const result = await Promise.race([promise, timeoutPromise]);
+    const result = await Promise.race([tracked.promise, timeoutPromise]);
     if (result === TIMEOUT_SENTINEL) {
+      // The tool may have finished in the same tick the timer fired and lost
+      // the race. Its real result is more honest than the timeout hedge.
+      const settledResult = tracked.fulfilledValue();
+      if (settledResult !== undefined) {
+        return settledResult;
+      }
       const sec = Math.round(safeMs / 1000);
       return {
         content: `Tool "${toolName}" timed out after ${sec}s. The operation may still be running in the background. Consider increasing timeouts.toolExecutionTimeoutSec in the config.`,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -21,7 +21,6 @@ import {
   recordToolError,
   recordToolExecuted,
 } from "../telemetry/tool-audit.js";
-import { type AbortReason, isAbortReason } from "../util/abort-reasons.js";
 import { PermissionDeniedError, ToolError } from "../util/errors.js";
 import { pathExists, safeStatSync } from "../util/fs.js";
 import { truncateForLog } from "../util/logger.js";
@@ -37,6 +36,7 @@ import { getHostShell } from "./host-shell.js";
 import { PermissionChecker } from "./permission-checker.js";
 import { getToolOwner } from "./registry.js";
 import { extractAndSanitize } from "./sensitive-output-placeholders.js";
+import { extractAbortReason } from "./shared/abort.js";
 import { applyEdit } from "./shared/filesystem/edit-engine.js";
 import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
@@ -416,27 +416,6 @@ export class ToolExecutor {
       };
     }
   }
-}
-
-/**
- * Extract the tagged {@link AbortReason} from a thrown value: the value
- * itself, its `reason` (an `AbortError` carrying the signal's reason), or a
- * provider wrapper's `abortReason`. Returns `undefined` for anything that is
- * not a daemon-owned abort.
- */
-function extractAbortReason(err: unknown): AbortReason | undefined {
-  if (isAbortReason(err)) {
-    return err;
-  }
-  const reason = (err as { reason?: unknown } | null)?.reason;
-  if (isAbortReason(reason)) {
-    return reason;
-  }
-  const abortReason = (err as { abortReason?: unknown } | null)?.abortReason;
-  if (isAbortReason(abortReason)) {
-    return abortReason;
-  }
-  return undefined;
 }
 
 /**

--- a/assistant/src/tools/filesystem/edit.ts
+++ b/assistant/src/tools/filesystem/edit.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { RiskLevel } from "../../permissions/types.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatEditDiff } from "../shared/filesystem/format-diff.js";
 import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
@@ -88,11 +89,14 @@ export const fileEditTool = {
       sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
+    throwIfCancelled(context);
+
     const result = await ops.editFileSafe({
       path: rawPath,
       oldString,
       newString,
       replaceAll,
+      ...(context.signal ? { signal: context.signal } : {}),
     });
 
     if (!result.ok) {

--- a/assistant/src/tools/filesystem/write.ts
+++ b/assistant/src/tools/filesystem/write.ts
@@ -7,6 +7,7 @@ import { RiskLevel } from "../../permissions/types.js";
 import { enqueuePkbIndexJob } from "../../plugins/defaults/memory/v1/jobs/embed-pkb-file.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import { FileSystemOps } from "../shared/filesystem/file-ops-service.js";
 import { formatWriteSummary } from "../shared/filesystem/format-diff.js";
 import { sandboxPolicyWithHostFallback } from "../shared/filesystem/path-policy.js";
@@ -129,9 +130,12 @@ export const fileWriteTool = {
       sandboxPolicyWithHostFallback(path, context.workingDir, opts),
     );
 
+    throwIfCancelled(context);
+
     const result = await ops.writeFileSafe({
       path: rawPath,
       content: fileContent,
+      ...(context.signal ? { signal: context.signal } : {}),
     });
 
     if (!result.ok) {

--- a/assistant/src/tools/followups/followup_create.ts
+++ b/assistant/src/tools/followups/followup_create.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { getContact } from "../../contacts/contact-store.js";
 import { createFollowUp } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -49,7 +50,7 @@ function formatFollowUp(f: FollowUp): string {
 
 export async function executeFollowupCreate(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const parsedInput = followupCreateInputSchema.safeParse(input);
   if (!parsedInput.success) {
@@ -103,6 +104,8 @@ export async function executeFollowupCreate(
     };
   }
 
+  throwIfCancelled(context);
+
   try {
     const now = Date.now();
     const expectedResponseBy = expectedResponseHours
@@ -123,6 +126,11 @@ export async function executeFollowupCreate(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a follow-up failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error: ${msg}`, isError: true };
   }

--- a/assistant/src/tools/followups/followup_resolve.ts
+++ b/assistant/src/tools/followups/followup_resolve.ts
@@ -5,6 +5,7 @@ import {
   resolveFollowUp,
 } from "../../followups/followup-store.js";
 import type { FollowUp } from "../../followups/types.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -38,7 +39,7 @@ function formatFollowUp(f: FollowUp): string {
 
 export async function executeFollowupResolve(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const parsedInput = followupResolveInputSchema.safeParse(input);
   if (!parsedInput.success) {
@@ -53,6 +54,8 @@ export async function executeFollowupResolve(
       isError: true,
     };
   }
+
+  throwIfCancelled(context);
 
   try {
     if (id) {
@@ -76,6 +79,11 @@ export async function executeFollowupResolve(
       };
     }
   } catch (err) {
+    // A cancelled turn is not a follow-up failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error: ${msg}`, isError: true };
   }

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -21,6 +21,7 @@ import {
   resolveCapabilities as resolveWorkflowCapabilities,
 } from "../../workflows/capabilities.js";
 import { resolveGroupReference } from "../conversation-groups/group_shared.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -92,6 +93,7 @@ export async function executeScheduleCreate(
   if (!parsedInput.success) {
     return invalidToolInputResult("schedule_create", parsedInput.error);
   }
+  throwIfCancelled(context);
   const parsed = parsedInput.data;
 
   const name = parsed.name;
@@ -252,32 +254,38 @@ export async function executeScheduleCreate(
     }
 
     try {
-      const job = await createSchedule({
-        name,
-        description,
-        cronExpression: null,
-        timezone,
-        message,
-        script,
-        enabled,
-        syntax: "cron",
-        expression: null,
-        nextRunAt: fireAtMs,
-        mode,
-        routingIntent: routingIntent as RoutingIntent | undefined,
-        routingHints,
-        quiet,
-        reuseConversation,
-        maxRetries,
-        retryBackoffMs,
-        timeoutMs,
-        workflowName,
-        workflowArgs,
-        capabilities,
-        inferenceProfile,
-        groupId,
-        createdFromConversationId: context.conversationId,
-      });
+      const job = await createSchedule(
+        {
+          name,
+          description,
+          cronExpression: null,
+          timezone,
+          message,
+          script,
+          enabled,
+          syntax: "cron",
+          expression: null,
+          nextRunAt: fireAtMs,
+          mode,
+          routingIntent: routingIntent as RoutingIntent | undefined,
+          routingHints,
+          quiet,
+          reuseConversation,
+          maxRetries,
+          retryBackoffMs,
+          timeoutMs,
+          workflowName,
+          workflowArgs,
+          capabilities,
+          inferenceProfile,
+          groupId,
+          createdFromConversationId: context.conversationId,
+        },
+        // The write retries with backoff on SQLite contention, so a cancel
+        // landing mid-retry must stop rather than sleep and then persist a
+        // schedule that would go on to run on its own.
+        context.signal ? { signal: context.signal } : undefined,
+      );
 
       const fireDate = formatLocalDate(job.nextRunAt);
       const integrations = await formatIntegrationSummary();
@@ -303,6 +311,11 @@ export async function executeScheduleCreate(
         isError: false,
       };
     } catch (err) {
+      // A cancelled turn is not a schedule failure: let it reach the executor's
+      // abort handling instead of being rendered as a tool error.
+      if (isAbortLikeError(err)) {
+        throw err;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       return { content: `Error creating schedule: ${msg}`, isError: true };
     }
@@ -346,31 +359,37 @@ export async function executeScheduleCreate(
   }
 
   try {
-    const job = await createSchedule({
-      name,
-      description,
-      cronExpression: resolved.expression,
-      timezone,
-      message,
-      script,
-      enabled,
-      syntax: resolved.syntax,
-      expression: resolved.expression,
-      mode,
-      routingIntent: routingIntent as RoutingIntent | undefined,
-      routingHints,
-      quiet,
-      reuseConversation,
-      maxRetries,
-      retryBackoffMs,
-      timeoutMs,
-      workflowName,
-      workflowArgs,
-      capabilities,
-      inferenceProfile,
-      groupId,
-      createdFromConversationId: context.conversationId,
-    });
+    const job = await createSchedule(
+      {
+        name,
+        description,
+        cronExpression: resolved.expression,
+        timezone,
+        message,
+        script,
+        enabled,
+        syntax: resolved.syntax,
+        expression: resolved.expression,
+        mode,
+        routingIntent: routingIntent as RoutingIntent | undefined,
+        routingHints,
+        quiet,
+        reuseConversation,
+        maxRetries,
+        retryBackoffMs,
+        timeoutMs,
+        workflowName,
+        workflowArgs,
+        capabilities,
+        inferenceProfile,
+        groupId,
+        createdFromConversationId: context.conversationId,
+      },
+      // The write retries with backoff on SQLite contention, so a cancel landing
+      // mid-retry must stop rather than sleep and then persist a schedule that
+      // would go on to run on its own.
+      context.signal ? { signal: context.signal } : undefined,
+    );
 
     const scheduleDescription =
       job.expression == null
@@ -405,6 +424,11 @@ export async function executeScheduleCreate(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a schedule failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error creating schedule: ${msg}`, isError: true };
   }

--- a/assistant/src/tools/schedule/delete.ts
+++ b/assistant/src/tools/schedule/delete.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { deleteSchedule, getSchedule } from "../../schedule/schedule-store.js";
 import { UserError } from "../../util/errors.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -19,7 +20,7 @@ export const scheduleDeleteInputSchema = z.looseObject({
 
 export async function executeScheduleDelete(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const parsedInput = scheduleDeleteInputSchema.safeParse(input);
   if (!parsedInput.success) {
@@ -29,6 +30,7 @@ export async function executeScheduleDelete(
   if (!jobId) {
     return { content: "Error: job_id is required", isError: true };
   }
+  throwIfCancelled(context);
 
   // Fetch the job first for the confirmation message
   const job = getSchedule(jobId);
@@ -38,7 +40,12 @@ export async function executeScheduleDelete(
 
   let deleted: boolean;
   try {
-    deleted = await deleteSchedule(jobId);
+    // The delete retries with backoff on SQLite contention, so a cancel
+    // landing mid-retry must stop rather than sleep and then remove the row.
+    deleted = await deleteSchedule(
+      jobId,
+      context.signal ? { signal: context.signal } : undefined,
+    );
   } catch (err) {
     // The store refuses to delete plugin-sourced rows with a UserError. That
     // refusal is an expected outcome for the model to relay, not a daemon

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -24,6 +24,7 @@ import {
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { resolveGroupReference } from "../conversation-groups/group_shared.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -98,6 +99,7 @@ export async function executeScheduleUpdate(
   if (!jobId) {
     return { content: "Error: job_id is required", isError: true };
   }
+  throwIfCancelled(context);
 
   const existing = getSchedule(jobId);
 
@@ -345,9 +347,13 @@ export async function executeScheduleUpdate(
     }
   }
 
+  // The store's writes retry with backoff on SQLite contention, so a cancel
+  // landing mid-retry must stop rather than sleep and then persist the edit.
+  const writeOpts = context.signal ? { signal: context.signal } : undefined;
+
   try {
     const job = isPluginSourced
-      ? await setUserEnabled(jobId, updates.enabled as boolean)
+      ? await setUserEnabled(jobId, updates.enabled as boolean, writeOpts)
       : await updateSchedule(
           jobId,
           updates as {
@@ -372,6 +378,7 @@ export async function executeScheduleUpdate(
             workflowArgs?: unknown;
             inferenceProfile?: string | null;
           },
+          writeOpts,
         );
 
     if (!job) {
@@ -400,6 +407,11 @@ export async function executeScheduleUpdate(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a schedule failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Error updating schedule: ${msg}`, isError: true };
   }

--- a/assistant/src/tools/shared/abort.ts
+++ b/assistant/src/tools/shared/abort.ts
@@ -1,0 +1,41 @@
+import { type AbortReason, isAbortReason } from "../../util/abort-reasons.js";
+
+// The guard itself lives on the plugin API surface, the one module a plugin
+// may import from, so host tools and plugin tools share a single
+// implementation. Re-exported here because this is where host tools look for
+// the cancellation vocabulary.
+export { throwIfCancelled } from "../../plugin-api/tool-cancellation.js";
+
+/**
+ * Extract the tagged {@link AbortReason} from a thrown value: the value
+ * itself, its `reason` (an `AbortError` carrying the signal's reason), or a
+ * provider wrapper's `abortReason`. Returns `undefined` for anything that is
+ * not a daemon-owned abort.
+ */
+export function extractAbortReason(err: unknown): AbortReason | undefined {
+  if (isAbortReason(err)) {
+    return err;
+  }
+  const reason = (err as { reason?: unknown } | null)?.reason;
+  if (isAbortReason(reason)) {
+    return reason;
+  }
+  const abortReason = (err as { abortReason?: unknown } | null)?.abortReason;
+  if (isAbortReason(abortReason)) {
+    return abortReason;
+  }
+  return undefined;
+}
+
+/**
+ * True when a thrown value is a cancellation rather than a tool failure: a
+ * daemon-owned abort reason, or the `AbortError` a plain `AbortSignal` throws.
+ * Wrappers that convert throws into error results must re-throw these so the
+ * cancellation reaches the executor's abort handling intact.
+ */
+export function isAbortLikeError(err: unknown): boolean {
+  return (
+    extractAbortReason(err) !== undefined ||
+    (err instanceof Error && err.name === "AbortError")
+  );
+}

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { minimatch } from "minimatch";
 
 import { ensureDir, pathExists } from "../../../util/fs.js";
+import { isAbortLikeError } from "../abort.js";
 import { applyEdit } from "./edit-engine.js";
 import * as Err from "./errors.js";
 import type { PathFailureReason, PathResult } from "./path-policy.js";
@@ -221,6 +222,11 @@ export class FileSystemOps {
 
     return withFileWriteLock(filePath, async (): Promise<WriteResult> => {
       try {
+        // Before `ensureDir`, which creates parent directories: a stopped turn
+        // must not leave a directory tree behind for a file it never wrote.
+        // Acquiring the write lock above is an await, so this is the first
+        // point after it.
+        input.signal?.throwIfAborted();
         ensureDir(dirname(filePath));
 
         let oldContent = "";
@@ -233,6 +239,7 @@ export class FileSystemOps {
           }
         }
 
+        input.signal?.throwIfAborted();
         await writeFile(filePath, input.content);
 
         return {
@@ -245,6 +252,11 @@ export class FileSystemOps {
           },
         };
       } catch (err) {
+        // A cancelled turn is not an IO failure. Reporting it as one would
+        // have the model treat a stop as a disk problem and retry the write.
+        if (isAbortLikeError(err)) {
+          throw err;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         return { ok: false, error: Err.ioError(filePath, msg) };
       }
@@ -315,6 +327,8 @@ export class FileSystemOps {
           error: Err.matchAmbiguous(filePath, result.matchCount),
         };
       }
+
+      input.signal?.throwIfAborted();
 
       try {
         await writeFile(filePath, result.updatedContent);

--- a/assistant/src/tools/shared/filesystem/types.ts
+++ b/assistant/src/tools/shared/filesystem/types.ts
@@ -28,6 +28,12 @@ export type ReadResult =
 export interface WriteInput {
   path: string;
   content: string;
+  /**
+   * Turn cancellation, checked immediately before the write. The lock wait and
+   * the previous-content read both yield, so a caller's entry guard cannot
+   * cover the moment the bytes land.
+   */
+  signal?: AbortSignal;
 }
 
 export interface WriteOutput {
@@ -54,6 +60,12 @@ export interface EditInput {
   oldString: string;
   newString: string;
   replaceAll: boolean;
+  /**
+   * Turn cancellation, checked immediately before the write. The lock wait,
+   * the size check and the content read all yield, so a caller's entry guard
+   * cannot cover the moment the bytes land.
+   */
+  signal?: AbortSignal;
 }
 
 export interface EditOutput {

--- a/assistant/src/tools/skills/delete-managed.ts
+++ b/assistant/src/tools/skills/delete-managed.ts
@@ -1,5 +1,6 @@
 import { refreshSkillCapabilityMemories } from "../../daemon/skill-memory-refresh.js";
 import { deleteManagedSkill } from "../../skills/managed-store.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
@@ -8,7 +9,7 @@ import type { ToolContext, ToolExecutionResult } from "../types.js";
  */
 export async function executeDeleteManagedSkill(
   input: Record<string, unknown>,
-  _context: ToolContext,
+  context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const skillId = input.skill_id;
   if (typeof skillId !== "string" || !skillId.trim()) {
@@ -17,6 +18,8 @@ export async function executeDeleteManagedSkill(
       isError: true,
     };
   }
+
+  throwIfCancelled(context);
 
   const result = deleteManagedSkill(skillId.trim());
 

--- a/assistant/src/tools/skills/find-similar-skills.test.ts
+++ b/assistant/src/tools/skills/find-similar-skills.test.ts
@@ -31,6 +31,7 @@ mock.module("../../skills/install-meta.js", () => ({
   },
 }));
 
+import { createAbortReason } from "../../util/abort-reasons.js";
 import type { ToolContext } from "../types.js";
 import { executeFindSimilarSkills } from "./find-similar-skills.js";
 
@@ -420,5 +421,61 @@ describe("find_similar_skills — input validation", () => {
       expect(result.isError).toBe(true);
       expect(result.content).toContain("limit must be a positive integer");
     }
+  });
+});
+
+describe("find_similar_skills cancellation", () => {
+  test("the shortlist search is handed the turn signal", async () => {
+    const controller = new AbortController();
+    let seen: AbortSignal | undefined;
+
+    await executeFindSimilarSkills(
+      { goal: "ship the web app" },
+      { ...makeContext(), signal: controller.signal },
+      {
+        nearestExistingSkills: async (
+          _goal: string,
+          opts?: { signal?: AbortSignal },
+        ) => {
+          seen = opts?.signal;
+          return [];
+        },
+        loadCatalog: () =>
+          catalog({
+            id: "deploy-web",
+            name: "Deploy Web",
+            description: "Ship the web app",
+            source: "managed",
+          }),
+      },
+    );
+
+    expect(seen).toBe(controller.signal);
+  });
+
+  test("a cancelled turn never reaches the paid shortlist", async () => {
+    const controller = new AbortController();
+    controller.abort(
+      createAbortReason("user_cancel", "find-similar-skills.test"),
+    );
+    const search = mock(async () => []);
+
+    await expect(
+      executeFindSimilarSkills(
+        { goal: "ship the web app" },
+        { ...makeContext(), signal: controller.signal },
+        {
+          nearestExistingSkills: search,
+          loadCatalog: () =>
+            catalog({
+              id: "deploy-web",
+              name: "Deploy Web",
+              description: "Ship the web app",
+              source: "managed",
+            }),
+        },
+      ),
+    ).rejects.toThrow();
+    expect(search).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/tools/skills/find-similar-skills.ts
+++ b/assistant/src/tools/skills/find-similar-skills.ts
@@ -7,6 +7,7 @@ import {
   filterSkillsByPlatform,
   type SkillPlatform,
 } from "../../skills/platform-compatibility.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import type { OwnerInfo, ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
@@ -103,9 +104,14 @@ export async function executeFindSimilarSkills(
       : catalog.filter((skill) => !outOfScope(skill)),
   );
 
+  throwIfCancelled(context);
+
   const hits = await findNearest(goal, {
     limit,
     loadCatalog: () => scopedCatalog,
+    // The shortlist is a paid embedding round-trip with its own retries, so a
+    // stopped turn stops paying rather than finishing a search nobody reads.
+    ...(context.signal ? { signal: context.signal } : {}),
   });
 
   const enriched: EnrichedHit[] = [];

--- a/assistant/src/tools/skills/scaffold-managed.ts
+++ b/assistant/src/tools/skills/scaffold-managed.ts
@@ -15,6 +15,7 @@ import {
 } from "../../skills/managed-store.js";
 import { recordWatchdogEvent } from "../../telemetry/watchdog-events-store.js";
 import { getLogger } from "../../util/logger.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 const log = getLogger("scaffold-managed-skill");
@@ -392,6 +393,8 @@ export async function executeScaffoldManagedSkill(
     typeof input.emoji === "string"
       ? sanitizeFrontmatterValue(input.emoji)
       : undefined;
+
+  throwIfCancelled(context);
 
   const result = createManagedSkill({
     id,

--- a/assistant/src/tools/skills/skill-script-runner.ts
+++ b/assistant/src/tools/skills/skill-script-runner.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "node:path";
 
 import { computeSkillVersionHash } from "../../skills/version-hash.js";
+import { isAbortLikeError } from "../shared/abort.js";
 import type { ExecutionTarget } from "../tool-types.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { runSkillToolScriptSandbox } from "./sandbox-runner.js";
@@ -112,6 +113,12 @@ export async function runSkillToolScript(
   try {
     return await module.run(input, context);
   } catch (err) {
+    // A cancellation is not a script failure. Re-throw it so the tool executor
+    // classifies the call as cancelled instead of reporting the abort reason
+    // as an opaque script error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const message = err instanceof Error ? err.message : String(err);
     return {
       content: `Skill tool script "${executorPath}" threw an error: ${message}`,

--- a/assistant/src/tools/subagent/message.ts
+++ b/assistant/src/tools/subagent/message.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { getSubagentManager } from "../../subagent/index.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -37,6 +38,7 @@ export async function executeSubagentMessage(
       isError: true,
     };
   }
+  throwIfCancelled(context);
 
   const manager = getSubagentManager();
 

--- a/assistant/src/tools/subagent/notify-parent.ts
+++ b/assistant/src/tools/subagent/notify-parent.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { RiskLevel } from "../../permissions/types.js";
 import { notifyParentFromChild } from "../../subagent/notify.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -55,6 +56,8 @@ export async function executeSubagentNotifyParent(
   if (!message) {
     return { content: '"message" is required.', isError: true };
   }
+
+  throwIfCancelled(context);
 
   const sent = notifyParentFromChild(context.conversationId, message, urgency);
 

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -30,6 +30,7 @@ import {
   type SubagentRole,
 } from "../../subagent/types.js";
 import { getLogger } from "../../util/logger.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -165,6 +166,7 @@ export async function executeSubagentSpawn(
   if (contractError) {
     return { content: contractError, isError: true };
   }
+  throwIfCancelled(context);
 
   let requestedOverrideProfile: string | undefined;
   let forceOverrideProfile = false;
@@ -440,6 +442,11 @@ async function spawnReservedSubagent(args: {
     // wrong, and the turn this result would have reached is already over.
     if (err instanceof SubagentSpawnCancelledError) {
       return spawnCancelledResult(label);
+    }
+    // A cancelled turn is not a spawn failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
     }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Failed to spawn subagent: ${msg}`, isError: true };

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -15,6 +15,7 @@ import {
 import { RiskLevel } from "../../permissions/types.js";
 import { isWeakOpenModel } from "../../providers/weak-open-model.js";
 import { desktopClientName } from "../client-os.js";
+import { throwIfCancelled } from "../shared/abort.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -49,6 +50,13 @@ function proxyExecute(toolName: string) {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> => {
+    // Showing or updating a surface writes to the user's screen. Dismissal is
+    // teardown and still runs on a cancelled turn, so the surface the model
+    // opened does not outlive the turn that opened it.
+    if (toolName !== "ui_dismiss") {
+      throwIfCancelled(context);
+    }
+
     if (toolName === "ui_show") {
       const teachingError = uiShowTeachingError(input);
       if (teachingError !== null) {

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -20,6 +20,7 @@ import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -148,6 +149,7 @@ export async function executeManageWorkflows(
           isError: true,
         };
       }
+      throwIfCancelled(context);
       // Don't resume — or reveal — a run the caller doesn't own; mirror
       // resume()'s own not-found message.
       const run = manager.status(runId);
@@ -169,6 +171,11 @@ export async function executeManageWorkflows(
           isError: false,
         };
       } catch (err) {
+        // A cancelled turn is not a workflow failure: let it reach the executor's
+        // abort handling instead of being rendered as a tool error.
+        if (isAbortLikeError(err)) {
+          throw err;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         return { content: `Failed to resume workflow: ${msg}`, isError: true };
       }

--- a/assistant/src/tools/workflows/run-workflow.ts
+++ b/assistant/src/tools/workflows/run-workflow.ts
@@ -22,6 +22,7 @@ import { FALLBACK_TURN_TRUST } from "../../daemon/trust-context.js";
 import type { TrustContext } from "../../daemon/trust-context-types.js";
 import { CapabilityManifestSchema } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
+import { isAbortLikeError, throwIfCancelled } from "../shared/abort.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -81,6 +82,8 @@ export async function executeRunWorkflow(
     };
   }
 
+  throwIfCancelled(context);
+
   const args = (input.args as Record<string, unknown> | undefined) ?? {};
   const trustContext = resolveTrustContext(context);
 
@@ -108,6 +111,11 @@ export async function executeRunWorkflow(
       isError: false,
     };
   } catch (err) {
+    // A cancelled turn is not a workflow failure: let it reach the executor's
+    // abort handling instead of being rendered as a tool error.
+    if (isAbortLikeError(err)) {
+      throw err;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return { content: `Failed to start workflow: ${msg}`, isError: true };
   }

--- a/assistant/src/util/__tests__/spawn-abort.test.ts
+++ b/assistant/src/util/__tests__/spawn-abort.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Cancellation behaviour of `spawnWithTimeout()`.
+ *
+ * ffmpeg transcodes and frame extractions run long enough that abandoning one
+ * after the user pressed Stop keeps a core busy for minutes on work nobody is
+ * waiting for, so the signal kills the process rather than just being checked
+ * around it.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { createAbortReason } from "../abort-reasons.js";
+import { spawnWithTimeout } from "../spawn.js";
+
+const REASON = createAbortReason("user_cancel", "spawn-abort.test");
+
+describe("spawnWithTimeout cancellation", () => {
+  test("an already-aborted signal never spawns", async () => {
+    const controller = new AbortController();
+    controller.abort(REASON);
+
+    await expect(
+      spawnWithTimeout(["sleep", "30"], 60_000, controller.signal),
+    ).rejects.toBe(REASON);
+  });
+
+  test("aborting mid-run kills the process and rejects", async () => {
+    const controller = new AbortController();
+    const started = Date.now();
+    const running = spawnWithTimeout(
+      ["sleep", "30"],
+      60_000,
+      controller.signal,
+    );
+    setTimeout(() => controller.abort(REASON), 20);
+
+    await expect(running).rejects.toBe(REASON);
+    // Rejects on the abort, not by waiting the process or the timeout out.
+    expect(Date.now() - started).toBeLessThan(5_000);
+  });
+
+  test("a live signal leaves a normal run alone", async () => {
+    const controller = new AbortController();
+    const result = await spawnWithTimeout(
+      ["echo", "hello"],
+      10_000,
+      controller.signal,
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("hello");
+  });
+});

--- a/assistant/src/util/__tests__/sqlite-retry.test.ts
+++ b/assistant/src/util/__tests__/sqlite-retry.test.ts
@@ -109,4 +109,62 @@ describe("withSqliteRetry", () => {
     // Initial attempt + 2 retries.
     expect(calls).toBe(3);
   });
+
+  test("an already-cancelled caller never attempts the write", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let calls = 0;
+
+    await expect(
+      withSqliteRetry(
+        () => {
+          calls += 1;
+          return "ok";
+        },
+        { op: "test-op", signal: controller.signal },
+      ),
+    ).rejects.toThrow();
+    expect(calls).toBe(0);
+  });
+
+  test("a cancel during the backoff stops the retry", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+
+    await expect(
+      withSqliteRetry(
+        () => {
+          calls += 1;
+          // The attempt threw, so nothing committed. Stopping here is safe.
+          controller.abort();
+          throw sqliteError("SQLITE_BUSY");
+        },
+        {
+          op: "test-op",
+          maxRetries: 3,
+          baseDelayMs: 1,
+          signal: controller.signal,
+        },
+      ),
+    ).rejects.toThrow();
+    expect(calls).toBe(1);
+  });
+
+  test("a caller with a live signal still retries", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+
+    const result = await withSqliteRetry(
+      () => {
+        calls += 1;
+        if (calls === 1) {
+          throw sqliteError("SQLITE_BUSY");
+        }
+        return "ok";
+      },
+      { op: "test-op", baseDelayMs: 1, signal: controller.signal },
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+  });
 });

--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -22,8 +22,13 @@ export const FFMPEG_PALETTE_TIMEOUT_MS = 30_000;
 export function spawnWithTimeout(
   cmd: string[],
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+      return;
+    }
     // Augment PATH so Homebrew-installed tools (ffmpeg, ffprobe)
     // are found even when the daemon runs as a bundled binary with minimal PATH.
     const proc = Bun.spawn(cmd, {
@@ -46,8 +51,16 @@ export function spawnWithTimeout(
       proc.kill();
       reject(new Error(`Process timed out after ${timeoutMs}ms: ${cmd[0]}`));
     }, timeoutMs);
+    // A cancelled caller stops the process rather than waiting out a transcode
+    // it has already been told never happened.
+    const onAbort = () => {
+      proc.kill();
+      reject(signal!.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
     proc.exited.then(async (exitCode) => {
       clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
       const stdout = await new Response(proc.stdout).text();
       const stderr = await new Response(proc.stderr).text();
       resolve({ exitCode, stdout, stderr });

--- a/assistant/src/util/sqlite-retry.ts
+++ b/assistant/src/util/sqlite-retry.ts
@@ -25,7 +25,7 @@
  */
 
 import { getLogger } from "./logger.js";
-import { computeRetryDelay } from "./retry.js";
+import { abortableSleep, computeRetryDelay } from "./retry.js";
 import { runWithSqliteQueryLabel } from "./sqlite-query-label.js";
 
 const log = getLogger("sqlite-retry");
@@ -50,6 +50,14 @@ export interface SqliteRetryOptions {
   baseDelayMs?: number;
   /** Extra structured fields to include in retry warnings (e.g. an id). */
   context?: Record<string, unknown>;
+  /**
+   * Cancellation for the work this write belongs to. Checked before every
+   * attempt and during the backoff, so a cancelled caller stops instead of
+   * sleeping and then landing its write. Only a retry is stopped this way: an
+   * attempt that already threw a retryable error did not commit, so there is
+   * nothing to undo. A write already in flight is never interrupted.
+   */
+  signal?: AbortSignal;
 }
 
 function sqliteErrorCode(err: unknown): string {
@@ -76,6 +84,7 @@ export async function withSqliteRetry<T>(
   const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
   const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
   for (let attempt = 0; ; attempt++) {
+    options.signal?.throwIfAborted();
     try {
       // The inner await must happen inside the label scope: a lazy thenable
       // (e.g. a Drizzle QueryPromise) executes its statement only when
@@ -93,7 +102,10 @@ export async function withSqliteRetry<T>(
           },
           "withSqliteRetry: transient SQLite error, retrying",
         );
-        await Bun.sleep(computeRetryDelay(attempt, baseDelayMs));
+        await abortableSleep(
+          computeRetryDelay(attempt, baseDelayMs),
+          options.signal,
+        );
         continue;
       }
       throw err;


### PR DESCRIPTION
An upcoming change makes a user message sent mid-turn abort the in-flight tool batch and tell the model the calls were interrupted. Today that claim is not true. `executeWithTimeout` is a bare `Promise.race`, the agent loop races the whole batch against the abort signal and `.catch(() => {})`s the abandoned promise, and every synthetic result reads "Cancelled by user". A tool that never reads `context.signal` keeps working: a file is written, a document is created, a message is sent, a phone rings, an image generation is paid for, all invisible to the model that believes none of it happened.

This PR does two things: it wires the abort signal into the tools that change state, and it makes the executor honest about the ones it still cannot stop.

## Audit

Every registered tool: `explicitTools` in `assistant/src/tools/tool-manifest.ts`, every bundled-skill tool with an `executor` in `assistant/src/config/bundled-skills/*/TOOLS.json`, the default plugin tools, and the proxy tools.

- **(a)** honours `context.signal` and stops.
- **(b)** short and side-effect-free, so ignoring the signal is harmless.
- **(c)** side-effecting and long enough that finishing after an abort matters.

### Registered tools (`explicitTools`) and default plugin tools

| tool | class | note |
| --- | --- | --- |
| `bash` | a | kills the process tree on abort |
| `host_bash` | a | kills the process tree on abort |
| `web_fetch` | a | signal threaded into `fetch` |
| `web_search` | a | provider call takes the signal |
| `code_search` | a | polls `signal.aborted` between files |
| `host_file_read` / `host_file_write` / `host_file_edit` / `host_file_transfer` | a | host proxy honours the signal |
| `ask_question` | a | resolves on abort |
| `recall` | a | forwards `context.signal` into agentic recall |
| `file_read` | b | read-only |
| `file_list` | b | read-only |
| `skill_load` | b | reads a skill into context |
| `skill_execute` | b | session-level dispatch stub; the sandbox runner honours the signal |
| `request_system_permission` | b | returns guidance text, no daemon-side effect |
| `watch_retro_report` | b | validates and returns |
| **`file_write`** | **c** | wired |
| **`file_edit`** | **c** | wired |
| **`remember`** | **c** | wired |
| **`delete_memory_page`** | **c** | wired |
| **`notify_parent`** | **c** | wired |
| **`react_to_message`** | **c** | wired |
| **`ui_show`** / **`ui_update`** | **c** | wired in the shared proxy executor |
| `ui_dismiss` | c, teardown | deliberately unguarded, see below |
| MCP tools | a | the MCP tool factory threads the signal |

### Bundled-skill tools

| tool | class | note |
| --- | --- | --- |
| `acp_status`, `acp_list_agents` | b | in-memory / PATH reads |
| `acp_abort` | c, teardown | deliberately unguarded |
| **`acp_spawn`**, **`acp_steer`** | **c** | auto-install plus a long-lived subprocess; steering can respawn one |
| `app_list` | b | in-memory list |
| **`app_create`**, **`app_update`**, **`app_delete`**, **`app_refresh`**, **`app_generate_icon`**, **`app_open`** | **c** | app rows, source-file writes, an esbuild spawn, a paid icon generation |
| `app_control_observe` | b | read-only capture |
| **`app_control_start/press/combo/sequence/type/click/drag`** | **c** | actuate the host |
| `app_control_stop` | c, teardown | deliberately unguarded |
| `computer_use_observe`, `computer_use_wait` | b | read-only capture, pure delay |
| **`computer_use_click/type_text/key/scroll/drag/open_app/run_applescript/respond`** | **c** | actuate the user's desktop |
| `computer_use_done` | c, teardown | deliberately unguarded |
| `contact_search`, `google_contacts` | b | read-only lookups |
| **`contact_merge`** | **c** | merges and destroys a contact record |
| `conversation_group_list` | b | DB read |
| **`conversation_group_create`**, **`conversation_move_to_group`** | **c** | writes plus a sync broadcast |
| `document_open`, `document_read`, `document_list`, `document_find`, `comment_list` | b | DB reads |
| **`document_create`**, **`document_update`**, **`document_delete`**, **`document_replace_text`**, **`comment_resolve`**, **`comment_reply`** | **c** | persist document and comment state |
| `followup_list` | b | DB read |
| **`followup_create`**, **`followup_resolve`** | **c** | persist follow-up state |
| **`media_generate_image`** | **c** | paid generation plus workspace writes |
| `media_status` | b | SQLite reads |
| **`ingest_media`**, **`extract_keyframes`**, **`analyze_keyframes`**, **`query_media`**, **`generate_clip`** | **c** | ffmpeg/ffprobe spawns, pipeline dirs, paid Gemini and LLM calls |
| `messaging_auth_test`, `messaging_list_conversations`, `messaging_read`, `messaging_search`, `messaging_sender_digest` | b | read-only provider calls |
| **`messaging_send`**, **`messaging_mark_read`**, **`messaging_analyze_style`**, **`messaging_draft`**, **`messaging_archive_by_sender`** | **c** | real sends, mailbox mutations, a paid style analysis, local draft writes |
| `call_status` | b | in-memory read |
| **`call_start`** | **c** | places a real outbound phone call |
| `call_end` | c, teardown | deliberately unguarded |
| `playbook_list` | b | SQLite select |
| **`playbook_create`**, **`playbook_update`**, **`playbook_delete`** | **c** | graph-node writes plus an embed job |
| `schedule_list` | b | store reads |
| **`schedule_create`**, **`schedule_update`**, **`schedule_delete`** | **c** | persist schedules that later run autonomously |
| `sequence_list`, `sequence_get`, `sequence_enrollment_list`, `sequence_analytics` | b | store reads |
| **`sequence_create`**, **`sequence_update`**, **`sequence_delete`**, **`sequence_enroll`**, **`sequence_import`** | **c** | persist sequences and schedule outbound email |
| **`voice_config_update`**, **`open_system_settings`**, **`navigate_settings_tab`** | **c** | config writes and client navigation the user sees |
| **`scaffold_managed_skill`**, **`delete_managed_skill`** | **c** | write and delete managed skill directories |
| **`find_similar_skills`** | **c** | paid embedding round-trip with retries |
| **`screen_point_at`** | **c** | draws on the screen the user is sharing |
| `screen_clear_marks` | c, teardown | deliberately unguarded |
| `subagent_status`, `subagent_read` | b | in-memory and row reads |
| **`subagent_spawn`**, **`subagent_message`** | **c** | launch or drive a paid autonomous child run |
| `subagent_abort` | c, teardown | deliberately unguarded |
| **`run_workflow`**, **`manage_workflows`** (`resume` only) | **c** | start or relaunch an autonomous multi-agent run |
| **`transcribe_media`** | **c** | ffmpeg transcode plus paid STT; only the chunk loop was covered before |

`visualize` and `system-storage-cleanup` declare no tools.

## What was wired

A new `assistant/src/tools/shared/abort.ts` exports `throwIfCancelled(context)`, a single documented place that calls `context.signal?.throwIfAborted()`. Throwing the signal's own reason matters: the daemon aborts with a tagged `AbortReason`, and the tool executor already classifies that as an expected cancellation rather than a tool failure.

Each class (c) tool calls it at the earliest point on the mutating path where it has validated its own input, before the first store read, network round-trip, or process spawn. On a turn the user already cancelled, the tool should not spend those either, and the uniform placement is what makes the guard test below able to reach every tool without pre-seeded world state. Tools with a read-only branch selected by input (`messaging_draft` list, `manage_workflows` status, `sequence_import` preview) keep the guard inside the mutating branch only.

The two proxy families each guard in one shared bridge (`app-control/skill-proxy-bridge.ts`, `computer-use/skill-proxy-bridge.ts`), covering fifteen tools between them.

**Teardown calls stay unguarded on purpose.** `app_control_stop`, `computer_use_done`, `ui_dismiss`, `acp_abort`, `subagent_abort`, `call_end` and `screen_clear_marks` exist to stop something. Refusing them on a cancelled turn would strand the session they close, or leave arrows drawn on a screen the user is sharing, which is the opposite of what a user pressing Stop wants. Teardown is read off the wire name in the two proxy bridges, except `screen_clear_marks`, which shares its wire name with `screen_point_at` and so declares the exemption at the call site.

Two layers turned a cancellation back into a tool error on the way out, and now re-throw it instead: the bundled-skill host runner (`skill-script-runner.ts`), and a few tool-local catches that convert throws into `{ isError: true }` results (`messaging_send`, `generate_clip`, `media_generate_image`). `extractAbortReason` moved out of `executor.ts` into the new module so both sides share one definition of what a cancellation looks like.

Where an underlying call already accepted a signal, it now gets the turn's, with one deliberate exception covered under "Cancelling a dispatched IPC call would lie" below.

## Executor wording

`assistant/src/agent/loop.ts` now tracks each dispatched call's settlement state. After an abort it waits a bounded 50ms grace (`ABORT_SETTLE_GRACE_MS`, returning as soon as every call settles) so a tool that honours the signal reports its real outcome, then writes a per-call result:

- a call that settled keeps its real content and `is_error`;
- a call still in flight gets **"Cancelled by user before the tool finished; it may still have completed, check before repeating it."**;
- a batch cancelled before dispatch keeps the plain "Cancelled by user", because nothing ran.

`executeWithTimeout` gains the same honesty in miniature: a tool that settles in the tick its timer fires now returns its real result instead of the timeout hedge. `trackSettlement` lives in `execution-timeout.ts` alongside the two message constants, so the loop and the executor share one vocabulary for "abandoned while possibly still running".

Behaviour is unchanged for tools that honour the signal and reject promptly: they settle inside the grace window and their real result reaches the model.

## Guard test

`assistant/src/tools/__tests__/side-effect-abort-guard.test.ts` enumerates the class (c) tools by name and asserts each one's execute, given an already-aborted signal and a lightweight fake context, rejects with the signal's own reason rather than validating, looking anything up, or acting. Skill tools are resolved through their skill's `TOOLS.json` executor entry, so the test follows the manifest rather than hard-coding paths. The list is explicit on purpose: a new side-effecting tool has to be added, and adding it fails until the tool honours the signal.

The memory plugin inlines `context.signal?.throwIfAborted()` rather than importing the shared helper, so the plugin-import boundary allowlist does not grow.

## Verification

- `bun run typecheck:fast` clean.
- `bun run lint` clean.
- `side-effect-abort-guard` 77 pass.
- `agent-loop` 61, `parallel-tool.benchmark` 4, `conversation-abort-tool-results` 2, `tool-executor` 85, `plugin-import-boundary-guard` 5.
- Review-round suites, rebased on `main`: `call-domain` 16 (two new cancellation cases), `call-start-guardian-guard` 4, `tool-execution-abort-cleanup` 20, `screen-annotation` 11 (two new cancellation cases).
- Adjacent tool suites, each run scoped: `schedule-tools` 102, `subagent-tools` 182, `sqlite-retry` 10, `spawn-abort` 3, `preprocess` 33, `audio-transcribe` 9, `find-similar-skills` 15, `file-ops-service` 36, `acp/session-manager` 19, `conversation-skill-tools` 90, `scaffold-managed-skill-tool` 61, `media-generate-image` 37, `active-skill-tools` 37, `computer-use-tools` 26, `followup-tools` 24, `conversation-group-tools` 20, `app-builder-tool-scripts` 20, `document-tool-security` 19, `memory/tools` 19, `playbook-tools` 18, `file-write-tool` 15, `react-to-message` 12, `contacts-tools` 14, `messaging-send-tool` 13, `delete-managed-skill-tool` 6, `app-control-flow` 4, `navigate-settings-tab` 4, `open-system-settings` 4, `computer-use-skill-proxy-bridge` 3, `request-permission` 3, `skill-boundary-guard` 2. All green.

Two existing abort assertions changed on purpose: the stuck-tool case in `agent-loop.test.ts` and the parallel-abort case in `parallel-tool.benchmark.test.ts` both drive tools that ignore the signal, so they now expect the unsettled wording. Cancellation still lands in ~117ms there, inside the existing 200ms bound.

## Review follow-ups

Two review passes landed on top of the original change.

**The guard runs where the spend is.** An entry guard is not enough wherever an `await` sits between it and the mutation. Every class (c) tool was swept for that gap; these gained a recheck immediately before the side effect, and their local catch now re-throws the abort instead of rendering it as a tool failure:

| tool | the await that opened the gap |
| --- | --- |
| `messaging_mark_read`, `messaging_archive_by_sender` | provider and connection resolution |
| `messaging_analyze_style` | provider resolution, the message search, and the paid analysis |
| `messaging_send` | attachment reads before the send |
| `analyze_keyframes` | credential and manifest loading |
| `media_generate_image` | credential resolution and source-image reads |
| `file_write`, `file_edit` | the write lock and the previous-content read (checked inside `FileSystemOps`, where the bytes land) |
| `acp_spawn` | adapter auto-install and agent-env preparation |
| `voice_config_update` | the managed-speech reachability probe |
| `contact_merge` | the two contact existence lookups |
| `app_generate_icon` | the dynamic imports before the icon rename |
| `call_start` | caller-identity resolution, the ingress preflight, and the two callback-URL lookups (checked in `startCall`, on both sides of the state it creates) |
| `subagent_spawn` | the manager's conversation bootstrap and provider resolution (checked in `manager.spawn`, on both sides of setup) |
| `messaging_send` | the Gmail thread and profile lookups, before each of the four draft branches |
| `screen_point_at` | shares the computer-use proxy bridge's guard |
| `messaging_send` (Outlook) | provider and connection resolution and the attachment reads, before each of the two Graph draft branches |
| `analyze_keyframes` (Gemini upload) | the file-size stat and the pipeline mkdir, before a file up to 2 GB starts uploading |
| `schedule_create`, `schedule_update`, `schedule_delete` | the SQLite contention backoff inside `withSqliteRetry` |
| `acp_steer` | cancelling the in-flight prompt, and restoring a session from history |
| `app_generate_icon` | credential resolution before the paid generation |
| `extract_keyframes` | the processing-state write, dead-time detection, each segment, transcription, palette analysis, and the commit that replaces the asset's keyframes |
| `transcribe_media` | the ffprobe duration read, the chunk split, and the WAV transcode (its STT calls were already covered) |
| `ingest_media` | the ffprobe duration read |
| `generate_clip` | the ffprobe read, both transcodes, and the attachment registration |
| `find_similar_skills` | the embedding round-trip and its retry backoff |
| `acp_spawn` | the protocol handshake and session creation, with the child process already running |
| `file_write` | the write lock, checked before `ensureDir` creates parent directories |

**A stopped turn never dials, and never launches a paid child.** Two of those rows are worth more than a table cell, because the recheck alone was not enough: both leave state behind.

`call_start` threads the turn signal into `startCall`. The early check sits before `createCallSession`, so a cancel during identity resolution or the ingress preflight leaves no call session, no voice conversation and no keepalive lease. The late check sits immediately before `provider.initiateCall()`, where that state does exist, so it marks the session `cancelled` and releases the lease before letting the abort out. `startCall`'s catch re-throws an abort ahead of its failure path, so a stopped turn does not also post a "call failed" pointer into the conversation.

`subagent_spawn` hands `manager.spawn` the turn signal. An already-aborted signal raises `SubagentSpawnCancelledError` before setup runs; a cancel landing mid-setup finds the child registered but not started, so the manager marks it terminal, lets `runSubagent`'s early-terminal guard release the conversation without starting the agent loop, and then raises the same error. Raising rather than returning the id is the point: the tool would otherwise answer `isError: false` with `status: "pending"` for a child that is already terminal, and the next model turn would wait on a run that can never produce anything. The signal is read once into `cancelledDuringSetup`, so an abort landing between the abort and the throw cannot report a cancellation for a run that is already going. The tool renders the error as `isError: false` with "was not spawned": no child ran, so there is nothing for the model to recover from.

This is otherwise the same shape as #42187 so the two branches merge cleanly. Note that #42187 currently carries the same fall-through to `return subagentId` and needs the same guard.

**Cancelling a dispatched IPC call would lie.** `contact_merge`'s destructive `merge_contacts` call, and the read-back after it, are deliberately detached from the turn signal. `cliIpcCall` destroys only the client socket, so an abort after the request is on the wire resolves a quick `{ ok: false, error: "Request aborted" }` while the assistant route and the gateway finish the merge anyway. That fast resolution settles inside the 50ms grace and would hand the model an ordinary failure for a merge that destroyed a contact. Detached, the call stays unsettled, the loop writes the "may still have completed" wording, and the model is told to check before repeating it. The existence lookups before the merge still carry the signal, and the recheck between them and the merge still stops a cancel that lands pre-dispatch.

**A retry is not a licence to land the write.** `withSqliteRetry` sleeps and re-runs on transient `SQLITE_BUSY` / `SQLITE_IOERR`, so a cancelled caller could wait out a backoff and then commit. It takes an optional `signal` now, checked before every attempt and passed to the backoff via `abortableSleep`. Only a retry is stopped this way: an attempt that threw a retryable error did not commit, so nothing is left half-applied, and a write already in flight is never interrupted. `createSchedule` threads the turn's signal through as a `ScheduleWriteOptions` argument, keeping cancellation out of the row data. The wrapper has only two consumers, `schedule-store` and the memory plugin; the followup, playbook and sequence writes do not retry, so they have no such window.

**A cancellation has to survive the wrappers on the way out.** Rechecking is useless if a local catch reshapes the abort into something the executor cannot recognise. Three cases needed that as much as they needed the guard. `acp_steer`: `steerOrResume` wraps failures in `AcpResumeError`, and a stop landing during a plain steer could fall through to the resume path and spawn an agent for a turn the user had ended, so aborts now escape all three catches unwrapped (the just-resumed session is still torn down first). `app_generate_icon`: `generateAppIcon` logged every failure as a skipped generation, and the executor moves the user's existing icon aside before generating, so the rethrow is paired with putting the backup back. `sequence_enroll`, described above, was the same shape.

**A commit has to be uninterruptible, not just guarded.** `extract_keyframes` swapped its frames directory into place before building the subject registry, so on a reprocess the previous run's frames were already deleted and the new set renamed in while cancellable work still followed. A cancel there left disk and DB disagreeing: new frames described by the old keyframe rows. The registry reads the frames under the temp directory instead, which lets the swap join the keyframe rows, the manifest and the stage transition in one step after the last checkpoint.

**A long subprocess is stopped, not just checked around.** `spawnWithTimeout` already killed on timeout, so it takes a signal and kills on abort too. A single ffmpeg pass can hold a core for minutes, so `extract_keyframes` threads the signal into all three of its spawns rather than only checking between segments.

## The sweep, and what stays non-abortable

Every `spawnWithTimeout`, `withSqliteRetry`, `simBatch` / embedding, `generateContent`, `transcribe`, `generateImage`, raw `fetch` and provider `sendMessage` call in `assistant/src` was traced back to see whether a tool execute path reaches it. Everything reachable now carries the turn signal, except the entries below, each left alone for a stated reason rather than an oversight.

**Deliberate: aborting would be a lie.**

- `call_start`'s Twilio `POST /Calls.json`. The domain rechecks immediately before it, but the request itself is the point of no return: aborting the POST does not un-place a call Twilio has already accepted, so cancelling here could report a cancellation for a phone that is ringing. Same reasoning as `contact_merge` above.
- `messaging_send`'s `provider.sendMessage`. Send-once, and `SendOptions` carries no signal, so every adapter would have to change to gain an abort that risks the same false negative. The checkpoint immediately before it is the honest guard.

**Deliberate: already detached from the turn.**

- The background app-icon generation in `tool-side-effects.ts`. It is fire-and-forget after `app_create` succeeded; the app exists, so its icon should still arrive. The turn-scoped `app_generate_icon` path does take the signal.
- `scaffold_managed_skill`'s notification emit, which is a `void` call the turn never awaits.

**Deliberate: the write must finish.**

- `resolveProactiveHomeConversation`, reached from `messaging_send`. It runs after the message is already sent, to record the delivered post. Stopping it would lose the record of a send that happened.
- `bootstrapConversation`'s row write, reached from `subagent_spawn`. Its retry backoff is sub-second, and `manager.spawn` rechecks the signal the moment it returns and marks the child terminal. Threading an abort into a partially-created conversation buys nothing and risks leaving one half-written.

**Not reachable from a turn.** The HTTP STT route's three ffmpeg helpers (a near-verbatim duplicate of `transcribe_media`'s, worth collapsing separately), the avatar generator (route-driven, not a tool), and every `withSqliteRetry` owned by the scheduler tick, plugin reconciler, memory retrospective worker, outbound-post reconciler, or the daemon conversation loop. None of these has a turn to be cancelled with.

**Read-only, so out of scope.** `google_contacts` pagination and the messaging read/search/list tools are long but side-effect-free; this PR is about work that changes state or costs money.

**Cancellation reaches the provider.** Where a request carried only its own deadline it now runs under that deadline composed with the turn's signal via `AbortSignal.any`, so stopping the turn aborts the paid call rather than abandoning it: `transcribe_media` (STT, both the single-shot and per-chunk paths), `query_media` (the 120s reduce deadline), `messaging_analyze_style` (the 30s analysis deadline), `media_generate_image` (threaded into the Gemini and OpenAI clients), and `analyze_keyframes` (the Gemini map fan-out and the direct-video upload, poll and generation).

**Aborts stop being reported as failures.** Twenty catches that converted throws into `{ isError: true }` now re-throw an abort first. The one that mattered most is `sequence_enroll`: its per-email catch was recording the abort as one contact's failure and then enrolling the next address.

**Grace-settled results take the normal path.** A call that finishes inside the 50ms grace ran, so it is no longer labelled a cancellation and no longer bypasses the pipeline: it is spooled and passed through the `post-tool-use` truncation hooks like any other result, then emitted with its diff, contentBlocks, status and risk metadata intact so the daemon does the bookkeeping its side effects need. `cancelled: true` is now set only for a synthetic result. The normal path and the abort path build that event and finalize those blocks through one shared function each.

**One guard, one owner.** `throwIfCancelled` lives on the `@vellumai/plugin-api` surface, the only module a plugin may import from, so the memory tools and every host tool share it. The plugin-import allowlist did not grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oPSTYuVjkzuXHZskHfpTm

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->






