### PR TITLE
feat(memory-v3): multi-section finder candidates and keyword-in-context snippets

### DIFF
--- a/assistant/docs/architecture/memory.md
+++ b/assistant/docs/architecture/memory.md
@@ -173,8 +173,9 @@ Ingested pages carry provenance frontmatter with distinct consumers:
 - **v3 (live)**: per-turn lane selection over concept pages (dense/sparse
   retrieval via `substrate/sim.ts` over the concept-page collection,
   learned edges, entity/hot/fresh/core sets). The injection unit is the
-  SECTION: `v3/injector.ts` renders each selected page's matched section
-  (its lead when it was selected without a match) into a `<memory>` block,
+  SECTION: the selector pool lists a page once per matched section, and
+  `v3/injector.ts` renders each selected page's selected sections (its lead
+  when it was selected with none) into a `<memory>` block,
   net-new sections only, deduped per `(page, section)` through
   `memory_v3_injected_sections` and bounded by a recency prune valve with no
   lane exemptions. Section bodies are backslash-escaped where a line would

--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -1214,6 +1214,7 @@ describe("forkConversation", () => {
         key: "",
         bytes: 120,
         injectedAt: 1_700_000_000_000,
+        lastSelectedAt: 1_700_000_000_000,
         prunedAt: null,
       },
       {
@@ -1221,6 +1222,7 @@ describe("forkConversation", () => {
         key: "Notes",
         bytes: 80,
         injectedAt: 1_700_000_000_000,
+        lastSelectedAt: 1_700_000_000_000,
         prunedAt: null,
       },
       {
@@ -1228,6 +1230,7 @@ describe("forkConversation", () => {
         key: "",
         bytes: 340,
         injectedAt: 1_700_000_000_000,
+        lastSelectedAt: 1_700_000_000_000,
         prunedAt: 1_700_000_001_000,
       },
     ]);

--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -22,6 +22,7 @@ describe("MemoryV3ConfigSchema", () => {
       denseK: 100,
       replyQueryK: 12,
       spanQueryK: 0,
+      finderSectionsPerPage: 3,
       selectorEnabled: true,
       selectorPromptPath: null,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -359,6 +359,14 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Per-chunk article budget for the span-query dense pass: the current message's clause spans (merged into at most 8 contiguous chunks) re-run through the dense lane as separate queries, union-additive into the candidate pool. 0 disables the pass; it is also inert when denseK is 0 or the message yields fewer than two chunks. Deliberately small next to denseK — the pass rescues motifs a long message's single query vector averages away, not a second full sweep.",
       ),
+    finderSectionsPerPage: z
+      .number({ error: "memory.v3.finderSectionsPerPage must be a number" })
+      .int("memory.v3.finderSectionsPerPage must be an integer")
+      .positive("memory.v3.finderSectionsPerPage must be a positive integer")
+      .default(3)
+      .describe(
+        "Maximum finder lines one page may carry in the selector pool per turn. Each distinct matched section a finder lane surfaces for a page is its own line, kept in surfacing order (needle, dense, reply, span, entity) until the cap; a section-less edge or learned hit counts as one line.",
+      ),
     selectorEnabled: z
       .boolean({ error: "memory.v3.selectorEnabled must be a boolean" })
       .default(true)

--- a/assistant/src/persistence/migrations/283-memory-v3-selections-message-id-and-sections.ts
+++ b/assistant/src/persistence/migrations/283-memory-v3-selections-message-id-and-sections.ts
@@ -12,7 +12,8 @@ import { getSqliteFrom } from "../db-connection.js";
  *     previously left the panel blank. NULL for pre-existing rows and until the
  *     turn-end backfill stamps it.
  *   - `section_ordinal INTEGER` / `section_title TEXT` — the matched section a
- *     finder-lane selection surfaced (from `OrchestrateResult.matchedSections`).
+ *     finder-lane selection surfaced (the selection's first section in
+ *     `OrchestrateResult.selections`).
  *     NULL for pre-existing rows and for core/hot/fresh/edge selections that
  *     carry no matched section (those render full-page, as before).
  *

--- a/assistant/src/persistence/schema/memory-injection.ts
+++ b/assistant/src/persistence/schema/memory-injection.ts
@@ -28,7 +28,8 @@ export const memoryV2InjectionEvents = sqliteTable(
 
 // Per-conversation record of every memory-v3 section ever injected, keyed by
 // (page slug, section key: `""` for the page lead or capability content), with
-// a pruned_at tombstone so re-injection can be suppressed after pruning. Lives
+// a pruned_at tombstone so re-injection can be suppressed after pruning and a
+// last_selected_at stamp the prune valve ranks eviction by. Lives
 // in the dedicated memory database (`assistant-memory.db`), not main, access
 // it via the memory connection (`getMemoryDb()` / `getMemorySqlite()`). The
 // legacy card-grain `memory_v3_ever_injected` table stays on disk (migrations
@@ -44,6 +45,13 @@ export const memoryV3InjectedSections = sqliteTable(
     injectedAt: integer("injected_at").notNull(),
     bytes: integer("bytes").notNull().default(0),
     prunedAt: integer("pruned_at"),
+    /** Epoch ms of the latest turn that selected the section, net-new or
+     *  already resident: the prune valve's recency, with `injected_at`
+     *  standing in while null. Plugin-owned like the table: the memory
+     *  plugin's schema ensure (`v3/plugin-schema.ts`) adds it to a table
+     *  created before the column existed, so it is null on rows written
+     *  before then and on a truncated fork's seeded rows. */
+    lastSelectedAt: integer("last_selected_at"),
   },
   (table) => [
     primaryKey({

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -130,9 +130,10 @@ imports the array and nothing else. A new tier injector is added to that array,
 never registered from the host.
 
 **v3 injection layers.** The v3 injection unit is the SECTION. Each turn the
-`memory-v3` injector renders every selected page's matched section (its lead
-when the page was selected without a match; a capability slug renders its
-whole capability content) into one frozen `<memory>` block, net-new only:
+`memory-v3` injector renders every section selected for each selected page
+(its lead when the page was selected with no section; a capability slug
+renders its whole capability content) into one frozen `<memory>` block,
+net-new only:
 `memory_v3_injected_sections` records one row per `(conversation, slug,
 section key)` ever injected, where the key is `v3/types.ts`'s `sectionKey()`
 (`""` for the lead, the trimmed heading title otherwise, `title#<n>` for the
@@ -409,15 +410,20 @@ blocks compaction stripped. `memory_v3_selections` itself is created by migratio
 `section_key` column is plugin-owned the same way: the selection log's writer
 (`writeTurnLog`) and the inspector's reader (`v3/selection-log-store.ts`) add
 it on the first use of a connection, and the `init` hook at boot. Every
-selection row records its matched section's `sectionKey` beside the title and
-ordinal, and the inspector resolves a row by that key first (exactly, so a
-repeated heading's other occurrence is never substituted), falling back to
-title-then-ordinal only for rows written before the column existed.
+selection row records one section per slug, the selection's first selected
+section, as its `sectionKey` beside the title and ordinal, and the inspector
+resolves a row by that key first (exactly, so a repeated heading's other
+occurrence is never substituted), falling back to title-then-ordinal only for
+rows written before the column existed.
 
 `memory_v3_pools` (`v3/pool-log-store.ts`) holds one row per turn: the
 selector's full candidate pool (every stable-prefix card and finder line, in
-pool order, with lane, matched section, and verdict) for the inspector's
-Memory tab, plus `selector_ran`. A turn whose selector never judged a pool
+pool order, with lane, matched section, and a per-line verdict) for the
+inspector's Memory tab, plus `selector_ran`. A page carries one finder line
+per distinct matched section, at most `memory.v3.finderSectionsPerPage` in
+surfacing order (needle, dense, reply, span, entity), and selecting a line
+selects that section; the selection log keeps one row per slug, so the pool
+row is where the per-section verdicts live. A turn whose selector never judged a pool
 (the injection gate hard-skipped it, or nothing was pooled) persists an empty
 pool with `selector_ran = 0`, and a turn that logged no selections is still
 reachable by its stamped `message_id`, so the inspector shows negative

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -175,13 +175,19 @@ by exactly its header span, in live history and at rehydration, drops the
 section's line from any `<memory_pointer>` that named it (a pointer left empty
 is dropped whole), and evicts by last selection recency with no lane
 exemptions. That recency is each section row's own `last_selected_at`: the
-injector's commit stamps it on every section the turn selected, the net-new
-ones with their record (`recordInjected`) and the resident ones, pointer
-entries and capability units alike, by `touchSelected`, so two sections of
-one page selected together both age from that turn, and a row with no stamp
-(a truncated fork's seed, or one written before the column existed) ranks by
-`injected_at`. The selection log (`memory_v3_selections`), which keeps one
-section per slug, plays no part in eviction. The live strip is idempotent over
+injector stamps it on every section the turn selected, the resident ones,
+pointer entries and capability units alike, by `touchSelected` in the same
+synchronous segment that classifies them (a valve queued by an earlier turn's
+commit fires on a timer and can run while the turn's page reads are awaited,
+so it ranks the fresh stamp, and a turn whose net-new sections all render
+empty, which carries no block and no commit, still stamps them; the stamp is
+a recency bump, never a claim, so a turn whose block does not attach bumps
+harmlessly), and the net-new ones with their record (`recordInjected`) at its
+commit, so two sections of one page selected together both age from that
+turn, and a row with no stamp (a truncated fork's seed, or one written before
+the column existed) ranks by `injected_at`. The selection log
+(`memory_v3_selections`), which keeps one section per slug, plays no part in
+eviction. The live strip is idempotent over
 the conversation's full tombstone set and runs both in the valve and at
 runtime assembly Step 0 on every turn:
 the valve fires on a timer while the turn that scheduled it may still be in
@@ -196,7 +202,11 @@ copy sits on a later message is dropped the same way
 identity (`markV3LiveBlock` / `isV3LiveBlock` in `v3/types.ts`: the blocks
 assembly attaches, `loadFromDb` splices, and the strip rewrites), never by
 text, so a pre-cutover v2 block byte-identical to a v3 entry is left alone. Re-selected sections that are already resident are listed, paths
-only, in the `memory-v3-pointer` injector's per-turn `<memory_pointer>` block.
+only, in the `memory-v3-pointer` injector's per-turn `<memory_pointer>` block,
+re-validated against the store at render time: a section the valve tombstoned
+between the sections injector's classification and the pointer's render is
+dropped from it (absent this turn, it re-injects on its next selection), and
+a pointer left with nothing is not emitted.
 Under a run-messages replacement (the Slack chronological transcript,
 `TurnContext.replacesRunMessages`, stated by runtime assembly ahead of the
 chain) no frozen block from an earlier turn is in the prompt, so the sections

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -174,8 +174,16 @@ re-imports leads whose blocks are gone. A page's lead injection carries its
 by exactly its header span, in live history and at rehydration, drops the
 section's line from any `<memory_pointer>` that named it (a pointer left empty
 is dropped whole), and evicts by last selection recency with no lane
-exemptions. The live strip is idempotent over the conversation's full tombstone
-set and runs both in the valve and at runtime assembly Step 0 on every turn:
+exemptions. That recency is each section row's own `last_selected_at`: the
+injector's commit stamps it on every section the turn selected, the net-new
+ones with their record (`recordInjected`) and the resident ones, pointer
+entries and capability units alike, by `touchSelected`, so two sections of
+one page selected together both age from that turn, and a row with no stamp
+(a truncated fork's seed, or one written before the column existed) ranks by
+`injected_at`. The selection log (`memory_v3_selections`), which keeps one
+section per slug, plays no part in eviction. The live strip is idempotent over
+the conversation's full tombstone set and runs both in the valve and at
+runtime assembly Step 0 on every turn:
 the valve fires on a timer while the turn that scheduled it may still be in
 flight, so a section pruned on the turn that injected it folds back in
 afterwards, and the assembly strip removes it on the next turn. A pruned section that is re-selected re-injects as a fresh entry on
@@ -386,7 +394,7 @@ Persisted rows; a rename orphans every existing install.
 | `memory_v2_injection_events`      | v2 scoring feedback                                             |
 | `memory_v3_selections`            | v3 selection log (`section_key` column plugin-added, see below) |
 | `memory_v3_pools`                 | v3 selector pool audit (plugin-created, see below)              |
-| `memory_v3_injected_sections`     | v3 section dedup + prune accounting (plugin-created, see below) |
+| `memory_v3_injected_sections`     | v3 section dedup, prune bytes + recency (plugin-created, below) |
 | `memory_v3_ever_injected`         | v3 card dedup (superseded, frozen)                              |
 | `memory_retrospective_state`      | retrospective (tier-agnostic)                                   |
 | `activation_sessions`             | onboarding activation rail                                      |
@@ -397,10 +405,12 @@ tables, created by the plugin rather than by the global migration chain
 boot, and each store ensures again on the first use of a connection in its
 process (the memory worker is a separate process), idempotently and fail-open,
 so a memory database that cannot be opened degrades the stores to no-ops
-instead of failing database readiness. The sections ensure also copies the
-legacy `memory_v3_ever_injected` rows in as zero-byte lead entries, once per
-database: the first ensure that finds the legacy table copies
-(`INSERT OR IGNORE`) and records `memory_v3_injected_sections:legacy_copy_done`
+instead of failing database readiness. The sections ensure adds the
+`last_selected_at` column (the prune valve's recency stamp) to a table created
+before it existed, and copies the legacy `memory_v3_ever_injected` rows in as
+zero-byte lead entries, once per database: the first ensure that finds the
+legacy table copies (`INSERT OR IGNORE`) and records
+`memory_v3_injected_sections:legacy_copy_done`
 in `memory_checkpoints`, later ensures skip on that record, and a ledger that
 cannot be read skips the copy rather than repeating it. The compaction reset
 (`clearConversation`) and the conversation purge delete a conversation's
@@ -411,7 +421,9 @@ blocks compaction stripped. `memory_v3_selections` itself is created by migratio
 (`writeTurnLog`) and the inspector's reader (`v3/selection-log-store.ts`) add
 it on the first use of a connection, and the `init` hook at boot. Every
 selection row records one section per slug, the selection's first selected
-section, as its `sectionKey` beside the title and ordinal, and the inspector
+section, as its `sectionKey` beside the title and ordinal (an inspector and
+frecency record only; the prune valve's recency lives on the section store's
+rows, see the v3 injection layers above), and the inspector
 resolves a row by that key first (exactly, so a repeated heading's other
 occurrence is never substituted), falling back to title-then-ordinal only for
 rows written before the column existed.

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/injected-block-slugs.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/injected-block-slugs.test.ts
@@ -139,7 +139,8 @@ describe("parseInjectedSections", () => {
 
   test("an escaped key (doubled #) round-trips through the header verbatim", () => {
     // `sectionKey` doubles a title's literal `#`; the header carries the key
-    // as-is and the parser hands it back unchanged for `sectionKeyTitle`.
+    // as-is and the parser hands it back unchanged, so a parsed ref carries
+    // the section store's identity.
     const header = injectedSectionHeader("topics/page-a", "Topic##1");
     expect(header).toBe("# memory/concepts/topics/page-a.md § Topic##1");
     expect(

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -11,6 +11,9 @@
  *   - commit deferral: the section-store write happens in the block's
  *     attachment-commit callback (invoked by assembly on user-tail turns),
  *     never in `produce()` itself;
+ *   - commit stamping: the commit stamps the turn's time on every selected
+ *     section, net-new and resident alike (capability units included), so
+ *     the prune valve's recency follows selection;
  *   - trust gate: an untrusted remote actor's turn produces nothing and
  *     records nothing (the v2 personal-memory gate);
  *   - fork dedup: a conversation whose record was seeded from inherited
@@ -28,13 +31,20 @@
  */
 
 import { Database } from "bun:sqlite";
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { setConfig } from "../../../../../__tests__/helpers/set-config.js";
 import type { Conversation } from "../../../../../daemon/conversation.js";
-import { ensureMemoryV3SelectionsSchema } from "../../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../../persistence/schema/index.js";
 import type { InjectionBlock } from "../../../../types.js";
 import { unwrapMemoryBlock } from "../../memory-marker.js";
@@ -96,16 +106,15 @@ mock.module("../../../../../util/logger.js", () => ({
 }));
 
 let testSqlite: Database;
-// The prune valve's recency ranking reads `memory_v3_selections` over the
-// dedicated memory connection, resolved via `getMemorySqlite` — stubbed to a
-// second in-memory DB carrying the relocated tables' schema.
+// The section store (the prune valve's candidate set and recency) lives on
+// the dedicated memory connection, resolved via `getMemorySqlite`, stubbed to
+// a second in-memory DB carrying the store's schema.
 let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
   testSqlite = new Database(":memory:");
   const db = drizzle(testSqlite, { schema });
   memorySqlite = new Database(":memory:");
-  ensureMemoryV3SelectionsSchema(memorySqlite);
   ensureMemoryV3InjectedSectionsSchema(memorySqlite);
   // The prune valve strips only sections locatable in persisted
   // `memoryV3InjectedBlock` rows (`collectPersistedV3Sections`), minimal
@@ -567,6 +576,63 @@ describe("memoryV3Injector: frozen net-new sections", () => {
     const pointer = await producePointer("conv-1", 1);
     expect(pointer!.text).toContain("memory/concepts/page-a.md § Beta");
     expect(pointer!.text).not.toContain("§ Alpha");
+  });
+
+  test("the commit stamps the turn's time on every selected section: net-new ones with their record, resident ones (pointer entries and capability units) by touch", async () => {
+    liveEnabled = true;
+    const skill = "skills/test-skill";
+    turnResults.set(
+      0,
+      result(
+        ["page-a", skill],
+        [
+          ["page-a", alpha],
+          ["page-a", beta],
+        ],
+      ),
+    );
+    // Turn 1 re-selects Beta (a pointer entry) and the skill (resident, with
+    // no pointer line) beside net-new page-c; Alpha is not selected.
+    turnResults.set(1, result(["page-a", "page-c", skill], [["page-a", beta]]));
+    const stamps = () =>
+      new Map(
+        getInjected("conv-1").map((row) => [
+          `${row.slug}§${row.key}`,
+          row.lastSelectedAt,
+        ]),
+      );
+
+    try {
+      setSystemTime(new Date(1_000_000));
+      await produceSections("conv-1", 0);
+      expect(stamps()).toEqual(
+        new Map([
+          ["page-a§Alpha", 1_000_000],
+          ["page-a§Beta", 1_000_000],
+          [`${skill}§`, 1_000_000],
+        ]),
+      );
+
+      setSystemTime(new Date(2_000_000));
+      await produceSections("conv-1", 1);
+      expect(stamps()).toEqual(
+        new Map([
+          ["page-a§Alpha", 1_000_000],
+          ["page-a§Beta", 2_000_000],
+          ["page-c§", 2_000_000],
+          [`${skill}§`, 2_000_000],
+        ]),
+      );
+      // A touched section keeps its record's injected_at.
+      expect(
+        getInjected("conv-1").find((row) => row.key === "Beta")!.injectedAt,
+      ).toBe(1_000_000);
+      const pointer = await producePointer("conv-1", 1);
+      expect(pointer!.text).toContain("memory/concepts/page-a.md § Beta");
+      expect(pointer!.text).not.toContain("test-skill");
+    } finally {
+      setSystemTime();
+    }
   });
 
   test("a capability page selected on two sections injects its content once", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -271,22 +271,27 @@ function section(slug: Slug, title: string, body: string): Section {
   };
 }
 
-/** An orchestrate result selecting `slugs`, with optional finder-matched
- *  sections (slug → section). */
+/** An orchestrate result selecting `slugs`, with optional selected sections
+ *  (slug → section; a slug listed twice selects two of its sections). */
 function result(
   slugs: Slug[],
   matched: Array<[Slug, Section]> = [],
 ): OrchestrateResult {
   return {
-    selections: slugs.map((slug) => ({ slug })),
-    matchedSections: new Map(matched),
+    selections: slugs.map((slug) => ({
+      slug,
+      sections: matched
+        .filter(([matchedSlug]) => matchedSlug === slug)
+        .map(([, section]) => section),
+    })),
     lanes: {
       core: [],
       hot: [],
       fresh: [],
       always: [],
-      finder: matched.map(([slug]) => ({
+      finder: matched.map(([slug, section]) => ({
         slug,
+        section,
         descriptor: "",
         lane: "needle" as const,
       })),
@@ -527,6 +532,62 @@ describe("memoryV3Injector: frozen net-new sections", () => {
     // Re-selecting Alpha injects nothing: both sections are resident.
     const t3 = await produceSections("conv-1", 2);
     expect(t3!.text).toBe("");
+  });
+
+  test("two sections of one page selected on one turn both inject, and either is resident afterwards", async () => {
+    liveEnabled = true;
+    turnResults.set(
+      0,
+      result(
+        ["page-a"],
+        [
+          ["page-a", alpha],
+          ["page-a", beta],
+        ],
+      ),
+    );
+    turnResults.set(1, result(["page-a"], [["page-a", beta]]));
+
+    const t1 = await produceSections("conv-1", 0);
+    expect(t1!.text).toContain(
+      "# memory/concepts/page-a.md § Alpha\nalpha section text",
+    );
+    expect(t1!.text).toContain(
+      "# memory/concepts/page-a.md § Beta\nbeta section text",
+    );
+    // Both sections were selected, so the lead is not the fallback unit.
+    expect(t1!.text).not.toContain(leadRender("page-a"));
+    expect(activeIds("conv-1")).toEqual(
+      new Set(["page-a§Alpha", "page-a§Beta"]),
+    );
+
+    // Re-selecting one of them injects nothing and points at it.
+    const t2 = await produceSections("conv-1", 1);
+    expect(t2!.text).toBe("");
+    const pointer = await producePointer("conv-1", 1);
+    expect(pointer!.text).toContain("memory/concepts/page-a.md § Beta");
+    expect(pointer!.text).not.toContain("§ Alpha");
+  });
+
+  test("a capability page selected on two sections injects its content once", async () => {
+    liveEnabled = true;
+    // Capability content injects whole under the empty key, so two selected
+    // sections of a skill page are one unit.
+    const skill = "skills/test-skill";
+    turnResults.set(
+      0,
+      result(
+        [skill],
+        [
+          [skill, section(skill, "Usage", "usage text")],
+          [skill, section(skill, "Notes", "notes text")],
+        ],
+      ),
+    );
+
+    const block = await produceSections("conv-1", 0);
+    expect(block!.text.split("# Skill: test-skill")).toHaveLength(2);
+    expect(activeIds("conv-1")).toEqual(new Set([`${skill}§`]));
   });
 
   test("a page selected without a matched section after a section injection injects its lead once", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -8,12 +8,16 @@
  *   - net-new dedup: a turn re-selecting already-injected sections renders
  *     zero new sections (empty-text block, still produced, so v2 suppression
  *     holds) and lists them in the pointer instead;
- *   - commit deferral: the section-store write happens in the block's
+ *   - commit deferral: the net-new record happens in the block's
  *     attachment-commit callback (invoked by assembly on user-tail turns),
  *     never in `produce()` itself;
- *   - commit stamping: the commit stamps the turn's time on every selected
- *     section, net-new and resident alike (capability units included), so
- *     the prune valve's recency follows selection;
+ *   - selection stamping: every selected section carries the turn's time,
+ *     the resident ones (capability units included) stamped at
+ *     classification ahead of any await, so a queued valve ranks the fresh
+ *     recency and an all-empty render still stamps them, and the net-new
+ *     ones with their record at commit;
+ *   - pointer re-validation: a resident entry the valve tombstones between
+ *     classification and the pointer render is dropped from the pointer;
  *   - trust gate: an untrusted remote actor's turn produces nothing and
  *     records nothing (the v2 personal-memory gate);
  *   - fork dedup: a conversation whose record was seeded from inherited
@@ -252,7 +256,7 @@ const {
   seedEverInjectedFromBlocks,
 } = await import("../ever-injected-store.js");
 const { V3_INJECTION_HEADER } = await import("../render-injection.js");
-const { flushPruneValveForTests } = await import("../prune.js");
+const { flushPruneValveForTests, runPruneValve } = await import("../prune.js");
 const { drainConversationNotices, resetConversationNoticesForTests } =
   await import("../../../../../daemon/conversation-notices.js");
 const { MemoryV3RetrievalUnavailableError } = await import("../pool-select.js");
@@ -578,7 +582,7 @@ describe("memoryV3Injector: frozen net-new sections", () => {
     expect(pointer!.text).not.toContain("§ Alpha");
   });
 
-  test("the commit stamps the turn's time on every selected section: net-new ones with their record, resident ones (pointer entries and capability units) by touch", async () => {
+  test("every selected section carries the turn's time: resident ones (pointer entries and capability units) are stamped at classification, net-new ones with their record at commit", async () => {
     liveEnabled = true;
     const skill = "skills/test-skill";
     turnResults.set(
@@ -613,8 +617,18 @@ describe("memoryV3Injector: frozen net-new sections", () => {
         ]),
       );
 
+      // The resident stamps land in produce() itself, ahead of the commit,
+      // while page-c is not yet recorded.
       setSystemTime(new Date(2_000_000));
-      await produceSections("conv-1", 1);
+      const block = await produceSectionsWithoutCommit("conv-1", 1);
+      expect(stamps()).toEqual(
+        new Map([
+          ["page-a§Alpha", 1_000_000],
+          ["page-a§Beta", 2_000_000],
+          [`${skill}§`, 2_000_000],
+        ]),
+      );
+      commitSectionsBlock(block);
       expect(stamps()).toEqual(
         new Map([
           ["page-a§Alpha", 1_000_000],
@@ -630,6 +644,77 @@ describe("memoryV3Injector: frozen net-new sections", () => {
       const pointer = await producePointer("conv-1", 1);
       expect(pointer!.text).toContain("memory/concepts/page-a.md § Beta");
       expect(pointer!.text).not.toContain("test-skill");
+    } finally {
+      setSystemTime();
+    }
+  });
+
+  test("a queued valve that runs between classification and the commit ranks a re-selected resident section by this turn's stamp and evicts the stale ones instead", async () => {
+    liveEnabled = true;
+    // Each stubbed lead is 52 bytes. Turn 0 injects three with the valve
+    // unconfigured, then the cap is set below their 156 resident bytes so the
+    // next valve run must free two of them.
+    turnResults.set(0, result(["page-a", "page-b", "page-d"]));
+    turnResults.set(1, result(["page-a", "page-c"]));
+    const stamp = (slug: Slug) =>
+      getInjected("conv-1").find((row) => row.slug === slug)?.lastSelectedAt;
+
+    try {
+      setSystemTime(new Date(1_000_000));
+      await produceSections("conv-1", 0);
+      await flushPruneValveForTests();
+      pruneConfig = { maxResidentBytes: 110, targetResidentBytes: 100 };
+
+      // Turn 1 re-selects page-a beside net-new page-c: page-a is stamped in
+      // produce() itself, ahead of the commit.
+      setSystemTime(new Date(2_000_000));
+      const block = await produceSectionsWithoutCommit("conv-1", 1);
+      expect(stamp("page-a")).toBe(2_000_000);
+      expect(stamp("page-b")).toBe(1_000_000);
+      expect(stamp("page-d")).toBe(1_000_000);
+
+      // The pending valve fires before the commit. On turn 0's stamps alone
+      // page-a would be the first to go (the slug tiebreak); this turn's
+      // stamp keeps it, and the two stale leads go instead.
+      const plan = await runPruneValve("conv-1", { liveMessages: () => null });
+      expect(plan?.sections).toEqual([
+        { slug: "page-b", key: "" },
+        { slug: "page-d", key: "" },
+      ]);
+      expect(prunedIds("conv-1")).toEqual(new Set(["page-b§", "page-d§"]));
+
+      commitSectionsBlock(block);
+      await flushPruneValveForTests();
+      expect(activeIds("conv-1")).toEqual(new Set(["page-a§", "page-c§"]));
+      const pointer = await producePointer("conv-1", 1);
+      expect(pointer!.text).toContain("memory/concepts/page-a.md");
+      expect(pointer!.text).not.toContain("page-b");
+    } finally {
+      setSystemTime();
+    }
+  });
+
+  test("a resident section selected beside net-new units that all render empty still takes this turn's stamp and is still pointed at", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a"]));
+    turnResults.set(1, result(["page-a", "missing-page"]));
+    const stamp = () =>
+      getInjected("conv-1").find((row) => row.slug === "page-a")!
+        .lastSelectedAt;
+
+    try {
+      setSystemTime(new Date(1_000_000));
+      await produceSections("conv-1", 0);
+      expect(stamp()).toBe(1_000_000);
+
+      // Every net-new unit renders empty: no block and no commit, but the
+      // resident page-a was selected this turn and ages from it.
+      setSystemTime(new Date(2_000_000));
+      expect(await produceSections("conv-1", 1)).toBeNull();
+      expect(stamp()).toBe(2_000_000);
+      expect(activeIds("conv-1")).toEqual(new Set(["page-a§"]));
+      const pointer = await producePointer("conv-1", 1);
+      expect(pointer!.text).toContain("memory/concepts/page-a.md");
     } finally {
       setSystemTime();
     }
@@ -946,22 +1031,54 @@ describe("memoryV3PointerInjector: ephemeral resident-section pointer", () => {
     turnResults.set(0, result(["page-a"]));
     turnResults.set(1, result(["page-a", "page-c"], [["page-c", gamma]]));
 
-    await produceSections("conv-1", 0);
-    const first = await produceSections("conv-1", 1);
-    const firstPointer = await producePointer("conv-1", 1);
-    expect(first!.text).toContain("§ Gamma");
-    expect(firstPointer!.text).toContain("memory/concepts/page-a.md");
-    expect(firstPointer!.text).not.toContain("page-c");
-    const storeBefore = getInjected("conv-1");
+    try {
+      setSystemTime(new Date(1_000_000));
+      await produceSections("conv-1", 0);
+      const first = await produceSections("conv-1", 1);
+      const firstPointer = await producePointer("conv-1", 1);
+      expect(first!.text).toContain("§ Gamma");
+      expect(firstPointer!.text).toContain("memory/concepts/page-a.md");
+      expect(firstPointer!.text).not.toContain("page-c");
+      const storeBefore = getInjected("conv-1");
 
-    // Re-entry (the re-injection strip cleared the tail's block and pointer):
-    // the same bytes come back. The store counts page-c's section active, so
-    // partitioning against it alone would have read it as resident.
-    const again = await produceSectionsWithoutCommit("conv-1", 1);
-    expect(again!.text).toBe(first!.text);
-    expect(again!.meta?.[MEMORY_V3_COMMIT_META_KEY]).toBeUndefined();
-    expect((await producePointer("conv-1", 1))!.text).toBe(firstPointer!.text);
-    expect(getInjected("conv-1")).toEqual(storeBefore);
+      // Re-entry (the re-injection strip cleared the tail's block and
+      // pointer): the same bytes come back. The store counts page-c's section
+      // active, so partitioning against it alone would have read it as
+      // resident. The clock is stepped so a stray selection stamp on page-a
+      // could not tie with the first produce's.
+      setSystemTime(new Date(2_000_000));
+      const again = await produceSectionsWithoutCommit("conv-1", 1);
+      expect(again!.text).toBe(first!.text);
+      expect(again!.meta?.[MEMORY_V3_COMMIT_META_KEY]).toBeUndefined();
+      expect((await producePointer("conv-1", 1))!.text).toBe(
+        firstPointer!.text,
+      );
+      expect(getInjected("conv-1")).toEqual(storeBefore);
+    } finally {
+      setSystemTime();
+    }
+  });
+
+  test("a resident section the valve tombstones between classification and the pointer render is left out of the pointer block", async () => {
+    liveEnabled = true;
+    turnResults.set(0, result(["page-a", "page-b"]));
+    turnResults.set(1, result(["page-a", "page-b", "page-c"]));
+
+    await produceSections("conv-1", 0);
+    // Turn 1 classifies page-a and page-b as resident (its pointer entries)
+    // beside net-new page-c, and a valve fires before the pointer renders,
+    // taking page-a.
+    const block = await produceSections("conv-1", 1);
+    expect(block!.text).toContain("# memory/concepts/page-c.md");
+    markPruned("conv-1", [{ slug: "page-a", key: "" }], Date.now());
+
+    const pointer = await producePointer("conv-1", 1);
+    expect(pointer!.text).toContain("\nmemory/concepts/page-b.md\n");
+    expect(pointer!.text).not.toContain("page-a");
+
+    // With every remembered entry tombstoned, no pointer is emitted at all.
+    markPruned("conv-1", [{ slug: "page-b", key: "" }], Date.now());
+    expect(await producePointer("conv-1", 1)).toBeNull();
   });
 
   test("a re-entry after a compaction's store reset re-emits the first produce's entries, renders the formerly resident pairs anew, and points at nothing", async () => {
@@ -1145,24 +1262,32 @@ describe("memoryV3Injector: run-messages replacement (Slack transcript)", () => 
       ),
     );
 
-    // Turn 0 froze Alpha into history and recorded it resident.
-    await produceSections("conv-1", 0);
-    expect(activeIds("conv-1")).toEqual(new Set(["page-a§Alpha"]));
-    const storeBefore = getInjected("conv-1");
+    try {
+      // Turn 0 froze Alpha into history and recorded it resident.
+      setSystemTime(new Date(1_000_000));
+      await produceSections("conv-1", 0);
+      expect(activeIds("conv-1")).toEqual(new Set(["page-a§Alpha"]));
+      const storeBefore = getInjected("conv-1");
 
-    // Turn 1 is assembled onto a transcript that carries no frozen block,
-    // so Alpha's body renders again beside the net-new Gamma.
-    const block = await produceReplaced("conv-1", 1);
-    expect(block!.text).toContain(
-      "# memory/concepts/page-a.md § Alpha\nalpha section text",
-    );
-    expect(block!.text).toContain(
-      "# memory/concepts/page-c.md § Gamma\ngamma section text",
-    );
-    expect(block!.meta?.[MEMORY_V3_COMMIT_META_KEY]).toBeUndefined();
-    expect(await producePointerReplaced("conv-1", 1)).toBeNull();
-    expect(getInjected("conv-1")).toEqual(storeBefore);
-    expect(activeIds("conv-1")).toEqual(new Set(["page-a§Alpha"]));
+      // Turn 1 is assembled onto a transcript that carries no frozen block,
+      // so Alpha's body renders again beside the net-new Gamma. Residency
+      // means nothing there, so Alpha takes no selection stamp either (the
+      // clock is stepped so a stray one could not tie with turn 0's).
+      setSystemTime(new Date(2_000_000));
+      const block = await produceReplaced("conv-1", 1);
+      expect(block!.text).toContain(
+        "# memory/concepts/page-a.md § Alpha\nalpha section text",
+      );
+      expect(block!.text).toContain(
+        "# memory/concepts/page-c.md § Gamma\ngamma section text",
+      );
+      expect(block!.meta?.[MEMORY_V3_COMMIT_META_KEY]).toBeUndefined();
+      expect(await producePointerReplaced("conv-1", 1)).toBeNull();
+      expect(getInjected("conv-1")).toEqual(storeBefore);
+      expect(activeIds("conv-1")).toEqual(new Set(["page-a§Alpha"]));
+    } finally {
+      setSystemTime();
+    }
   });
 
   test("a re-entry of a replaced turn re-emits the same bytes and still carries no commit", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -277,14 +277,19 @@ async function runTurn(
     sectionIndex.sections[sectionIndex.byArticle.get(slug)![0]!]!;
   const netNew: Slug[] = [];
   const entries: Array<{ slug: Slug; key: string; text: string }> = [];
-  for (const { slug } of result.selections) {
-    const section = result.matchedSections.get(slug) ?? leadOf(slug);
-    const key = sectionKey(section);
-    if (sectionRefSetHas(active, slug, key)) {
-      continue;
+  for (const { slug, sections } of result.selections) {
+    for (const section of sections.length > 0 ? sections : [leadOf(slug)]) {
+      const key = sectionKey(section);
+      if (sectionRefSetHas(active, slug, key)) {
+        continue;
+      }
+      netNew.push(slug);
+      entries.push({
+        slug,
+        key,
+        text: renderV3SectionInjection(slug, section),
+      });
     }
-    netNew.push(slug);
-    entries.push({ slug, key, text: renderV3SectionInjection(slug, section) });
   }
   recordInjected(
     conversationId,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -195,6 +195,28 @@ async function buildLanes(): Promise<Lanes> {
   return { sectionIndex, needle, edgeGraph };
 }
 
+/** Lanes over an ad-hoc page map (bodies only, no `links:` frontmatter), for
+ *  tests whose fixture needs pages the shared corpus does not have. */
+async function customLanes(pages: Record<Slug, string>): Promise<Lanes> {
+  const slugs = Object.keys(pages);
+  const entries: PageIndexEntry[] = slugs.map((slug, i) => ({
+    id: i + 1,
+    slug,
+    summary: `summary of ${slug}`,
+    edges: [],
+    leaves: [],
+    modifiedAt: 0,
+    freshAt: null,
+  }));
+  const sectionIndex = await buildSectionIndex(slugs, async (s) => pages[s]!);
+  const needle = buildSectionNeedle(sectionIndex);
+  const edgeGraph = await buildEdgeGraph(
+    entries,
+    async (s) => `---\nedges: []\n---\n${pages[s]}`,
+  );
+  return { sectionIndex, needle, edgeGraph };
+}
+
 const config = {} as never;
 
 /**
@@ -448,6 +470,7 @@ describe("orchestrate — candidate pool composition", () => {
       },
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     providerStub = selectProvider([]);
     await orchestrate(makeTurn(1, "x"), depsOf(lanes, { needle }));
@@ -521,14 +544,19 @@ describe("orchestrate — candidate pool composition", () => {
     });
   });
 
-  test("matchedSections is populated from matched lane sections", async () => {
+  test("a finder line carries its matched section and terms, and selecting it selects that section", async () => {
     const lanes = await buildLanes();
     denseHits = [];
     providerStub = selectProvider(["topic-a"]);
     const result = await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
     // topic-a matched "apple" in its `## Details` section.
-    expect(result.matchedSections.get("topic-a")?.article).toBe("topic-a");
-    expect(result.matchedSections.get("topic-a")?.text).toContain("apple");
+    const line = result.lanes.finder.find((c) => c.slug === "topic-a");
+    expect(line?.section?.article).toBe("topic-a");
+    expect(line?.section?.text).toContain("apple");
+    expect(line?.terms).toEqual(["apple"]);
+    expect(result.selections).toEqual([
+      { slug: "topic-a", sections: [line!.section!] },
+    ]);
   });
 });
 
@@ -604,11 +632,13 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
       ["topic-b", "reply"],
       ["topic-d", "edge"],
     ]);
-    // The reply-matched section is recorded for injection.
-    expect(result.matchedSections.has("topic-b")).toBe(true);
+    // The reply-matched section rides its finder line.
+    expect(
+      result.lanes.finder.find((c) => c.slug === "topic-b")?.section?.text,
+    ).toContain("cherry date");
   });
 
-  test("a slug both queries surface keeps its primary-lane attribution", async () => {
+  test("a section both queries surface is pooled once, under the primary lane", async () => {
     const lanes = await buildLanes();
     denseHits = [];
     providerStub = selectProvider([]);
@@ -671,9 +701,11 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
       ["topic-d", "edge"],
       ["topic-c", "learned"],
     ]);
-    // Association, not lexical relevance, surfaced topic-c — no matched
-    // section is recorded (injection falls back to the full page).
-    expect(result.matchedSections.has("topic-c")).toBe(false);
+    // Association, not lexical relevance, surfaced topic-c: its line carries
+    // no section (a selection of it injects the lead).
+    expect(
+      result.lanes.finder.find((c) => c.slug === "topic-c")?.section,
+    ).toBeUndefined();
   });
 
   test("learnedCap = 0 disables the learned pass", async () => {
@@ -782,11 +814,13 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
     expect(
       lastPoolLines.find((l) => /^\[2\] (?:\([^)]*\) )?topic-a — /.test(l)),
     ).toContain("apple");
-    // Selecting both ids still yields ONE selection (slug dedup), the finder
-    // lane records the hit, and the matched section survives downstream.
-    expect(result.selections).toEqual([{ slug: "topic-a" }]);
-    expect(result.lanes.finder.map((c) => c.slug)).toContain("topic-a");
-    expect(result.matchedSections.get("topic-a")?.text).toContain("apple");
+    // Selecting both ids still yields ONE selection (merged per slug), which
+    // carries the finder line's matched section.
+    const line = result.lanes.finder.find((c) => c.slug === "topic-a");
+    expect(line?.section?.text).toContain("apple");
+    expect(result.selections).toEqual([
+      { slug: "topic-a", sections: [line!.section!] },
+    ]);
   });
 
   test("a hot slug duplicated into core is defensively dropped from hot", async () => {
@@ -833,7 +867,7 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
 // ---------------------------------------------------------------------------
 
 describe("orchestrate — edge-only injection", () => {
-  test("an edge-only page records NO matchedSections entry (→ full-page inject)", async () => {
+  test("an edge-only page carries NO section (its selection injects the lead)", async () => {
     const lanes = await buildLanes();
     // "apple" hits topic-a (needle); topic-a links to topic-d (edge-only — the
     // query never hits topic-d). Select topic-d so it is in the result.
@@ -841,18 +875,19 @@ describe("orchestrate — edge-only injection", () => {
     providerStub = selectProvider(["topic-d"]);
     const result = await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
 
-    // topic-d was selected, but with NO matched section — so
-    // `renderV3SectionContent(slug, undefined)` falls back to the full page.
-    expect(result.selections.map((s) => s.slug)).toContain("topic-d");
-    expect(result.matchedSections.has("topic-d")).toBe(false);
+    // topic-d was selected with NO section, so the injector renders its lead.
+    expect(result.selections).toContainEqual({ slug: "topic-d", sections: [] });
+    expect(
+      result.lanes.finder.find((c) => c.slug === "topic-d")?.section,
+    ).toBeUndefined();
   });
 
   test("an edge-only page with no curated description falls back to bestSection text as the descriptor", async () => {
     // A bare `links:` entry (no ` — `) carries NO description, so the edge
     // candidate's descriptor falls back to the page's best section against the
     // query. The query never hits dst-page, so bestSection returns its lead;
-    // that lead text becomes the descriptor (and the page is still injected in
-    // full, with no matchedSections entry).
+    // that lead text becomes the descriptor (and the line still carries no
+    // section).
     const pages: Record<Slug, string> = {
       "src-page": "lead for src\n## Body\nalpha bravo about src",
       "dst-page": "lead content for dst page\n## Extra\nnothing relevant here",
@@ -885,10 +920,12 @@ describe("orchestrate — edge-only injection", () => {
       depsOf({ sectionIndex, needle, edgeGraph }),
     );
 
-    // Descriptor fell back to dst-page's lead text; still no matched section.
+    // Descriptor fell back to dst-page's lead text; still no section.
     const line = lastPoolLines.find((l) => / dst-page — /.test(l));
     expect(line).toContain("lead content for dst page");
-    expect(result.matchedSections.has("dst-page")).toBe(false);
+    expect(
+      result.lanes.finder.find((c) => c.slug === "dst-page")?.section,
+    ).toBeUndefined();
   });
 });
 
@@ -933,9 +970,11 @@ describe("orchestrate — dense liveness filter", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Lane provenance: each finder candidate records the lane that FIRST surfaced
-// it (needle → dense → edge precedence), exposed via `result.lanes.finder` so
-// the selection telemetry can attribute true sources.
+// Lane provenance: each finder line records the lane that surfaced it, exposed
+// via `result.lanes.finder` so the selection telemetry can attribute true
+// sources. A section two lanes both score is pooled once, under the first lane
+// (needle → dense → reply → span → entity order); a different section of the
+// same page is its own line under its own lane.
 // ---------------------------------------------------------------------------
 
 describe("orchestrate — finder lane provenance", () => {
@@ -956,17 +995,47 @@ describe("orchestrate — finder lane provenance", () => {
     expect(laneOf.get("topic-d")).toBe("edge");
   });
 
-  test("a slug surfaced by needle AND dense keeps the needle lane (first wins)", async () => {
+  test("the same section surfaced by needle AND dense is pooled once, under the needle lane", async () => {
     const lanes = await buildLanes();
-    // topic-a is surfaced by the needle on "apple"; dense ALSO returns topic-a.
-    // Needle runs first, so the recorded lane stays needle.
-    denseHits = [{ article: "topic-a", section: 0 }];
+    // topic-a is surfaced by the needle on "apple" (`## Details`, ordinal 1);
+    // dense ALSO returns that section. Needle runs first, so the one line
+    // reads needle.
+    denseHits = [{ article: "topic-a", section: 1 }];
     providerStub = selectProvider([]);
-    const result = await orchestrate(makeTurn(1, "apple"), depsOf(lanes));
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100 }),
+    );
 
     const entries = result.lanes.finder.filter((c) => c.slug === "topic-a");
     expect(entries).toHaveLength(1);
     expect(entries[0]!.lane).toBe("needle");
+  });
+
+  test("a different section of a needle-surfaced page reached by dense is its own dense line", async () => {
+    const lanes = await buildLanes();
+    // needle: topic-a `## Details` (ordinal 1); dense: topic-a's lead
+    // (ordinal 0). Two sections, two lines, needle first.
+    denseHits = [{ article: "topic-a", section: 0 }];
+    providerStub = selectProvider(["topic-a"]);
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { denseK: 100 }),
+    );
+
+    const entries = result.lanes.finder.filter((c) => c.slug === "topic-a");
+    expect(entries.map((c) => [c.lane, c.section?.ordinal])).toEqual([
+      ["needle", 1],
+      ["dense", 0],
+    ]);
+    // The pool shows both lines; keeping both selects both sections.
+    expect(lastPool.filter((s) => s === "topic-a")).toHaveLength(2);
+    expect(result.selections).toEqual([
+      {
+        slug: "topic-a",
+        sections: [entries[0]!.section!, entries[1]!.section!],
+      },
+    ]);
   });
 });
 
@@ -986,6 +1055,7 @@ describe("orchestrate — degradation", () => {
           queryScored: () => [],
           bestSection: () => -1,
           idf: () => 0,
+          topTerms: () => [],
         },
       }),
     );
@@ -1013,12 +1083,13 @@ describe("orchestrate — degradation", () => {
 
 // ---------------------------------------------------------------------------
 // Entity lane: the heading section is the identity the lane exists to surface,
-// so it overrides a bulk-theme section a prior lane already recorded for the
-// same page, and surfaces a heading-named page no other lane found.
+// so it joins the pool as its own line beside any bulk-theme section a prior
+// lane pooled for the same page, and surfaces a heading-named page no other
+// lane found.
 // ---------------------------------------------------------------------------
 
 describe("orchestrate — entity lane", () => {
-  test("overrides the matched section + descriptor to the heading when another lane already surfaced the page", async () => {
+  test("adds the heading section as its own line beside the bulk-theme section another lane pooled", async () => {
     const lanes = await buildLanes();
     const { sectionIndex } = lanes;
     // topic-a sections: [leadDoc] = lead (bulk), [headingDoc] = "## Details".
@@ -1033,6 +1104,7 @@ describe("orchestrate — entity lane", () => {
       queryScored: () => [{ article: "topic-a", section: leadDoc!, score: 1 }],
       bestSection: () => leadDoc!,
       idf: () => 0,
+      topTerms: () => [],
     };
     const entityIndex = new Map<string, number[]>([["widget", [headingDoc!]]]);
 
@@ -1041,15 +1113,45 @@ describe("orchestrate — entity lane", () => {
       depsOf(lanes, { needle, entityIndex, selectorEnabled: false }),
     );
 
-    // The page is surfaced once and keeps the needle's first-lane attribution…
+    // Two lines for the page: the needle's bulk match keeps its line and
+    // attribution, and the heading joins under the entity lane with the
+    // heading text as its descriptor.
     const hits = result.lanes.finder.filter((c) => c.slug === "topic-a");
-    expect(hits).toHaveLength(1);
-    expect(hits[0]!.lane).toBe("needle");
-    // …but its matched section and pool descriptor are the HEADING, not the
-    // bulk lead the needle recorded.
-    expect(result.matchedSections.get("topic-a")).toBe(heading);
-    expect(result.matchedSections.get("topic-a")).not.toBe(lead);
-    expect(hits[0]!.descriptor).toBe(heading.text);
+    expect(hits.map((c) => [c.lane, c.section])).toEqual([
+      ["needle", lead],
+      ["entity", heading],
+    ]);
+    expect(hits[1]!.descriptor).toBe(heading.text);
+    // Both sections reach the selection (the passthrough keeps every line).
+    expect(result.selections).toContainEqual({
+      slug: "topic-a",
+      sections: [lead, heading],
+    });
+  });
+
+  test("an entity hit on the heading a prior lane already pooled is a no-op", async () => {
+    const lanes = await buildLanes();
+    const { sectionIndex } = lanes;
+    const [, headingDoc] = sectionIndex.byArticle.get("topic-a")!;
+    const heading = sectionIndex.sections[headingDoc!]!;
+    const needle = {
+      query: () => [{ article: "topic-a", section: headingDoc! }],
+      queryScored: () => [
+        { article: "topic-a", section: headingDoc!, score: 1 },
+      ],
+      bestSection: () => headingDoc!,
+      idf: () => 0,
+      topTerms: () => [],
+    };
+    const entityIndex = new Map<string, number[]>([["widget", [headingDoc!]]]);
+
+    const result = await orchestrate(
+      makeTurn(1, "tell me about the widget"),
+      depsOf(lanes, { needle, entityIndex, selectorEnabled: false }),
+    );
+
+    const hits = result.lanes.finder.filter((c) => c.slug === "topic-a");
+    expect(hits.map((c) => [c.lane, c.section])).toEqual([["needle", heading]]);
   });
 
   test("surfaces a heading-named page no other lane found, tagged `entity`", async () => {
@@ -1062,6 +1164,7 @@ describe("orchestrate — entity lane", () => {
       queryScored: () => [],
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     const entityIndex = new Map<string, number[]>([["gadget", [headingDoc!]]]);
 
@@ -1073,8 +1176,11 @@ describe("orchestrate — entity lane", () => {
     const hits = result.lanes.finder.filter((c) => c.slug === "topic-c");
     expect(hits).toHaveLength(1);
     expect(hits[0]!.lane).toBe("entity");
-    expect(result.matchedSections.get("topic-c")).toBe(heading);
-    expect(result.selections.map((s) => s.slug)).toContain("topic-c");
+    expect(hits[0]!.section).toBe(heading);
+    expect(result.selections).toContainEqual({
+      slug: "topic-c",
+      sections: [heading],
+    });
   });
 });
 
@@ -1151,6 +1257,7 @@ describe("orchestrate — injection gate", () => {
       queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1177,6 +1284,7 @@ describe("orchestrate — injection gate", () => {
       queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1224,7 +1332,7 @@ describe("orchestrate — injection gate", () => {
       true,
     );
     expect(result.lanes.finder).toEqual([]);
-    expect(result.matchedSections.size).toBe(0);
+    expect(result.selections.every((s) => s.sections.length === 0)).toBe(true);
     // The selector judged the stable-only pool, so the result says it ran.
     expect(result.selectorRan).toBe(true);
   });
@@ -1257,7 +1365,7 @@ describe("orchestrate — injection gate", () => {
       "topic-d",
     ]);
     expect(result.lanes.finder).toEqual([]);
-    expect(result.matchedSections.size).toBe(0);
+    expect(result.selections.every((s) => s.sections.length === 0)).toBe(true);
     expect(result.selectorRan).toBe(false);
   });
 
@@ -1341,6 +1449,7 @@ describe("orchestrate — injection gate", () => {
       queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1368,6 +1477,7 @@ describe("orchestrate — injection gate", () => {
       queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1413,6 +1523,7 @@ describe("orchestrate — injection gate", () => {
       queryScored: () => [{ article: "topic-a", section: 0, score: 0.1 }],
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1620,6 +1731,7 @@ describe("orchestrate — injection gate", () => {
       queryScored: () => [],
       bestSection: () => -1,
       idf: () => 0,
+      topTerms: () => [],
     };
     denseHits = [];
     providerStub = selectProvider([]);
@@ -1860,11 +1972,13 @@ describe("orchestrate — span-query pass", () => {
     expect(result.lanes.finder.filter((c) => c.slug === "topic-a").length).toBe(
       1,
     );
-    // The span hit's matched section is recorded for injection.
-    expect(result.matchedSections.get("topic-d")?.article).toBe("topic-d");
-    expect(result.matchedSections.get("topic-d")?.text).toContain(
-      "lead for topic d",
-    );
+    // The span hit's matched section rides its line and its selection.
+    const spanLine = result.lanes.finder.find((c) => c.slug === "topic-d");
+    expect(spanLine?.section?.text).toContain("lead for topic d");
+    expect(result.selections).toContainEqual({
+      slug: "topic-d",
+      sections: [spanLine!.section!],
+    });
     // Additive: the span-only page joins the passthrough selections alongside
     // every other lane's candidates.
     expect(new Set(result.selections.map((s) => s.slug))).toEqual(
@@ -1872,11 +1986,11 @@ describe("orchestrate — span-query pass", () => {
     );
   });
 
-  test("an article hit by several chunks records its highest-scoring section", async () => {
+  test("an article hit by several chunks on different sections pools them strongest cosine first", async () => {
     const lanes = await buildLanes();
-    // Both chunks surface topic-d; the EARLIER chunk's hit is the weaker one.
-    // Chunk order must not decide the recorded section — the strong match
-    // (ordinal 1, `## Notes`) wins over the lead (ordinal 0).
+    // Both chunks surface topic-d on different sections; the EARLIER chunk's
+    // hit is the weaker one. Chunk order must not decide the line order: the
+    // strong match (ordinal 1, `## Notes`) is pooled before the lead.
     denseHits = [];
     denseHitsByQuery.set(CHUNK_1, [
       { article: "topic-d", section: 0, score: 0.2 },
@@ -1890,19 +2004,23 @@ describe("orchestrate — span-query pass", () => {
       depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
     );
 
-    expect(result.matchedSections.get("topic-d")?.ordinal).toBe(1);
-    expect(result.matchedSections.get("topic-d")?.text).toContain("grape");
-    expect(
-      result.lanes.finder.filter((c) => c.slug === "topic-d"),
-    ).toHaveLength(1);
+    const lines = result.lanes.finder.filter((c) => c.slug === "topic-d");
+    expect(lines.map((c) => [c.lane, c.section?.ordinal])).toEqual([
+      ["span", 1],
+      ["span", 0],
+    ]);
+    expect(lines[0]!.section?.text).toContain("grape");
+    expect(result.selections).toContainEqual({
+      slug: "topic-d",
+      sections: [lines[0]!.section!, lines[1]!.section!],
+    });
   });
 
-  test("a strictly stronger span cosine upgrades a dense-recorded section, keeping the lane", async () => {
+  test("a span hit on a different section of a dense-surfaced page joins as its own span line", async () => {
     const lanes = await buildLanes();
-    // Full-message dense records topic-b's lead (ordinal 0) at cosine 0.4;
-    // chunk 2 finds `## More` (ordinal 1) at 0.9 — same encoder and
-    // collection, strictly stronger, so the recorded section and finder
-    // descriptor upgrade while the lane attribution stays "dense".
+    // Full-message dense pools topic-b's lead (ordinal 0); chunk 2 finds
+    // `## More` (ordinal 1). Different sections, so the page carries both
+    // lines: the dense one keeps its place and the span one follows.
     denseHits = [{ article: "topic-b", section: 0, score: 0.4 }];
     denseHitsByQuery.set(CHUNK_2, [
       { article: "topic-b", section: 1, score: 0.9 },
@@ -1913,26 +2031,26 @@ describe("orchestrate — span-query pass", () => {
       depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
     );
 
-    expect(result.matchedSections.get("topic-b")?.ordinal).toBe(1);
-    expect(result.matchedSections.get("topic-b")?.text).toContain(
-      "cherry date",
-    );
-    const entry = result.lanes.finder.find((c) => c.slug === "topic-b");
-    expect(entry?.lane).toBe("dense");
-    expect(entry?.descriptor).toContain("cherry date");
+    const lines = result.lanes.finder.filter((c) => c.slug === "topic-b");
+    expect(lines.map((c) => [c.lane, c.section?.ordinal])).toEqual([
+      ["dense", 0],
+      ["span", 1],
+    ]);
+    expect(lines[1]!.descriptor).toContain("cherry date");
   });
 
-  test("weaker span hits and needle-recorded sections are not overridden", async () => {
+  test("a span hit on a section already pooled is a no-op, whatever its cosine", async () => {
     const lanes = await buildLanes();
-    // topic-b: span cosine 0.3 < full-message 0.4 — the lead stays recorded.
-    // topic-a: needle recorded the `## Details` match; span scores are not
-    // comparable to BM25, so the span hit must not touch it.
+    // topic-a: the needle pooled `## Details` (ordinal 1); chunk 1 scores the
+    // same section higher than anything else this turn. topic-b: dense pooled
+    // the lead; chunk 2 scores the lead lower. Neither adds a line, and the
+    // attributions stay.
     denseHits = [{ article: "topic-b", section: 0, score: 0.4 }];
     denseHitsByQuery.set(CHUNK_1, [
-      { article: "topic-a", section: 0, score: 0.99 },
+      { article: "topic-a", section: 1, score: 0.99 },
     ]);
     denseHitsByQuery.set(CHUNK_2, [
-      { article: "topic-b", section: 1, score: 0.3 },
+      { article: "topic-b", section: 0, score: 0.3 },
     ]);
 
     const result = await orchestrate(
@@ -1940,10 +2058,133 @@ describe("orchestrate — span-query pass", () => {
       depsOf(lanes, { denseK: 100, spanQueryK: 7, selectorEnabled: false }),
     );
 
-    expect(result.matchedSections.get("topic-b")?.ordinal).toBe(0);
-    expect(result.matchedSections.get("topic-a")?.text).toContain("apple");
-    expect(result.lanes.finder.find((c) => c.slug === "topic-a")?.lane).toBe(
-      "needle",
+    const linesOf = (slug: Slug) =>
+      result.lanes.finder
+        .filter((c) => c.slug === slug)
+        .map((c) => [c.lane, c.section?.ordinal]);
+    expect(linesOf("topic-a")).toEqual([["needle", 1]]);
+    expect(linesOf("topic-b")).toEqual([["dense", 0]]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-section finder lines: a page whose sections match different parts of
+// the message carries one line per matched section (capped per page), each
+// snippet showing the matched terms in context, and selecting the lines
+// selects those sections.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate: multi-section finder lines", () => {
+  // A page whose `## Parody` section matches the message's bulk and whose
+  // `## Pumpkin` section matches only its last clause, deep in its body. The
+  // slug shares no token with the queries: its last segment heads every
+  // section's text, so a query term in it would score every section.
+  const FILLER = "filler words to push the match deep into the section ";
+  const GOURD_PAGES: Record<Slug, string> = {
+    "autumn-notes": [
+      "lead for the squash page",
+      "## Parody",
+      "the parody verse everyone laughed at, a hilarious pumpkin patch skit",
+      "## Pumpkin",
+      `${FILLER.repeat(8)}the gourd loves the pumpkin song`,
+    ].join("\n"),
+  };
+  const BULK = "the parody verse was hilarious and everyone laughed.";
+  const CLAUSE = "please remind me about the gourd.";
+
+  test("a page whose sections match the bulk and the last clause carries both lines, and keeping both selects both sections", async () => {
+    const lanes = await customLanes(GOURD_PAGES);
+    const [, parodyDoc, pumpkinDoc] =
+      lanes.sectionIndex.byArticle.get("autumn-notes")!;
+    const parody = lanes.sectionIndex.sections[parodyDoc!]!;
+    const pumpkin = lanes.sectionIndex.sections[pumpkinDoc!]!;
+    // The needle scores the bulk theme (`## Parody`); the span pass over the
+    // last clause reaches `## Pumpkin`.
+    denseHits = [];
+    denseHitsByQuery.set(CLAUSE, [{ article: "autumn-notes", section: 2 }]);
+    providerStub = selectProvider(["autumn-notes"]);
+
+    const result = await orchestrate(
+      makeTurn(1, `${BULK} ${CLAUSE}`),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7 }),
     );
+
+    const lines = result.lanes.finder.filter((c) => c.slug === "autumn-notes");
+    expect(lines.map((c) => [c.lane, c.section])).toEqual([
+      ["needle", parody],
+      ["span", pumpkin],
+    ]);
+    // Two pool lines, each a keyword-in-context snippet of its own section.
+    const poolLines = lastPoolLines.filter((l) => l.includes(" autumn-notes "));
+    expect(poolLines).toHaveLength(2);
+    expect(poolLines[0]).toContain("§Parody: ");
+    expect(poolLines[0]).toContain("parody");
+    expect(poolLines[1]).toContain("§Pumpkin: ");
+    expect(poolLines[1]).toContain("gourd");
+    // Keeping both ids selects both sections.
+    expect(result.selections).toEqual([
+      { slug: "autumn-notes", sections: [parody, pumpkin] },
+    ]);
+  });
+
+  test("a needle line's snippet is a window around its top contributing term, not the section head", async () => {
+    const lanes = await customLanes(GOURD_PAGES);
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(makeTurn(1, "gourd"), depsOf(lanes));
+
+    expect(result.lanes.finder[0]?.terms).toEqual(["gourd"]);
+    const line = lastPoolLines.find((l) => l.includes(" autumn-notes "))!;
+    // "gourd" sits past the first 300 characters of `## Pumpkin`, so a
+    // section-head snippet would not show it; the window is centered on it
+    // and the synthetic head line is not shown.
+    expect(line).toContain("§Pumpkin: … ");
+    expect(line).toContain("the gourd loves the pumpkin song");
+    expect(line).not.toContain("autumn-notes - Pumpkin");
+  });
+
+  test("finderSectionsPerPage caps a page's lines in surfacing order", async () => {
+    const lanes = await customLanes({
+      "many-page": [
+        "lead for the many page",
+        "## Alpha",
+        "alpha text",
+        "## Bravo",
+        "bravo text",
+        "## Charlie",
+        "charlie text",
+      ].join("\n"),
+    });
+    // needle → `## Alpha` (ordinal 1); full-message dense → `## Bravo`
+    // (ordinal 2); the span pass over the second sentence → `## Charlie`
+    // (ordinal 3).
+    const first = "alpha is the subject of the first sentence.";
+    const second = "the second sentence is about something else.";
+    denseHits = [{ article: "many-page", section: 2 }];
+    denseHitsByQuery.set(second, [{ article: "many-page", section: 3 }]);
+    providerStub = selectProvider([]);
+
+    const capped = await orchestrate(
+      makeTurn(1, `${first} ${second}`),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7, finderSectionsPerPage: 2 }),
+    );
+    expect(
+      capped.lanes.finder.map((c) => [c.lane, c.section?.ordinal]),
+    ).toEqual([
+      ["needle", 1],
+      ["dense", 2],
+    ]);
+
+    const uncapped = await orchestrate(
+      makeTurn(2, `${first} ${second}`),
+      depsOf(lanes, { denseK: 100, spanQueryK: 7 }),
+    );
+    expect(
+      uncapped.lanes.finder.map((c) => [c.lane, c.section?.ordinal]),
+    ).toEqual([
+      ["needle", 1],
+      ["dense", 2],
+      ["span", 3],
+    ]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/plugin-schema.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/plugin-schema.test.ts
@@ -1,7 +1,8 @@
 /**
  * The memory-v3 plugin's own schema on the memory connection
  * (`v3/plugin-schema.ts`): `memory_v3_injected_sections` is created
- * idempotently and seeded once per database from the card-grain
+ * idempotently, its `last_selected_at` column added to a table created
+ * without it, and seeded once per database from the card-grain
  * `memory_v3_ever_injected`, one zero-byte lead entry per legacy row, with
  * the copy recorded in the checkpoint ledger; `deleteLegacyCardRows` clears
  * a conversation's legacy rows for the compaction reset; `memory_v3_pools`
@@ -67,6 +68,12 @@ function objectNames(db: Database, type: "table" | "index"): string[] {
       .query(`SELECT name FROM sqlite_master WHERE type = ?`)
       .all(type) as Array<{ name: string }>
   ).map((row) => row.name);
+}
+
+function columnNames(db: Database, table: string): string[] {
+  return (
+    db.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>
+  ).map((column) => column.name);
 }
 
 /** A map-backed checkpoint ledger whose reads or writes can be made to
@@ -275,6 +282,57 @@ describe("ensureMemoryV3InjectedSectionsSchema", () => {
     expect(checkpoints.values.get(SECTIONS_LEGACY_COPY_DONE_KEY)).toBe("1");
   });
 
+  test("creates a fresh table with last_selected_at, and adds it to a table created without it, keeping its rows", () => {
+    ensureMemoryV3InjectedSectionsSchema(memorySqlite, ledger());
+    expect(columnNames(memorySqlite, "memory_v3_injected_sections")).toContain(
+      "last_selected_at",
+    );
+
+    // A table an earlier build created, carrying a row.
+    const older = new Database(":memory:");
+    older.exec(/*sql*/ `
+      CREATE TABLE memory_v3_injected_sections (
+        conversation_id TEXT NOT NULL,
+        slug TEXT NOT NULL,
+        section_key TEXT NOT NULL,
+        injected_at INTEGER NOT NULL,
+        bytes INTEGER NOT NULL DEFAULT 0,
+        pruned_at INTEGER,
+        PRIMARY KEY (conversation_id, slug, section_key)
+      )
+    `);
+    older.exec(/*sql*/ `
+      INSERT INTO memory_v3_injected_sections
+        (conversation_id, slug, section_key, injected_at, bytes, pruned_at)
+      VALUES ('conv-1', 'topics/page-a', 'Notes', 1000, 120, NULL)
+    `);
+
+    ensureMemoryV3InjectedSectionsSchema(older, ledger());
+
+    expect(columnNames(older, "memory_v3_injected_sections")).toContain(
+      "last_selected_at",
+    );
+    expect(
+      older
+        .query(
+          `SELECT slug, section_key, bytes, last_selected_at
+           FROM memory_v3_injected_sections`,
+        )
+        .all(),
+    ).toEqual([
+      {
+        slug: "topics/page-a",
+        section_key: "Notes",
+        bytes: 120,
+        last_selected_at: null,
+      },
+    ]);
+    // A second ensure adds nothing.
+    const columns = columnNames(older, "memory_v3_injected_sections");
+    ensureMemoryV3InjectedSectionsSchema(older, ledger());
+    expect(columnNames(older, "memory_v3_injected_sections")).toEqual(columns);
+  });
+
   test("a table carrying an extra nullable column is left as is and still takes the copy", () => {
     memorySqlite.exec(/*sql*/ `
       CREATE TABLE memory_v3_injected_sections (
@@ -387,14 +445,6 @@ describe("ensureMemoryV3PoolsSchema", () => {
 });
 
 describe("ensureMemoryV3SelectionsSectionKey", () => {
-  function columnNames(db: Database): string[] {
-    return (
-      db.query(`PRAGMA table_info(memory_v3_selections)`).all() as Array<{
-        name: string;
-      }>
-    ).map((column) => column.name);
-  }
-
   test("adds section_key to the table migration 338 creates, keeping its rows", () => {
     ensureMemoryV3SelectionsSchema(memorySqlite);
     memorySqlite.exec(/*sql*/ `
@@ -406,7 +456,9 @@ describe("ensureMemoryV3SelectionsSectionKey", () => {
 
     ensureMemoryV3SelectionsSectionKey(memorySqlite);
 
-    expect(columnNames(memorySqlite)).toContain("section_key");
+    expect(columnNames(memorySqlite, "memory_v3_selections")).toContain(
+      "section_key",
+    );
     expect(
       memorySqlite
         .query(
@@ -421,11 +473,11 @@ describe("ensureMemoryV3SelectionsSectionKey", () => {
   test("is a no-op on a table that already has the column", () => {
     ensureMemoryV3SelectionsSchema(memorySqlite);
     ensureMemoryV3SelectionsSectionKey(memorySqlite);
-    const columns = columnNames(memorySqlite);
+    const columns = columnNames(memorySqlite, "memory_v3_selections");
 
     ensureMemoryV3SelectionsSectionKey(memorySqlite);
 
-    expect(columnNames(memorySqlite)).toEqual(columns);
+    expect(columnNames(memorySqlite, "memory_v3_selections")).toEqual(columns);
     expect(columns.filter((name) => name === "section_key")).toHaveLength(1);
   });
 
@@ -438,7 +490,9 @@ describe("ensureMemoryV3SelectionsSectionKey", () => {
     ensureMemoryV3SelectionsSchema(memorySqlite);
     ensureMemoryV3SelectionsSectionKeyOnce(memorySqlite);
 
-    expect(columnNames(memorySqlite)).toContain("section_key");
+    expect(columnNames(memorySqlite, "memory_v3_selections")).toContain(
+      "section_key",
+    );
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-log-store.test.ts
@@ -86,26 +86,28 @@ function section(article: Slug, title: string, ordinal: number): Section {
  * no matched section.
  */
 function orchestrated(): OrchestrateResult {
+  const recent = section("core/page", "Recent", 3);
+  const lead = section("topic/a", "", 0);
   return {
     selections: [
-      { slug: "core/page" },
-      { slug: "topic/a" },
-      { slug: "topic/c" },
+      { slug: "core/page", sections: [recent] },
+      { slug: "topic/a", sections: [lead] },
+      { slug: "topic/c", sections: [] },
     ],
-    matchedSections: new Map([
-      ["core/page", section("core/page", "Recent", 3)],
-      ["topic/a", section("topic/a", "", 0)],
-      ["topic/b", section("topic/b", "Details", 2)],
-    ]),
     lanes: {
       core: ["core/page"],
       hot: ["hot/page"],
       fresh: ["fresh/page"],
       always: ["skills/example"],
       finder: [
-        { slug: "topic/a", descriptor: "", lane: "needle" },
-        { slug: "core/page", descriptor: "", lane: "dense" },
-        { slug: "topic/b", descriptor: "", lane: "entity" },
+        { slug: "topic/a", section: lead, descriptor: "", lane: "needle" },
+        { slug: "core/page", section: recent, descriptor: "", lane: "dense" },
+        {
+          slug: "topic/b",
+          section: section("topic/b", "Details", 2),
+          descriptor: "",
+          lane: "entity",
+        },
         { slug: "topic/c", descriptor: "", lane: "edge" },
       ],
     },
@@ -121,7 +123,6 @@ function orchestrated(): OrchestrateResult {
 function hardSkipped(): OrchestrateResult {
   return {
     selections: [],
-    matchedSections: new Map(),
     lanes: {
       core: ["core/page"],
       hot: ["hot/page"],
@@ -200,7 +201,6 @@ describe("buildPoolRecord", () => {
     expect(
       buildPoolRecord({
         selections: [],
-        matchedSections: new Map(),
         lanes: { core: [], hot: [], fresh: [], always: [], finder: [] },
         selectorRan: false,
       }),
@@ -223,6 +223,35 @@ describe("buildPoolRecord", () => {
     });
   });
 
+  test("verdicts are per line: only the selected section's line reads chosen, and the card reads chosen when the page was kept", () => {
+    const first = section("topic/a", "One", 1);
+    const second = section("topic/a", "Two", 2);
+    const record = buildPoolRecord({
+      selections: [{ slug: "topic/a", sections: [second] }],
+      lanes: {
+        core: ["topic/a"],
+        hot: [],
+        fresh: [],
+        always: [],
+        finder: [
+          { slug: "topic/a", section: first, descriptor: "", lane: "needle" },
+          { slug: "topic/a", section: second, descriptor: "", lane: "span" },
+        ],
+      },
+      selectorRan: true,
+    });
+
+    expect(
+      record.candidates.map((c) => [c.lane, c.section_title, c.chosen]),
+    ).toEqual([
+      ["core", null, true],
+      ["needle", "One", false],
+      ["span", "Two", true],
+    ]);
+    expect(record.pool_size).toBe(3);
+    expect(record.selected_count).toBe(1);
+  });
+
   test("a pool the selector rejected wholesale keeps every candidate, unchosen", () => {
     const record = buildPoolRecord({ ...orchestrated(), selections: [] });
 
@@ -237,11 +266,10 @@ describe("buildPoolRecord", () => {
     // a selector judgment: the pool was real, so it is recorded.
     const record = buildPoolRecord({
       selections: [
-        { slug: "core/page" },
-        { slug: "hot/page" },
-        { slug: "fresh/page" },
+        { slug: "core/page", sections: [] },
+        { slug: "hot/page", sections: [] },
+        { slug: "fresh/page", sections: [] },
       ],
-      matchedSections: new Map(),
       lanes: {
         core: ["core/page"],
         hot: ["hot/page"],

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -10,9 +10,12 @@
  *   - Numbering stability: for identical stable lanes the rendered prefix
  *     block is byte-identical across renders; only the tail varies.
  *   - Returned IDs map over the CONCATENATED numbering; out-of-range IDs and
- *     unknown input keys are ignored; selections deduped by slug (a page can
- *     appear as both a card and a finder line).
- *   - Omitted `ids` → keep ALL candidates (recall-safe, slug-deduped).
+ *     unknown input keys are ignored; selections merge per slug (a page can
+ *     appear as a card and on several finder lines), each carrying the
+ *     sections of its selected finder lines.
+ *   - Omitted `ids` → keep ALL candidates (recall-safe, merged per slug).
+ *   - A finder line with a section and contributing terms renders a
+ *     keyword-in-context window under its heading; otherwise the head snippet.
  *   - Explicit `ids: []` → keep none (deliberate abstention) — a normal result.
  *   - Empty candidate pool → keep none (nothing to select).
  *   - Finder snippets are whitespace-collapsed and truncated (~300 chars).
@@ -37,7 +40,8 @@ import type {
 } from "@vellumai/plugin-api";
 
 import { ProviderError } from "../../../../../util/errors.js";
-import type { MemoryRoutingTurn } from "../types.js";
+import { sectionHeadLine } from "../sections.js";
+import type { MemoryRoutingTurn, Section } from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Mocks installed BEFORE the pool-select import so the module observes them at
@@ -174,6 +178,17 @@ function makePool(): SelectorPool {
   };
 }
 
+/** A section as the section index would build it: synthetic head line plus
+ *  body (the lead, titled `""`, is ordinal 0). */
+function sectionOf(slug: string, title: string, body: string): Section {
+  return {
+    article: slug,
+    title,
+    text: `${sectionHeadLine(slug, title)}\n${body}`,
+    ordinal: title === "" ? 0 : 1,
+  };
+}
+
 function makeTurn(currentMessage: string): MemoryRoutingTurn {
   return {
     conversationId: "conv-xyz",
@@ -217,7 +232,10 @@ describe("selectPool — id mapping", () => {
   test("IDs map over cards then finder lines in selection order", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [3, 1] }));
     const result = await selectPool(makePool(), makeTurn("how's the rollout?"));
-    expect(result.pages).toEqual([{ slug: "topic-x" }, { slug: "page-a" }]);
+    expect(result.pages).toEqual([
+      { slug: "topic-x", sections: [] },
+      { slug: "page-a", sections: [] },
+    ]);
     expect(result.keptAll).toBe(false);
   });
 
@@ -225,7 +243,7 @@ describe("selectPool — id mapping", () => {
     // page-a is id 1 (card) AND id 4 (finder line).
     providerStub = makeProvider(toolUseResponse({ ids: [1, 4] }));
     const result = await selectPool(makePool(), makeTurn("the alpha plan"));
-    expect(result.pages).toEqual([{ slug: "page-a" }]);
+    expect(result.pages).toEqual([{ slug: "page-a", sections: [] }]);
     expect(result.keptAll).toBe(false);
   });
 
@@ -235,7 +253,7 @@ describe("selectPool — id mapping", () => {
     // changes the selection.
     providerStub = makeProvider(toolUseResponse({ ids: [2], extra_ids: [1] }));
     const result = await selectPool(makePool(), makeTurn("the metrics"));
-    expect(result.pages).toEqual([{ slug: "page-b" }]);
+    expect(result.pages).toEqual([{ slug: "page-b", sections: [] }]);
     expect(result.keptAll).toBe(false);
   });
 
@@ -243,9 +261,9 @@ describe("selectPool — id mapping", () => {
     providerStub = makeProvider(toolUseResponse({}));
     const result = await selectPool(makePool(), makeTurn("anything"));
     expect(result.pages).toEqual([
-      { slug: "page-a" },
-      { slug: "page-b" },
-      { slug: "topic-x" },
+      { slug: "page-a", sections: [] },
+      { slug: "page-b", sections: [] },
+      { slug: "topic-x", sections: [] },
     ]);
     // The fallback fired — the model gave up judging, not "selected everything".
     expect(result.keptAll).toBe(true);
@@ -262,7 +280,7 @@ describe("selectPool — id mapping", () => {
   test("out-of-range and duplicate IDs are ignored without throwing", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [2, 99, 0, -1, 2] }));
     const result = await selectPool(makePool(), makeTurn("the metrics"));
-    expect(result.pages).toEqual([{ slug: "page-b" }]);
+    expect(result.pages).toEqual([{ slug: "page-b", sections: [] }]);
     expect(result.keptAll).toBe(false);
   });
 
@@ -457,7 +475,7 @@ describe("selectPool — infrastructure failures throw", () => {
       toolUseResponse({ ids: [2] }),
     ]);
     const result = await selectPool(makePool(), makeTurn("the metrics"));
-    expect(result.pages).toEqual([{ slug: "page-b" }]);
+    expect(result.pages).toEqual([{ slug: "page-b", sections: [] }]);
     expect(result.keptAll).toBe(false);
     expect(providerCalls).toHaveLength(2);
   });
@@ -608,5 +626,191 @@ describe("selectPool — request shape", () => {
     expect(prompt).toMatch(/persist/);
     // Generous: explicitly no selection limit.
     expect(prompt).toMatch(/no limit/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectPool sections: a finder line carries its matched section, selecting
+// the line selects that section, and selections merge per slug; a line with a
+// section and contributing terms renders a keyword-in-context snippet.
+// ---------------------------------------------------------------------------
+
+describe("selectPool: sections and keyword-in-context snippets", () => {
+  const alpha = sectionOf(
+    "page-a",
+    "Alpha",
+    "the alpha rollout plan in detail",
+  );
+  const beta = sectionOf("page-a", "Beta", "the beta metrics review");
+
+  /** `makePool` with page-a on two finder lines: ids 1-2 are the cards, 3 is
+   *  topic-x, 4 is page-a § Alpha, 5 is page-a § Beta. */
+  function sectionedPool(): SelectorPool {
+    const pool = makePool();
+    pool.finder = [
+      { slug: "topic-x", descriptor: "section: about topic x" },
+      {
+        slug: "page-a",
+        descriptor: alpha.text,
+        section: alpha,
+        terms: ["rollout"],
+      },
+      {
+        slug: "page-a",
+        descriptor: beta.text,
+        section: beta,
+        terms: ["metrics"],
+      },
+    ];
+    return pool;
+  }
+
+  function finderOnly(candidate: SelectorPool["finder"][number]): SelectorPool {
+    return { stable: [], finder: [candidate] };
+  }
+
+  test("selecting a page's card alone carries no section", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [1] }));
+    const result = await selectPool(sectionedPool(), makeTurn("page a?"));
+    expect(result.pages).toEqual([{ slug: "page-a", sections: [] }]);
+  });
+
+  test("selecting a finder line selects its section, merged with the page's card", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [4, 1] }));
+    const result = await selectPool(
+      sectionedPool(),
+      makeTurn("the alpha plan"),
+    );
+    expect(result.pages).toEqual([{ slug: "page-a", sections: [alpha] }]);
+  });
+
+  test("two finder lines of one page merge into one selection carrying both sections in pool order", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [5, 3, 4, 5] }));
+    const result = await selectPool(
+      sectionedPool(),
+      makeTurn("alpha and beta"),
+    );
+    // Pages keep the order they were first picked; a page's sections follow
+    // the pool, not the id order.
+    expect(result.pages).toEqual([
+      { slug: "page-a", sections: [alpha, beta] },
+      { slug: "topic-x", sections: [] },
+    ]);
+  });
+
+  test("keeping every candidate merges each page's finder sections", async () => {
+    providerStub = makeProvider(toolUseResponse({}));
+    const result = await selectPool(sectionedPool(), makeTurn("anything"));
+    expect(result.pages).toEqual([
+      { slug: "page-a", sections: [alpha, beta] },
+      { slug: "page-b", sections: [] },
+      { slug: "topic-x", sections: [] },
+    ]);
+    expect(result.keptAll).toBe(true);
+  });
+
+  test("a line with a section and a contributing term renders a window around the term under its heading", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const filler =
+      "filler words that push the match well past the head of the section ";
+    const deep = sectionOf(
+      "page-a",
+      "Rollout",
+      `${filler.repeat(6)}the Gourd milestone slipped a week ${filler.repeat(3)}`,
+    );
+    await selectPool(
+      finderOnly({
+        slug: "page-a",
+        descriptor: deep.text,
+        section: deep,
+        terms: ["absent", "gourd"],
+        lane: "needle",
+      }),
+      makeTurn("gourd?"),
+    );
+    const [block] = sentBlocks();
+    const line = block.text
+      .split("\n")
+      .find((l) => l.startsWith("[1] (needle) page-a "))!;
+    // The first term that occurs in the body (not `absent`) centers the
+    // window; the match is case-insensitive and the head line is not shown.
+    expect(line).toContain("§Rollout: … ");
+    expect(line).toContain("Gourd milestone");
+    expect(line).not.toContain("page-a - Rollout");
+    expect(line.endsWith(" …")).toBe(true);
+    // The window itself stays at the snippet cap (plus its ellipses).
+    const windowStart = line.indexOf("… ") + "… ".length;
+    expect(line.length - windowStart).toBeLessThanOrEqual(300 + " …".length);
+  });
+
+  test("a line whose terms do not occur in the section body falls back to the head snippet", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    await selectPool(
+      finderOnly({
+        slug: "page-a",
+        descriptor: alpha.text,
+        section: alpha,
+        terms: ["missing"],
+      }),
+      makeTurn("x"),
+    );
+    const [block] = sentBlocks();
+    const line = block.text
+      .split("\n")
+      .find((l) => l.startsWith("[1] page-a "))!;
+    expect(
+      line.endsWith("page-a - Alpha the alpha rollout plan in detail"),
+    ).toBe(true);
+    expect(line).not.toContain("§");
+  });
+
+  test("a lead section renders its window without a heading prefix", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const lead = sectionOf(
+      "page-a",
+      "",
+      "the lead mentions the rollout early on",
+    );
+    await selectPool(
+      finderOnly({
+        slug: "page-a",
+        descriptor: lead.text,
+        section: lead,
+        terms: ["rollout"],
+      }),
+      makeTurn("x"),
+    );
+    const [block] = sentBlocks();
+    const line = block.text
+      .split("\n")
+      .find((l) => l.startsWith("[1] page-a "))!;
+    expect(line.endsWith("the lead mentions the rollout early on")).toBe(true);
+    expect(line).not.toContain("§");
+    expect(line).not.toContain("…");
+  });
+
+  test("a bigram term matches its two words across punctuation", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const notes = sectionOf(
+      "page-a",
+      "Notes",
+      "we said: little, gourd is the nickname",
+    );
+    await selectPool(
+      finderOnly({
+        slug: "page-a",
+        descriptor: notes.text,
+        section: notes,
+        terms: ["little_gourd"],
+      }),
+      makeTurn("x"),
+    );
+    const [block] = sentBlocks();
+    const line = block.text
+      .split("\n")
+      .find((l) => l.startsWith("[1] page-a "))!;
+    expect(
+      line.endsWith("§Notes: we said: little, gourd is the nickname"),
+    ).toBe(true);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { buildSectionNeedle } from "../section-needle.js";
+import { buildSectionNeedle, findTerm } from "../section-needle.js";
 import { buildSectionIndex } from "../sections.js";
 import type { SectionIndex, Slug } from "../types.js";
 
@@ -195,5 +195,68 @@ describe("queryScored", () => {
 
     expect(needle.queryScored("zzzznomatch", 5)).toEqual([]);
     expect(needle.queryScored("apple", 0)).toEqual([]);
+  });
+
+  test("topTerms ranks a section's query terms by their BM25F contribution, capped at n", async () => {
+    const idx = await index({
+      "page-a": [
+        "## Mango",
+        "the mango tree and the common word appear here",
+      ].join("\n"),
+      "page-b": "## Notes\ncommon filler about gardens and the",
+    });
+    const needle = buildSectionNeedle(idx);
+    const [, mangoDoc] = idx.byArticle.get("page-a")!;
+
+    // "mango" sits in the head line and the body, "tree" only in the body,
+    // "common" in the body of two sections (lower IDF), "missing" nowhere.
+    expect(needle.topTerms(mangoDoc!, "mango common tree missing", 3)).toEqual([
+      "mango",
+      "tree",
+      "common",
+    ]);
+    expect(needle.topTerms(mangoDoc!, "mango common tree missing", 2)).toEqual([
+      "mango",
+      "tree",
+    ]);
+    expect(needle.topTerms(mangoDoc!, "missing absent", 3)).toEqual([]);
+    expect(needle.topTerms(mangoDoc!, "mango", 0)).toEqual([]);
+    expect(needle.topTerms(-1, "mango", 3)).toEqual([]);
+    expect(needle.topTerms(idx.sections.length, "mango", 3)).toEqual([]);
+  });
+
+  test("topTerms includes adjacent-token bigrams and breaks score ties by term", async () => {
+    const idx = await index({
+      "page-a": "## Mango\nthe mango tree grows here",
+    });
+    const needle = buildSectionNeedle(idx);
+    const [, mangoDoc] = idx.byArticle.get("page-a")!;
+
+    // "mango_tree" occurs once in the body like "tree" does, so the two tie
+    // and sort by term; "mango" outranks both from its head-line weight.
+    expect(needle.topTerms(mangoDoc!, "mango tree", 3)).toEqual([
+      "mango",
+      "mango_tree",
+      "tree",
+    ]);
+  });
+
+  test("findTerm locates a term as a whole token, case-insensitively, and a bigram across punctuation", () => {
+    expect(findTerm("The Gourd sits here", "gourd")).toEqual({
+      start: 4,
+      end: 9,
+    });
+    // A substring inside a longer token is not an occurrence.
+    expect(findTerm("gourds and gourd", "gourd")).toEqual({
+      start: 11,
+      end: 16,
+    });
+    expect(findTerm("we said: little, gourd", "little_gourd")).toEqual({
+      start: 9,
+      end: 22,
+    });
+    expect(findTerm("nothing here", "gourd")).toBeUndefined();
+    // Only tokenizer-shaped terms are searched.
+    expect(findTerm("a (b) c", "(b)")).toBeUndefined();
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -431,7 +431,9 @@ describe("memory-v3 integration — core + hot stable prefix", () => {
       core: ["page-a"],
     });
     expect(lastPool.filter((s) => s === "page-a")).toHaveLength(2);
-    expect(result.selections).toEqual([{ slug: "page-a" }]);
+    // ...merged into one selection carrying the finder line's section.
+    expect(result.selections.map((s) => s.slug)).toEqual(["page-a"]);
+    expect(result.selections[0]!.sections).toHaveLength(1);
     expect(result.lanes.finder.map((c) => c.slug)).toContain("page-a");
     expect(loggedSources(1)).toEqual([{ slug: "page-a", source: "core" }]);
   });
@@ -446,9 +448,9 @@ describe("memory-v3 integration — core + hot stable prefix", () => {
 describe("memory-v3 integration — lane-source attribution", () => {
   test("a needle-ranked capability selection is logged with the needle source", async () => {
     const lanes = await buildLanes();
-    // "durian" matches the capability page's content section, so selecting it
-    // records a `matchedSections` entry and the lane mapping attributes it
-    // `needle` (capabilities are indexed pages now, not sectionless add-ins).
+    // "durian" matches the capability page's content section, so its finder
+    // line carries that section and the lane mapping attributes the selection
+    // `needle` (capabilities are indexed pages, not sectionless add-ins).
     const result = await runTurn(1, "durian", [CAPABILITY_SLUG], { lanes });
     expect(result.selections.map((s) => s.slug)).toEqual([CAPABILITY_SLUG]);
     expect(loggedSources(1)).toEqual([

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -48,6 +48,7 @@ import { MEMORY_V3_FULL_PROFILE_MIN_PAGES } from "../tuning-profile.js";
 import {
   MEMORY_V3_COMMIT_META_KEY,
   type MemoryRoutingTurn,
+  type Section,
   type SectionIndex,
   type SelectionSource,
 } from "../types.js";
@@ -141,33 +142,46 @@ const CAPABILITY_CONTENT = "use the kumquat skill to do the thing";
 // in the fresh lane, the always-candidate skill in the always lane (pooled but
 // NOT selected, so the pool record carries an unchosen entry), and the finder
 // entries page-1 → "needle", page-2 → "dense", page-3 → "edge";
-// `attributeSelections` reads it directly. `matchedSections` carries the
-// matched section for the slugs that had one (page-1/page-2) — consumed by the
-// live injector's progressive disclosure, independent of source attribution.
+// `attributeSelections` reads it directly. The finder lines for page-1 and
+// page-2 carry a matched section, which their selections carry too (consumed
+// by the live injector, independent of source attribution).
+const PAGE_1_LEAD: Section = {
+  article: "page-1",
+  title: "",
+  text: "x",
+  ordinal: 0,
+};
+const PAGE_2_LEAD: Section = {
+  article: "page-2",
+  title: "",
+  text: "y",
+  ordinal: 0,
+};
 const orchestrateSpy = mock(
   async (): Promise<OrchestrateResult> => ({
     selections: [
-      { slug: "page-core" },
-      { slug: "page-hot" },
-      { slug: "page-fresh" },
-      { slug: "page-1" },
-      { slug: "page-2" },
-      { slug: "page-3" },
-      { slug: "page-4" },
-      { slug: "page-5" },
+      { slug: "page-core", sections: [] },
+      { slug: "page-hot", sections: [] },
+      { slug: "page-fresh", sections: [] },
+      { slug: "page-1", sections: [PAGE_1_LEAD] },
+      { slug: "page-2", sections: [PAGE_2_LEAD] },
+      { slug: "page-3", sections: [] },
+      { slug: "page-4", sections: [] },
+      { slug: "page-5", sections: [] },
     ],
-    matchedSections: new Map([
-      ["page-1", { article: "page-1", title: "", text: "x", ordinal: 0 }],
-      ["page-2", { article: "page-2", title: "", text: "y", ordinal: 0 }],
-    ]),
     lanes: {
       core: ["page-core"],
       hot: ["page-hot"],
       fresh: ["page-fresh"],
       always: [CAPABILITY_SLUG],
       finder: [
-        { slug: "page-1", descriptor: "", lane: "needle" },
-        { slug: "page-2", descriptor: "", lane: "dense" },
+        {
+          slug: "page-1",
+          section: PAGE_1_LEAD,
+          descriptor: "",
+          lane: "needle",
+        },
+        { slug: "page-2", section: PAGE_2_LEAD, descriptor: "", lane: "dense" },
         { slug: "page-3", descriptor: "", lane: "edge" },
         { slug: "page-4", descriptor: "", lane: "reply" },
         { slug: "page-5", descriptor: "", lane: "learned" },
@@ -613,8 +627,7 @@ function chosenBySlug(): Record<string, boolean> {
  *  `kept`. */
 function poolOf(kept: string[]): OrchestrateResult {
   return {
-    selections: kept.map((slug) => ({ slug })),
-    matchedSections: new Map(),
+    selections: kept.map((slug) => ({ slug, sections: [] })),
     lanes: {
       core: [],
       hot: [],
@@ -876,7 +889,6 @@ describe("memory-v3 engine", () => {
     // lanes (the injector's prune exemptions) but the selector never saw them.
     orchestrateSpy.mockImplementationOnce(async () => ({
       selections: [],
-      matchedSections: new Map(),
       lanes: {
         core: ["page-core"],
         hot: ["page-hot"],
@@ -1017,8 +1029,7 @@ describe("memory-v3 engine", () => {
 
   test("a selection of a core page a finder also hit attributes to core (pool position wins)", () => {
     const rows = attributeSelections({
-      selections: [{ slug: "page-core" }],
-      matchedSections: new Map(),
+      selections: [{ slug: "page-core", sections: [] }],
       lanes: {
         core: ["page-core"],
         hot: [],
@@ -1042,26 +1053,28 @@ describe("memory-v3 engine", () => {
   });
 
   test("a finder hit records the matched section's key beside its title and ordinal, so a repeat of a heading keeps its occurrence", () => {
+    const repeatedNotes: Section = {
+      article: "page-1",
+      title: "Notes",
+      text: "page-1 - Notes\nsecond notes",
+      ordinal: 3,
+      occurrence: 1,
+    };
     const rows = attributeSelections({
-      selections: [{ slug: "page-1" }],
-      matchedSections: new Map([
-        [
-          "page-1",
-          {
-            article: "page-1",
-            title: "Notes",
-            text: "page-1 - Notes\nsecond notes",
-            ordinal: 3,
-            occurrence: 1,
-          },
-        ],
-      ]),
+      selections: [{ slug: "page-1", sections: [repeatedNotes] }],
       lanes: {
         core: [],
         hot: [],
         fresh: [],
         always: [],
-        finder: [{ slug: "page-1", descriptor: "", lane: "needle" }],
+        finder: [
+          {
+            slug: "page-1",
+            section: repeatedNotes,
+            descriptor: "",
+            lane: "needle",
+          },
+        ],
       },
       selectorRan: true,
     });
@@ -1072,6 +1085,44 @@ describe("memory-v3 engine", () => {
         sectionOrdinal: 3,
         sectionTitle: "Notes",
         sectionKey: "Notes#1",
+      },
+    ]);
+  });
+
+  test("a page selected on several sections logs its first selected section under the lane of its first line", () => {
+    const details: Section = {
+      article: "page-1",
+      title: "Details",
+      text: "page-1 - Details\ndetails",
+      ordinal: 1,
+    };
+    const notes: Section = {
+      article: "page-1",
+      title: "Notes",
+      text: "page-1 - Notes\nnotes",
+      ordinal: 2,
+    };
+    const rows = attributeSelections({
+      selections: [{ slug: "page-1", sections: [notes, details] }],
+      lanes: {
+        core: [],
+        hot: [],
+        fresh: [],
+        always: [],
+        finder: [
+          { slug: "page-1", section: details, descriptor: "", lane: "needle" },
+          { slug: "page-1", section: notes, descriptor: "", lane: "span" },
+        ],
+      },
+      selectorRan: true,
+    });
+    expect(rows).toEqual([
+      {
+        slug: "page-1",
+        source: "needle",
+        sectionOrdinal: 2,
+        sectionTitle: "Notes",
+        sectionKey: "Notes",
       },
     ]);
   });
@@ -1310,7 +1361,6 @@ describe("memory-v3 engine", () => {
     liveEnabled = true;
     orchestrateSpy.mockImplementationOnce(async () => ({
       selections: [],
-      matchedSections: new Map(),
       lanes: { core: [], hot: [], fresh: [], always: [], finder: [] },
       selectorRan: false,
     }));

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/types.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/types.test.ts
@@ -4,7 +4,6 @@ import {
   type MemoryRoutingTurn,
   type Section,
   sectionKey,
-  sectionKeyTitle,
   type SelectionSource,
   type Slug,
 } from "../types.js";
@@ -70,7 +69,7 @@ describe("sectionKey", () => {
     expect(sectionKey(section("Issue #12"))).toBe("Issue ##12");
   });
 
-  test("sectionKeyTitle is the exact inverse of sectionKey", () => {
+  test("distinct (title, occurrence, chunk) triples never share a key, titles ending in a suffix marker included", () => {
     const titles = [
       "",
       "Notes",
@@ -87,19 +86,16 @@ describe("sectionKey", () => {
       "x#1~2",
       "5",
     ];
+    const keys = new Set<string>();
+    let triples = 0;
     for (const title of titles) {
       for (const occurrence of [undefined, 1, 12]) {
         for (const chunk of [undefined, 1, 3]) {
-          const s = section(title, { occurrence, chunk });
-          expect(sectionKeyTitle(sectionKey(s))).toBe(title);
+          keys.add(sectionKey(section(title, { occurrence, chunk })));
+          triples += 1;
         }
       }
     }
-    // Keys that differ decode to different (title, occurrence, chunk) triples.
-    expect(sectionKeyTitle("Topic##1")).toBe("Topic#1");
-    expect(sectionKeyTitle("Topic#1")).toBe("Topic");
-    expect(sectionKeyTitle("Topic~~1")).toBe("Topic~1");
-    expect(sectionKeyTitle("Topic~1")).toBe("Topic");
-    expect(sectionKeyTitle("Topic##1#1~1")).toBe("Topic#1");
+    expect(keys.size).toBe(triples);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
@@ -5,6 +5,9 @@
  *     clearing `pruned_at`;
  *   - `markPruned` excluding exactly the named pair from the active set and
  *     `residentBytes`, leaving sibling sections of the page resident;
+ *   - `touchSelected` stamping `last_selected_at` on exactly the named rows
+ *     (batched past SQLite's expression depth), the stamp `recordInjected`
+ *     sets for new and re-recorded rows and a full fork copies;
  *   - `clearConversation` (compaction reset), the conversation's legacy card
  *     rows included so no later copy re-imports them;
  *   - fork hooks: full-row copy (pruned state included) and truncated-fork
@@ -98,6 +101,7 @@ const {
   residentBytes,
   sectionRefSetHas,
   seedEverInjectedFromBlocks,
+  touchSelected,
 } = await import("./ever-injected-store.js");
 
 beforeEach(() => {
@@ -164,6 +168,10 @@ describe("recordInjected / getInjected / getActiveSections", () => {
       { slug: "topics/page-a", key: "Notes", bytes: 80, prunedAt: null },
       { slug: "topics/page-b", key: "Design#1", bytes: 250, prunedAt: null },
     ]);
+    // The turn that injects a section selected it.
+    expect(getInjected("conv-1").map((row) => row.lastSelectedAt)).toEqual([
+      1_000, 1_000, 1_000,
+    ]);
     const active = getActiveSections("conv-1");
     expect(active).toEqual(
       new Map([
@@ -179,7 +187,7 @@ describe("recordInjected / getInjected / getActiveSections", () => {
     expect(getActiveSections("conv-other").size).toBe(0);
   });
 
-  test("re-recording a pruned section clears pruned_at and refreshes bytes and injected_at", () => {
+  test("re-recording a pruned section clears pruned_at and refreshes bytes, injected_at, and last_selected_at", () => {
     recordInjected(
       "conv-1",
       [{ slug: "topics/page-a", key: "Notes", bytes: 100 }],
@@ -202,6 +210,7 @@ describe("recordInjected / getInjected / getActiveSections", () => {
         key: "Notes",
         bytes: 140,
         injectedAt: 3_000,
+        lastSelectedAt: 3_000,
         prunedAt: null,
       },
     ]);
@@ -242,7 +251,13 @@ describe("markPruned / residentBytes / getPrunedSections", () => {
       new Map([["topics/page-a", new Set(["Notes"])]]),
     );
     expect(getActiveEntries("conv-1")).toEqual([
-      { slug: "topics/page-a", key: "Notes", bytes: 250, injectedAt: 1_000 },
+      {
+        slug: "topics/page-a",
+        key: "Notes",
+        bytes: 250,
+        injectedAt: 1_000,
+        lastSelectedAt: 1_000,
+      },
     ]);
     expect(getPrunedSections("conv-1")).toEqual(
       new Map([
@@ -289,6 +304,82 @@ describe("markPruned / residentBytes / getPrunedSections", () => {
     markPruned("conv-1", [], 2_000);
     expect(residentBytes("conv-1")).toBe(100);
     expect(residentBytes("conv-unknown")).toBe(0);
+  });
+});
+
+describe("touchSelected", () => {
+  /** Each row's selection stamp, by `(slug, key)`. */
+  function stamps(conversationId: string) {
+    return getInjected(conversationId).map(({ slug, key, lastSelectedAt }) => [
+      slug,
+      key,
+      lastSelectedAt,
+    ]);
+  }
+
+  test("stamps exactly the named rows, leaving injected_at and other conversations alone; an unknown ref is a no-op", () => {
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "topics/page-a", key: "", bytes: 100 },
+        { slug: "topics/page-a", key: "Notes", bytes: 80 },
+        { slug: "topics/page-b", key: "", bytes: 50 },
+      ],
+      1_000,
+    );
+    recordInjected(
+      "conv-2",
+      [{ slug: "topics/page-a", key: "Notes", bytes: 80 }],
+      1_000,
+    );
+
+    touchSelected(
+      "conv-1",
+      [
+        { slug: "topics/page-a", key: "Notes" },
+        { slug: "topics/page-b", key: "" },
+        { slug: "topics/page-c", key: "" },
+      ],
+      2_000,
+    );
+
+    expect(stamps("conv-1")).toEqual([
+      ["topics/page-a", "", 1_000],
+      ["topics/page-a", "Notes", 2_000],
+      ["topics/page-b", "", 2_000],
+    ]);
+    expect(stamps("conv-2")).toEqual([["topics/page-a", "Notes", 1_000]]);
+    expect(getInjected("conv-1").every((row) => row.injectedAt === 1_000)).toBe(
+      true,
+    );
+  });
+
+  test("stamps a ref list far larger than one batch (and SQLite's expression depth) in one call", () => {
+    const refs = Array.from({ length: 1_100 }, (_, i) => ({
+      slug: `topics/page-${i}`,
+      key: i % 2 === 0 ? "" : "Notes",
+    }));
+    recordInjected(
+      "conv-1",
+      refs.map((ref) => ({ ...ref, bytes: 1 })),
+      1_000,
+    );
+
+    touchSelected("conv-1", refs, 2_000);
+
+    expect(
+      getInjected("conv-1").filter((row) => row.lastSelectedAt === 2_000),
+    ).toHaveLength(1_100);
+  });
+
+  test("empty ref list is a no-op", () => {
+    recordInjected(
+      "conv-1",
+      [{ slug: "topics/page-a", key: "", bytes: 100 }],
+      1_000,
+    );
+    touchSelected("conv-1", [], 2_000);
+    expect(stamps("conv-1")).toEqual([["topics/page-a", "", 1_000]]);
   });
 });
 
@@ -349,7 +440,7 @@ describe("clearConversation", () => {
 });
 
 describe("forkEverInjected", () => {
-  test("copies the parent's full record, pruned state included", () => {
+  test("copies the parent's full record, pruned state and selection stamps included", () => {
     recordInjected(
       "conv-parent",
       [
@@ -359,6 +450,7 @@ describe("forkEverInjected", () => {
       1_000,
     );
     markPruned("conv-parent", [{ slug: "topics/page-a", key: "Notes" }], 2_000);
+    touchSelected("conv-parent", [{ slug: "topics/page-a", key: "" }], 3_000);
 
     forkEverInjected("conv-parent", "conv-child");
 
@@ -368,6 +460,7 @@ describe("forkEverInjected", () => {
         key: "",
         bytes: 100,
         injectedAt: 1_000,
+        lastSelectedAt: 3_000,
         prunedAt: null,
       },
       {
@@ -375,6 +468,7 @@ describe("forkEverInjected", () => {
         key: "Notes",
         bytes: 250,
         injectedAt: 1_000,
+        lastSelectedAt: 1_000,
         prunedAt: 2_000,
       },
     ]);
@@ -402,7 +496,7 @@ describe("seedEverInjectedFromBlocks", () => {
   const blockA = `${leadA}\n\n${notesA}`;
   const designB = `${injectedSectionHeader("topics/page-b", "Design#1")}\nDesign B`;
 
-  test("seeds a row per inherited section, stamped at the given time, with the bytes of its inherited span", () => {
+  test("seeds a row per inherited section, stamped at the given time with no selection stamp, with the bytes of its inherited span", () => {
     seedEverInjectedFromBlocks(
       "conv-parent",
       "conv-child",
@@ -416,6 +510,7 @@ describe("seedEverInjectedFromBlocks", () => {
         key: "",
         bytes: renderedBytes(leadA),
         injectedAt: 5_000,
+        lastSelectedAt: null,
         prunedAt: null,
       },
       {
@@ -423,6 +518,7 @@ describe("seedEverInjectedFromBlocks", () => {
         key: "Notes",
         bytes: renderedBytes(notesA),
         injectedAt: 5_000,
+        lastSelectedAt: null,
         prunedAt: null,
       },
       {
@@ -430,6 +526,7 @@ describe("seedEverInjectedFromBlocks", () => {
         key: "Design#1",
         bytes: renderedBytes(designB),
         injectedAt: 5_000,
+        lastSelectedAt: null,
         prunedAt: null,
       },
     ]);
@@ -711,6 +808,9 @@ describe("fail-soft without a memory database", () => {
     expect(getPrunedSections("conv-1").size).toBe(0);
     expect(getInjected("conv-1")).toEqual([]);
     expect(residentBytes("conv-1")).toBe(0);
+    expect(() =>
+      touchSelected("conv-1", [{ slug: "topics/page-a", key: "" }], 2_000),
+    ).not.toThrow();
     expect(() => clearConversation("conv-1")).not.toThrow();
   });
 });
@@ -742,6 +842,9 @@ describe("fail-soft when the underlying statement fails", () => {
     ).not.toThrow();
     expect(() =>
       markPruned("conv-1", [{ slug: "topics/page-a", key: "" }], 2_000),
+    ).not.toThrow();
+    expect(() =>
+      touchSelected("conv-1", [{ slug: "topics/page-a", key: "" }], 2_000),
     ).not.toThrow();
     expect(() => clearConversation("conv-1")).not.toThrow();
     expect(() => forkEverInjected("conv-parent", "conv-child")).not.toThrow();

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
@@ -9,13 +9,18 @@
  * page's lead and for capability content (skills and CLI commands inject
  * whole). The active (non-pruned) rows are the injection dedup record: a pair
  * present here rides the cached message prefix and must not be re-rendered.
- * `bytes` sums into the resident footprint the prune valve bounds. Rows are
- * never deleted by pruning (`pruned_at` is set instead) so the record stays
- * auditable; a pruned section that is re-selected re-injects by clearing
- * `pruned_at` on upsert. `clearConversation` is the compaction reset: the
- * cached blocks those sections lived on are gone, so future turns are free to
- * re-inject them; it takes the conversation's legacy card rows with it
- * (`plugin-schema.ts`), so no later copy re-imports them.
+ * `bytes` sums into the resident footprint the prune valve bounds, and
+ * `last_selected_at` is the recency the valve ranks by: the injector's commit
+ * stamps it on every section the turn selected, the net-new ones through
+ * `recordInjected` and the resident ones through `touchSelected`, so each
+ * section ages from its own latest selection (`injected_at` stands in for a
+ * row with no stamp). Rows are never deleted by pruning (`pruned_at` is set
+ * instead) so the record stays auditable; a pruned section that is
+ * re-selected re-injects by clearing `pruned_at` on upsert.
+ * `clearConversation` is the compaction reset: the cached blocks those
+ * sections lived on are gone, so future turns are free to re-inject them; it
+ * takes the conversation's legacy card rows with it (`plugin-schema.ts`), so
+ * no later copy re-imports them.
  *
  * Fork semantics mirror v2's activation-store hooks. The fork copy runs on the
  * memory connection, so it is not atomic with the main-DB `forkConversation()`
@@ -156,6 +161,9 @@ export interface InjectedSectionRow extends SectionRef {
   bytes: number;
   /** Epoch ms the section was (last) injected. */
   injectedAt: number;
+  /** Epoch ms of the latest turn that selected the section, or `null` for a
+   *  row no turn has stamped (see {@link ActiveInjectedEntry}). */
+  lastSelectedAt: number | null;
   /** Epoch ms the prune valve removed the section, or `null` while resident. */
   prunedAt: number | null;
 }
@@ -196,6 +204,7 @@ export function getInjected(conversationId: string): InjectedSectionRow[] {
         key: memoryV3InjectedSections.sectionKey,
         bytes: memoryV3InjectedSections.bytes,
         injectedAt: memoryV3InjectedSections.injectedAt,
+        lastSelectedAt: memoryV3InjectedSections.lastSelectedAt,
         prunedAt: memoryV3InjectedSections.prunedAt,
       })
       .from(memoryV3InjectedSections)
@@ -242,10 +251,14 @@ export function getActiveSections(conversationId: string): SectionRefSet {
 /** One active (resident) row of the prune valve's candidate set. */
 export interface ActiveInjectedEntry extends SectionRef {
   bytes: number;
-  /** Epoch ms the section was (last) injected: the recency fallback for
-   *  sections with no matching selection rows (e.g. rows copied by a full
-   *  fork). */
+  /** Epoch ms the section was (last) injected: the recency the prune valve
+   *  falls back to for a row with no `lastSelectedAt`. */
   injectedAt: number;
+  /** Epoch ms of the latest turn that selected the section, net-new or
+   *  already resident: the prune valve's recency. `null` for a row no turn
+   *  has stamped (a truncated fork's seeded row, or one written before the
+   *  column existed). */
+  lastSelectedAt: number | null;
 }
 
 /**
@@ -262,6 +275,7 @@ export function getActiveEntries(
         key: memoryV3InjectedSections.sectionKey,
         bytes: memoryV3InjectedSections.bytes,
         injectedAt: memoryV3InjectedSections.injectedAt,
+        lastSelectedAt: memoryV3InjectedSections.lastSelectedAt,
       })
       .from(memoryV3InjectedSections)
       .where(
@@ -284,9 +298,11 @@ export function getPrunedSections(conversationId: string): SectionRefSet {
 }
 
 /**
- * Upsert this turn's injected sections. Re-recording an existing pair clears
- * `pruned_at` and refreshes `bytes`/`injected_at`: a pruned section that is
- * re-selected re-injects as a fresh entry on the current message. Its older
+ * Upsert this turn's injected sections, each stamped `last_selected_at = at`
+ * (the turn that injects a section selected it). Re-recording an existing
+ * pair clears `pruned_at` and refreshes `bytes`, `injected_at`, and the
+ * stamp: a pruned section that is re-selected re-injects as a fresh entry on
+ * the current message. Its older
  * copies stay in earlier messages' persisted metadata; rehydration and the
  * live strip keep only the newest persisted copy of a pair
  * (`newestCopyIndexes` in `prune.ts`), so clearing the tombstone never
@@ -316,6 +332,7 @@ export function recordInjected(
           slug: entry.slug,
           sectionKey: entry.key,
           injectedAt: at,
+          lastSelectedAt: at,
           bytes: entry.bytes,
           prunedAt: null,
         })
@@ -325,7 +342,12 @@ export function recordInjected(
             memoryV3InjectedSections.slug,
             memoryV3InjectedSections.sectionKey,
           ],
-          set: { injectedAt: at, bytes: entry.bytes, prunedAt: null },
+          set: {
+            injectedAt: at,
+            lastSelectedAt: at,
+            bytes: entry.bytes,
+            prunedAt: null,
+          },
         })
         .run();
     }
@@ -334,36 +356,39 @@ export function recordInjected(
   }
 }
 
-/** Composite keys per tombstone statement. Each key is one `OR` term, and
- *  SQLite caps expression depth at 1000, so a plan of any size is applied in
- *  batches well under that. */
-const PRUNE_KEY_BATCH_SIZE = 100;
+/** Composite keys per statement of a `(slug, key)`-addressed update. Each
+ *  key is one `OR` term, and SQLite caps expression depth at 1000, so a ref
+ *  list of any size is applied in batches well under that. */
+const REF_KEY_BATCH_SIZE = 100;
 
 /**
- * Mark sections pruned from the live context. Rows are never deleted: the
- * record stays auditable and the sections stay eligible for re-injection.
- * The update runs in {@link PRUNE_KEY_BATCH_SIZE}-key batches inside one
- * transaction, so a large plan neither exceeds SQLite's expression-depth
- * limit nor leaves a partially applied tombstone set.
+ * Apply `set` to the conversation's rows named by `refs`, in
+ * {@link REF_KEY_BATCH_SIZE}-key batches inside one transaction, so a list of
+ * any size neither exceeds SQLite's expression-depth limit nor leaves a
+ * partially applied update. Best-effort like every store write: a degraded
+ * memory connection or a failed statement logs `failureMessage` and leaves
+ * the rows as they were. A ref with no row is a no-op.
  */
-export function markPruned(
+function updateRefs(
+  context: string,
   conversationId: string,
   refs: SectionRef[],
-  at: number,
+  set: Partial<typeof memoryV3InjectedSections.$inferInsert>,
+  failureMessage: string,
 ): void {
   if (refs.length === 0) {
     return;
   }
   try {
-    const mdb = memoryDb("markPruned");
+    const mdb = memoryDb(context);
     if (!mdb) {
       return;
     }
     mdb.transaction((tx) => {
-      for (let i = 0; i < refs.length; i += PRUNE_KEY_BATCH_SIZE) {
-        const batch = refs.slice(i, i + PRUNE_KEY_BATCH_SIZE);
+      for (let i = 0; i < refs.length; i += REF_KEY_BATCH_SIZE) {
+        const batch = refs.slice(i, i + REF_KEY_BATCH_SIZE);
         tx.update(memoryV3InjectedSections)
-          .set({ prunedAt: at })
+          .set(set)
           .where(
             and(
               eq(memoryV3InjectedSections.conversationId, conversationId),
@@ -381,8 +406,47 @@ export function markPruned(
       }
     });
   } catch (err) {
-    log.warn({ err }, "failed to mark injected sections pruned; continuing");
+    log.warn({ err }, failureMessage);
   }
+}
+
+/**
+ * Mark sections pruned from the live context. Rows are never deleted: the
+ * record stays auditable and the sections stay eligible for re-injection.
+ */
+export function markPruned(
+  conversationId: string,
+  refs: SectionRef[],
+  at: number,
+): void {
+  updateRefs(
+    "markPruned",
+    conversationId,
+    refs,
+    { prunedAt: at },
+    "failed to mark injected sections pruned; continuing",
+  );
+}
+
+/**
+ * Stamp `last_selected_at = at` on the sections a turn selected that were
+ * already resident (the injector's pointer entries and its resident
+ * capability units): the prune valve's recency, so a section re-selected
+ * turn after turn is never evicted as stale. The turn's net-new sections
+ * take the stamp from {@link recordInjected} instead.
+ */
+export function touchSelected(
+  conversationId: string,
+  refs: SectionRef[],
+  at: number,
+): void {
+  updateRefs(
+    "touchSelected",
+    conversationId,
+    refs,
+    { lastSelectedAt: at },
+    "failed to stamp selected sections; continuing",
+  );
 }
 
 /**
@@ -459,6 +523,7 @@ export function forkEverInjected(
         slug: memoryV3InjectedSections.slug,
         sectionKey: memoryV3InjectedSections.sectionKey,
         injectedAt: memoryV3InjectedSections.injectedAt,
+        lastSelectedAt: memoryV3InjectedSections.lastSelectedAt,
         bytes: memoryV3InjectedSections.bytes,
         prunedAt: memoryV3InjectedSections.prunedAt,
       })
@@ -477,6 +542,7 @@ export function forkEverInjected(
           ],
           set: {
             injectedAt: row.injectedAt,
+            lastSelectedAt: row.lastSelectedAt,
             bytes: row.bytes,
             prunedAt: row.prunedAt,
           },
@@ -498,11 +564,13 @@ export function forkEverInjected(
  * `seedForkActivationState`: a wholesale copy would over-claim, while seeding
  * nothing would re-attach every inherited section as a duplicate.
  *
- * Rows are stamped `injected_at = at` and `bytes` = the byte length of the
- * section's span in the inherited block (header through body, the measure
- * `recordInjected` takes from the live render), so the child's resident
- * accounting starts at what it actually inherited and the valve can evict an
- * inherited section like any other. A section present in several inherited
+ * Rows are stamped `injected_at = at`, with no `last_selected_at` (no turn of
+ * the child has selected them; the valve ranks them by `injected_at` until
+ * one does), and `bytes` = the byte length of the section's span in the
+ * inherited block (header through body, the measure `recordInjected` takes
+ * from the live render), so the child's resident accounting starts at what it
+ * actually inherited and the valve can evict an inherited section like any
+ * other. A section present in several inherited
  * blocks (re-injected after a prune) takes its latest span, mirroring the
  * upsert. An inherited capability chunk (`# Skill: ` / `# CLI command: `)
  * seeds its capability slug exactly as the injector records one: under the

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
@@ -10,11 +10,12 @@
  * whole). The active (non-pruned) rows are the injection dedup record: a pair
  * present here rides the cached message prefix and must not be re-rendered.
  * `bytes` sums into the resident footprint the prune valve bounds, and
- * `last_selected_at` is the recency the valve ranks by: the injector's commit
- * stamps it on every section the turn selected, the net-new ones through
- * `recordInjected` and the resident ones through `touchSelected`, so each
- * section ages from its own latest selection (`injected_at` stands in for a
- * row with no stamp). Rows are never deleted by pruning (`pruned_at` is set
+ * `last_selected_at` is the recency the valve ranks by: the injector stamps
+ * it on every section the turn selected, the resident ones through
+ * `touchSelected` as soon as it classifies them and the net-new ones through
+ * `recordInjected` at its commit, so each section ages from its own latest
+ * selection (`injected_at` stands in for a row with no stamp). Rows are
+ * never deleted by pruning (`pruned_at` is set
  * instead) so the record stays auditable; a pruned section that is
  * re-selected re-injects by clearing `pruned_at` on upsert.
  * `clearConversation` is the compaction reset: the cached blocks those
@@ -432,8 +433,10 @@ export function markPruned(
  * Stamp `last_selected_at = at` on the sections a turn selected that were
  * already resident (the injector's pointer entries and its resident
  * capability units): the prune valve's recency, so a section re-selected
- * turn after turn is never evicted as stale. The turn's net-new sections
- * take the stamp from {@link recordInjected} instead.
+ * turn after turn is never evicted as stale. The injector stamps them in the
+ * same synchronous segment that classifies them, so a valve already queued
+ * never ranks the stale stamp in between. The turn's net-new sections take
+ * the stamp from {@link recordInjected} instead.
  */
 export function touchSelected(
   conversationId: string,

--- a/assistant/src/plugins/defaults/memory/v3/injector.ts
+++ b/assistant/src/plugins/defaults/memory/v3/injector.ts
@@ -8,8 +8,8 @@
  *
  *  - {@link memoryV3Injector} (id `memory-v3`, `after-memory-prefix`): the
  *    PERSISTENT layer. The injection unit is the SECTION: each selected page
- *    contributes its finder-matched section, or its lead when it was selected
- *    without a match (a capability slug contributes its whole capability
+ *    contributes every section selected for it, or its lead when it was
+ *    selected with none (a capability slug contributes its whole capability
  *    content). Renders only this turn's NET-NEW sections, pairs
  *    `(slug, section key)` not already active in the section store, inside
  *    one `<memory>` block and returns the block. The store write
@@ -135,6 +135,7 @@ import {
   MEMORY_V3_POINTER_BLOCK_ID,
   type Section,
   type SectionRef,
+  type SelectedPage,
   type Slug,
 } from "./types.js";
 
@@ -335,14 +336,44 @@ export function resetMemoryV3InjectorStateForTests(): void {
 
 // ─── injectors ───────────────────────────────────────────────────────────────
 
-/** One selection this assembly's block carries, in selection order: `text`
- *  is the first produce's entry when re-emitted by a re-entry, and is
- *  rendered here otherwise. */
-interface BlockSlot {
+/** One injection unit of a selection: the page, the unit's section-store
+ *  key, and the matched section it renders (`undefined` for the lead and
+ *  for capability content). */
+interface InjectionUnit {
   slug: Slug;
   key: string;
   matched: Section | undefined;
+}
+
+/** One unit this assembly's block carries, in selection order: `text` is
+ *  the first produce's entry when re-emitted by a re-entry, and is rendered
+ *  here otherwise. */
+interface BlockSlot extends InjectionUnit {
   text: string | undefined;
+}
+
+/**
+ * The injection units of a turn's selections, in selection order: one per
+ * selected section, or one lead unit for a page selected with none, deduped
+ * by `(slug, key)` (a capability page's sections all inject as its whole
+ * content under the empty key).
+ */
+function injectionUnits(selections: SelectedPage[]): InjectionUnit[] {
+  const units: InjectionUnit[] = [];
+  const seen = new Map<Slug, Set<string>>();
+  for (const { slug, sections } of selections) {
+    for (const matched of sections.length > 0 ? sections : [undefined]) {
+      const key = injectionSectionKey(slug, matched);
+      const keys = seen.get(slug) ?? new Set<string>();
+      if (keys.has(key)) {
+        continue;
+      }
+      keys.add(key);
+      seen.set(slug, keys);
+      units.push({ slug, key, matched });
+    }
+  }
+  return units;
 }
 
 export const memoryV3Injector: Injector = {
@@ -385,10 +416,11 @@ export const memoryV3Injector: Injector = {
     const result = observed;
 
     try {
-      // Partition this turn's selections. Each page injects under ONE key
-      // this turn: its matched section's key, or `""` for the lead (and for
-      // capability content, which injects whole). A resident pair (active in
-      // the section store) is a pointer entry; capability slugs are left out
+      // Partition this turn's injection units. Each selected section injects
+      // under its own key, and a page selected with none under `""` (its
+      // lead; capability content injects whole under `""` too). A resident
+      // pair (active in the section store) is a pointer entry; capability
+      // slugs are left out
       // of the pointer because they have no `memory/concepts/` path to point
       // at. On a re-entry assembly (`rendered` set by the turn's first
       // produce) an entry the first produce rendered is re-emitted from the
@@ -414,9 +446,7 @@ export const memoryV3Injector: Injector = {
         : getPrunedSections(ctx.conversationId);
       const resident: SectionRef[] = [];
       const slots: BlockSlot[] = [];
-      for (const { slug } of result.selections) {
-        const matched = result.matchedSections.get(slug);
-        const key = injectionSectionKey(slug, matched);
+      for (const { slug, key, matched } of injectionUnits(result.selections)) {
         if (pruned && sectionRefSetHas(pruned, slug, key)) {
           continue;
         }

--- a/assistant/src/plugins/defaults/memory/v3/injector.ts
+++ b/assistant/src/plugins/defaults/memory/v3/injector.ts
@@ -12,13 +12,16 @@
  *    selected with none (a capability slug contributes its whole capability
  *    content). Renders only this turn's NET-NEW sections, pairs
  *    `(slug, section key)` not already active in the section store, inside
- *    one `<memory>` block and returns the block. The store write
- *    (`recordInjected`) and the prune-valve schedule are DEFERRED to a commit
- *    callback the block carries (`meta[MEMORY_V3_COMMIT_META_KEY]`): runtime
- *    assembly invokes it only when the turn's tail is a user message — the
- *    same gate as metadata capture — so a turn whose block silently fails to
- *    attach never claims its sections in the store (which would suppress
- *    them until compaction). Runtime assembly splices the block onto the
+ *    one `<memory>` block and returns the block. The store writes
+ *    (`recordInjected` for the net-new sections, and `touchSelected` stamping
+ *    the turn's selection time on the resident ones so the prune valve's
+ *    recency follows every selected section) and the prune-valve schedule
+ *    are DEFERRED to a commit callback the block carries
+ *    (`meta[MEMORY_V3_COMMIT_META_KEY]`): runtime assembly invokes it only
+ *    when the turn's tail is a user message (the same gate as metadata
+ *    capture), so a turn whose block silently fails to attach never claims
+ *    its sections in the store (which would suppress them until compaction).
+ *    Runtime assembly splices the block onto the
  *    current user message and the user-prompt-submit hook persists the
  *    unwrapped inner text under `metadata.memoryV3InjectedBlock`;
  *    `conversation.ts` rehydrates it on load. The block is FROZEN thereafter:
@@ -119,6 +122,7 @@ import {
   getPrunedSections,
   recordInjected,
   sectionRefSetHas,
+  touchSelected,
 } from "./ever-injected-store.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { renderV3InjectionEntry } from "./page-content.js";
@@ -419,11 +423,12 @@ export const memoryV3Injector: Injector = {
       // Partition this turn's injection units. Each selected section injects
       // under its own key, and a page selected with none under `""` (its
       // lead; capability content injects whole under `""` too). A resident
-      // pair (active in the section store) is a pointer entry; capability
-      // slugs are left out
-      // of the pointer because they have no `memory/concepts/` path to point
-      // at. On a re-entry assembly (`rendered` set by the turn's first
-      // produce) an entry the first produce rendered is re-emitted from the
+      // pair (active in the section store) is a pointer entry, and the
+      // commit stamps the turn's selection time on it; capability slugs are
+      // stamped too but left out of the pointer because they have no
+      // `memory/concepts/` path to point at. On a re-entry assembly
+      // (`rendered` set by the turn's first produce) an entry the first
+      // produce rendered is re-emitted from the
       // memo byte for byte: the store counts it active, but its only copy
       // rode the tail the re-injection strip cleared, so the store alone
       // would read it as resident and drop it for the rest of the turn. A
@@ -456,14 +461,16 @@ export const memoryV3Injector: Injector = {
           continue;
         }
         if (active && sectionRefSetHas(active, slug, key)) {
-          if (!isCapabilitySlug(slug)) {
-            resident.push({ slug, key });
-          }
+          resident.push({ slug, key });
           continue;
         }
         slots.push({ slug, key, matched, text: undefined });
       }
-      rememberPointerEntries(ctx.conversationId, ctx.turnIndex, resident);
+      rememberPointerEntries(
+        ctx.conversationId,
+        ctx.turnIndex,
+        resident.filter(({ slug }) => !isCapabilitySlug(slug)),
+      );
 
       // Render net-new sections (each an independent page read, so in
       // parallel), skipping pairs that resolve to no content (deleted pages,
@@ -514,21 +521,24 @@ export const memoryV3Injector: Injector = {
       if (replaced) {
         return block;
       }
-      // The section-store write and the prune-valve schedule are DEFERRED to
-      // this commit callback, invoked by runtime assembly at the point where
-      // attachment is guaranteed (the turn's tail is a user message, the
-      // same gate as metadata capture). Recording here in `produce()` would
-      // let a never-attached turn (non-user tail) claim sections in the
-      // store, suppressing them until compaction. Only the turn's first
-      // produce carries it: a re-entry block re-emits what this one
-      // rendered and is never persisted, so it must not record anything.
-      // The valve is scheduled after `recordInjected` so the resident
-      // accounting includes this turn's sections; it evicts by recency with
-      // no lane exemptions. It runs on a timer, so this turn's block may not
-      // have folded back into the live history when it strips; a section it
-      // prunes from this very turn is stripped by assembly Step 0 on the
-      // next turn, which applies the store's full tombstone set every turn.
+      // The section-store writes (the net-new record and the resident
+      // sections' selection stamp) and the prune-valve schedule are DEFERRED
+      // to this commit callback, invoked by runtime assembly at the point
+      // where attachment is guaranteed (the turn's tail is a user message,
+      // the same gate as metadata capture). Recording here in `produce()`
+      // would let a never-attached turn (non-user tail) claim sections in
+      // the store, suppressing them until compaction. Only the turn's first
+      // produce carries it: a re-entry block re-emits what this one rendered
+      // and is never persisted, so it must not record anything. The valve is
+      // scheduled after both writes so the resident accounting, and the
+      // recency it ranks by, include this turn's sections; it evicts by
+      // recency with no lane exemptions. It runs on a timer, so this turn's
+      // block may not have folded back into the live history when it strips;
+      // a section it prunes from this very turn is stripped by assembly Step
+      // 0 on the next turn, which applies the store's full tombstone set
+      // every turn.
       const commit = (): void => {
+        const at = Date.now();
         recordInjected(
           ctx.conversationId,
           entries.map(({ slug, key, text }) => ({
@@ -541,7 +551,9 @@ export const memoryV3Injector: Injector = {
             // (the valve would otherwise loop-fire on bytes it cannot free).
             bytes: isCapabilitySlug(slug) ? 0 : renderedBytes(text),
           })),
+          at,
         );
+        touchSelected(ctx.conversationId, resident, at);
         schedulePruneValve(ctx.conversationId);
       };
       return { ...block, meta: { [MEMORY_V3_COMMIT_META_KEY]: commit } };

--- a/assistant/src/plugins/defaults/memory/v3/injector.ts
+++ b/assistant/src/plugins/defaults/memory/v3/injector.ts
@@ -12,11 +12,16 @@
  *    selected with none (a capability slug contributes its whole capability
  *    content). Renders only this turn's NET-NEW sections, pairs
  *    `(slug, section key)` not already active in the section store, inside
- *    one `<memory>` block and returns the block. The store writes
- *    (`recordInjected` for the net-new sections, and `touchSelected` stamping
- *    the turn's selection time on the resident ones so the prune valve's
- *    recency follows every selected section) and the prune-valve schedule
- *    are DEFERRED to a commit callback the block carries
+ *    one `<memory>` block and returns the block. The resident pairs are
+ *    stamped with the turn's selection time (`touchSelected`, the prune
+ *    valve's recency) synchronously at classification, before the page reads
+ *    yield: a valve queued by an earlier turn's commit fires on a timer and
+ *    can run while those reads are awaited, so it ranks this turn's recency
+ *    rather than the stale one, and a turn whose net-new pairs all render
+ *    empty (no block, no commit) still stamps them. The stamp is a recency
+ *    bump, never a claim, so a turn whose block does not attach bumps
+ *    harmlessly. The net-new record (`recordInjected`) and the prune-valve
+ *    schedule are DEFERRED to a commit callback the block carries
  *    (`meta[MEMORY_V3_COMMIT_META_KEY]`): runtime assembly invokes it only
  *    when the turn's tail is a user message (the same gate as metadata
  *    capture), so a turn whose block silently fails to attach never claims
@@ -41,7 +46,12 @@
  *    selected sections that are ALREADY resident in history (selected again,
  *    not injected net-new this turn) as a `<memory_pointer>` block of
  *    `memory/concepts/<slug>.md § <key>` lines, no bodies, so the model knows
- *    which frozen sections the turn is about. Runtime assembly splices the
+ *    which frozen sections the turn is about. The entries are re-validated
+ *    against the section store at render time: a pair the valve tombstoned
+ *    since the sections injector classified it (its body stripped from the
+ *    live history) is dropped rather than pointed at, and with nothing left
+ *    no block is emitted. Such a section is simply absent this turn and
+ *    re-injects on its next selection. Runtime assembly splices the
  *    block onto the current user message immediately after any frozen
  *    `<memory>` sections; the user-prompt-submit hook persists the wrapped
  *    text under `metadata.memoryV3PointerBlock` and `conversation.ts`
@@ -423,9 +433,9 @@ export const memoryV3Injector: Injector = {
       // Partition this turn's injection units. Each selected section injects
       // under its own key, and a page selected with none under `""` (its
       // lead; capability content injects whole under `""` too). A resident
-      // pair (active in the section store) is a pointer entry, and the
-      // commit stamps the turn's selection time on it; capability slugs are
-      // stamped too but left out of the pointer because they have no
+      // pair (active in the section store) is a pointer entry and is stamped
+      // with the turn's selection time below; capability slugs are stamped
+      // too but left out of the pointer because they have no
       // `memory/concepts/` path to point at. On a re-entry assembly
       // (`rendered` set by the turn's first produce) an entry the first
       // produce rendered is re-emitted from the
@@ -471,6 +481,21 @@ export const memoryV3Injector: Injector = {
         ctx.turnIndex,
         resident.filter(({ slug }) => !isCapabilitySlug(slug)),
       );
+      // The turn's selection time, stamped on the resident pairs NOW, in the
+      // same synchronous segment as the classification above: the page reads
+      // below yield to the event loop, and a prune valve queued by an earlier
+      // turn's commit fires on a timer, so it can run while they are awaited
+      // and would otherwise rank a pair this turn is about by its stale
+      // stamp and evict it. The stamp is a recency bump, not a claim, so a
+      // turn whose block never attaches (or that returns null below because
+      // every net-new pair rendered empty) bumps harmlessly. Only the first
+      // produce stamps: a re-entry re-emits the turn's selections, and a
+      // run-messages replacement claims nothing (`resident` is empty there).
+      // The net-new pairs take the same time with their record in the commit.
+      const selectedAt = Date.now();
+      if (firstProduce) {
+        touchSelected(ctx.conversationId, resident, selectedAt);
+      }
 
       // Render net-new sections (each an independent page read, so in
       // parallel), skipping pairs that resolve to no content (deleted pages,
@@ -521,24 +546,23 @@ export const memoryV3Injector: Injector = {
       if (replaced) {
         return block;
       }
-      // The section-store writes (the net-new record and the resident
-      // sections' selection stamp) and the prune-valve schedule are DEFERRED
-      // to this commit callback, invoked by runtime assembly at the point
-      // where attachment is guaranteed (the turn's tail is a user message,
-      // the same gate as metadata capture). Recording here in `produce()`
-      // would let a never-attached turn (non-user tail) claim sections in
-      // the store, suppressing them until compaction. Only the turn's first
+      // The net-new record and the prune-valve schedule are DEFERRED to this
+      // commit callback, invoked by runtime assembly at the point where
+      // attachment is guaranteed (the turn's tail is a user message, the
+      // same gate as metadata capture). Recording here in `produce()` would
+      // let a never-attached turn (non-user tail) claim sections in the
+      // store, suppressing them until compaction. Only the turn's first
       // produce carries it: a re-entry block re-emits what this one rendered
       // and is never persisted, so it must not record anything. The valve is
-      // scheduled after both writes so the resident accounting, and the
-      // recency it ranks by, include this turn's sections; it evicts by
+      // scheduled after the record so the resident accounting, and the
+      // recency it ranks by, include this turn's sections (the resident
+      // pairs carry their stamp from the classification above); it evicts by
       // recency with no lane exemptions. It runs on a timer, so this turn's
       // block may not have folded back into the live history when it strips;
       // a section it prunes from this very turn is stripped by assembly Step
       // 0 on the next turn, which applies the store's full tombstone set
       // every turn.
       const commit = (): void => {
-        const at = Date.now();
         recordInjected(
           ctx.conversationId,
           entries.map(({ slug, key, text }) => ({
@@ -551,9 +575,8 @@ export const memoryV3Injector: Injector = {
             // (the valve would otherwise loop-fire on bytes it cannot free).
             bytes: isCapabilitySlug(slug) ? 0 : renderedBytes(text),
           })),
-          at,
+          selectedAt,
         );
-        touchSelected(ctx.conversationId, resident, at);
         schedulePruneValve(ctx.conversationId);
       };
       return { ...block, meta: { [MEMORY_V3_COMMIT_META_KEY]: commit } };
@@ -580,8 +603,21 @@ export const memoryV3PointerInjector: Injector = {
     if (!turnIsEligible(ctx)) {
       return null;
     }
-    const entries = observedTurn(ctx.conversationId, ctx.turnIndex)?.pointer;
-    if (!entries || entries.length === 0) {
+    const remembered = observedTurn(ctx.conversationId, ctx.turnIndex)?.pointer;
+    if (!remembered || remembered.length === 0) {
+      return null;
+    }
+    // Re-validate against the store at render time: the sections injector
+    // classified these pairs as resident before awaiting its page reads, and
+    // a prune valve queued by an earlier turn's commit can fire in that
+    // window and tombstone one of them, stripping its body from the live
+    // history. A pair no longer active is dropped rather than pointed at; it
+    // is simply absent this turn and re-injects on its next selection.
+    const active = getActiveSections(ctx.conversationId);
+    const entries = remembered.filter(({ slug, key }) =>
+      sectionRefSetHas(active, slug, key),
+    );
+    if (entries.length === 0) {
       return null;
     }
     return {

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -32,8 +32,11 @@
  *   2. Build the candidate pool in CACHE ORDER: the stable prefix —
  *      `[...core (file order), ...hot (score order), ...fresh (recency order),
  *      ...always-candidate (skills listed every turn)]`, all computed at lane
- *      init — followed by the finder candidates (needle → dense → edge
- *      surfacing order). The stable prefix
+ *      init, followed by the finder candidates (needle → dense → reply →
+ *      span → entity → edge → learned surfacing order), one line per
+ *      distinct (page, matched section) and at most `finderSectionsPerPage`
+ *      lines per page, so a page whose sections match different parts of
+ *      the message is shown section by section. The stable prefix
  *      is identical across consecutive turns while the lanes are unchanged
  *      (lane invalidation at consolidation is the recompute cadence), so the
  *      selector input's leading segment rides the provider KV cache (the
@@ -42,16 +45,17 @@
  *      Stable-prefix candidates render as FULL CARDS (`renderCard` — head
  *      section + TOC), pre-rendered at lane init (`prefixCards`) so the
  *      rendered prefix is byte-identical across turns. Finder candidates
- *      render as compact snippet lines: the matched section's text (or the
- *      curated `links` description for an edge hit), falling back to the
- *      page's lead-section text when no match text exists.
+ *      render as compact snippet lines: the matched section's
+ *      keyword-in-context window around the query terms that scored it (or
+ *      the curated `links` description for an edge hit), falling back to
+ *      the page's lead-section text when no match text exists.
  *
  *      The finder tail is NOT deduped against the stable prefix: a finder hit
  *      on a core/hot page keeps its matched-section line (and its
- *      `matchedSections` ref + `lanes.finder` entry), so the selector and the
+ *      `lanes.finder` entry), so the selector and the
  *      section injection see that page's CURRENT relevance even though the
- *      page itself sits in the stable prefix. The selector dedupes selections
- *      by slug.
+ *      page itself sits in the stable prefix. The selector merges selections
+ *      per slug, carrying every selected section.
  *   3. A SINGLE forced-tool select (`selectPool`) over the whole pool. The
  *      result is this turn's selections — current turn only. Cross-turn
  *      persistence is the injector's job (net-new blocks frozen into history),
@@ -65,7 +69,6 @@ import {
 } from "../../../../daemon/turn-latency-sub-spans.js";
 import { recordWatchdogEvent } from "../../../../telemetry/watchdog-events-store.js";
 import { getLogger } from "../logging.js";
-import type { DenseHitScored } from "./dense.js";
 import { denseLaneScored } from "./dense.js";
 import type { EdgeGraph } from "./edge.js";
 import { edgeExpand } from "./edge.js";
@@ -80,13 +83,14 @@ import type {
 import { selectAllPoolCandidates, selectPool } from "./pool-select.js";
 import type { SectionNeedle } from "./section-needle.js";
 import { spanChunksOf } from "./span-query.js";
-import type {
-  FinderLane,
-  MemoryRoutingTurn,
-  Section,
-  SectionIndex,
-  SelectedPage,
-  Slug,
+import {
+  type FinderLane,
+  type MemoryRoutingTurn,
+  type Section,
+  type SectionIndex,
+  sectionKey,
+  type SelectedPage,
+  type Slug,
 } from "./types.js";
 
 // Named to disambiguate from the unrelated `src/config/memory-v3-gate.ts`: this
@@ -159,6 +163,12 @@ export const DEFAULT_NEEDLE_K = 12;
 export const DEFAULT_DENSE_K = 0;
 /** Default hard cap on entity-lane articles folded into the pool per turn. */
 export const DEFAULT_ENTITY_CAP = 8;
+/** Default cap on finder lines (matched sections) one page may carry. */
+export const DEFAULT_FINDER_SECTIONS_PER_PAGE = 3;
+/** Contributing query terms carried per finder candidate for its
+ *  keyword-in-context snippet (the renderer uses the first one that occurs
+ *  in the section body). */
+const SNIPPET_TERMS = 3;
 
 export interface OrchestrateDeps {
   sectionIndex: SectionIndex;
@@ -197,6 +207,12 @@ export interface OrchestrateDeps {
   /** Hard cap on entity-lane articles. Defaults to {@link DEFAULT_ENTITY_CAP}.
    *  Ignored when `entityIndex` is omitted (the lane is off). */
   entityCap?: number;
+  /** Cap on finder lines one page may carry per turn, applied in surfacing
+   *  order (needle, dense, reply, span, entity); a section-less edge or
+   *  learned line counts as one. Defaults to
+   *  {@link DEFAULT_FINDER_SECTIONS_PER_PAGE} (canonical value:
+   *  `memory.v3.finderSectionsPerPage`). */
+  finderSectionsPerPage?: number;
   /** Per-lane article budget for the reply-query pass (needle + dense re-run
    *  over `turn.previousAssistantMessage` as separate queries). `0` or
    *  omitted disables the pass (canonical value: `memory.v3.replyQueryK`). */
@@ -242,8 +258,8 @@ export interface OrchestrateDeps {
    *  `MEMORY_V3_FULL_PROFILE_MIN_PAGES`; omitted drops the field from the
    *  telemetry detail (the gate itself never reads it). */
   realConceptPageCount?: number;
-  /** Whether a selected page's injection unit for this turn (its matched
-   *  section, or its lead when `section` is undefined) is already resident in
+  /** Whether one of a selection's injection units for this turn (a selected
+   *  section, or the lead when `section` is undefined) is already resident in
    *  the conversation. Used ONLY to compute the `net_new_count` telemetry
    *  field, selections it rejects are what the injector actually renders.
    *  Read-only and side-effect-free: selection never consults it, and
@@ -252,10 +268,16 @@ export interface OrchestrateDeps {
   isResident?: (slug: Slug, section: Section | undefined) => boolean;
 }
 
-/** A finder-lane candidate: the slug, the descriptor that justified it, and
- *  the finder lane that FIRST surfaced it (needle → dense → edge precedence). */
+/** A finder-lane candidate, one pool line: the slug, the matched section
+ *  when the lane scored one (absent for an edge or learned hit), the query
+ *  terms that contributed most to that match (best first; they drive the
+ *  selector's keyword-in-context snippet), the descriptor that justified the
+ *  line, and the lane that surfaced it. One page can carry several
+ *  candidates, one per distinct matched section, in surfacing order. */
 export interface FinderCandidate {
   slug: Slug;
+  section?: Section;
+  terms?: string[];
   descriptor: string;
   lane: FinderLane;
 }
@@ -276,20 +298,17 @@ export interface OrchestrateLanes {
   fresh: Slug[];
   /** Always-candidate skills, install order (never overlaps core/hot/fresh). */
   always: Slug[];
-  /** Finder candidates in surfacing order, deduped among themselves only. */
+  /** Finder candidates in surfacing order: one per distinct (page, matched
+   *  section), capped per page, deduped among themselves only. */
   finder: FinderCandidate[];
 }
 
 export interface OrchestrateResult {
-  /** This turn's selections, deduped by slug (the dedup is `selectPool`'s
-   *  contract). Current turn only: there is no carried-forward set unioned
-   *  in. */
+  /** This turn's selections, one per slug with the selected finder lines'
+   *  sections merged in pool order (the merge is `selectPool`'s contract);
+   *  the injector renders each of them. Current turn only: there is no
+   *  carried-forward set unioned in. */
   selections: SelectedPage[];
-  /** The matched `Section` for each candidate slug that had one, keyed by slug.
-   *  Populated from the finder-lane hits — including hits on core/hot pages —
-   *  and consumed by the injector to render each selected slug's matched
-   *  section (progressive disclosure). */
-  matchedSections: Map<Slug, Section>;
   /** The candidate lanes in cache order; see {@link OrchestrateLanes}. Consumed
    *  by the selection telemetry (lane attribution), the per-turn pool record
    *  (`pool-log-store.ts`), and the downstream selector rendering. */
@@ -435,152 +454,148 @@ export async function orchestrate(
     deps.sectionIndex.byArticle.has(hit.article),
   );
 
-  // `matchedSections` records the matched `Section` (when one is known) for
-  // every finder hit — INCLUDING hits on stable-prefix slugs — for downstream
-  // injection. `finder` accumulates one entry per distinct
-  // finder-surfaced article; the first lane to surface a slug wins the entry,
-  // so the needle → dense → edge call order encodes lane precedence.
-  const matchedSections = new Map<Slug, Section>();
+  // `finder` accumulates the pool's dynamic tail: one entry per distinct
+  // (article, matched section), in the needle → dense → reply → span →
+  // entity call order, so a page whose sections match different parts of
+  // the message carries one line per section and the selector sees each
+  // section's own text. A hit that resolves to no section (an edge or
+  // learned neighbour, a dense ordinal the index no longer holds) is one
+  // section-less line per page, added only when nothing has surfaced the
+  // page yet. Each page's lines are capped at `finderSectionsPerPage` in
+  // surfacing order. Hits on stable-prefix slugs are kept like any other, so
+  // the selector and the injection see those pages' CURRENT relevance.
+  const finderCap =
+    deps.finderSectionsPerPage ?? DEFAULT_FINDER_SECTIONS_PER_PAGE;
   const finder: FinderCandidate[] = [];
-  const finderSeen = new Set<Slug>();
+  const finderByArticle = new Map<Slug, FinderCandidate[]>();
 
-  // `descriptor` overrides the section text when supplied (the edge lane
-  // prefers a curated `links` description).
-  const addFinder = (
+  // Pool a line for its page unless the page already carries it or is at
+  // the cap: a line with a section duplicates a line for the same section
+  // key; a section-less line duplicates any line.
+  const poolLine = (candidate: FinderCandidate): void => {
+    const lines = finderByArticle.get(candidate.slug) ?? [];
+    const key = candidate.section ? sectionKey(candidate.section) : undefined;
+    const duplicate =
+      key === undefined
+        ? lines.length > 0
+        : lines.some((c) => c.section && sectionKey(c.section) === key);
+    if (duplicate || lines.length >= finderCap) {
+      return;
+    }
+    lines.push(candidate);
+    finderByArticle.set(candidate.slug, lines);
+    finder.push(candidate);
+  };
+
+  // A lane hit on section `doc` (an index into `sections`) scored against
+  // `query`, whose best-contributing terms ride the line for the selector's
+  // keyword-in-context snippet. A `doc` the index does not hold pools as a
+  // section-less line with a blank descriptor.
+  const addSectionHit = (
     slug: Slug,
-    section: Section | undefined,
+    doc: number | undefined,
+    lane: FinderLane,
+    query: string,
+  ): void => {
+    const section = doc === undefined ? undefined : sections[doc];
+    poolLine(
+      doc !== undefined && section
+        ? {
+            slug,
+            section,
+            terms: deps.needle.topTerms(doc, query, SNIPPET_TERMS),
+            descriptor: section.text,
+            lane,
+          }
+        : { slug, descriptor: "", lane },
+    );
+  };
+
+  // A page surfaced by association (an edge or learned neighbour): no
+  // section, described by its curated `links` text or a fallback.
+  const addNeighbour = (
+    slug: Slug,
     descriptor: string | undefined,
     lane: FinderLane,
   ): void => {
-    if (section && !matchedSections.has(slug)) {
-      matchedSections.set(slug, section);
-    }
-    if (finderSeen.has(slug)) {
-      return;
-    }
-    finderSeen.add(slug);
-    finder.push({
-      slug,
-      descriptor: descriptor ?? section?.text ?? "",
-      lane,
-    });
+    poolLine({ slug, descriptor: descriptor ?? "", lane });
   };
 
-  // Step 1a: needle hits — descriptor is the matched section's text. `section`
-  // is an index into `sections`.
+  // Step 1a: needle hits, `section` is an index into `sections`.
   for (const hit of needled) {
-    addFinder(hit.article, sections[hit.section], undefined, "needle");
+    addSectionHit(hit.article, hit.section, "needle", turn.currentMessage);
   }
 
-  // Step 1b: dense hits — `section` is the matched ORDINAL; resolve it to the
-  // concrete `Section` via the section index. Falls back to undefined (blank
-  // descriptor) if the ordinal is not in the in-memory index.
-  //
-  // `denseOwnedSection` tracks the articles whose recorded matched section
-  // came from THIS loop (needle records first and wins ties), along with the
-  // hit's cosine score — the span pass upgrades those sections when a clause
-  // query finds a strictly stronger match under the same metric.
-  const denseOwnedSection = new Map<Slug, number>();
+  // Step 1b: dense hits, `section` is the matched ORDINAL; resolve it to the
+  // section's index via the section index. An ordinal the in-memory index
+  // does not hold yields a section-less candidate (blank descriptor).
   for (const hit of densed) {
     // A deleted page's points can linger in Qdrant; keep only live-index
     // articles. The section index is rebuilt from `getPageIndex` at `initLanes`,
     // so `byArticle` holds exactly the live pages (synthetic capability slugs
-    // included) — only truly-deleted pages are dropped here.
+    // included), only truly-deleted pages are dropped here.
     if (!deps.sectionIndex.byArticle.has(hit.article)) {
       continue;
     }
-    const section = sectionByOrdinal(
-      deps.sectionIndex,
+    addSectionHit(
       hit.article,
-      hit.section,
+      sectionDocByOrdinal(deps.sectionIndex, hit.article, hit.section),
+      "dense",
+      turn.currentMessage,
     );
-    if (section && !matchedSections.has(hit.article)) {
-      denseOwnedSection.set(hit.article, hit.score);
-    }
-    addFinder(hit.article, section, undefined, "dense");
   }
 
-  // Step 1b': reply-query hits — candidates the user-message lanes already
-  // surfaced keep their primary attribution (`addFinder`'s first-lane-wins
-  // dedup); only genuinely reply-surfaced articles tag `"reply"`. Matched
-  // sections are recorded the same way as the primary lanes', so injection
-  // renders the reply-matched section.
+  // Step 1b': reply-query hits. A section the user-message lanes already
+  // pooled is a no-op (`poolLine`'s pair dedup), so only a genuinely
+  // reply-surfaced section tags `"reply"`; its snippet terms come from the
+  // reply text it was scored against.
   for (const hit of replyNeedled) {
-    addFinder(hit.article, sections[hit.section], undefined, "reply");
+    addSectionHit(hit.article, hit.section, "reply", replyQuery);
   }
   for (const hit of replyDensed) {
     if (!deps.sectionIndex.byArticle.has(hit.article)) {
       continue;
     }
-    addFinder(
+    addSectionHit(
       hit.article,
-      sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
-      undefined,
+      sectionDocByOrdinal(deps.sectionIndex, hit.article, hit.section),
       "reply",
+      replyQuery,
     );
   }
 
-  // Step 1b'': span-query hits — union-additive at the pass's own small
-  // budget. Candidates the primary or reply lanes already surfaced keep their
-  // attribution (`addFinder`'s first-lane-wins dedupe); only genuinely
-  // span-surfaced articles tag `"span"`. Like the reply pass, span hits are
-  // excluded from the injection gate (which scores current-message needle +
-  // dense only) and from the edge-expansion seeds.
+  // Step 1b'': span-query hits, union-additive at the pass's own small
+  // budget. A section a primary or reply lane already pooled is a no-op; a
+  // different section of an already-surfaced page joins as its own line,
+  // which is the buried-clause match the pass exists to recover. Like the
+  // reply pass, span hits are excluded from the injection gate (which scores
+  // current-message needle + dense only) and from the edge-expansion seeds.
   //
-  // An article can be surfaced by SEVERAL chunks; dedupe by best cosine score
-  // before `addFinder`, since chunk order would otherwise decide which section
-  // gets recorded — letting an earlier chunk's weak match mask the strong
-  // buried-clause match the pass exists to recover.
-  const bestSpanHits = new Map<Slug, DenseHitScored>();
-  for (const hit of spanDensed.flat()) {
-    const prev = bestSpanHits.get(hit.article);
-    if (!prev || hit.score > prev.score) {
-      bestSpanHits.set(hit.article, hit);
-    }
-  }
-  // For an article a primary lane already surfaced, upgrade its matched
-  // section/descriptor ONLY when the existing section was recorded by the
-  // full-message dense hit and the span's cosine is strictly higher — same
-  // encoder, same collection, so the comparison is evidence, not judgment.
-  // Needle- and reply-recorded sections stay (BM25 and cosine scores are not
-  // comparable, and the reply pass's own convention is first-wins); lane
-  // attribution never changes here.
-  for (const hit of bestSpanHits.values()) {
+  // Several chunks can hit one article on different sections; they are
+  // pooled strongest cosine first, so chunk order never decides which
+  // sections fill the page's cap.
+  const spanHits = spanDensed.flat().sort((a, c) => c.score - a.score);
+  for (const hit of spanHits) {
     if (!deps.sectionIndex.byArticle.has(hit.article)) {
       continue;
     }
-    const section = sectionByOrdinal(
-      deps.sectionIndex,
+    addSectionHit(
       hit.article,
-      hit.section,
+      sectionDocByOrdinal(deps.sectionIndex, hit.article, hit.section),
+      "span",
+      turn.currentMessage,
     );
-    const denseScore = denseOwnedSection.get(hit.article);
-    if (section && denseScore !== undefined && hit.score > denseScore) {
-      matchedSections.set(hit.article, section);
-      const existing = finder.find((c) => c.slug === hit.article);
-      if (existing) {
-        existing.descriptor = section.text;
-      }
-      continue;
-    }
-    addFinder(hit.article, section, undefined, "span");
   }
 
-  // Step 1b''': entity lane — sections whose `## ` heading NAMES a distinctive
+  // Step 1b''': entity lane, sections whose `## ` heading NAMES a distinctive
   // entity the message mentions. Additive BM25 buries a single named entity
   // under a long, multi-topic message's bulk theme; this keys on the heading
-  // vocabulary so the page the user named surfaces regardless of the bulk
-  // theme. Runs before edge expansion so an entity hit joins `finderSeen` (edge
-  // won't re-surface it section-less); it is NOT added to the edge seeds, so it
-  // only contributes its own page.
-  //
-  // The heading section IS the identity this lane exists to surface, so it
-  // takes precedence over any bulk-theme section a prior lane (needle / dense /
-  // reply) already recorded for the SAME page: `addFinder` keeps the first
-  // matched section and skips duplicate slugs, so override the matched section
-  // and the existing finder descriptor here before delegating, ensuring
-  // injection and the selector snippet both render the heading rather than
-  // the earlier non-entity match.
+  // vocabulary so the section the user named surfaces regardless of the bulk
+  // theme, as its own line beside any bulk-theme section a prior lane pooled
+  // for the same page (a no-op when that lane already pooled the heading).
+  // Runs before edge expansion so an entity hit counts as surfaced (edge
+  // won't re-surface its page section-less); it is NOT added to the edge
+  // seeds, so it only contributes its own section.
   if (deps.entityIndex) {
     for (const hit of entityLane(
       deps.entityIndex,
@@ -588,15 +603,7 @@ export async function orchestrate(
       turn.currentMessage,
       deps.entityCap ?? DEFAULT_ENTITY_CAP,
     )) {
-      const section = sections[hit.section];
-      if (section) {
-        matchedSections.set(hit.article, section);
-        const existing = finder.find((c) => c.slug === hit.article);
-        if (existing) {
-          existing.descriptor = section.text;
-        }
-      }
-      addFinder(hit.article, section, undefined, "entity");
+      addSectionHit(hit.article, hit.section, "entity", turn.currentMessage);
     }
   }
 
@@ -669,21 +676,20 @@ export async function orchestrate(
   //     candidate was kept without a real judgment. Distinguishes "kept the whole
   //     pool because it gave up" from "explicitly selected a large set", which
   //     otherwise look identical and inflate the same way.
-  //   - net_new: selections whose injection unit (matched section, else lead)
-  //     is not already live in the conversation, the injector renders only
-  //     these (prior turns' sections ride history), so it is the real
-  //     incremental injection, where `selected_count` re-counts the whole
-  //     standing set every turn. Omitted when the caller did not supply
-  //     `isResident` (tests, shadow-less paths). `sections` is the matched
-  //     map the returned result carries, so the count reads the same unit the
-  //     injector will (a closed gate returns no sections, so it counts leads).
+  //   - net_new: the injection units among the selections (each selected
+  //     section, or the lead of a page selected with none) not already live
+  //     in the conversation, the injector renders only these (prior turns'
+  //     sections ride history), so it is the real incremental injection,
+  //     where `selected_count` re-counts the whole standing set every turn.
+  //     Omitted when the caller did not supply `isResident` (tests,
+  //     shadow-less paths). The count reads the same units the injector will
+  //     (a closed gate's selections carry no sections, so it counts leads).
   const selectorRanOver = (poolSize: number): boolean =>
     deps.selectorEnabled !== false && poolSize > 0;
   const recordSelection = (
     selections: SelectedPage[],
     poolSize: number,
     keptAll: boolean,
-    sections: ReadonlyMap<Slug, Section>,
   ): void => {
     const detail: Record<string, unknown> = {
       gate_reason: gateOutcome?.reason ?? null,
@@ -693,10 +699,16 @@ export async function orchestrate(
       selected_count: selections.length,
       pool_size: poolSize,
     };
-    if (deps.isResident !== undefined) {
-      detail.net_new_count = selections.filter(
-        (s) => !deps.isResident!(s.slug, sections.get(s.slug)),
-      ).length;
+    const isResident = deps.isResident;
+    if (isResident !== undefined) {
+      detail.net_new_count = selections.reduce(
+        (count, { slug, sections }) =>
+          count +
+          (sections.length > 0 ? sections : [undefined]).filter(
+            (unit) => !isResident(slug, unit),
+          ).length,
+        0,
+      );
     }
     if (deps.realConceptPageCount !== undefined) {
       detail.real_concept_page_count = deps.realConceptPageCount;
@@ -757,15 +769,13 @@ export async function orchestrate(
           checked_articles: gate.checkedArticles,
         });
         if (!gate.pass) {
-          // A closed gate produces no finder lane and no matched sections; only
-          // `selections` and `selectorRan` differ between bypass (stable
-          // prefix) and hard-skip.
+          // A closed gate produces no finder lane; only `selections` and
+          // `selectorRan` differ between bypass (stable prefix) and hard-skip.
           const closed = (
             selections: SelectedPage[],
             selectorRan: boolean,
           ): OrchestrateResult => ({
             selections,
-            matchedSections: new Map(),
             lanes: { core, hot, fresh, always, finder: [] },
             selectorRan,
           });
@@ -784,14 +794,14 @@ export async function orchestrate(
               stable: stableOnly,
               finder: [],
             });
-            recordSelection(bypassed, stableOnly.length, keptAll, new Map());
+            recordSelection(bypassed, stableOnly.length, keptAll);
             return closed(bypassed, selectorRanOver(stableOnly.length));
           }
           // Hard skip: the selector is never consulted, so this is a zero
           // selection BY CONSTRUCTION, not a judgment that nothing was relevant.
           // `selector_ran: false` keeps it out of any relevance rate, and the
           // result's `selectorRan` keeps it out of the persisted pool record.
-          recordSelection([], 0, false, new Map());
+          recordSelection([], 0, false);
           return closed([], false);
         }
       }
@@ -807,8 +817,8 @@ export async function orchestrate(
   // its first/lead section on a zero-score match. That lead is often empty for
   // heading-structured pages, and it is the curated `links` description (not
   // the lead) that made the candidate relevant. So we record NO matched
-  // section for edge-only pages (pass `undefined`), which makes injection fall
-  // back to the FULL page — where the link-relevant content lives.
+  // section for edge-only pages (pass `undefined`): the candidate is a
+  // section-less line and a selection of it injects the page's lead.
   // `bestSection`'s text is kept only as the select-pool DESCRIPTOR fallback
   // for when the traversed edge carried no curated `links` description.
   const seeds = unique<Slug>([
@@ -819,14 +829,13 @@ export async function orchestrate(
     seedCount: deps.edgeSeeds,
     perSeed: deps.edgePerSeed,
     cap: deps.edgeCap,
-    alive: (slug) => !finderSeen.has(slug) && !stablePrefix.has(slug),
+    alive: (slug) => !finderByArticle.has(slug) && !stablePrefix.has(slug),
   });
   for (const neighbor of surfaced) {
     const best = deps.needle.bestSection(neighbor.article, turn.currentMessage);
     const fallbackDescriptor = best >= 0 ? sections[best]?.text : undefined;
-    addFinder(
+    addNeighbour(
       neighbor.article,
-      undefined,
       neighbor.description ?? fallbackDescriptor,
       "edge",
     );
@@ -844,16 +853,15 @@ export async function orchestrate(
       seedCount: deps.edgeSeeds,
       perSeed: deps.learnedPerSeed,
       cap: deps.learnedCap,
-      alive: (slug) => !finderSeen.has(slug) && !stablePrefix.has(slug),
+      alive: (slug) => !finderByArticle.has(slug) && !stablePrefix.has(slug),
     });
     for (const neighbor of learned) {
       const best = deps.needle.bestSection(
         neighbor.article,
         turn.currentMessage,
       );
-      addFinder(
+      addNeighbour(
         neighbor.article,
-        undefined,
         best >= 0 ? sections[best]?.text : undefined,
         "learned",
       );
@@ -867,12 +875,15 @@ export async function orchestrate(
   // byte-identical across turns while the lanes are unchanged. The tail is
   // NOT deduped against the prefix — a finder hit on a core/hot page renders
   // its own snippet line so its CURRENT relevance stays visible; `selectPool`
-  // dedupes selections by slug. Finder candidates with no match text fall
-  // back to the page's lead-section snippet.
+  // merges selections per slug. Each line carries its matched section and
+  // snippet terms; a candidate with no match text falls back to the page's
+  // lead-section snippet.
   const stable = buildStable();
   const finderTail: PoolCandidate[] = finder.map((c) => ({
     slug: c.slug,
     lane: c.lane,
+    section: c.section,
+    terms: c.terms,
     descriptor:
       c.descriptor.trim().length > 0
         ? c.descriptor
@@ -891,39 +902,44 @@ export async function orchestrate(
   );
   const poolSize = stable.length + finderTail.length;
   const { selections, keptAll } = await runSelection(pool);
-  recordSelection(selections, poolSize, keptAll, matchedSections);
+  recordSelection(selections, poolSize, keptAll);
 
   return {
     selections,
-    matchedSections,
     lanes: { core, hot, fresh, always, finder },
     selectorRan: selectorRanOver(poolSize),
   };
 }
 
 /**
- * Resolve a dense-lane hit's matched ordinal to the concrete `Section` in the
- * in-memory index. The dense store keys sections by `(article, ordinal)`, so we
- * scan the article's sections for the matching ordinal. Returns `undefined`
- * when the article or ordinal is not in the index (e.g. the dense store is
- * ahead of the in-memory rebuild).
+ * Resolve a dense-lane hit's matched ordinal to its index into
+ * `index.sections`. The dense store keys sections by `(article, ordinal)`, so
+ * we scan the article's sections for the matching ordinal. Returns
+ * `undefined` when the article or ordinal is not in the index (e.g. the dense
+ * store is ahead of the in-memory rebuild).
  */
+function sectionDocByOrdinal(
+  index: SectionIndex,
+  article: Slug,
+  ordinal: number,
+): number | undefined {
+  for (const doc of index.byArticle.get(article) ?? []) {
+    if (index.sections[doc]?.ordinal === ordinal) {
+      return doc;
+    }
+  }
+  return undefined;
+}
+
+/** The concrete `Section` a dense-lane hit's ordinal resolves to; see
+ *  {@link sectionDocByOrdinal}. */
 export function sectionByOrdinal(
   index: SectionIndex,
   article: Slug,
   ordinal: number,
 ): Section | undefined {
-  const indices = index.byArticle.get(article);
-  if (!indices) {
-    return undefined;
-  }
-  for (const i of indices) {
-    const section = index.sections[i];
-    if (section && section.ordinal === ordinal) {
-      return section;
-    }
-  }
-  return undefined;
+  const doc = sectionDocByOrdinal(index, article, ordinal);
+  return doc === undefined ? undefined : index.sections[doc];
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/v3/plugin-schema.ts
+++ b/assistant/src/plugins/defaults/memory/v3/plugin-schema.ts
@@ -139,9 +139,12 @@ function legacyCardsTableExists(memoryRaw: MemorySqlite): boolean {
 }
 
 /**
- * Create `memory_v3_injected_sections` and its index, then seed it from the
- * card-grain `memory_v3_ever_injected` (the superseded record, relocated to
- * the memory connection by migration 345 and frozen there): every legacy row
+ * Create `memory_v3_injected_sections` and its index, adding
+ * `last_selected_at` (the prune valve's recency stamp, see
+ * `ever-injected-store.ts`) to a table created before the column existed,
+ * then seed it from the card-grain `memory_v3_ever_injected` (the
+ * superseded record, relocated to the memory connection by migration 345
+ * and frozen there): every legacy row
  * becomes that page's LEAD entry (`section_key = ''`) at zero bytes, keeping
  * its `injected_at` and `pruned_at`, so in-flight conversations keep their
  * dedup state across the cutover (a frozen card in history is the page's
@@ -179,9 +182,11 @@ export function ensureMemoryV3InjectedSectionsSchema(
       injected_at INTEGER NOT NULL,
       bytes INTEGER NOT NULL DEFAULT 0,
       pruned_at INTEGER,
+      last_selected_at INTEGER,
       PRIMARY KEY (conversation_id, slug, section_key)
     )
   `);
+  ensureColumn(memoryRaw, SECTIONS_TABLE, "last_selected_at", "INTEGER");
   memoryRaw.exec(/*sql*/ `
     CREATE INDEX IF NOT EXISTS idx_memory_v3_injected_sections_conv
       ON ${SECTIONS_TABLE} (conversation_id)

--- a/assistant/src/plugins/defaults/memory/v3/pool-log-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-log-store.ts
@@ -6,7 +6,8 @@
  * so without this record a retrieval miss can only be diagnosed by rebuilding
  * the lanes offline. `memory_v3_pools` (memory connection, one row per
  * `(conversation, turn)`) stores every candidate the selector saw, in pool
- * order, with its lane, its matched section, and whether it was chosen, plus
+ * order (a page hit on several sections has one entry per section), with its
+ * lane, its matched section, and whether it was chosen, plus
  * `selector_ran`: whether the selector judged that pool at all. A turn the
  * injection gate hard-skipped never assembles a pool, so its row is an empty
  * pool with `selector_ran = 0`; the row exists so the inspector can show the
@@ -35,7 +36,7 @@ import {
   ensureMemoryV3PoolsSchema,
   ensureOncePerConnection,
 } from "./plugin-schema.js";
-import type { FinderLane, Slug } from "./types.js";
+import { type FinderLane, sectionKey, type Slug } from "./types.js";
 
 const log = getLogger("memory-v3-pool-log");
 
@@ -47,12 +48,13 @@ export type PoolLane = "core" | "hot" | "fresh" | "always" | FinderLane;
 export interface PoolCandidateRecord {
   slug: Slug;
   lane: PoolLane;
-  /** Heading of the matched section a finder lane surfaced (`""` for the
-   *  lead); null for stable-prefix cards and finder lines with no matched
-   *  section. */
+  /** Heading of the matched section this finder line carries (`""` for the
+   *  lead); null for stable-prefix cards and section-less finder lines. */
   section_title: string | null;
   section_ordinal: number | null;
-  /** Whether the selector kept this candidate's page. */
+  /** Whether the selector kept this line: for a finder line carrying a
+   *  section, whether that section was selected; for a card or a
+   *  section-less line, whether its page was kept at all. */
   chosen: boolean;
 }
 
@@ -80,10 +82,11 @@ export interface StoredPool {
  * Build the turn's pool record from an orchestrate result. The stable prefix
  * comes first in cache order (core, hot, fresh, always-candidate) as
  * whole-page cards with no section; the finder tail follows in surfacing
- * order, each line tagged with the lane that surfaced it and the slug's
- * matched section. A finder hit on a stable-prefix page therefore appears
- * twice, exactly as the selector saw it. `chosen` is slug membership in the
- * selection set, so every entry for a selected page reads chosen.
+ * order, each line tagged with the lane that surfaced it and the section it
+ * carries. A finder hit on a stable-prefix page therefore appears twice, and
+ * a page hit on several sections once per section, exactly as the selector
+ * saw it. A card or a section-less line reads chosen when its page was kept;
+ * a line carrying a section reads chosen when that section was selected.
  *
  * When the selector did not run and nothing was selected, no pool reached it:
  * either the injection gate hard-skipped selection (the result's lanes still
@@ -102,7 +105,12 @@ export function buildPoolRecord(result: OrchestrateResult): PoolRecord {
       selector_ran: false,
     };
   }
-  const selected = new Set<Slug>(result.selections.map((s) => s.slug));
+  const selected = new Map<Slug, Set<string>>(
+    result.selections.map((s) => [
+      s.slug,
+      new Set(s.sections.map((section) => sectionKey(section))),
+    ]),
+  );
   const card = (slug: Slug, lane: PoolLane): PoolCandidateRecord => ({
     slug,
     lane,
@@ -116,16 +124,17 @@ export function buildPoolRecord(result: OrchestrateResult): PoolRecord {
     ...hot.map((slug) => card(slug, "hot")),
     ...fresh.map((slug) => card(slug, "fresh")),
     ...always.map((slug) => card(slug, "always")),
-    ...finder.map((candidate): PoolCandidateRecord => {
-      const section = result.matchedSections.get(candidate.slug);
-      return {
-        slug: candidate.slug,
-        lane: candidate.lane,
+    ...finder.map(
+      ({ slug, lane, section }): PoolCandidateRecord => ({
+        slug,
+        lane,
         section_title: section?.title ?? null,
         section_ordinal: section?.ordinal ?? null,
-        chosen: selected.has(candidate.slug),
-      };
-    }),
+        chosen: section
+          ? (selected.get(slug)?.has(sectionKey(section)) ?? false)
+          : selected.has(slug),
+      }),
+    ),
   ];
   return {
     candidates,

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.test.ts
@@ -127,7 +127,7 @@ describe("selectPool", () => {
         },
       ]);
     expect(await selectPool(pool, turn)).toEqual({
-      pages: [{ slug: "page-a" }],
+      pages: [{ slug: "page-a", sections: [] }],
       keptAll: false,
     });
   });
@@ -138,7 +138,7 @@ describe("selectPool", () => {
         { type: "tool_use", id: "call-1", name: "select_pages", input: {} },
       ]);
     expect(await selectPool(pool, turn)).toEqual({
-      pages: [{ slug: "page-a" }],
+      pages: [{ slug: "page-a", sections: [] }],
       keptAll: true,
     });
   });

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.ts
@@ -27,8 +27,9 @@
  * the stable prefix per conversation state and bust the cache. Re-selecting
  * an injected page is harmless (injection dedup happens downstream) and feeds
  * hot-set frecency + section injection. A page may appear BOTH as a
- * stable-prefix card and as a finder line (its current matched section);
- * selections are deduped by slug.
+ * stable-prefix card and on finder lines, one per matched section (its
+ * current relevance); selecting a finder line selects that section, and
+ * selections are merged per slug with every selected section.
  *
  * Failure handling distinguishes a DELIBERATE empty selection from an
  * INFRASTRUCTURE failure — the two are different outcomes, not the same one:
@@ -65,7 +66,15 @@ import {
 import { getLogger } from "../logging.js";
 import { loadPromptOverride } from "../prompt-override.js";
 import { retryForResult } from "./llm-retry.js";
-import type { MemoryRoutingTurn, SelectedPage, Slug } from "./types.js";
+import { findTerm } from "./section-needle.js";
+import { sectionBody } from "./sections.js";
+import {
+  type MemoryRoutingTurn,
+  type Section,
+  sectionKey,
+  type SelectedPage,
+  type Slug,
+} from "./types.js";
 
 const log = getLogger("memory-v3-pool-select");
 
@@ -116,13 +125,20 @@ function providerBillingNoticeFromError(
 }
 
 /** A dynamic-tail (finder) candidate: the slug plus the descriptor that
- *  justifies it — a matched section for a needle/dense hit, or a curated link
- *  description for an edge page. Rendered as a one-line snippet, prefixed
- *  with the surfacing lane when one is supplied. */
+ *  justifies it (a matched section's text for a needle/dense hit, or a
+ *  curated link description for an edge page), rendered as a one-line
+ *  snippet and prefixed with the surfacing lane when one is supplied. A
+ *  candidate that also carries its matched `section` and the query `terms`
+ *  that scored it (best first) renders a keyword-in-context snippet instead:
+ *  a window of the section body around the first of those terms that occurs
+ *  in it. One page can appear on several lines, one per matched section;
+ *  selecting a line selects that section. */
 export interface PoolCandidate {
   slug: Slug;
   descriptor: string;
   lane?: string;
+  section?: Section;
+  terms?: string[];
 }
 
 /** A stable-prefix candidate: the slug plus its pre-rendered FULL card
@@ -139,7 +155,8 @@ export interface StableCandidate {
  * (core+hot cards) then the dynamic finder tail. The two segments share one
  * numbering — `[1]…[m]` cards, `[m+1]…` finder lines — and MAY repeat a slug
  * (a finder hit on a core/hot page keeps its matched-section line so the
- * page's CURRENT relevance stays visible); selections are deduped by slug.
+ * page's CURRENT relevance stays visible, and a page hit on several sections
+ * has one line per section); selections are merged per slug.
  */
 export interface SelectorPool {
   stable: StableCandidate[];
@@ -215,6 +232,8 @@ const SELECT_PAGES_TOOL: ToolDefinition = {
 
 const SYSTEM_PROMPT = `You are given the candidate memory pages for an assistant's next reply, in two segments that share one numbering: full page cards first (the curated core, recently-recurring, and recently-modified pages, shown every turn), then this turn's search hits as one-line snippets. Cards carry a \`[lane: …]\` annotation — core is curated, hot recurs by selection frequency, fresh was recently modified (with its last-update time) — and search hits are tagged with the lane that surfaced them.
 
+A page can appear on several search-hit lines, one per matched section, each snippet showing the matched words in context; selecting a line selects that section, so keep every line whose section the reply would draw on.
+
 Select EVERY candidate whose content the upcoming reply would draw on. That includes facts the reply needs, current task and event state (open items, deadlines, schedules, recent activity), and equally register, established framing, calibration rules, and relationship/person/project texture — pages that shape HOW to reply, not only what to say. There is no limit on how many you may select; recall matters more than precision, so when a candidate could plausibly inform the reply, keep it. For a list or an "all of X" request, keep EVERY candidate that belongs to X rather than guessing a representative subset.
 
 Pages you select persist in the conversation automatically, and re-selecting a page that is already in context is harmless (duplicates are removed downstream) — so never withhold a candidate because it might have been selected before. Judge each candidate only by whether the upcoming reply would draw on it.
@@ -245,9 +264,57 @@ export function resolveSelectorPrompt(
   );
 }
 
-/** Collapse a descriptor to one line and cap its length for a finder line. */
-function renderSnippet(descriptor: string): string {
-  return truncate(descriptor.replace(/\s+/g, " ").trim(), SNIPPET_MAX_CHARS);
+/** Collapse text to one line. */
+function oneLine(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * The keyword-in-context snippet of a candidate's matched section:
+ * `§<title>: … <window> …`, the window being up to {@link SNIPPET_MAX_CHARS}
+ * of the one-line section body centered on the first occurrence of the
+ * best-contributing query term that occurs in it (the lead, titled `""`,
+ * renders the window alone). `undefined` when no term occurs in the body.
+ */
+function renderKeywordInContext(
+  section: Section,
+  terms: string[],
+): string | undefined {
+  const body = oneLine(sectionBody(section));
+  for (const term of terms) {
+    const span = findTerm(body, term);
+    if (!span) {
+      continue;
+    }
+    const center = Math.floor((span.start + span.end) / 2);
+    const start = Math.max(
+      0,
+      Math.min(
+        center - Math.floor(SNIPPET_MAX_CHARS / 2),
+        body.length - SNIPPET_MAX_CHARS,
+      ),
+    );
+    const end = Math.min(body.length, start + SNIPPET_MAX_CHARS);
+    const window = [
+      start > 0 ? "… " : "",
+      body.slice(start, end).trim(),
+      end < body.length ? " …" : "",
+    ].join("");
+    const title = section.title.trim();
+    return title.length > 0 ? `§${title}: ${window}` : window;
+  }
+  return undefined;
+}
+
+/** A finder candidate's one-line snippet: the keyword-in-context window when
+ *  it carries a section and a query term that occurs in that section's body,
+ *  otherwise its descriptor collapsed to one line and capped. */
+function renderSnippet(candidate: PoolCandidate): string {
+  const kwic =
+    candidate.section && candidate.terms
+      ? renderKeywordInContext(candidate.section, candidate.terms)
+      : undefined;
+  return kwic ?? truncate(oneLine(candidate.descriptor), SNIPPET_MAX_CHARS);
 }
 
 function readStringField(value: unknown, key: string): string | undefined {
@@ -330,7 +397,7 @@ function renderCardSegment(stable: StableCandidate[]): string {
  */
 function renderFinderSegment(finder: PoolCandidate[], offset: number): string {
   const lines = finder.map((c, i) => {
-    const snippet = renderSnippet(c.descriptor);
+    const snippet = renderSnippet(c);
     const id = offset + i + 1;
     const lane = c.lane !== undefined ? `(${c.lane}) ` : "";
     return snippet.length > 0
@@ -340,21 +407,61 @@ function renderFinderSegment(finder: PoolCandidate[], offset: number): string {
   return `<candidates>\n${lines.join("\n")}\n</candidates>`;
 }
 
-/** Dedupe selections by slug, preserving first-seen order (a page can be
- *  selected as both a card and a finder line). */
-function dedupeBySlug(slugs: Slug[]): SelectedPage[] {
-  return [...new Set(slugs)].map((slug) => ({ slug }));
+/** One pool line as a selectable unit: a stable-prefix card (no section) or
+ *  a finder line with the section it carries (none for a section-less edge
+ *  or learned line). */
+interface PoolLine {
+  slug: Slug;
+  section?: Section;
 }
 
-/** Every candidate slug in the pool's concatenated numbering: ids 1…m are the
+/** Every line in the pool's concatenated numbering: ids 1…m are the
  *  stable-prefix cards, ids m+1… are the finder lines. */
-function orderedSlugs(pool: SelectorPool): Slug[] {
-  return [...pool.stable.map((c) => c.slug), ...pool.finder.map((c) => c.slug)];
+function orderedLines(pool: SelectorPool): PoolLine[] {
+  return [
+    ...pool.stable.map((c): PoolLine => ({ slug: c.slug })),
+    ...pool.finder.map((c): PoolLine => ({ slug: c.slug, section: c.section })),
+  ];
 }
 
-/** Return every candidate in pool order, deduped by slug. */
+/**
+ * Merge the picked lines (0-based indices into `lines`, in the order the
+ * selector listed them) into pages: one per slug in first-picked order (a
+ * page can be picked as a card and on several finder lines), each carrying
+ * the sections of its picked finder lines in pool order, deduped by section
+ * key. A card or a section-less line contributes no section.
+ */
+function mergeSelectedLines(
+  lines: PoolLine[],
+  picked: number[],
+): SelectedPage[] {
+  const pages = new Map<Slug, SelectedPage>();
+  for (const index of picked) {
+    const { slug } = lines[index]!;
+    if (!pages.has(slug)) {
+      pages.set(slug, { slug, sections: [] });
+    }
+  }
+  for (const index of [...new Set(picked)].sort((a, c) => a - c)) {
+    const { slug, section } = lines[index]!;
+    const page = pages.get(slug)!;
+    if (
+      section &&
+      !page.sections.some((s) => sectionKey(s) === sectionKey(section))
+    ) {
+      page.sections.push(section);
+    }
+  }
+  return [...pages.values()];
+}
+
+/** Return every candidate in pool order, merged per slug. */
 export function selectAllPoolCandidates(pool: SelectorPool): SelectedPage[] {
-  return dedupeBySlug(orderedSlugs(pool));
+  const lines = orderedLines(pool);
+  return mergeSelectedLines(
+    lines,
+    lines.map((_, index) => index),
+  );
 }
 
 /** A selection plus whether it came from the recall-safe keep-all fallback. */
@@ -369,9 +476,9 @@ export interface PoolSelection {
 
 /**
  * Run the single forced-tool selector over the unified candidate pool. Returns
- * the pages to inject, deduped by slug (a page that appeared as both a card
- * and a finder line yields one entry), plus a `keptAll` flag marking the
- * recall-safe fallback.
+ * the pages to inject, merged per slug (a page selected as a card and on
+ * finder lines yields one entry carrying every selected section), plus a
+ * `keptAll` flag marking the recall-safe fallback.
  *
  * An omitted `ids` keeps ALL candidates (the recall-safe "all of these are
  * relevant" signal, `keptAll: true`); an explicit `[]` keeps none; an
@@ -387,7 +494,7 @@ export async function selectPool(
   turn: MemoryRoutingTurn,
   systemPrompt: string = SYSTEM_PROMPT,
 ): Promise<PoolSelection> {
-  const ordered = orderedSlugs(pool);
+  const ordered = orderedLines(pool);
   if (ordered.length === 0) {
     return { pages: [], keptAll: false };
   }
@@ -572,13 +679,13 @@ export async function selectPool(
 
   // Omitted `ids` is the recall-safe "keep all candidates" signal.
   if (parsed.ids === undefined) {
-    return { pages: dedupeBySlug(ordered), keptAll: true };
+    return { pages: selectAllPoolCandidates(pool), keptAll: true };
   }
 
   // Map 1-based IDs over the concatenated numbering, dropping out-of-range
-  // IDs without throwing, then dedupe by slug.
-  const selected = parsed.ids
+  // IDs without throwing, then merge the picked lines per slug.
+  const picked = parsed.ids
     .filter((id) => id >= 1 && id <= ordered.length)
-    .map((id) => ordered[id - 1]!);
-  return { pages: dedupeBySlug(selected), keptAll: false };
+    .map((id) => id - 1);
+  return { pages: mergeSelectedLines(ordered, picked), keptAll: false };
 }

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -11,11 +11,11 @@
  *     section was re-injected further down, leaves the `<memory_pointer>`
  *     block; an emptied pointer collapses to `""`;
  *   - `planPrune`: no-op below the cap, oldest-first selection-recency ranking
- *     down to the target at section grain (a heading section's recency is its
- *     own title's selections; a lead's is any selection of the page), no lane
- *     exemptions, `injected_at` fallback, zero-byte (capability) rows
- *     skipped, a truncated fork's inherited sections as candidates carrying
- *     their spans' bytes, idempotence below the cap;
+ *     down to the target at section grain (each row's own `last_selected_at`,
+ *     so two sections of one page selected on one turn both age from it), no
+ *     lane exemptions, `injected_at` fallback for an unstamped row, zero-byte
+ *     (capability) rows skipped, a truncated fork's inherited sections as
+ *     candidates carrying their spans' bytes, idempotence below the cap;
  *   - `runPruneValve` + the live strip: the blocks memory-v3 placed (owned by
  *     object identity) stripped in place by header span, an unowned twin
  *     untouched even when byte-identical, all-pruned blocks removed,
@@ -40,7 +40,6 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ContentBlock, Message } from "@vellumai/plugin-api";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { ensureMemoryV3SelectionsSchema } from "../../../../persistence/migrations/338-move-memory-v3-selections-to-memory-db.js";
 import * as schema from "../../../../persistence/schema/index.js";
 import { wrapMemoryBlock, wrapMemoryPointerBlock } from "../memory-marker.js";
 import {
@@ -67,9 +66,9 @@ let pruneConfig: {
 } | null = null;
 
 let testSqlite: Database;
-// `planPrune`'s recency ranking reads `memory_v3_selections` over the
-// dedicated memory connection, resolved via `getMemorySqlite` — stubbed to a
-// second in-memory DB carrying the relocated tables' schema.
+// The section store, which carries `planPrune`'s candidates and recency,
+// lives on the dedicated memory connection, resolved via `getMemorySqlite`,
+// stubbed to a second in-memory DB carrying the store's schema.
 let memorySqlite: Database;
 let testDb = makeDb();
 function makeDb() {
@@ -88,7 +87,6 @@ function makeDb() {
     )
   `);
   memorySqlite = new Database(":memory:");
-  ensureMemoryV3SelectionsSchema(memorySqlite);
   ensureMemoryV3InjectedSectionsSchema(memorySqlite);
   return db;
 }
@@ -135,6 +133,7 @@ const {
   recordInjected,
   residentBytes,
   seedEverInjectedFromBlocks,
+  touchSelected,
 } = await import("./ever-injected-store.js");
 const { markV3LiveBlock } = await import("./types.js");
 const { V3_INJECTION_HEADER, renderInjectionBlockInner, renderPointerInner } =
@@ -190,22 +189,21 @@ function v3Block(
   return markV3LiveBlock({ type: "text" as const, text }, format);
 }
 
-function insertSelection(
+/** Clear a row's selection stamp, as a row written before the column existed
+ *  carries none. */
+function clearSelectionStamp(
   conversationId: string,
-  turn: number,
   slug: string,
-  createdAt: number,
-  sectionTitle: string | null = null,
+  key: string,
 ): void {
   memorySqlite
     .query(
       /*sql*/ `
-      INSERT OR REPLACE INTO memory_v3_selections
-        (conversation_id, turn, slug, source, created_at, section_title)
-      VALUES (?, ?, ?, 'needle', ?, ?)
+      UPDATE memory_v3_injected_sections SET last_selected_at = NULL
+      WHERE conversation_id = ? AND slug = ? AND section_key = ?
     `,
     )
-    .run(conversationId, turn, slug, createdAt, sectionTitle);
+    .run(conversationId, slug, key);
 }
 
 function insertUserRowWithV3Block(
@@ -659,10 +657,11 @@ describe("planPrune", () => {
       ],
       1_000,
     );
-    insertSelection("conv-1", 0, "page-a", 1_000);
-    insertSelection("conv-1", 0, "page-b", 2_000);
-    insertSelection("conv-1", 0, "page-c", 3_000);
-    insertSelection("conv-1", 0, "page-d", 4_000);
+    // Later turns re-select b, c, and d in that order; a keeps its record's
+    // stamp (1_000).
+    touchSelected("conv-1", [{ slug: "page-b", key: "" }], 2_000);
+    touchSelected("conv-1", [{ slug: "page-c", key: "" }], 3_000);
+    touchSelected("conv-1", [{ slug: "page-d", key: "" }], 4_000);
 
     const plan = planPrune(deps, "conv-1");
     expect(plan).toEqual({
@@ -674,7 +673,7 @@ describe("planPrune", () => {
     });
   });
 
-  test("a heading section's recency is its own title's selections; the lead's is any selection of the page", () => {
+  test("recency is per section row: two sections of one page selected on one turn both carry its stamp, and neither is evicted ahead of an older section", () => {
     recordInjected(
       "conv-1",
       [
@@ -685,89 +684,60 @@ describe("planPrune", () => {
       ],
       1_000,
     );
-    // page-a: Notes selected at 2_000, Design at 5_000, and the page again
-    // (no section) at 6_000, the lead reads 6_000, Notes 2_000, Design 5_000.
-    insertSelection("conv-1", 0, "page-a", 2_000, "Notes");
-    insertSelection("conv-1", 1, "page-a", 5_000, "Design");
-    insertSelection("conv-1", 2, "page-a", 6_000, null);
-    // page-b's Notes was selected at 3_000 under a DIFFERENT title only, so
-    // its Notes section falls back to injected_at (1_000): the oldest.
-    insertSelection("conv-1", 0, "page-b", 3_000, "Other");
+    // A later turn re-selects page-b's Notes, and the turn after it
+    // re-selects page-a's Notes and Design together; page-a's lead keeps its
+    // record's stamp.
+    touchSelected("conv-1", [{ slug: "page-b", key: "Notes" }], 3_000);
+    touchSelected(
+      "conv-1",
+      [
+        { slug: "page-a", key: "Notes" },
+        { slug: "page-a", key: "Design" },
+      ],
+      5_000,
+    );
 
-    const plan = planPrune(deps, "conv-1");
-    expect(plan!.sections).toEqual([
+    // Resident 400 > max 300: page-a's lead (1_000) goes first, then page-b's
+    // Notes (3_000); both sections selected at 5_000 survive.
+    expect(planPrune(deps, "conv-1")!.sections).toEqual([
+      { slug: "page-a", key: "" },
       { slug: "page-b", key: "Notes" },
-      { slug: "page-a", key: "Notes" },
-    ]);
-  });
-
-  test("a chunked heading (key~n) shares its title's recency", () => {
-    recordInjected(
-      "conv-1",
-      [
-        { slug: "page-a", key: "Long~1", bytes: 200 },
-        { slug: "page-b", key: "", bytes: 200 },
-      ],
-      1_000,
-    );
-    insertSelection("conv-1", 0, "page-a", 9_000, "Long");
-    insertSelection("conv-1", 0, "page-b", 2_000);
-
-    expect(planPrune(deps, "conv-1")!.sections).toEqual([
-      { slug: "page-b", key: "" },
-    ]);
-  });
-
-  test("a heading whose own title ends in #<n> decodes to its selections' title, distinct from a repeated heading", () => {
-    // The literal heading `Topic#1` keys as `Topic##1`; a second `Topic`
-    // heading keys as `Topic#1`. Each row must find its own selections.
-    recordInjected(
-      "conv-1",
-      [
-        { slug: "page-a", key: "Topic##1", bytes: 200 },
-        { slug: "page-a", key: "Topic#1", bytes: 200 },
-        { slug: "page-b", key: "", bytes: 200 },
-      ],
-      1_000,
-    );
-    insertSelection("conv-1", 0, "page-a", 9_000, "Topic#1");
-    insertSelection("conv-1", 1, "page-a", 8_000, "Topic");
-    insertSelection("conv-1", 0, "page-b", 2_000);
-
-    // Resident 600 > max 300: page-b's lead (2_000) goes first, then the
-    // repeated `Topic` section (8_000); the literal `Topic#1` heading (9_000)
-    // is the most recent and survives.
-    expect(planPrune(deps, "conv-1")!.sections).toEqual([
-      { slug: "page-b", key: "" },
-      { slug: "page-a", key: "Topic#1" },
     ]);
   });
 
   test("re-selection recency outranks injection order", () => {
     recordInjected(
       "conv-1",
-      [
-        { slug: "page-old", key: "", bytes: 200 },
-        { slug: "page-new", key: "", bytes: 200 },
-      ],
+      [{ slug: "page-old", key: "", bytes: 200 }],
       1_000,
+    );
+    recordInjected(
+      "conv-1",
+      [{ slug: "page-new", key: "", bytes: 200 }],
+      2_000,
     );
     // page-old was injected first but re-selected most recently; page-new was
     // selected only at injection time.
-    insertSelection("conv-1", 0, "page-old", 1_000);
-    insertSelection("conv-1", 1, "page-new", 2_000);
-    insertSelection("conv-1", 5, "page-old", 9_000);
+    touchSelected("conv-1", [{ slug: "page-old", key: "" }], 9_000);
 
     const plan = planPrune(deps, "conv-1");
     expect(plan!.sections).toEqual([{ slug: "page-new", key: "" }]);
   });
 
-  test("never-selected sections fall back to injected_at for recency", () => {
+  test("a row with no selection stamp ranks by injected_at", () => {
     recordInjected("conv-1", [{ slug: "page-a", key: "", bytes: 200 }], 5_000);
     recordInjected("conv-1", [{ slug: "page-b", key: "", bytes: 200 }], 1_000);
+    recordInjected("conv-1", [{ slug: "page-c", key: "", bytes: 200 }], 9_000);
+    clearSelectionStamp("conv-1", "page-b", "");
+    clearSelectionStamp("conv-1", "page-c", "");
 
-    const plan = planPrune(deps, "conv-1");
-    expect(plan!.sections).toEqual([{ slug: "page-b", key: "" }]);
+    // Resident 600 > max 300: page-b (injected 1_000, unstamped) goes first,
+    // then page-a (stamped 5_000); page-c (injected 9_000, unstamped) is the
+    // most recent and survives.
+    expect(planPrune(deps, "conv-1")!.sections).toEqual([
+      { slug: "page-b", key: "" },
+      { slug: "page-a", key: "" },
+    ]);
   });
 
   test("no lane exemptions: the oldest section is pruned whatever page it belongs to", () => {
@@ -780,9 +750,8 @@ describe("planPrune", () => {
       ],
       1_000,
     );
-    insertSelection("conv-1", 0, "core-page", 1_000);
-    insertSelection("conv-1", 0, "page-b", 2_000);
-    insertSelection("conv-1", 0, "page-c", 3_000);
+    touchSelected("conv-1", [{ slug: "page-b", key: "" }], 2_000);
+    touchSelected("conv-1", [{ slug: "page-c", key: "" }], 3_000);
 
     // Resident 450 > max 300: reaching the 200 target needs the two oldest,
     // and the core page's lead is simply the oldest.
@@ -1166,8 +1135,9 @@ describe("runPruneValve", () => {
       ],
       1_000,
     );
-    insertSelection("conv-1", 0, "page-drifted", 1_000);
-    insertSelection("conv-1", 0, "page-a", 2_000);
+    // page-a was re-selected after both were injected: the drifted row is
+    // the oldest candidate.
+    touchSelected("conv-1", [{ slug: "page-a", key: "" }], 2_000);
 
     const liveMessages: Message[] = [
       {
@@ -1225,9 +1195,10 @@ describe("runPruneValve", () => {
       ],
       1_000,
     );
-    insertSelection("conv-1", 0, "page-a", 1_000);
-    insertSelection("conv-1", 1, "page-a", 2_000, "Notes");
-    insertSelection("conv-1", 1, "page-c", 3_000);
+    // Turn 1 re-selected page-a's Notes and turn 2 selected page-c; page-a's
+    // lead keeps its record's stamp, the oldest.
+    touchSelected("conv-1", [{ slug: "page-a", key: "Notes" }], 2_000);
+    touchSelected("conv-1", [{ slug: "page-c", key: "" }], 3_000);
 
     // Live history as rehydration would build it, plus a v2-lookalike block
     // that must survive untouched.
@@ -1394,8 +1365,7 @@ describe("schedulePruneValve", () => {
       ],
       1_000,
     );
-    insertSelection("conv-1", 0, "page-a", 1_000);
-    insertSelection("conv-1", 0, "page-b", 2_000);
+    touchSelected("conv-1", [{ slug: "page-b", key: "" }], 2_000);
 
     pruneConfig = { maxResidentBytes: 300, targetResidentBytes: 200 };
     schedulePruneValve("conv-1", { liveMessages: () => null });

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -98,7 +98,6 @@ import type { ContentBlock, Message } from "@vellumai/plugin-api";
 
 import { getMemoryConfig } from "../config.js";
 import { getLogger } from "../logging.js";
-import { memorySqliteOrNull } from "../memory-db.js";
 import {
   unwrapMemoryBlock,
   unwrapMemoryPointerBlock,
@@ -126,7 +125,6 @@ import {
   type InjectedBlock,
   type InjectedBlockFormat,
   markV3LiveBlock,
-  sectionKeyTitle,
   type SectionRef,
   v3LiveBlockFormat,
 } from "./types.js";
@@ -364,18 +362,16 @@ export interface PruneDeps {
  * within `maxResidentBytes` (or nothing is prunable).
  *
  * The footprint and the candidates both range over the ACTIVE injected
- * sections. Candidates are ranked by last selection recency, read from
- * `memory_v3_selections` over the dedicated memory connection (an unavailable
- * memory database reads as no selection rows): a heading section takes the
- * latest `created_at` of a selection of its page whose `section_title` is
- * that heading (the key decoded through `sectionKeyTitle`, so a chunked or
- * repeated heading shares its title's recency), and a lead section (empty
- * title) takes the latest selection of its page under any title. A section
- * with no matching selection rows (e.g. rows copied or seeded by a fork)
- * falls back to the store's `injected_at`. Candidates are taken oldest-first
- * until the footprint is at `targetResidentBytes`. There are no exemptions;
- * zero-byte rows (capability slugs: dedup-only, no byte accounting) are
- * skipped, since pruning them frees nothing.
+ * sections. Candidates are ranked by last selection recency, carried on the
+ * section row itself: `last_selected_at`, which the injector's commit stamps
+ * on every section the turn selected, net-new (`recordInjected`) and already
+ * resident (`touchSelected`) alike, so each of a page's selected sections
+ * ages from its own selections. A row with no stamp (a truncated fork's
+ * seeded row, or one written before the column existed) ranks by the store's
+ * `injected_at`. Candidates are taken oldest-first until the footprint is at
+ * `targetResidentBytes`. There are no exemptions; zero-byte rows (capability
+ * slugs: dedup-only, no byte accounting) are skipped, since pruning them
+ * frees nothing.
  */
 export function planPrune(
   deps: PruneDeps,
@@ -387,49 +383,12 @@ export function planPrune(
     return null;
   }
 
-  const memoryRaw = memorySqliteOrNull("planPrune");
-  const selectionRows = memoryRaw
-    ? (memoryRaw
-        .query(
-          /*sql*/ `
-      SELECT slug, section_title AS title, MAX(created_at) AS lastSelectedAt
-      FROM memory_v3_selections
-      WHERE conversation_id = ?
-      GROUP BY slug, section_title
-    `,
-        )
-        .all(conversationId) as Array<{
-        slug: string;
-        title: string | null;
-        lastSelectedAt: number;
-      }>)
-    : [];
-  const bySlug = new Map<string, number>();
-  const byTitle = new Map<string, number>();
-  for (const row of selectionRows) {
-    bySlug.set(
-      row.slug,
-      Math.max(bySlug.get(row.slug) ?? -Infinity, row.lastSelectedAt),
-    );
-    if (row.title !== null) {
-      const id = `${row.slug}\n${row.title}`;
-      byTitle.set(
-        id,
-        Math.max(byTitle.get(id) ?? -Infinity, row.lastSelectedAt),
-      );
-    }
-  }
-
   const candidates = activeEntries
     .filter((entry) => entry.bytes > 0)
-    .map((entry) => {
-      const title = sectionKeyTitle(entry.key);
-      const lastSelectedAt =
-        title.length === 0
-          ? bySlug.get(entry.slug)
-          : byTitle.get(`${entry.slug}\n${title}`);
-      return { ...entry, recency: lastSelectedAt ?? entry.injectedAt };
-    })
+    .map((entry) => ({
+      ...entry,
+      recency: entry.lastSelectedAt ?? entry.injectedAt,
+    }))
     // Oldest first; slug then key ascending as the deterministic tiebreak.
     .sort(
       (a, b) =>

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -363,10 +363,11 @@ export interface PruneDeps {
  *
  * The footprint and the candidates both range over the ACTIVE injected
  * sections. Candidates are ranked by last selection recency, carried on the
- * section row itself: `last_selected_at`, which the injector's commit stamps
- * on every section the turn selected, net-new (`recordInjected`) and already
- * resident (`touchSelected`) alike, so each of a page's selected sections
- * ages from its own selections. A row with no stamp (a truncated fork's
+ * section row itself: `last_selected_at`, which the injector stamps on every
+ * section the turn selected, the resident ones (`touchSelected`) as it
+ * classifies them and the net-new ones (`recordInjected`) at its commit, so
+ * each of a page's selected sections ages from its own selections. A row
+ * with no stamp (a truncated fork's
  * seeded row, or one written before the column existed) ranks by the store's
  * `injected_at`. Candidates are taken oldest-first until the footprint is at
  * `targetResidentBytes`. There are no exemptions; zero-byte rows (capability

--- a/assistant/src/plugins/defaults/memory/v3/section-needle.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-needle.ts
@@ -59,14 +59,52 @@ export interface SectionNeedle {
    * entity keys (hub words like "vellum" fall below the floor).
    */
   idf(term: string): number;
+  /**
+   * The query terms contributing the most BM25F score to the section at
+   * `doc` (an index into `SectionIndex.sections`), best first, at most `n`;
+   * ties break by term. Empty when no query term occurs in that section.
+   * Feeds the keyword-in-context finder snippets in `pool-select.ts`.
+   */
+  topTerms(doc: number, queryText: string, n: number): string[];
 }
 
-/** Lowercase, split on non-alphanumeric, drop empties. */
+/** The characters of a needle token; the tokenizer splits on any other. */
+const TOKEN_CHARS = "a-z0-9";
+const NON_TOKEN_RUN = new RegExp(`[^${TOKEN_CHARS}]+`);
+/** The shape of a needle term: a unigram of token characters, or a bigram
+ *  of two joined by `_`. */
+const TERM_SHAPE = new RegExp(`^[${TOKEN_CHARS}]+(?:_[${TOKEN_CHARS}]+)*$`);
+
+/** Lowercase, split on non-token characters, drop empties. */
 function tokenizeUnigrams(text: string): string[] {
   return text
     .toLowerCase()
-    .split(/[^a-z0-9]+/)
+    .split(NON_TOKEN_RUN)
     .filter((token) => token.length > 0);
+}
+
+/**
+ * The span of the first whole-token occurrence of a needle `term` in `text`,
+ * or `undefined`. The term matches case-insensitively at token boundaries,
+ * with a bigram's halves separated by any run of non-token characters, so
+ * the occurrence found is one the tokenizer would have indexed. Feeds the
+ * keyword-in-context snippets in `pool-select.ts`.
+ */
+export function findTerm(
+  text: string,
+  term: string,
+): { start: number; end: number } | undefined {
+  if (!TERM_SHAPE.test(term)) {
+    return undefined;
+  }
+  const halves = term.split("_").join(`[^${TOKEN_CHARS}]+`);
+  const match = new RegExp(
+    `(?<![${TOKEN_CHARS}])${halves}(?![${TOKEN_CHARS}])`,
+    "i",
+  ).exec(text);
+  return match
+    ? { start: match.index, end: match.index + match[0].length }
+    : undefined;
 }
 
 /** Unigrams plus adjacent-token bigrams (`a_b`), matching the harness. */
@@ -144,6 +182,14 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     return idfFromDf(postings.get(term)?.length ?? 0);
   }
 
+  /** One term's BM25F contribution to section `doc`. */
+  function termScore(doc: number, weightedTf: number, termIdf: number): number {
+    const norm = weightedTf * (k1 + 1);
+    const denom =
+      weightedTf + k1 * (1 - b + b * (docLengths[doc]! / avgDocLength));
+    return termIdf * (norm / denom);
+  }
+
   /** BM25F score per section for the given query terms. */
   function scoreSections(queryTerms: Set<string>): Map<number, number> {
     const scores = new Map<number, number>();
@@ -160,14 +206,56 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
       const termIdf = idfFromDf(list.length);
 
       for (const { doc, weightedTf } of list) {
-        const norm = weightedTf * (k1 + 1);
-        const denom =
-          weightedTf + k1 * (1 - b + b * (docLengths[doc]! / avgDocLength));
-        scores.set(doc, (scores.get(doc) ?? 0) + termIdf * (norm / denom));
+        scores.set(
+          doc,
+          (scores.get(doc) ?? 0) + termScore(doc, weightedTf, termIdf),
+        );
       }
     }
 
     return scores;
+  }
+
+  /** The posting of `doc` in `list`, or `undefined` when the term is absent
+   *  from that section. Sections are indexed in ascending order, so every
+   *  postings list is sorted by `doc` and a binary search finds it. */
+  function postingFor(list: Posting[], doc: number): Posting | undefined {
+    let lo = 0;
+    let hi = list.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      const posting = list[mid]!;
+      if (posting.doc === doc) {
+        return posting;
+      }
+      if (posting.doc < doc) {
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return undefined;
+  }
+
+  function topTerms(doc: number, queryText: string, n: number): string[] {
+    if (n <= 0 || doc < 0 || doc >= docCount) {
+      return [];
+    }
+    const contributions: Array<{ term: string; score: number }> = [];
+    for (const term of new Set(tokenize(queryText))) {
+      const list = postings.get(term);
+      const posting = list ? postingFor(list, doc) : undefined;
+      if (list && posting) {
+        contributions.push({
+          term,
+          score: termScore(doc, posting.weightedTf, idfFromDf(list.length)),
+        });
+      }
+    }
+    contributions.sort(
+      (a, c) => c.score - a.score || a.term.localeCompare(c.term),
+    );
+    return contributions.slice(0, n).map((c) => c.term);
   }
 
   /** Deterministic order: score desc, then (article, ordinal) asc. */
@@ -249,5 +337,5 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     return best;
   }
 
-  return { query, queryScored, bestSection, idf };
+  return { query, queryScored, bestSection, idf, topTerms };
 }

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -602,14 +602,14 @@ async function buildShadowTurn(
 interface SelectionRow {
   slug: Slug;
   source: SelectionSource;
-  /** Ordinal of the matched section a finder lane surfaced; null for
-   *  core/hot/fresh/edge selections with no matched section. */
+  /** Ordinal of the selection's first selected section; null for a page
+   *  selected with no section (a card, or a section-less edge or learned
+   *  line). */
   sectionOrdinal: number | null;
-  /** Heading of the matched section; null when there is no matched section. */
+  /** Heading of that section; null when there is no selected section. */
   sectionTitle: string | null;
-  /** The matched section's `sectionKey` (`types.ts`), the identity the
-   *  inspector resolves the section by; null when there is no matched
-   *  section. */
+  /** That section's `sectionKey` (`types.ts`), the identity the inspector
+   *  resolves the section by; null when there is no selected section. */
   sectionKey: string | null;
 }
 
@@ -622,19 +622,25 @@ interface SelectionRow {
  * time). A finder hit on a stable-prefix page therefore still logs as its
  * prefix lane — the prefix is where the candidate lived. (`"needle"` is the
  * fallback if a selected slug is somehow absent from every lane, which should
- * not happen since every pooled candidate comes from one.)
+ * not happen since every pooled candidate comes from one.) A page with
+ * several finder lines is attributed the lane of its first line.
+ *
+ * The row holds one section per slug: the selection's FIRST selected section
+ * (pool order) stands for the page; a page selected with no section (a card,
+ * or a section-less edge or learned line) logs none.
  */
 export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   const core = new Set<Slug>(result.lanes.core);
   const hot = new Set<Slug>(result.lanes.hot);
   const fresh = new Set<Slug>(result.lanes.fresh);
-  const finderLane = new Map(
-    result.lanes.finder.map((c) => [c.slug, c.lane] as const),
-  );
+  const finderLane = new Map<Slug, SelectionSource>();
+  for (const candidate of result.lanes.finder) {
+    if (!finderLane.has(candidate.slug)) {
+      finderLane.set(candidate.slug, candidate.lane);
+    }
+  }
   return result.selections.map((sel) => {
-    // The matched section is populated only for finder-lane hits (including
-    // hits on core/hot pages); core/hot/fresh/edge-only selections have none.
-    const section = result.matchedSections.get(sel.slug);
+    const section = sel.sections[0];
     return {
       slug: sel.slug,
       source: core.has(sel.slug)
@@ -851,6 +857,7 @@ export async function observeTurn(
           injectionSectionKey(slug, section),
         ),
       entityCap: v3.entity.cap,
+      finderSectionsPerPage: v3.finderSectionsPerPage,
       replyQueryK: tuning.replyQueryK,
       spanQueryK: tuning.spanQueryK,
       edgeSeeds: tuning.edgeSeedCount,

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -218,9 +218,15 @@ export interface SectionIndex {
   byArticle: Map<Slug, number[]>;
 }
 
-/** A page selected from the candidate pool. */
+/**
+ * A page selected from the candidate pool, with the matched sections whose
+ * finder lines were selected, in pool order and deduped by {@link sectionKey}.
+ * Empty when only the page's stable-prefix card, or a section-less edge or
+ * learned line, was selected: the injector then injects the page's lead.
+ */
 export interface SelectedPage {
   slug: Slug;
+  sections: Section[];
 }
 
 export interface MemoryRoutingTurn {

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -154,12 +154,11 @@ export interface Section {
  * edits that shift ordinals, and across a re-chunking of one heading, which
  * changes only that heading's own `~` keys.
  *
- * The key is a bijection of `(title, occurrence, chunk)`: every literal `#`
+ * The key is injective over `(title, occurrence, chunk)`: every literal `#`
  * and `~` in the title is doubled before the single-character suffixes are
  * appended, so a heading that itself ends in `#<n>` (`Topic#1`, key
  * `Topic##1`) can never collide with a repeat's key (`Topic` again, key
- * `Topic#1`), nor one ending in `~<n>` with a chunk's. {@link sectionKeyTitle}
- * is the exact inverse.
+ * `Topic#1`), nor one ending in `~<n>` with a chunk's.
  */
 export function sectionKey(section: Section): string {
   const encoded = section.title
@@ -169,36 +168,6 @@ export function sectionKey(section: Section): string {
   const occurrence = section.occurrence ? `#${section.occurrence}` : "";
   const chunk = section.chunk ? `~${section.chunk}` : "";
   return `${encoded}${occurrence}${chunk}`;
-}
-
-/**
- * Match a key's trailing `<marker><n>` suffix together with the run of the
- * marker that precedes the digits. A suffix separator is one marker character
- * and every one a title contributes is doubled by {@link sectionKey}, so the
- * run is odd exactly when the suffix is present: `Topic#1` (run of 1, a
- * repeat of `Topic`) versus `Topic##1` (run of 2, the literal heading
- * `Topic#1`).
- */
-const OCCURRENCE_SUFFIX_REGEX = /^([\s\S]*?)(#+)(\d+)$/;
-const CHUNK_SUFFIX_REGEX = /^([\s\S]*?)(~+)(\d+)$/;
-
-function stripOddRunSuffix(key: string, suffix: RegExp): string {
-  const match = suffix.exec(key);
-  return match && match[2]!.length % 2 === 1
-    ? `${match[1]}${match[2]!.slice(1)}`
-    : key;
-}
-
-/** The section title a {@link sectionKey} names (`""` for the lead): the
- *  exact inverse of the key encoding. The chunk suffix is outermost, so it
- *  is stripped first. */
-export function sectionKeyTitle(key: string): string {
-  return stripOddRunSuffix(
-    stripOddRunSuffix(key, CHUNK_SUFFIX_REGEX),
-    OCCURRENCE_SUFFIX_REGEX,
-  )
-    .replaceAll("##", "#")
-    .replaceAll("~~", "~");
 }
 
 /** One injected section's identity in the section store: page slug plus


### PR DESCRIPTION
## Summary
- A page can carry several matched sections in the selector pool, one line per (page, section), capped per page by memory.v3.finderSectionsPerPage (default 3); first-lane-wins and the span override are gone.
- Finder lines show the matched terms in context (a window around the top contributing BM25F term) instead of the section's first 300 characters.
- Selecting a line selects that section; the injector injects every selected section; the pool record carries one entry per line.
- Prune recency lives on the section row: a plugin-ensured `last_selected_at` column that the injector stamps on every section the turn selected (resident ones at classification, net-new ones with their record at commit), and that `planPrune` ranks by (falling back to `injected_at`), so a page's second and third selected sections no longer age from their injection time. The selections table no longer drives eviction, and the `sectionKeyTitle` decoder that only served the old title lookup is removed.
- Resident recency is stamped synchronously at classification, ahead of the page reads, so a prune valve queued by an earlier turn's commit ranks this turn's stamp when it fires mid-produce, and a turn whose net-new sections all render empty (no block, no commit) still stamps them; the pointer injector re-validates its entries against the section store at render time and drops any pair tombstoned in between (absent this turn, it re-injects on its next selection).

## Notes
- OrchestrateResult.matchedSections is removed rather than widened: each FinderCandidate now carries its own section (and snippet terms) and each SelectedPage carries its selected sections, which left the map with no consumer.
- A selection's sections merge in pool order (deterministic regardless of the order the selector lists ids); pages keep first-picked order as before.
- The per-page cap applies in surfacing order (needle, dense, reply, span, entity), so an entity heading can be capped out behind three earlier lines on the same page; a lane-priority cap is a possible follow-up.
- SectionNeedle gains topTerms(doc, query, n) and findTerm(text, term); the rare-term lane (PR 5) can pass its term as the query to addSectionHit and get a keyword-in-context line for free.

Part of plan: memory-v3-section-injection.md (PR 4 of 5)

## Lead gate: gourd replay (2026-09-05 turn, pre-miss corpus snapshot)

Replayed user message `01a0718e-e442-74fb-b277-be6bcd1a9867` through this branch's needle over the concepts corpus as of workspace commit 6f9348fde6 (07:21 CDT, before the turn; 13,665 sections over 1,936 pages).

- Full message, K=100: `silliness-canon-lines` at rank 52 with the parody section attached (ordinal 70). Reproduces the original attribution miss.
- Clause "I love you my little gourd" alone, K=20: the page is not in the top 20 by BM25F; its only distinctive token is `gourd`.
- `topTerms` for both pumpkin sections (ordinals 8 and 73) against the full message: `gourd` first, so the keyword-in-context line centers on it once a lane surfaces the section.

Conclusion: this PR is necessary but not sufficient for that turn. It lets a clause-level lane hit (the dense span pass surfaced the pumpkin section in the original run and was discarded by first-lane-wins) become a second pool line with the matching term in view. PR 5's rare-term lane surfaces the section deterministically from `gourd` alone.


