### PR TITLE
fix(acp): use the maintained Codex ACP adapter to enable Astra

### DIFF
--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -199,7 +199,7 @@ describe("ensureAdapterInstalled", () => {
     );
     expect(installedPackages.sort()).toEqual([
       "@agentclientprotocol/claude-agent-acp",
-      "@zed-industries/codex-acp",
+      "@agentclientprotocol/codex-acp",
     ]);
   });
 });
@@ -237,6 +237,40 @@ describe("resolveAgentWithAutoInstall - resolution order", () => {
     expect(result.failureMessage).toBeUndefined();
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(execFileMock.mock.calls[0][0]).toBe(BUN_BIN);
+  });
+
+  test("missing codex installs the successor package and resolves the same command", async () => {
+    let installed = false;
+    which.setWhich((cmd) => {
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (cmd === "codex-acp" && installed) {
+        return "/usr/local/bin/codex-acp";
+      }
+      return null;
+    });
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        installed = true;
+      },
+    });
+
+    const result = await resolveAgentWithAutoInstall("codex");
+
+    expect(result.resolved.ok).toBe(true);
+    if (!result.resolved.ok) {
+      return;
+    }
+    expect(result.resolved.agent.command).toBe("codex-acp");
+    expect(result.autoInstalledPackage).toBe("@agentclientprotocol/codex-acp");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      "@agentclientprotocol/codex-acp",
+    ]);
   });
 
   test("binary missing + bun absent: no install, plain failure with the hint", async () => {

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -56,7 +56,7 @@ describe("resolveAcpAgent", () => {
       return;
     }
     expect(result.agent.command).toBe("codex-acp");
-    expect(result.agent.description).toContain("@zed-industries/codex-acp");
+    expect(result.agent.description).toContain("@agentclientprotocol/codex-acp");
   });
 
   test("falls back to default profile for claude when no user entry", () => {
@@ -240,7 +240,7 @@ describe("resolveAcpAgent", () => {
     if (result.reason !== "binary_not_found") {
       return;
     }
-    expect(result.hint).toBe("bun add -g @zed-industries/codex-acp");
+    expect(result.hint).toBe("bun add -g @agentclientprotocol/codex-acp");
   });
 
   test("binary preflight honors agent.env.PATH override (matches spawn env)", () => {
@@ -430,7 +430,7 @@ describe("listAcpAgents", () => {
     const codex = result.agents.find((a) => a.id === "codex");
     expect(codex?.available).toBe(false);
     expect(codex?.unavailableReason).toBe("'codex-acp' is not on PATH");
-    expect(codex?.setupHint).toBe("bun add -g @zed-industries/codex-acp");
+    expect(codex?.setupHint).toBe("bun add -g @agentclientprotocol/codex-acp");
   });
 
   test("aliases are resolution sugar, not catalog entries", () => {

--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -21,11 +21,11 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
     });
   });
 
-  test("codex profile uses the @zed-industries adapter binary", () => {
+  test("codex profile uses the @agentclientprotocol adapter binary", () => {
     expect(DEFAULT_ACP_AGENT_PROFILES.codex).toEqual({
       command: "codex-acp",
       args: [],
-      description: "OpenAI Codex CLI (via @zed-industries/codex-acp)",
+      description: "OpenAI Codex CLI (via @agentclientprotocol/codex-acp)",
     });
   });
 
@@ -45,7 +45,7 @@ describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
   test("is keyed by command name with the canonical npm package", () => {
     expect(DEFAULT_AGENT_NPM_PACKAGES).toEqual({
       "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
-      "codex-acp": "@zed-industries/codex-acp",
+      "codex-acp": "@agentclientprotocol/codex-acp",
     });
   });
 

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -28,14 +28,14 @@ export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
   codex: Object.freeze({
     command: "codex-acp",
     args: FROZEN_EMPTY_ARGS,
-    description: "OpenAI Codex CLI (via @zed-industries/codex-acp)",
+    description: "OpenAI Codex CLI (via @agentclientprotocol/codex-acp)",
   }),
 });
 
 /**
- * Single source of truth for adapter binary → npm package name. Both the
- * version-check probe in `acp_spawn` and the resolver's install-hint format
- * key off this map, so a new adapter only needs one entry here.
+ * Single source of truth for adapter binary → npm package name. Automatic
+ * installation and the resolver's install hints use this map, so a new
+ * adapter only needs one entry here.
  *
  * Keyed by command name (not agent id) so the mapping follows the binary
  * regardless of how a user's config aliases an agent.
@@ -43,5 +43,5 @@ export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
 export const DEFAULT_AGENT_NPM_PACKAGES: Readonly<Record<string, string>> =
   Object.freeze({
     "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
-    "codex-acp": "@zed-industries/codex-acp",
+    "codex-acp": "@agentclientprotocol/codex-acp",
   });

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -99,19 +99,6 @@ bun add -g @agentclientprotocol/codex-acp@latest
 
 Codex uses the adapter's bundled dependency by default, within the version range declared by the adapter. If `CODEX_PATH` selects a separate CLI, update that installation separately. Verify the required model with a fresh `acp_spawn` call after updating.
 
-### Migrating the legacy package
-
-Existing `@zed-industries/codex-acp` installations need an explicit replacement because both packages provide the `codex-acp` command.
-
-Before replacing it, get approval, let active sessions finish, and record the installed package/version and custom profile settings for rollback. Use the package manager that owns the installation. For bun:
-
-```bash
-bun remove -g @zed-industries/codex-acp
-bun add -g @agentclientprotocol/codex-acp
-```
-
-Preserve custom profiles and executable paths. Verify the resolved `codex-acp` belongs to the successor package, check `codex-acp --version`, and start a fresh session. If verification fails, restore the recorded package/version and settings.
-
 ## When to use acp_steer vs acp_spawn
 
 - **On a running session, `acp_steer` interrupts the in-flight prompt.** Use it to course-correct ("stop, do X instead"). It cancels whatever the agent is currently working on and replaces it with the new instruction. Queued follow-ups behind a running prompt are not supported - wait for the `acp_session_completed` notification instead.

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -43,13 +43,13 @@ ACP is always available - default profiles for `claude` and `codex` ship out-of-
 
 When `acp_spawn` finds the agent's binary missing from PATH, the assistant installs it once via a sandboxed bun global install and then runs the real installed binary. The install runs in a fresh empty temporary directory (never the task's project directory), with known secrets stripped from the installer environment and the registry pinned to the public npm registry, so a malicious project directory cannot hijack package resolution or capture a token. After this one-time install, the adapter is a normal trusted binary on PATH and every later spawn (and resume) uses it directly.
 
-Only the allowlisted out-of-box packages are ever installed this way (`@agentclientprotocol/claude-agent-acp`, `@zed-industries/codex-acp`); user-configured agents with custom commands are never installed automatically.
+Only the allowlisted out-of-box packages are ever installed this way (`@agentclientprotocol/claude-agent-acp`, `@agentclientprotocol/codex-acp`); user-configured agents with custom commands are never installed automatically.
 
 Manual installation is fallback guidance for unusual setups: bun unavailable, restricted global installs, or an auto-install failure (the failure reason is surfaced in the tool result).
 
 ```bash
 bun add -g @agentclientprotocol/claude-agent-acp   # claude
-bun add -g @zed-industries/codex-acp               # codex
+bun add -g @agentclientprotocol/codex-acp          # codex
 ```
 
 ## Claude setup
@@ -72,14 +72,11 @@ Do NOT ask the user to paste the token into chat — the secure prompt keeps it 
 
 ## Codex setup
 
-The `codex-acp` adapter is installed automatically when missing, but it shells out to the underlying `codex` CLI, which must also be on PATH:
+The `@agentclientprotocol/codex-acp` adapter runs Codex App Server using its included `@openai/codex` dependency.
 
-1. **Install the Codex CLI** (version 0.111 or higher) via OpenAI's distribution channel of choice. The adapter will fail if `codex` isn't on PATH.
+**Authenticate.** The adapter reuses an existing Codex login. To sign in, use `codex login` from an installed Codex CLI. API-key authentication supports `CODEX_API_KEY` and `OPENAI_API_KEY`.
 
-2. **Authenticate.** The `codex-acp` adapter inherits whatever auth the underlying `codex` CLI uses. Typical flows:
-   - `codex login` (OAuth)
-   - `CODEX_API_KEY` environment variable
-   - `OPENAI_API_KEY` environment variable
+**Optional CLI override.** Set `CODEX_PATH` in the agent profile's `env` to use a different compatible Codex executable. Keep the agent command as `codex-acp`.
 
 Do NOT put API keys (or any secret) in the workspace config file - secrets never belong in the workspace directory. Use the credential store instead.
 
@@ -92,15 +89,28 @@ Do NOT put API keys (or any secret) in the workspace config file - secrets never
 
 ## Updating an adapter
 
-Adapters are installed once via a bun global install. To update one to the latest version, ask the user first, then re-install it globally:
+Adapters are installed automatically when missing. To update an installed adapter, ask the user first and use its owning package manager. For bun installations:
 
 ```bash
 bun add -g @agentclientprotocol/claude-agent-acp@latest
 # or
-bun add -g @zed-industries/codex-acp@latest
+bun add -g @agentclientprotocol/codex-acp@latest
 ```
 
-Then retry the `acp_spawn` call.
+Codex uses the adapter's bundled dependency by default, within the version range declared by the adapter. If `CODEX_PATH` selects a separate CLI, update that installation separately. Verify the required model with a fresh `acp_spawn` call after updating.
+
+### Migrating the legacy package
+
+Existing `@zed-industries/codex-acp` installations need an explicit replacement because both packages provide the `codex-acp` command.
+
+Before replacing it, get approval, let active sessions finish, and record the installed package/version and custom profile settings for rollback. Use the package manager that owns the installation. For bun:
+
+```bash
+bun remove -g @zed-industries/codex-acp
+bun add -g @agentclientprotocol/codex-acp
+```
+
+Preserve custom profiles and executable paths. Verify the resolved `codex-acp` belongs to the successor package, check `codex-acp --version`, and start a fresh session. If verification fails, restore the recorded package/version and settings.
 
 ## When to use acp_steer vs acp_spawn
 

--- a/assistant/src/tools/acp/list-agents.test.ts
+++ b/assistant/src/tools/acp/list-agents.test.ts
@@ -90,7 +90,7 @@ describe("executeAcpListAgents", () => {
     const codex = parsed.agents.find((a: { id: string }) => a.id === "codex");
     expect(codex.available).toBe(false);
     expect(codex.unavailableReason).toBe("'codex-acp' is not on PATH");
-    expect(codex.setupHint).toBe("bun add -g @zed-industries/codex-acp");
+    expect(codex.setupHint).toBe("bun add -g @agentclientprotocol/codex-acp");
 
     const claude = parsed.agents.find((a: { id: string }) => a.id === "claude");
     expect(claude.available).toBe(true);

--- a/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
@@ -129,12 +129,6 @@ export function SkillsReferenceACPContent() {
               unless you accept.
             </li>
             <li>
-              <strong>Existing Codex installations.</strong> If you use the legacy
-              @zed-industries/codex-acp package, ask your assistant to migrate to
-              @agentclientprotocol/codex-acp. It will ask for approval, preserve your
-              custom settings, and verify the replacement in a fresh session.
-            </li>
-            <li>
               <strong>Fully independent.</strong> ACP agents are separate processes with their own
               context window and tools.
             </li>

--- a/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
@@ -35,9 +35,9 @@ export function SkillsReferenceACPContent() {
           <p className="mb-0 text-zinc-600">
             The protocol adapter is installed automatically the first time you use an agent. For
             Claude Code that is everything: sign-in runs through an in-app Connect card, so there is
-            nothing to install yourself. Codex additionally needs the Codex CLI (version 0.111 or
-            higher) already on your PATH, since its adapter calls that CLI and inherits its
-            sign-in. Say &ldquo;Set up ACP&rdquo; to walk through it. Naming Claude Code or Codex is
+            nothing to install yourself. The Codex adapter, @agentclientprotocol/codex-acp,
+            includes Codex and reuses your existing Codex login. Say
+            &ldquo;Set up ACP&rdquo; to walk through authentication. Naming Claude Code or Codex is
             also enough: the assistant offers once to connect it here, then continues.
           </p>
         </section>
@@ -127,6 +127,12 @@ export function SkillsReferenceACPContent() {
               <strong>Name it to connect.</strong> Mentioning Claude Code or Codex is enough for a
               one-time offer to connect and run it here. The assistant does not start the agent
               unless you accept.
+            </li>
+            <li>
+              <strong>Existing Codex installations.</strong> If you use the legacy
+              @zed-industries/codex-acp package, ask your assistant to migrate to
+              @agentclientprotocol/codex-acp. It will ask for approval, preserve your
+              custom settings, and verify the replacement in a fresh session.
             </li>
             <li>
               <strong>Fully independent.</strong> ACP agents are separate processes with their own

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "d894ec9c9c7137a50f101db9835c57e9860f890a45c71760c5df2f48cbff6b50"
+      "sha256": "3f23e06b0301b9456acb03a7aa81158e61094b3a663a89175ec40028bcc65a65"
     },
     "app-builder": {
       "docsSlug": "app-builder",

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "67517f5395e67fb866c6c114bca282cbae5160a9862d25d824c7b0ca46eb01e6"
+      "sha256": "d894ec9c9c7137a50f101db9835c57e9860f890a45c71760c5df2f48cbff6b50"
     },
     "app-builder": {
       "docsSlug": "app-builder",


### PR DESCRIPTION
## Summary

Replace `@zed-industries/codex-acp` with the maintained `@agentclientprotocol/codex-acp` package to unblock GPT-6 Astra on the tested Vellum ACP route and follow upstream's migration guidance.

The legacy adapter (0.16.0) rejects `gpt-6-astra` even when a working, newer standalone Codex CLI is installed:

> The 'gpt-6-astra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.

Updating the standalone CLI does not replace the legacy adapter's embedded Codex engine. The successor uses Codex App Server and includes its own compatible Codex dependency; a controlled comparison successfully ran Astra through that adapter with Codex 0.153.4.

Upstream has retired the legacy implementation and archived its repository. Its [README migration notice](https://github.com/zed-industries/codex-acp/blob/296069e841634cd4bb9bc4515602d836e49231ec/README.md) explicitly directs users to the replacement:

> Development has moved to agentclientprotocol/codex-acp.

> Use `@agentclientprotocol/codex-acp` for new installs.

We compared this migration with Vellum's earlier Claude adapter migration to `@agentclientprotocol/claude-agent-acp` in #28114 and the full `acp-codex-claude.md` implementation series: #28070, #28076, #28075, #28097, #28105, #28104, #28110, #28114, and #28115, plus self-review follow-ups #28116, #28117, and #28125. We used those changes as a checklist for defaults, package resolution, tool and HTTP spawn paths, install hints, custom profiles, resume hints, documentation, and tests; the comparison identified no additional implementation surfaces needed for this package-selection change. Like that earlier approach, this PR does not replace already-installed legacy adapters. Historical release-note migrations remain unchanged under the current contribution rules.

## Prompt / plan

Use the existing ACP installation mechanism rather than introducing a new updater:

- Change the default Codex package mapping, profile description, and install hints to the successor, preserving the `codex-acp` command and custom profiles.
- Update package expectations and add a regression test for installing and resolving a missing Codex adapter.
- Correct the bundled skill and public setup docs to explain the included Codex dependency. Keep the existing setup/update sections rather than adding a dedicated legacy-migration guide.
- Update the Codex command in the skill's existing **Updating an adapter** section, alongside Claude's update command. Keep future-upgrade guidance there rather than adding new public-doc callouts.
- Refresh the skill/docs fingerprint without changing historical migration 053, dependency manifests, or lockfiles.

`CODEX_PATH` remains unset by default. Future updates normally use the adapter's owning package manager, such as `bun add -g @agentclientprotocol/codex-acp@latest` for a bun-managed installation. The installed Codex version follows the adapter's dependency range, not automatically the newest CLI release. Users who explicitly set `CODEX_PATH` maintain that compatible CLI separately and verify the required model after updating.

Both packages expose `codex-acp`, so an existing legacy binary still satisfies Vellum's PATH check. This PR changes fresh-install selection and existing setup/update guidance. Updating Vellum alone will not fix Astra for users still running the legacy adapter: they must explicitly replace it with the successor. Automatic migration of installed adapters is outside this PR.

## Test plan

Validation used Bun 1.3.11 in an isolated checkout with frozen-lockfile installation and lifecycle scripts disabled.

### Automated checks

- **126 distinct tests passed:** 54 covering defaults, resolution, installation, and agent listing; 62 adjacent ACP regressions; and 10 documentation/history guards. The default-package expectations first produced two expected failures before implementation.
- **Final focused rerun:** 55 tests passed after the documentation revisions, including the refreshed fingerprint guard.
- **Scoped ESLint and** `git diff --check`**:** passed for the changed files.

### Runtime comparisons

| Probe | Legacy adapter 0.16.0 | Successor adapter 1.10.0 |
| --- | --- | --- |
| Astra, identical no-tools prompt and working directory | Failed with the version error above, reproduced in a fresh run | Returned exactly `ASTRA_ACP_NEXT_OK`; recorded `gpt-6-astra`, high effort, and zero tool calls, using `CODEX_PATH` to select Codex 0.153.4 |
| GPT-5.5, identical disposable file-edit task | Read the fixture and changed `BEFORE` to `AFTER` with one successful `apply_patch` | Made the same verified edit using bundled Codex 0.153.4, without `CODEX_PATH` |

A further no-tools probe ran Astra at high effort using the successor's bundled Codex 0.153.4, with no `CODEX_PATH` override. After completion, Vellum resumed the session from persisted history and the agent correctly recalled a marker supplied only in the first turn. The recorded trace confirmed two Astra/high turns and zero tool calls. This verifies successor-created session resume, not migration of legacy session history.

The edit results were independently checked against the files and tool traces. Temporary profiles and installations were removed afterward; the original global adapter and settings were preserved. These probes establish the tested model and editing behavior, not comprehensive equivalence across operations or platforms.

### Remaining verification

- Full assistant typecheck is incomplete: `bun run typecheck:fast` timed out after 120 seconds, and a direct compiler retry timed out after 90 seconds, both without diagnostics. The full repository suite, production build, and cross-platform tests were not run.
