### PR TITLE
refactor(memory-v3): remove the unused selector pinned flag

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9985,8 +9985,6 @@ paths:
                                   type: string
                                 source:
                                   type: string
-                                pinned:
-                                  type: boolean
                                 sectionOrdinal:
                                   anyOf:
                                     - type: number
@@ -9998,7 +9996,6 @@ paths:
                               required:
                                 - slug
                                 - source
-                                - pinned
                               additionalProperties: false
                           injectedText:
                             type: string
@@ -22193,8 +22190,6 @@ paths:
                                   type: string
                                 source:
                                   type: string
-                                pinned:
-                                  type: boolean
                                 sectionOrdinal:
                                   anyOf:
                                     - type: number
@@ -22206,7 +22201,6 @@ paths:
                               required:
                                 - slug
                                 - source
-                                - pinned
                               additionalProperties: false
                           injectedText:
                             type: string

--- a/assistant/src/api/responses/memory-v3-selection-log.ts
+++ b/assistant/src/api/responses/memory-v3-selection-log.ts
@@ -30,14 +30,13 @@ import { z } from "zod";
  * the daemon emits `core`, `hot`, `needle`, `dense`, or `edge` (historical
  * rows may carry retired labels) — but the schema stays a permissive string
  * so a new lane label (or a historical pre-lane row) doesn't break parsing on
- * the FE. `pinned` marks a page the turn was centrally about.
- * `sectionOrdinal`/`sectionHeading` identify the matched section a finder lane
- * surfaced (null for core/hot/fresh/edge selections and pre-migration rows).
+ * the FE. `sectionOrdinal`/`sectionHeading` identify the matched section a
+ * finder lane surfaced (null for core/hot/fresh/edge selections and
+ * pre-migration rows).
  */
 export const MemoryV3SelectionRowSchema = z.object({
   slug: z.string(),
   source: z.string(),
-  pinned: z.boolean(),
   // The matched section a finder lane surfaced for this selection. Null for
   // core/hot/fresh/edge selections with no matched section, and for rows
   // written before the section columns existed. Optional + nullable so older

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/carry-integration.test.ts
@@ -416,8 +416,8 @@ async function buildFixtureLanes(): Promise<FixtureLanes> {
   // with distinct frecency so the hot order is deterministic.
   const seed = memorySqlite.query(/*sql*/ `
     INSERT INTO memory_v3_selections
-      (conversation_id, turn, slug, source, pinned, created_at)
-    VALUES (?, ?, ?, 'needle', 0, ?)
+      (conversation_id, turn, slug, source, created_at)
+    VALUES (?, ?, ?, 'needle', ?)
   `);
   const seedCounts: Array<[Slug, number]> = [
     ["hot-one", 3],

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/dense.test.ts
@@ -4,7 +4,7 @@ import type { AssistantConfig } from "../../../../../config/types.js";
 
 // Keep the real exports (e.g. getQdrantClient) so this partial mock is harmless
 // when section-dense-store's transitive imports pull them in; only
-// resolveQdrantUrl is pinned to a fixed URL.
+// resolveQdrantUrl is stubbed to a fixed URL.
 const realQdrantClient =
   await import("../../../../../persistence/embeddings/qdrant-client.js");
 mock.module("../../../../../persistence/embeddings/qdrant-client.js", () => ({

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -238,7 +238,7 @@ function result(
   matched: Array<[Slug, Section]> = [],
 ): OrchestrateResult {
   return {
-    selections: slugs.map((slug) => ({ slug, pinned: false })),
+    selections: slugs.map((slug) => ({ slug })),
     matchedSections: new Map(matched),
     lanes: {
       core: [],

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -222,23 +222,19 @@ function candidateSlugs(messages: Message[]): Slug[] {
   return entries.sort((a, b) => a.id - b.id).map((e) => e.slug);
 }
 
-/** Provider that selects (and optionally pins) the pooled candidates in `keep`. */
-function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
+/** Provider that selects the pooled candidates in `keep`. */
+function selectProvider(keep: Slug[]): Provider {
   return {
     name: "stub",
     sendMessage: async (messages) => {
       const pool = candidateSlugs(messages);
       const ids: number[] = [];
-      const pinned_ids: number[] = [];
       pool.forEach((slug, i) => {
         if (keep.includes(slug)) {
           ids.push(i + 1);
         }
-        if (pin.includes(slug)) {
-          pinned_ids.push(i + 1);
-        }
       });
-      return toolUseResponse({ ids, pinned_ids });
+      return toolUseResponse({ ids });
     },
   };
 }

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -304,14 +304,14 @@ function parsePool(messages: Message[]): {
 
 /**
  * Provider that selects the pool candidates whose slug is in `keep` (mapping
- * each back to its 1-based id), pinning those in `pin`. Captures the rendered
- * candidate list (slugs and raw lines) for pool assertions.
+ * each back to its 1-based id). Captures the rendered candidate list (slugs
+ * and raw lines) for pool assertions.
  */
 let lastPool: Slug[] = [];
 let lastPoolLines: string[] = [];
 let lastPrefixBlock: string | null = null;
 let selectCalls = 0;
-function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
+function selectProvider(keep: Slug[]): Provider {
   return {
     name: "stub",
     sendMessage: async (messages) => {
@@ -321,16 +321,12 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
       lastPoolLines = parsed.lines;
       lastPrefixBlock = parsed.prefixBlock;
       const ids: number[] = [];
-      const pinned_ids: number[] = [];
       parsed.slugs.forEach((slug, i) => {
         if (keep.includes(slug)) {
           ids.push(i + 1);
         }
-        if (pin.includes(slug)) {
-          pinned_ids.push(i + 1);
-        }
       });
-      return toolUseResponse({ ids, pinned_ids });
+      return toolUseResponse({ ids });
     },
   };
 }
@@ -402,7 +398,7 @@ describe("orchestrate — candidate pool composition", () => {
     expect(lastPool).toContain(CAP);
   });
 
-  test("always-candidate slugs are pinned into the stable prefix and are selectable", async () => {
+  test("always-candidate slugs are placed in the stable prefix and are selectable", async () => {
     const lanes = await buildLanes();
     const WF: Slug = "skills/workflows";
     // No retrieval lane surfaces WF for "apple" (hits topic-a/b/d) — it reaches
@@ -780,7 +776,7 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
     ).toContain("apple");
     // Selecting both ids still yields ONE selection (slug dedup), the finder
     // lane records the hit, and the matched section survives downstream.
-    expect(result.selections).toEqual([{ slug: "topic-a", pinned: false }]);
+    expect(result.selections).toEqual([{ slug: "topic-a" }]);
     expect(result.lanes.finder.map((c) => c.slug)).toContain("topic-a");
     expect(result.matchedSections.get("topic-a")?.text).toContain("apple");
   });
@@ -817,13 +813,6 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
     providerStub = selectProvider(["topic-b"]);
     const t2 = await orchestrate(makeTurn(2, "cherry"), deps);
     expect(t2.selections.map((s) => s.slug)).toEqual(["topic-b"]);
-  });
-
-  test("pinned flags survive selection dedup", async () => {
-    const lanes = await buildLanes();
-    providerStub = selectProvider(["topic-a"], ["topic-a"]);
-    const result = await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
-    expect(result.selections).toEqual([{ slug: "topic-a", pinned: true }]);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -9,9 +9,9 @@
  *     un-cached block.
  *   - Numbering stability: for identical stable lanes the rendered prefix
  *     block is byte-identical across renders; only the tail varies.
- *   - Returned IDs map over the CONCATENATED numbering, with `pinned` driven
- *     by `pinned_ids`; out-of-range IDs dropped; selections deduped by slug
- *     (a page can appear as both a card and a finder line; pinned flags OR).
+ *   - Returned IDs map over the CONCATENATED numbering; out-of-range IDs and
+ *     unknown input keys are ignored; selections deduped by slug (a page can
+ *     appear as both a card and a finder line).
  *   - Omitted `ids` → keep ALL candidates (recall-safe, slug-deduped).
  *   - Explicit `ids: []` → keep none (deliberate abstention) — a normal result.
  *   - Empty candidate pool → keep none (nothing to select).
@@ -214,26 +214,28 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("selectPool — id mapping", () => {
-  test("IDs map over cards then finder lines, pinned driven by pinned_ids", async () => {
-    providerStub = makeProvider(
-      toolUseResponse({ ids: [3, 1], pinned_ids: [1] }),
-    );
+  test("IDs map over cards then finder lines in selection order", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [3, 1] }));
     const result = await selectPool(makePool(), makeTurn("how's the rollout?"));
-    expect(result.pages).toEqual([
-      { slug: "topic-x", pinned: false },
-      { slug: "page-a", pinned: true },
-    ]);
+    expect(result.pages).toEqual([{ slug: "topic-x" }, { slug: "page-a" }]);
     expect(result.keptAll).toBe(false);
   });
 
-  test("a page selected as both card and finder line dedupes to one slug, pinned ORed", async () => {
-    // page-a is id 1 (card) AND id 4 (finder line); pinned only via the
-    // finder-line id.
-    providerStub = makeProvider(
-      toolUseResponse({ ids: [1, 4], pinned_ids: [4] }),
-    );
+  test("a page selected as both card and finder line dedupes to one slug", async () => {
+    // page-a is id 1 (card) AND id 4 (finder line).
+    providerStub = makeProvider(toolUseResponse({ ids: [1, 4] }));
     const result = await selectPool(makePool(), makeTurn("the alpha plan"));
-    expect(result.pages).toEqual([{ slug: "page-a", pinned: true }]);
+    expect(result.pages).toEqual([{ slug: "page-a" }]);
+    expect(result.keptAll).toBe(false);
+  });
+
+  test("unknown input keys are ignored and ids still selects", async () => {
+    // The input schema is non-strict: a stray key alongside `ids` (e.g. one a
+    // prompt override still asks the model for) neither fails parsing nor
+    // changes the selection.
+    providerStub = makeProvider(toolUseResponse({ ids: [2], extra_ids: [1] }));
+    const result = await selectPool(makePool(), makeTurn("the metrics"));
+    expect(result.pages).toEqual([{ slug: "page-b" }]);
     expect(result.keptAll).toBe(false);
   });
 
@@ -241,9 +243,9 @@ describe("selectPool — id mapping", () => {
     providerStub = makeProvider(toolUseResponse({}));
     const result = await selectPool(makePool(), makeTurn("anything"));
     expect(result.pages).toEqual([
-      { slug: "page-a", pinned: false },
-      { slug: "page-b", pinned: false },
-      { slug: "topic-x", pinned: false },
+      { slug: "page-a" },
+      { slug: "page-b" },
+      { slug: "topic-x" },
     ]);
     // The fallback fired — the model gave up judging, not "selected everything".
     expect(result.keptAll).toBe(true);
@@ -260,7 +262,7 @@ describe("selectPool — id mapping", () => {
   test("out-of-range and duplicate IDs are ignored without throwing", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [2, 99, 0, -1, 2] }));
     const result = await selectPool(makePool(), makeTurn("the metrics"));
-    expect(result.pages).toEqual([{ slug: "page-b", pinned: false }]);
+    expect(result.pages).toEqual([{ slug: "page-b" }]);
     expect(result.keptAll).toBe(false);
   });
 
@@ -455,7 +457,7 @@ describe("selectPool — infrastructure failures throw", () => {
       toolUseResponse({ ids: [2] }),
     ]);
     const result = await selectPool(makePool(), makeTurn("the metrics"));
-    expect(result.pages).toEqual([{ slug: "page-b", pinned: false }]);
+    expect(result.pages).toEqual([{ slug: "page-b" }]);
     expect(result.keptAll).toBe(false);
     expect(providerCalls).toHaveLength(2);
   });
@@ -477,7 +479,12 @@ describe("selectPool — request shape", () => {
     expect(cfg?.callSite).toBe("memoryV3SelectL2");
     expect(cfg?.tool_choice).toEqual({ type: "tool", name: "select_pages" });
     expect(cfg?.disableTurnStartCache).toBe(true);
-    expect(call.options?.tools?.[0]?.name).toBe("select_pages");
+    const tool = call.options?.tools?.[0];
+    expect(tool?.name).toBe("select_pages");
+    const inputSchema = tool?.input_schema as {
+      properties?: Record<string, unknown>;
+    };
+    expect(Object.keys(inputSchema.properties ?? {})).toEqual(["ids"]);
   });
 
   test("stable prefix renders full cards in its own block carrying cache_control", async () => {
@@ -593,7 +600,7 @@ describe("selectPool — request shape", () => {
     );
   });
 
-  test("system prompt is carry-aware and generous (persistence + pinned + no limit)", async () => {
+  test("system prompt is carry-aware and generous (persistence + no limit)", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectPool(makePool(), makeTurn("x"));
     const prompt = providerCalls[0].options?.systemPrompt ?? "";
@@ -601,7 +608,5 @@ describe("selectPool — request shape", () => {
     expect(prompt).toMatch(/persist/);
     // Generous: explicitly no selection limit.
     expect(prompt).toMatch(/no limit/i);
-    // Pinning commitment.
-    expect(prompt).toMatch(/pinned/);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -10,7 +10,7 @@
  *   - NO blind fallback to a neighbouring turn/message;
  *   - the fork fallback: a turn inherited from a fork resolves to the parent's
  *     rows via the message's `forkSourceMessageId` back-pointer;
- *   - source/pinned/section mapping and the rendered `<memory>` block;
+ *   - source/section mapping and the rendered `<memory>` block;
  *   - `live` reflects the config gate.
  *
  * `mock.module` is process-global and leaks into sibling files in a
@@ -66,7 +66,6 @@ function seed(
   rows: Array<{
     slug: string;
     source: string;
-    pinned?: boolean;
     sectionOrdinal?: number;
     sectionTitle?: string;
   }>,
@@ -74,9 +73,9 @@ function seed(
 ): void {
   const stmt = memorySqlite.query(
     `INSERT INTO memory_v3_selections
-       (conversation_id, turn, slug, source, pinned, created_at,
+       (conversation_id, turn, slug, source, created_at,
         message_id, section_ordinal, section_title)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   for (const r of rows) {
     stmt.run(
@@ -84,7 +83,6 @@ function seed(
       turn,
       r.slug,
       r.source,
-      r.pinned ? 1 : 0,
       1000 + turn,
       messageId,
       r.sectionOrdinal ?? null,
@@ -196,14 +194,14 @@ describe("getMemoryV3SelectionForInspector", () => {
     expect(await getMemoryV3SelectionForInspector("conv-3", 3)).toBeNull();
   });
 
-  test("maps source/pinned/section and renders the <memory> block", async () => {
+  test("maps source/section and renders the <memory> block", async () => {
     // The second row carries a retired free-text source label (the column is
     // permissive); the inspector passes it through verbatim. Neither row has a
     // matched section, so section fields are null and the block falls back to
     // full pages.
     seed("conv-4", 1, [
-      { slug: "domain-a/page-1", source: "edge", pinned: true },
-      { slug: "domain-b/page-2", source: "legacy-carry", pinned: false },
+      { slug: "domain-a/page-1", source: "edge" },
+      { slug: "domain-b/page-2", source: "legacy-carry" },
     ]);
 
     const log = await getMemoryV3SelectionForInspector("conv-4", 1);
@@ -211,14 +209,12 @@ describe("getMemoryV3SelectionForInspector", () => {
       {
         slug: "domain-a/page-1",
         source: "edge",
-        pinned: true,
         sectionOrdinal: null,
         sectionHeading: null,
       },
       {
         slug: "domain-b/page-2",
         source: "legacy-carry",
-        pinned: false,
         sectionOrdinal: null,
         sectionHeading: null,
       },
@@ -273,14 +269,12 @@ describe("getMemoryV3SelectionForInspectorByMessageIds", () => {
       {
         slug: "domain-a/page-1",
         source: "needle",
-        pinned: false,
         sectionOrdinal: 2,
         sectionHeading: "Heading A",
       },
       {
         slug: "domain-b/page-2",
         source: "core",
-        pinned: false,
         sectionOrdinal: null,
         sectionHeading: null,
       },
@@ -388,7 +382,7 @@ describe("summarizeSelections", () => {
     ]);
     // Turn 2: page-1 re-selected (needle) + page-2 re-surfaced by edge.
     seed("conv-a", 2, [
-      { slug: "domain-a/page-1", source: "needle", pinned: true },
+      { slug: "domain-a/page-1", source: "needle" },
       { slug: "domain-b/page-2", source: "edge" },
     ]);
     // A different conversation must not bleed into the aggregate.

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -259,12 +259,12 @@ function candidateSlugs(messages: Message[]): Slug[] {
 
 /**
  * Provider that selects the pooled candidates in `keep` (mapping each back to
- * its 1-based id), pinning those in `pin`. Records the rendered pool and counts
- * the select calls so the test can assert one select per turn over the union.
+ * its 1-based id). Records the rendered pool and counts the select calls so
+ * the test can assert one select per turn over the union.
  */
 let lastPool: Slug[] = [];
 let selectCalls = 0;
-function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
+function selectProvider(keep: Slug[]): Provider {
   return {
     name: "stub",
     sendMessage: async (messages) => {
@@ -272,16 +272,12 @@ function selectProvider(keep: Slug[], pin: Slug[] = []): Provider {
       const pool = candidateSlugs(messages);
       lastPool = pool;
       const ids: number[] = [];
-      const pinned_ids: number[] = [];
       pool.forEach((slug, i) => {
         if (keep.includes(slug)) {
           ids.push(i + 1);
         }
-        if (pin.includes(slug)) {
-          pinned_ids.push(i + 1);
-        }
       });
-      return toolUseResponse({ ids, pinned_ids });
+      return toolUseResponse({ ids });
     },
   };
 }
@@ -309,7 +305,6 @@ async function runTurn(
   turnNumber: number,
   query: string,
   keep: Slug[],
-  pin: Slug[],
   deps: {
     lanes: Awaited<ReturnType<typeof buildLanes>>;
     core?: Slug[];
@@ -319,7 +314,7 @@ async function runTurn(
     denseK?: number;
   },
 ): Promise<OrchestrateResult> {
-  providerStub = selectProvider(keep, pin);
+  providerStub = selectProvider(keep);
   const stableSlugs = [...(deps.core ?? []), ...(deps.hot ?? [])];
   const result = await orchestrate(makeTurn(turnNumber, query), {
     sectionIndex: deps.lanes.sectionIndex,
@@ -367,7 +362,7 @@ describe("memory-v3 integration — candidate pool", () => {
     // does NOT match the capability page, so it is not pooled this turn —
     // capability pages are lane-ranked, not always-added.
     denseHits = [{ article: "page-b", section: 0 }];
-    await runTurn(1, "apple", [], [], { lanes, denseK: 100 });
+    await runTurn(1, "apple", [], { lanes, denseK: 100 });
 
     expect(selectCalls).toBe(1);
     expect(new Set(lastPool)).toEqual(new Set(["page-a", "page-b", "topic-x"]));
@@ -377,7 +372,7 @@ describe("memory-v3 integration — candidate pool", () => {
     const lanes = await buildLanes();
     // "durian" is the distinctive term in the capability page's content, so the
     // real needle ranks it and folds it into the pool.
-    await runTurn(1, "durian", [], [], { lanes });
+    await runTurn(1, "durian", [], { lanes });
 
     expect(selectCalls).toBe(1);
     expect(lastPool).toContain(CAPABILITY_SLUG);
@@ -397,7 +392,7 @@ describe("memory-v3 integration — core + hot stable prefix", () => {
 
     // Turn 1: "apple" hits page-a (needle). The prefix precedes it in pool
     // order even though the query never matches topic-x / page-b.
-    const t1 = await runTurn(1, "apple", ["topic-x", "page-a"], [], {
+    const t1 = await runTurn(1, "apple", ["topic-x", "page-a"], {
       lanes,
       ...prefix,
     });
@@ -412,7 +407,7 @@ describe("memory-v3 integration — core + hot stable prefix", () => {
     // Turn 2: a different query — the stable prefix is unchanged, the finder
     // tail differs, and turn 1's un-re-selected page-a does NOT reappear in
     // the result (no carry in orchestration).
-    const t2 = await runTurn(2, "durian", ["page-b"], [], { lanes, ...prefix });
+    const t2 = await runTurn(2, "durian", ["page-b"], { lanes, ...prefix });
     expect(lastPool.slice(0, 2)).toEqual(["topic-x", "page-b"]);
     expect(t2.selections.map((s) => s.slug)).toEqual(["page-b"]);
     expect(loggedSources(2)).toEqual([{ slug: "page-b", source: "hot" }]);
@@ -423,12 +418,12 @@ describe("memory-v3 integration — core + hot stable prefix", () => {
     // "apple" hits page-a via the needle, but page-a is CORE — the pool lists
     // it twice (stable-prefix card + finder snippet line, by design), the
     // selection dedupes to one slug, and the row attributes to core.
-    const result = await runTurn(1, "apple", ["page-a"], [], {
+    const result = await runTurn(1, "apple", ["page-a"], {
       lanes,
       core: ["page-a"],
     });
     expect(lastPool.filter((s) => s === "page-a")).toHaveLength(2);
-    expect(result.selections).toEqual([{ slug: "page-a", pinned: false }]);
+    expect(result.selections).toEqual([{ slug: "page-a" }]);
     expect(result.lanes.finder.map((c) => c.slug)).toContain("page-a");
     expect(loggedSources(1)).toEqual([{ slug: "page-a", source: "core" }]);
   });
@@ -446,7 +441,7 @@ describe("memory-v3 integration — lane-source attribution", () => {
     // "durian" matches the capability page's content section, so selecting it
     // records a `matchedSections` entry and the lane mapping attributes it
     // `needle` (capabilities are indexed pages now, not sectionless add-ins).
-    const result = await runTurn(1, "durian", [CAPABILITY_SLUG], [], { lanes });
+    const result = await runTurn(1, "durian", [CAPABILITY_SLUG], { lanes });
     expect(result.selections.map((s) => s.slug)).toEqual([CAPABILITY_SLUG]);
     expect(loggedSources(1)).toEqual([
       { slug: CAPABILITY_SLUG, source: "needle" },
@@ -465,11 +460,11 @@ describe("memory-v3 integration — selection-log readout", () => {
     const prefix = { hot: ["topic-x"] };
 
     // Turn 1: needle selects page-a (matched "apple"), plus the hot topic-x.
-    await runTurn(1, "apple", ["page-a", "topic-x"], [], { lanes, ...prefix });
+    await runTurn(1, "apple", ["page-a", "topic-x"], { lanes, ...prefix });
     // Turn 2: needle selects page-b (matched "banana"); dense also surfaces it
     // (denseK enables the lane), but needle precedence wins the attribution.
     denseHits = [{ article: "page-b", section: 0 }];
-    await runTurn(2, "banana", ["page-b"], [], {
+    await runTurn(2, "banana", ["page-b"], {
       lanes,
       ...prefix,
       denseK: 100,
@@ -477,7 +472,7 @@ describe("memory-v3 integration — selection-log readout", () => {
     // Turn 3: needle selects the capability page (matched "durian" in its
     // content).
     denseHits = [];
-    await runTurn(3, "durian", [CAPABILITY_SLUG], [], { lanes, ...prefix });
+    await runTurn(3, "durian", [CAPABILITY_SLUG], { lanes, ...prefix });
 
     const summary = summarizeSelections(CONV);
     // needle: page-a (t1) + page-b (t2) + capability page (t3) = 3.

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -134,14 +134,14 @@ const CAPABILITY_CONTENT = "use the kumquat skill to do the thing";
 const orchestrateSpy = mock(
   async (): Promise<OrchestrateResult> => ({
     selections: [
-      { slug: "page-core", pinned: false },
-      { slug: "page-hot", pinned: false },
-      { slug: "page-fresh", pinned: false },
-      { slug: "page-1", pinned: true },
-      { slug: "page-2", pinned: false },
-      { slug: "page-3", pinned: false },
-      { slug: "page-4", pinned: false },
-      { slug: "page-5", pinned: false },
+      { slug: "page-core" },
+      { slug: "page-hot" },
+      { slug: "page-fresh" },
+      { slug: "page-1" },
+      { slug: "page-2" },
+      { slug: "page-3" },
+      { slug: "page-4" },
+      { slug: "page-5" },
     ],
     matchedSections: new Map([
       ["page-1", { article: "page-1", title: "", text: "x", ordinal: 0 }],
@@ -523,10 +523,8 @@ afterAll(() => {
 
 function readRows() {
   return memorySqlite
-    .query(
-      `SELECT slug, source, pinned FROM memory_v3_selections ORDER BY slug`,
-    )
-    .all() as Array<{ slug: string; source: SelectionSource; pinned: number }>;
+    .query(`SELECT slug, source FROM memory_v3_selections ORDER BY slug`)
+    .all() as Array<{ slug: string; source: SelectionSource }>;
 }
 
 beforeEach(() => {
@@ -604,7 +602,6 @@ describe("memory-v3 engine", () => {
         {
           slug: "page-1",
           source: "needle",
-          pinned: 0,
           sectionOrdinal: null,
           sectionTitle: null,
         },
@@ -629,21 +626,21 @@ describe("memory-v3 engine", () => {
     // dense-only page-2 logs "dense", not "needle". The result is
     // current-turn selections only.
     expect(rows).toEqual([
-      // page-1 was surfaced by the needle lane → "needle", pinned.
-      { slug: "page-1", source: "needle", pinned: 1 },
+      // page-1 was surfaced by the needle lane → "needle".
+      { slug: "page-1", source: "needle" },
       // page-2 was surfaced by the dense lane → "dense".
-      { slug: "page-2", source: "dense", pinned: 0 },
+      { slug: "page-2", source: "dense" },
       // page-3 was surfaced by the edge lane → "edge".
-      { slug: "page-3", source: "edge", pinned: 0 },
+      { slug: "page-3", source: "edge" },
       // page-4 was first surfaced by the reply-query pass → "reply".
-      { slug: "page-4", source: "reply", pinned: 0 },
+      { slug: "page-4", source: "reply" },
       // page-5 was first surfaced by the learned-edge pass → "learned".
-      { slug: "page-5", source: "learned", pinned: 0 },
+      { slug: "page-5", source: "learned" },
       // page-core / page-hot / page-fresh sit in the stable prefix →
       // "core" / "hot" / "fresh".
-      { slug: "page-core", source: "core", pinned: 0 },
-      { slug: "page-fresh", source: "fresh", pinned: 0 },
-      { slug: "page-hot", source: "hot", pinned: 0 },
+      { slug: "page-core", source: "core" },
+      { slug: "page-fresh", source: "fresh" },
+      { slug: "page-hot", source: "hot" },
     ]);
   });
 
@@ -686,7 +683,7 @@ describe("memory-v3 engine", () => {
 
   test("a selection of a core page a finder also hit attributes to core (pool position wins)", () => {
     const rows = attributeSelections({
-      selections: [{ slug: "page-core", pinned: false }],
+      selections: [{ slug: "page-core" }],
       matchedSections: new Map(),
       lanes: {
         core: ["page-core"],
@@ -701,7 +698,6 @@ describe("memory-v3 engine", () => {
       {
         slug: "page-core",
         source: "core",
-        pinned: 0,
         sectionOrdinal: null,
         sectionTitle: null,
       },

--- a/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/hot-set.test.ts
@@ -40,10 +40,10 @@ let nextTurn = 0;
 /** Insert one selection row per createdAt (distinct turns keep the PK unique). */
 function seed(slug: string, createdAts: number[]): void {
   const stmt = sqlite.query(
-    `INSERT INTO memory_v3_selections (conversation_id, turn, slug, source, pinned, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO memory_v3_selections (conversation_id, turn, slug, source, created_at) VALUES (?, ?, ?, ?, ?)`,
   );
   for (const createdAt of createdAts) {
-    stmt.run("conv-1", nextTurn++, slug, "needle", 0, createdAt);
+    stmt.run("conv-1", nextTurn++, slug, "needle", createdAt);
   }
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/learned-edges.test.ts
@@ -43,11 +43,11 @@ let nextTurn = 0;
 /** Insert one selector call: every slug shares the same (conv, created_at). */
 function seedCall(slugs: string[], createdAt = NOW, conv = "conv-1"): void {
   const stmt = sqlite.query(
-    `INSERT INTO memory_v3_selections (conversation_id, turn, slug, source, pinned, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO memory_v3_selections (conversation_id, turn, slug, source, created_at) VALUES (?, ?, ?, ?, ?)`,
   );
   const turn = nextTurn++;
   for (const slug of slugs) {
-    stmt.run(conv, turn, slug, "needle", 0, createdAt);
+    stmt.run(conv, turn, slug, "needle", createdAt);
   }
 }
 

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -31,7 +31,7 @@
  *      throw inside it logs a warning and falls through to normal selection.
  *   2. Build the candidate pool in CACHE ORDER: the stable prefix —
  *      `[...core (file order), ...hot (score order), ...fresh (recency order),
- *      ...always-candidate (skills pinned every turn)]`, all computed at lane
+ *      ...always-candidate (skills listed every turn)]`, all computed at lane
  *      init — followed by the finder candidates (needle → dense → edge
  *      surfacing order). The stable prefix
  *      is identical across consecutive turns while the lanes are unchanged
@@ -180,7 +180,7 @@ export interface OrchestrateDeps {
   /** The modification-recency fresh set in recency order (computed at lane
    *  init with core and hot excluded). Follows hot in the stable prefix. */
   freshSlugs: Slug[];
-  /** Skills pinned into the candidate pool every turn regardless of retrieval
+  /** Skills placed in the candidate pool every turn regardless of retrieval
    *  (existence-filtered and core/hot/fresh-excluded at lane init). Follow fresh
    *  in the stable prefix so the selector always sees them. */
   alwaysCandidateSlugs?: Slug[];
@@ -278,9 +278,9 @@ export interface OrchestrateLanes {
 }
 
 export interface OrchestrateResult {
-  /** This turn's selections, deduped by slug (pinned flags ORed; the dedup is
-   *  `selectPool`'s contract). Current turn only — there is no
-   *  carried-forward set unioned in. */
+  /** This turn's selections, deduped by slug (the dedup is `selectPool`'s
+   *  contract). Current turn only: there is no carried-forward set unioned
+   *  in. */
   selections: SelectedPage[];
   /** The matched `Section` for each candidate slug that had one, keyed by slug.
    *  Populated from the finder-lane hits — including hits on core/hot pages —
@@ -856,9 +856,9 @@ export async function orchestrate(
   }));
 
   // Step 3: a SINGLE forced-tool select over the cache-ordered pool. The
-  // selections come back slug-deduped (pinned flags ORed) — `selectPool`'s
-  // contract. `selectorPrompt` is the (optionally overridden) instruction
-  // scaffold; `undefined` falls through to the bundled default.
+  // selections come back slug-deduped (`selectPool`'s contract).
+  // `selectorPrompt` is the (optionally overridden) instruction scaffold;
+  // `undefined` falls through to the bundled default.
   const pool = { stable, finder: finderTail };
   recordLatencySubSpan(
     "v3_expand",

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.test.ts
@@ -127,7 +127,7 @@ describe("selectPool", () => {
         },
       ]);
     expect(await selectPool(pool, turn)).toEqual({
-      pages: [{ slug: "page-a", pinned: false }],
+      pages: [{ slug: "page-a" }],
       keptAll: false,
     });
   });
@@ -138,7 +138,7 @@ describe("selectPool", () => {
         { type: "tool_use", id: "call-1", name: "select_pages", input: {} },
       ]);
     expect(await selectPool(pool, turn)).toEqual({
-      pages: [{ slug: "page-a", pinned: false }],
+      pages: [{ slug: "page-a" }],
       keptAll: true,
     });
   });

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.ts
@@ -191,7 +191,6 @@ const SelectPagesSchema = z.object({
   // Optional: an omitted `ids` field is the recall-safe "keep everything"
   // signal, distinct from an explicit empty array (deliberate abstention).
   ids: z.array(z.number().int()).optional(),
-  pinned_ids: z.array(z.number().int()).optional(),
 });
 
 const SELECT_PAGES_TOOL: ToolDefinition = {
@@ -199,19 +198,14 @@ const SELECT_PAGES_TOOL: ToolDefinition = {
   description:
     "Select the candidate pages whose content the reply would draw on. Lean " +
     "inclusive — when in doubt, keep a candidate; for a list or " +
-    '"all of X" request keep every candidate that belongs. Pass `pinned_ids` ' +
-    "for pages the conversation is centrally about. Omit `ids` only as a " +
-    "recall-safe fallback when you cannot judge the pool (keeps every " +
+    '"all of X" request keep every candidate that belongs. Omit `ids` only ' +
+    "as a recall-safe fallback when you cannot judge the pool (keeps every " +
     "candidate); return `[]` when candidates are present but none are " +
     "relevant.",
   input_schema: {
     type: "object",
     properties: {
       ids: {
-        type: "array",
-        items: { type: "integer" },
-      },
-      pinned_ids: {
         type: "array",
         items: { type: "integer" },
       },
@@ -227,7 +221,7 @@ Pages you select persist in the conversation automatically, and re-selecting a p
 
 A page can be relevant because of the current situation — the date or the live scratchpad — not only the message: keep a page the situation makes pertinent (e.g. a person whose anniversary is today). When the message asks about status, plans, schedule, or what's pending, treat pages carrying current task/event state — especially recently-updated (fresh) ones — as first-class candidates.
 
-If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the pool (keeps every candidate); return \`[]\` when candidates are present but none are relevant.`;
+Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the pool (keeps every candidate); return \`[]\` when candidates are present but none are relevant.`;
 
 /**
  * Resolve the selector system prompt: the file at `overridePath` when it is set
@@ -346,25 +340,21 @@ function renderFinderSegment(finder: PoolCandidate[], offset: number): string {
   return `<candidates>\n${lines.join("\n")}\n</candidates>`;
 }
 
-/** Dedupe selections by slug, preserving first-seen order and ORing pinned
- *  flags (a page can be selected as both a card and a finder line). */
-function dedupeBySlug(
-  entries: Array<{ slug: Slug; pinned: boolean }>,
-): SelectedPage[] {
-  const bySlug = new Map<Slug, boolean>();
-  for (const entry of entries) {
-    bySlug.set(entry.slug, (bySlug.get(entry.slug) ?? false) || entry.pinned);
-  }
-  return [...bySlug].map(([slug, pinned]) => ({ slug, pinned }));
+/** Dedupe selections by slug, preserving first-seen order (a page can be
+ *  selected as both a card and a finder line). */
+function dedupeBySlug(slugs: Slug[]): SelectedPage[] {
+  return [...new Set(slugs)].map((slug) => ({ slug }));
+}
+
+/** Every candidate slug in the pool's concatenated numbering: ids 1…m are the
+ *  stable-prefix cards, ids m+1… are the finder lines. */
+function orderedSlugs(pool: SelectorPool): Slug[] {
+  return [...pool.stable.map((c) => c.slug), ...pool.finder.map((c) => c.slug)];
 }
 
 /** Return every candidate in pool order, deduped by slug. */
 export function selectAllPoolCandidates(pool: SelectorPool): SelectedPage[] {
-  const ordered: Slug[] = [
-    ...pool.stable.map((c) => c.slug),
-    ...pool.finder.map((c) => c.slug),
-  ];
-  return dedupeBySlug(ordered.map((slug) => ({ slug, pinned: false })));
+  return dedupeBySlug(orderedSlugs(pool));
 }
 
 /** A selection plus whether it came from the recall-safe keep-all fallback. */
@@ -380,8 +370,8 @@ export interface PoolSelection {
 /**
  * Run the single forced-tool selector over the unified candidate pool. Returns
  * the pages to inject, deduped by slug (a page that appeared as both a card
- * and a finder line yields one entry, pinned flags ORed), plus a `keptAll` flag
- * marking the recall-safe fallback.
+ * and a finder line yields one entry), plus a `keptAll` flag marking the
+ * recall-safe fallback.
  *
  * An omitted `ids` keeps ALL candidates (the recall-safe "all of these are
  * relevant" signal, `keptAll: true`); an explicit `[]` keeps none; an
@@ -397,17 +387,10 @@ export async function selectPool(
   turn: MemoryRoutingTurn,
   systemPrompt: string = SYSTEM_PROMPT,
 ): Promise<PoolSelection> {
-  // The concatenated numbering: ids 1…m are the stable-prefix cards, ids
-  // m+1… are the finder lines.
-  const ordered: Slug[] = [
-    ...pool.stable.map((c) => c.slug),
-    ...pool.finder.map((c) => c.slug),
-  ];
+  const ordered = orderedSlugs(pool);
   if (ordered.length === 0) {
     return { pages: [], keptAll: false };
   }
-
-  const keepAll = (): SelectedPage[] => selectAllPoolCandidates(pool);
 
   const provider = await getConfiguredProvider(MEMORY_V3_SELECT_CALL_SITE);
   if (!provider) {
@@ -589,19 +572,13 @@ export async function selectPool(
 
   // Omitted `ids` is the recall-safe "keep all candidates" signal.
   if (parsed.ids === undefined) {
-    return { pages: keepAll(), keptAll: true };
+    return { pages: dedupeBySlug(ordered), keptAll: true };
   }
-
-  const pinned = new Set(parsed.pinned_ids ?? []);
 
   // Map 1-based IDs over the concatenated numbering, dropping out-of-range
-  // IDs without throwing, then dedupe by slug (pinned flags ORed).
-  const selected: Array<{ slug: Slug; pinned: boolean }> = [];
-  for (const id of parsed.ids) {
-    if (id < 1 || id > ordered.length) {
-      continue;
-    }
-    selected.push({ slug: ordered[id - 1]!, pinned: pinned.has(id) });
-  }
+  // IDs without throwing, then dedupe by slug.
+  const selected = parsed.ids
+    .filter((id) => id >= 1 && id <= ordered.length)
+    .map((id) => ordered[id - 1]!);
   return { pages: dedupeBySlug(selected), keptAll: false };
 }

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -133,8 +133,8 @@ function insertSelection(
     .query(
       /*sql*/ `
       INSERT OR REPLACE INTO memory_v3_selections
-        (conversation_id, turn, slug, source, pinned, created_at)
-      VALUES (?, ?, ?, 'needle', 0, ?)
+        (conversation_id, turn, slug, source, created_at)
+      VALUES (?, ?, ?, 'needle', ?)
     `,
     )
     .run(conversationId, turn, slug, createdAt);

--- a/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/selection-log-store.ts
@@ -39,12 +39,11 @@ interface SelectionRow {
   turn: number;
   slug: string;
   source: string;
-  pinned: number;
   section_ordinal: number | null;
   section_title: string | null;
 }
 
-const SELECTION_COLUMNS = `turn, slug, source, pinned, section_ordinal, section_title`;
+const SELECTION_COLUMNS = `turn, slug, source, section_ordinal, section_title`;
 
 function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
   const raw = memorySqliteOrNull("rowsForTurn");
@@ -191,7 +190,6 @@ async function buildSelectionLog(
   const selections = rows.map((r) => ({
     slug: r.slug,
     source: r.source,
-    pinned: r.pinned === 1,
     sectionOrdinal: r.section_ordinal,
     sectionHeading: r.section_title,
   }));

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -119,7 +119,7 @@ export interface ShadowLanes {
   /** Modification-recency fresh set in recency order: core and hot excluded,
    *  filtered to pages in the section index. */
   freshSlugs: string[];
-  /** Skills pinned into the stable prefix every turn (`always-candidate: true`
+  /** Skills placed in the stable prefix every turn (`always-candidate: true`
    *  in SKILL.md), existence-filtered and core/hot/fresh-excluded. */
   alwaysCandidateSlugs: string[];
   /** Learned-edge graph: co-selection NPMI associations over the selection
@@ -297,7 +297,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     excludeSlugs: new Set([...coreSlugs, ...hotSlugs]),
   }).filter((slug) => sectionIndex.byArticle.has(slug));
 
-  // Always-candidate skills are pinned into the stable prefix every turn so the
+  // Always-candidate skills are placed in the stable prefix every turn so the
   // selector can choose a cross-cutting capability (e.g. workflows) even when no
   // retrieval lane surfaces it — its relevance is a judgment the model makes,
   // not something embedding similarity finds. Filtered to skills present in the
@@ -569,7 +569,6 @@ async function buildShadowTurn(
 interface SelectionRow {
   slug: Slug;
   source: SelectionSource;
-  pinned: number;
   /** Ordinal of the matched section a finder lane surfaced; null for
    *  core/hot/fresh/edge selections with no matched section. */
   sectionOrdinal: number | null;
@@ -608,7 +607,6 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
           : fresh.has(sel.slug)
             ? ("fresh" as const)
             : (finderLane.get(sel.slug) ?? "needle"),
-      pinned: sel.pinned ? 1 : 0,
       sectionOrdinal: section?.ordinal ?? null,
       sectionTitle: section?.title ?? null,
     };
@@ -640,9 +638,9 @@ export function writeSelections(
     // `backfillMemoryV3SelectionMessageId`.
     const stmt = raw.query(/*sql*/ `
       INSERT OR REPLACE INTO memory_v3_selections (
-        conversation_id, turn, slug, source, pinned, created_at,
+        conversation_id, turn, slug, source, created_at,
         message_id, section_ordinal, section_title
-      ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?)
     `);
     const now = Date.now();
     for (const row of rows) {
@@ -651,7 +649,6 @@ export function writeSelections(
         turn,
         row.slug,
         row.source,
-        row.pinned,
         now,
         row.sectionOrdinal,
         row.sectionTitle,

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -65,10 +65,9 @@ export interface SectionIndex {
   byArticle: Map<Slug, number[]>;
 }
 
-/** A page selected from the candidate pool, with whether the turn centers on it. */
+/** A page selected from the candidate pool. */
 export interface SelectedPage {
   slug: Slug;
-  pinned: boolean;
 }
 
 export interface MemoryRoutingTurn {

--- a/clients/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
@@ -548,7 +548,6 @@ function MemoryV3Section({
   const carryCount = selection.selections.filter(
     (s) => s.source === "carry-forward",
   ).length;
-  const pinnedCount = selection.selections.filter((s) => s.pinned).length;
 
   // `selection.live` reflects whether v3 is the assistant's CURRENT live memory
   // source, not per-turn history. Persisted `memory_v3_selections` rows can be
@@ -581,9 +580,6 @@ function MemoryV3Section({
         <CountPill label={t("memoryTab.corePill", { count: fmt(coreCount) })} />
         <CountPill
           label={t("memoryTab.carriedPill", { count: fmt(carryCount) })}
-        />
-        <CountPill
-          label={t("memoryTab.pinnedPill", { count: fmt(pinnedCount) })}
         />
       </div>
 
@@ -664,8 +660,7 @@ function V3SelectionRow({
           </span>
         ) : null}
       </code>
-      <div className="flex shrink-0 items-center gap-1.5">
-        {row.pinned && <TypeChip label={t("memoryTab.pinnedChip")} />}
+      <div className="shrink-0">
         <TypeChip label={formatV3Source(row.source, t)} />
       </div>
     </div>

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1081,8 +1081,6 @@
     "pillMemoryV2": "Memory V2",
     "pillMemoryV3": "Memory V3",
     "pillRecallV1": "Recall (v1)",
-    "pinnedChip": "pinned",
-    "pinnedPill": "Pinned: {count}",
     "providerLabel": "Provider",
     "queryContextSubtitle": "The text embedded as the search vector for semantic retrieval.",
     "queryContextTitle": "Query context",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1037,8 +1037,6 @@
     "pillMemoryV2": "Memoria V2",
     "pillMemoryV3": "Memoria V3",
     "pillRecallV1": "Recuperación (v1)",
-    "pinnedChip": "fijada",
-    "pinnedPill": "Fijadas: {count}",
     "providerLabel": "Proveedor",
     "queryContextSubtitle": "El texto incrustado como vector de búsqueda para la recuperación semántica.",
     "queryContextTitle": "Contexto de consulta",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -605,8 +605,6 @@
     "pillMemoryV2": "Memory V2",
     "pillMemoryV3": "Memory V3",
     "pillRecallV1": "Recall (v1)",
-    "pinnedChip": "закреплено",
-    "pinnedPill": "Закреплено: {count}",
     "providerLabel": "Провайдер",
     "queryContextSubtitle": "Текст, который встроили как поисковый вектор для семантического поиска.",
     "queryContextTitle": "Контекст запроса",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1019,8 +1019,6 @@
     "pillMemoryV2": "記憶體 V2",
     "pillMemoryV3": "記憶體 V3",
     "pillRecallV1": "回溯 (v1)",
-    "pinnedChip": "已釘選",
-    "pinnedPill": "已釘選: {count}",
     "providerLabel": "提供者",
     "queryContextSubtitle": "作為語義檢索搜尋向量嵌入的文字。",
     "queryContextTitle": "查詢上下文",

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1019,8 +1019,6 @@
     "pillMemoryV2": "记忆 V2",
     "pillMemoryV3": "记忆 V3",
     "pillRecallV1": "召回 (v1)",
-    "pinnedChip": "已固定",
-    "pinnedPill": "已固定: {count}",
     "providerLabel": "提供者",
     "queryContextSubtitle": "作为语义检索搜索向量嵌入的文本。",
     "queryContextTitle": "查询上下文",


### PR DESCRIPTION
## Summary
- Remove pinned_ids from the memory-v3 pool selector tool and prompt, and the pinned flag from selections, the selection log write, and the inspector API and panel.
- The memory_v3_selections.pinned column stays; it just stops being written.

Part of plan: memory-v3-section-injection.md (PR 1 of 5)