### PR TITLE
feat(memory-v3): rare-term finder lane for single distinctive query terms

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -27,6 +27,7 @@ describe("MemoryV3ConfigSchema", () => {
       selectorPromptPath: null,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
       entity: { enabled: true, idfFloor: 4, cap: 8 },
+      rareTerm: { enabled: true, maxDf: 12, perTerm: 2, cap: 24 },
       gate: {
         enabled: true,
         denseThreshold: 0.66,
@@ -125,6 +126,31 @@ describe("MemoryV3ConfigSchema", () => {
       MemoryV3ConfigSchema.parse({ edge: { perSeed: 0 } }),
     ).toThrow();
     expect(() => MemoryV3ConfigSchema.parse({ edge: { cap: -1 } })).toThrow();
+  });
+
+  test("accepts a partial rareTerm override, defaulting the rest", () => {
+    const parsed = MemoryV3ConfigSchema.parse({
+      rareTerm: { maxDf: 5, enabled: false },
+    });
+    expect(parsed.rareTerm).toEqual({
+      enabled: false,
+      maxDf: 5,
+      perTerm: 2,
+      cap: 24,
+    });
+  });
+
+  test("rareTerm knobs must be positive integers and enabled a boolean", () => {
+    for (const key of ["maxDf", "perTerm", "cap"]) {
+      for (const bad of [0, -1, 1.5]) {
+        expect(() =>
+          MemoryV3ConfigSchema.parse({ rareTerm: { [key]: bad } }),
+        ).toThrow();
+      }
+    }
+    expect(() =>
+      MemoryV3ConfigSchema.parse({ rareTerm: { enabled: "yes" } }),
+    ).toThrow();
   });
 
   test("accepts a partial gate override, defaulting the rest", () => {

--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -30,7 +30,7 @@ describe("MemoryV3ConfigSchema", () => {
       rareTerm: {
         enabled: true,
         maxDf: 12,
-        maxDfFraction: 0.001,
+        maxDfFraction: 0.002,
         perTerm: 2,
         cap: 24,
       },
@@ -141,14 +141,14 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed.rareTerm).toEqual({
       enabled: false,
       maxDf: 5,
-      maxDfFraction: 0.001,
+      maxDfFraction: 0.002,
       perTerm: 2,
       cap: 24,
     });
   });
 
-  test("rareTerm.maxDfFraction defaults to 0.001, takes a value in (0, 1], and rejects the rest", () => {
-    expect(MemoryV3ConfigSchema.parse({}).rareTerm.maxDfFraction).toBe(0.001);
+  test("rareTerm.maxDfFraction defaults to 0.002, takes a value in (0, 1], and rejects the rest", () => {
+    expect(MemoryV3ConfigSchema.parse({}).rareTerm.maxDfFraction).toBe(0.002);
     expect(
       MemoryV3ConfigSchema.parse({ rareTerm: { maxDfFraction: 0.05 } }).rareTerm
         .maxDfFraction,

--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -27,7 +27,13 @@ describe("MemoryV3ConfigSchema", () => {
       selectorPromptPath: null,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
       entity: { enabled: true, idfFloor: 4, cap: 8 },
-      rareTerm: { enabled: true, maxDf: 12, perTerm: 2, cap: 24 },
+      rareTerm: {
+        enabled: true,
+        maxDf: 12,
+        maxDfFraction: 0.001,
+        perTerm: 2,
+        cap: 24,
+      },
       gate: {
         enabled: true,
         denseThreshold: 0.66,
@@ -135,9 +141,27 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed.rareTerm).toEqual({
       enabled: false,
       maxDf: 5,
+      maxDfFraction: 0.001,
       perTerm: 2,
       cap: 24,
     });
+  });
+
+  test("rareTerm.maxDfFraction defaults to 0.001, takes a value in (0, 1], and rejects the rest", () => {
+    expect(MemoryV3ConfigSchema.parse({}).rareTerm.maxDfFraction).toBe(0.001);
+    expect(
+      MemoryV3ConfigSchema.parse({ rareTerm: { maxDfFraction: 0.05 } }).rareTerm
+        .maxDfFraction,
+    ).toBe(0.05);
+    expect(
+      MemoryV3ConfigSchema.parse({ rareTerm: { maxDfFraction: 1 } }).rareTerm
+        .maxDfFraction,
+    ).toBe(1);
+    for (const bad of [0, -0.001, 1.5]) {
+      expect(() =>
+        MemoryV3ConfigSchema.parse({ rareTerm: { maxDfFraction: bad } }),
+      ).toThrow();
+    }
   });
 
   test("rareTerm knobs must be positive integers and enabled a boolean", () => {

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -220,13 +220,14 @@ export const MemoryV3EntitySchema = z
   );
 
 /**
- * Rare-term lane tuning: a query word that occurs in at most `maxDf` sections
- * surfaces its top `perTerm` sections by single-term BM25F as their own
- * finder lines, tagged with the word. A word that rare is a near-certain
- * signal on its own, whatever the rest of the message is about: additive
- * BM25 lets the message's bulk theme pick a page's section, and a query on
- * the clause alone cannot rank a page whose only distinctive token is that
- * word.
+ * Rare-term lane tuning: a query word rare across the corpus surfaces its top
+ * `perTerm` sections by single-term BM25F as their own finder lines, tagged
+ * with the word. A word that rare is a near-certain signal on its own,
+ * whatever the rest of the message is about: additive BM25 lets the
+ * message's bulk theme pick a page's section, and a query on the clause
+ * alone cannot rank a page whose only distinctive token is that word. Rare
+ * is corpus-relative: `maxDf` is the absolute df ceiling and `maxDfFraction`
+ * lowers it on a smaller corpus (the rule is on that field).
  */
 export const MemoryV3RareTermSchema = z
   .object({
@@ -242,7 +243,15 @@ export const MemoryV3RareTermSchema = z
       .positive("memory.v3.rareTerm.maxDf must be a positive integer")
       .default(12)
       .describe(
-        "Highest number of sections a query word may occur in and still count as rare. A word the corpus does not hold never matches; there is no token-shape filtering.",
+        "Highest number of sections a query word may occur in and still count as rare, before maxDfFraction lowers the ceiling on a smaller corpus. A word the corpus does not hold never matches; there is no token-shape filtering.",
+      ),
+    maxDfFraction: z
+      .number({ error: "memory.v3.rareTerm.maxDfFraction must be a number" })
+      .positive("memory.v3.rareTerm.maxDfFraction must be greater than 0")
+      .max(1, "memory.v3.rareTerm.maxDfFraction must be at most 1")
+      .default(0.001)
+      .describe(
+        "Fraction of the corpus's section count that bounds the rare-word ceiling: the ceiling in force is min(maxDf, max(1, floor(sectionCount * maxDfFraction))), so what counts as rare scales with the corpus. At the default, a corpus of 12,000 sections or more runs at maxDf and a corpus of a few hundred sections counts only a word unique to one section as rare (an absolute ceiling would make most of its ordinary words rare). 1 leaves maxDf as the sole ceiling.",
       ),
     perTerm: z
       .number({ error: "memory.v3.rareTerm.perTerm must be a number" })

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -220,6 +220,50 @@ export const MemoryV3EntitySchema = z
   );
 
 /**
+ * Rare-term lane tuning: a query word that occurs in at most `maxDf` sections
+ * surfaces its top `perTerm` sections by single-term BM25F as their own
+ * finder lines, tagged with the word. A word that rare is a near-certain
+ * signal on its own, whatever the rest of the message is about: additive
+ * BM25 lets the message's bulk theme pick a page's section, and a query on
+ * the clause alone cannot rank a page whose only distinctive token is that
+ * word.
+ */
+export const MemoryV3RareTermSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "memory.v3.rareTerm.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Whether the rare-term lane runs: surface the sections a query word rare across the corpus occurs in, regardless of the message's bulk theme. Recall-additive and a synchronous in-memory pass.",
+      ),
+    maxDf: z
+      .number({ error: "memory.v3.rareTerm.maxDf must be a number" })
+      .int("memory.v3.rareTerm.maxDf must be an integer")
+      .positive("memory.v3.rareTerm.maxDf must be a positive integer")
+      .default(12)
+      .describe(
+        "Highest number of sections a query word may occur in and still count as rare. A word the corpus does not hold never matches; there is no token-shape filtering.",
+      ),
+    perTerm: z
+      .number({ error: "memory.v3.rareTerm.perTerm must be a number" })
+      .int("memory.v3.rareTerm.perTerm must be an integer")
+      .positive("memory.v3.rareTerm.perTerm must be a positive integer")
+      .default(2)
+      .describe(
+        "Sections surfaced per rare word: its top single-term BM25F hits.",
+      ),
+    cap: z
+      .number({ error: "memory.v3.rareTerm.cap must be a number" })
+      .int("memory.v3.rareTerm.cap must be an integer")
+      .positive("memory.v3.rareTerm.cap must be a positive integer")
+      .default(24)
+      .describe(
+        "Hard cap on rare-term lines surfaced per turn, rarest words first.",
+      ),
+  })
+  .describe("Memory v3 rare-term lane (single distinctive query word) tuning.");
+
+/**
  * Per-turn injection-gate tuning: thresholds the retrieval signals must clear
  * for the gate to open and run the selector. The gate runs only when the
  * `enabled` kill-switch below is on.
@@ -365,7 +409,7 @@ export const MemoryV3ConfigSchema = z
       .positive("memory.v3.finderSectionsPerPage must be a positive integer")
       .default(3)
       .describe(
-        "Maximum finder lines one page may carry in the selector pool per turn. Each distinct matched section a finder lane surfaces for a page is its own line, kept in surfacing order (needle, dense, reply, span, entity) until the cap; a section-less edge or learned hit counts as one line.",
+        "Maximum finder lines one page may carry in the selector pool per turn. Each distinct matched section a finder lane surfaces for a page is its own line, kept in surfacing order (needle, dense, reply, span, entity, rare) until the cap; a section-less edge or learned hit counts as one line.",
       ),
     selectorEnabled: z
       .boolean({ error: "memory.v3.selectorEnabled must be a boolean" })
@@ -382,6 +426,7 @@ export const MemoryV3ConfigSchema = z
       ),
     edge: MemoryV3EdgeSchema.default(MemoryV3EdgeSchema.parse({})),
     entity: MemoryV3EntitySchema.default(MemoryV3EntitySchema.parse({})),
+    rareTerm: MemoryV3RareTermSchema.default(MemoryV3RareTermSchema.parse({})),
     gate: MemoryV3GateSchema.default(MemoryV3GateSchema.parse({})),
   })
   .describe("Memory v3 — section-grain lane retrieval");

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -249,9 +249,9 @@ export const MemoryV3RareTermSchema = z
       .number({ error: "memory.v3.rareTerm.maxDfFraction must be a number" })
       .positive("memory.v3.rareTerm.maxDfFraction must be greater than 0")
       .max(1, "memory.v3.rareTerm.maxDfFraction must be at most 1")
-      .default(0.001)
+      .default(0.002)
       .describe(
-        "Fraction of the corpus's section count that bounds the rare-word ceiling: the ceiling in force is min(maxDf, max(1, floor(sectionCount * maxDfFraction))), so what counts as rare scales with the corpus. At the default, a corpus of 12,000 sections or more runs at maxDf and a corpus of a few hundred sections counts only a word unique to one section as rare (an absolute ceiling would make most of its ordinary words rare). 1 leaves maxDf as the sole ceiling.",
+        "Fraction of the corpus's section count that bounds the rare-word ceiling: the ceiling in force is min(maxDf, max(1, floor(sectionCount * maxDfFraction))), so what counts as rare scales with the corpus. At the default, a corpus of 6,000 sections or more runs at maxDf and a corpus of a few hundred sections counts only a word unique to one section as rare (an absolute ceiling would make most of its ordinary words rare). 1 leaves maxDf as the sole ceiling.",
       ),
     perTerm: z
       .number({ error: "memory.v3.rareTerm.perTerm must be a number" })

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -463,15 +463,24 @@ edge and learned, and each only ever adds lines. The entity lane
 (`v3/entity-lane.ts`, `memory.v3.entity`) and the rare-term lane
 (`v3/rare-term-lane.ts`, `memory.v3.rareTerm`) key on one strong token rather
 than the whole message: a distinctive `## ` heading token the message names,
-and a query word that occurs in at most `maxDf` sections (default 12), which
-surfaces its top `perTerm` sections by single-term BM25F (`SectionNeedle.df`
-and `scoreTerm`), rarest words first up to `cap` per turn, with no token-shape
-filtering (a word the corpus does not hold has df 0 and drops out on its own;
-bigram terms are never eligible). Both are synchronous in-memory passes that
-run at every corpus size (the lean profile does not switch them off), feed
-neither the injection gate nor the edge seeds, and pool through the same
+and a query word rare across the corpus, which surfaces its top `perTerm`
+sections by single-term BM25F (`SectionNeedle.df` and `scoreTerm`), rarest
+words first up to `cap` per turn, with no token-shape filtering (a word the
+corpus does not hold has df 0 and drops out on its own; bigram terms are never
+eligible). Rare is corpus-relative: a word qualifies when its df is at most
+`min(maxDf, max(1, floor(sectionCount * maxDfFraction)))` (defaults 12 and
+0.001), so a corpus of 12,000 sections or more runs at `maxDf` and a corpus of
+a few hundred sections counts only a word unique to one section as rare; an
+absolute ceiling would make most ordinary words of a small corpus rare and
+fill `cap` with noise every turn. Both are synchronous in-memory passes that
+feed neither the injection gate nor the edge seeds, and pool through the same
 per-page cap and `(page, section key)` dedupe as every other lane, so a
-section another lane already pooled is a no-op. A rare hit's pool line is
+section another lane already pooled is a no-op. The entity lane runs at every
+corpus size (the lean profile does not switch it off); the rare-term lane runs
+only when the selector does (`v3/shadow-plugin.ts` threads `rareTerm` only
+with `selectorEnabled`), because rare lines are candidates for a judge, not
+evidence strong enough to inject unjudged, and with the selector off every
+pooled line is injected. A rare hit's pool line is
 tagged `(rare: <word>)` with a keyword-in-context snippet centered on the
 word, and its selection records `source = 'rare'`; the pool record and the
 selection log carry the lane name with no other change.

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -469,7 +469,7 @@ words first up to `cap` per turn, with no token-shape filtering (a word the
 corpus does not hold has df 0 and drops out on its own; bigram terms are never
 eligible). Rare is corpus-relative: a word qualifies when its df is at most
 `min(maxDf, max(1, floor(sectionCount * maxDfFraction)))` (defaults 12 and
-0.001), so a corpus of 12,000 sections or more runs at `maxDf` and a corpus of
+0.002), so a corpus of 6,000 sections or more runs at `maxDf` and a corpus of
 a few hundred sections counts only a word unique to one section as rare; an
 absolute ceiling would make most ordinary words of a small corpus rare and
 fill `cap` with noise every turn. Both are synchronous in-memory passes that

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -443,7 +443,7 @@ selector's full candidate pool (every stable-prefix card and finder line, in
 pool order, with lane, matched section, and a per-line verdict) for the
 inspector's Memory tab, plus `selector_ran`. A page carries one finder line
 per distinct matched section, at most `memory.v3.finderSectionsPerPage` in
-surfacing order (needle, dense, reply, span, entity), and selecting a line
+surfacing order (needle, dense, reply, span, entity, rare), and selecting a line
 selects that section; the selection log keeps one row per slug, so the pool
 row is where the per-section verdicts live. A turn whose selector never judged a pool
 (the injection gate hard-skipped it, or nothing was pooled) persists an empty
@@ -456,6 +456,25 @@ selection rows always describe the same observation. Rows are per-turn
 diagnostics, roughly 10KB each, with no retention job; a conversation delete
 purges them with the other conversation-keyed tables
 (`conversation-memory-purge.ts`).
+
+**v3 finder lanes.** The per-turn finder lanes (`v3/orchestrate.ts`) surface
+candidates in a fixed order, needle, dense, reply, span, entity, rare, then
+edge and learned, and each only ever adds lines. The entity lane
+(`v3/entity-lane.ts`, `memory.v3.entity`) and the rare-term lane
+(`v3/rare-term-lane.ts`, `memory.v3.rareTerm`) key on one strong token rather
+than the whole message: a distinctive `## ` heading token the message names,
+and a query word that occurs in at most `maxDf` sections (default 12), which
+surfaces its top `perTerm` sections by single-term BM25F (`SectionNeedle.df`
+and `scoreTerm`), rarest words first up to `cap` per turn, with no token-shape
+filtering (a word the corpus does not hold has df 0 and drops out on its own;
+bigram terms are never eligible). Both are synchronous in-memory passes that
+run at every corpus size (the lean profile does not switch them off), feed
+neither the injection gate nor the edge seeds, and pool through the same
+per-page cap and `(page, section key)` dedupe as every other lane, so a
+section another lane already pooled is a no-op. A rare hit's pool line is
+tagged `(rare: <word>)` with a keyword-in-context snippet centered on the
+word, and its selection records `source = 'rare'`; the pool record and the
+selection log carry the lane name with no other change.
 
 ### Job types (`memory_jobs.type`)
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -471,6 +471,8 @@ describe("orchestrate — candidate pool composition", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     providerStub = selectProvider([]);
     await orchestrate(makeTurn(1, "x"), depsOf(lanes, { needle }));
@@ -1056,6 +1058,8 @@ describe("orchestrate — degradation", () => {
           bestSection: () => -1,
           idf: () => 0,
           topTerms: () => [],
+          df: () => 0,
+          scoreTerm: () => [],
         },
       }),
     );
@@ -1105,6 +1109,8 @@ describe("orchestrate — entity lane", () => {
       bestSection: () => leadDoc!,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     const entityIndex = new Map<string, number[]>([["widget", [headingDoc!]]]);
 
@@ -1142,6 +1148,8 @@ describe("orchestrate — entity lane", () => {
       bestSection: () => headingDoc!,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     const entityIndex = new Map<string, number[]>([["widget", [headingDoc!]]]);
 
@@ -1165,6 +1173,8 @@ describe("orchestrate — entity lane", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     const entityIndex = new Map<string, number[]>([["gadget", [headingDoc!]]]);
 
@@ -1258,6 +1268,8 @@ describe("orchestrate — injection gate", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1285,6 +1297,8 @@ describe("orchestrate — injection gate", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1450,6 +1464,8 @@ describe("orchestrate — injection gate", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1478,6 +1494,8 @@ describe("orchestrate — injection gate", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1524,6 +1542,8 @@ describe("orchestrate — injection gate", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     providerStub = selectProvider(["topic-a"]);
 
@@ -1732,6 +1752,8 @@ describe("orchestrate — injection gate", () => {
       bestSection: () => -1,
       idf: () => 0,
       topTerms: () => [],
+      df: () => 0,
+      scoreTerm: () => [],
     };
     denseHits = [];
     providerStub = selectProvider([]);
@@ -2186,5 +2208,169 @@ describe("orchestrate: multi-section finder lines", () => {
       ["dense", 2],
       ["span", 3],
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rare-term lane: a query word that occurs in at most `maxDf` sections
+// surfaces its top sections as their own lines tagged with the word, after
+// the entity lane; a section a prior lane pooled is a no-op, and rare hits
+// feed neither the injection gate nor the edge seeds.
+// ---------------------------------------------------------------------------
+
+describe("orchestrate: rare-term lane", () => {
+  // The message's bulk theme (the parody) matches `## Parody`; its last
+  // clause's one distinctive word, "gourd", sits twice each in two other
+  // sections of the page and once, in a longer body, on a second page. The
+  // common words recur in every section, so among the message's words only
+  // the parody words (which hit `## Parody` alone) and "gourd" are rare.
+  const GOURD_PAGES: Record<Slug, string> = {
+    "silly-lines": [
+      "here is my little log of silly lines",
+      "## Parody",
+      "parody verse: everyone laughed, hilarious skit, roast, encore, standing ovation, crowd; here is my little friend",
+      "## Pumpkin",
+      "pumpkin bit: here is my little gourd, gourd of my heart",
+      "## Harvest",
+      "harvest song: gourd on the porch, gourd in the pie; here is my little ballad",
+    ].join("\n"),
+    "autumn-recipes": [
+      "## Soup",
+      "gourd soup: here is my little pot; onions, celery, carrots, thyme, cream, salt, pepper, and a long simmer",
+    ].join("\n"),
+  };
+  const MESSAGE =
+    "parody verse hilarious, everyone laughed: skit, roast, encore, standing ovation, crowd. Here is my little gourd";
+  const RARE = { maxDf: 3, perTerm: 2, cap: 24 };
+
+  test("a rare word's top sections join as lines tagged with the word beside the bulk-theme line, and selecting them selects the sections", async () => {
+    const lanes = await customLanes(GOURD_PAGES);
+    const [, parodyDoc, pumpkinDoc, harvestDoc] =
+      lanes.sectionIndex.byArticle.get("silly-lines")!;
+    const parody = lanes.sectionIndex.sections[parodyDoc!]!;
+    const pumpkin = lanes.sectionIndex.sections[pumpkinDoc!]!;
+    const harvest = lanes.sectionIndex.sections[harvestDoc!]!;
+    providerStub = selectProvider(["silly-lines"]);
+
+    const result = await orchestrate(
+      makeTurn(1, MESSAGE),
+      depsOf(lanes, { rareTerm: RARE }),
+    );
+
+    const lines = result.lanes.finder.filter((c) => c.slug === "silly-lines");
+    expect(lines.map((c) => [c.lane, c.section, c.term])).toEqual([
+      ["needle", parody, undefined],
+      ["rare", pumpkin, "gourd"],
+      ["rare", harvest, "gourd"],
+    ]);
+    expect(lines[1]!.terms).toEqual(["gourd"]);
+    // The second page's only "gourd" section is the needle's own line for
+    // it, and the third-ranked "gourd" section is past perTerm anyway.
+    expect(
+      result.lanes.finder
+        .filter((c) => c.slug === "autumn-recipes")
+        .map((c) => c.lane),
+    ).toEqual(["needle"]);
+    // Each rare line is tagged with the word and snippets the section
+    // around it.
+    const rareLines = lastPoolLines.filter((l) => l.includes("(rare: gourd) "));
+    expect(rareLines).toHaveLength(2);
+    expect(rareLines[0]).toContain("(rare: gourd) silly-lines ");
+    expect(rareLines[0]).toContain(
+      "§Pumpkin: pumpkin bit: here is my little gourd",
+    );
+    expect(rareLines[1]).toContain("§Harvest: ");
+    expect(rareLines[1]).toContain("gourd");
+    expect(result.selections).toContainEqual({
+      slug: "silly-lines",
+      sections: [parody, pumpkin, harvest],
+    });
+  });
+
+  test("a rare hit on a section the needle already pooled is a no-op", async () => {
+    const lanes = await customLanes(GOURD_PAGES);
+    const [, , pumpkinDoc, harvestDoc] =
+      lanes.sectionIndex.byArticle.get("silly-lines")!;
+    const pumpkin = lanes.sectionIndex.sections[pumpkinDoc!]!;
+    const harvest = lanes.sectionIndex.sections[harvestDoc!]!;
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "gourd"),
+      depsOf(lanes, {
+        needle: {
+          ...lanes.needle,
+          queryScored: () => [
+            { article: "silly-lines", section: pumpkinDoc!, score: 1 },
+          ],
+        },
+        rareTerm: RARE,
+      }),
+    );
+
+    expect(result.lanes.finder.map((c) => [c.slug, c.lane, c.section])).toEqual(
+      [
+        ["silly-lines", "needle", pumpkin],
+        ["silly-lines", "rare", harvest],
+      ],
+    );
+  });
+
+  test("omitting the rare-term tuning disables the lane", async () => {
+    const lanes = await customLanes(GOURD_PAGES);
+    providerStub = selectProvider([]);
+
+    const without = await orchestrate(makeTurn(1, "gourd"), depsOf(lanes));
+    expect(without.lanes.finder.some((c) => c.lane === "rare")).toBe(false);
+
+    const withLane = await orchestrate(
+      makeTurn(2, "gourd"),
+      depsOf(lanes, { rareTerm: RARE }),
+    );
+    expect(withLane.lanes.finder.some((c) => c.lane === "rare")).toBe(true);
+  });
+
+  test("rare hits seed no edge expansion", async () => {
+    // topic-a links to topic-d, and "apple" occurs only in topic-a's
+    // `## Details`. With the needle finding nothing for the message, the
+    // rare lane alone surfaces topic-a, and the edge lane has no seed.
+    const lanes = await buildLanes();
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        needle: { ...lanes.needle, queryScored: () => [] },
+        rareTerm: RARE,
+      }),
+    );
+
+    expect(result.lanes.finder.map((c) => [c.slug, c.lane, c.term])).toEqual([
+      ["topic-a", "rare", "apple"],
+    ]);
+    expect(lastPool).not.toContain("topic-d");
+  });
+
+  test("rare hits do not open the injection gate", async () => {
+    // No sparse signal (the needle finds nothing) and a dense top-1 far
+    // below every threshold close the gate; the rare hit on topic-a neither
+    // opens it nor survives the closed gate.
+    const lanes = await buildLanes();
+    denseHits = [{ article: "topic-b", section: 0, score: 0.1 }];
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        needle: { ...lanes.needle, queryScored: () => [] },
+        denseK: 100,
+        gateConfig: gateConfigOf(),
+        rareTerm: RARE,
+      }),
+    );
+
+    expect(selectCalls).toBe(0);
+    expect(result.selections).toEqual([]);
+    expect(result.lanes.finder).toEqual([]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -2241,7 +2241,7 @@ describe("orchestrate: rare-term lane", () => {
   };
   const MESSAGE =
     "parody verse hilarious, everyone laughed: skit, roast, encore, standing ovation, crowd. Here is my little gourd";
-  const RARE = { maxDf: 3, perTerm: 2, cap: 24 };
+  const RARE = { maxDf: 3, maxDfFraction: 1, perTerm: 2, cap: 24 };
 
   test("a rare word's top sections join as lines tagged with the word beside the bulk-theme line, and selecting them selects the sections", async () => {
     const lanes = await customLanes(GOURD_PAGES);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -789,6 +789,36 @@ describe("selectPool: sections and keyword-in-context snippets", () => {
     expect(line).not.toContain("…");
   });
 
+  test("a rare-term line tags its lane with the word and centers the window on it", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const filler =
+      "filler words that push the match well past the head of the section ";
+    const pumpkin = sectionOf(
+      "silly-lines",
+      "Pumpkin",
+      `${filler.repeat(6)}the pumpkin bit: my little gourd ${filler.repeat(3)}`,
+    );
+    await selectPool(
+      finderOnly({
+        slug: "silly-lines",
+        descriptor: pumpkin.text,
+        section: pumpkin,
+        terms: ["gourd"],
+        term: "gourd",
+        lane: "rare",
+      }),
+      makeTurn("here is my little gourd"),
+    );
+    const [block] = sentBlocks();
+    const line = block.text
+      .split("\n")
+      .find((l) => l.startsWith("[1] (rare: gourd) silly-lines "))!;
+    expect(line).toContain("§Pumpkin: … ");
+    expect(line).toContain("my little gourd");
+    // The selector is told what the tag means.
+    expect(providerCalls[0]!.options?.systemPrompt).toContain("(rare: word)");
+  });
+
   test("a bigram term matches its two words across punctuation", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [] }));
     const notes = sectionOf(

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
@@ -260,3 +260,63 @@ describe("queryScored", () => {
     expect(findTerm("a (b) c", "(b)")).toBeUndefined();
   });
 });
+
+describe("df and scoreTerm", () => {
+  test("df counts the sections a unigram occurs in, head or body, and reads 0 when absent", async () => {
+    const idx = await index({
+      "page-a": "## Mango\nthe mango tree\n\n## Notes\nno fruit here",
+      "page-b": "## Notes\nmango jam",
+    });
+    const needle = buildSectionNeedle(idx);
+
+    expect(needle.df("mango")).toBe(2);
+    // Head-line occurrences count: both `## Notes` headings.
+    expect(needle.df("notes")).toBe(2);
+    expect(needle.df("fruit")).toBe(1);
+    expect(needle.df("absent")).toBe(0);
+  });
+
+  test("a bigram is never a single-term signal: df 0 and no hits", async () => {
+    const idx = await index({
+      "page-a": "## Notes\nthe mango tree grows here",
+    });
+    const needle = buildSectionNeedle(idx);
+    const [, notesDoc] = idx.byArticle.get("page-a")!;
+
+    // The bigram is indexed for the query lanes but reads as absent here.
+    expect(needle.topTerms(notesDoc!, "mango tree", 3)).toContain("mango_tree");
+    expect(needle.df("mango_tree")).toBe(0);
+    expect(needle.scoreTerm("mango_tree", 3)).toEqual([]);
+  });
+
+  test("scoreTerm ranks a unigram's sections by its own contribution, head above body, cut at k", async () => {
+    const idx = await index({
+      "page-a": "## Mango\nfiller words to balance length across the docs here",
+      "page-b":
+        "## Notes\nfiller words mango plus more padding to balance length",
+      "page-c": "## Notes\nnothing relevant",
+    });
+    const needle = buildSectionNeedle(idx);
+    const [, mangoDoc] = idx.byArticle.get("page-a")!;
+    const [, notesDoc] = idx.byArticle.get("page-b")!;
+
+    const hits = needle.scoreTerm("mango", 5);
+    expect(hits.map((h) => h.doc)).toEqual([mangoDoc, notesDoc]);
+    expect(hits[0]!.score).toBeGreaterThan(hits[1]!.score);
+    expect(needle.scoreTerm("mango", 1).map((h) => h.doc)).toEqual([mangoDoc]);
+    expect(needle.scoreTerm("mango", 0)).toEqual([]);
+    expect(needle.scoreTerm("absent", 5)).toEqual([]);
+  });
+
+  test("scoreTerm breaks score ties by (article, ordinal)", async () => {
+    const idx = await index({
+      "page-b": "## S\nidentical pineapple content",
+      "page-a": "## S\nidentical pineapple content",
+    });
+    const needle = buildSectionNeedle(idx);
+
+    expect(
+      needle.scoreTerm("pineapple", 5).map((h) => idx.sections[h.doc]!.article),
+    ).toEqual(["page-a", "page-b"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/selection-log-store.test.ts
@@ -673,6 +673,7 @@ describe("summarizeSelections", () => {
       span: 0,
       learned: 0,
       entity: 0,
+      rare: 0,
     });
     expect(summary.turns).toBe(2);
     // page-1 and page-2 — distinct across the two turns.
@@ -692,6 +693,7 @@ describe("summarizeSelections", () => {
         span: 0,
         learned: 0,
         entity: 0,
+        rare: 0,
       },
       turns: 0,
       distinctSlugs: 0,
@@ -715,6 +717,7 @@ describe("summarizeSelections", () => {
         span: 0,
         learned: 0,
         entity: 0,
+        rare: 0,
       },
       turns: 0,
       distinctSlugs: 0,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-integration.test.ts
@@ -515,6 +515,7 @@ describe("memory-v3 integration — selection-log readout", () => {
         span: 0,
         learned: 0,
         entity: 0,
+        rare: 0,
       },
       turns: 0,
       distinctSlugs: 0,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -120,6 +120,9 @@ let selectorEnabledCfg = false;
 // Mutable `memory.v3.gate.enabled` config kill-switch carried by the mocked
 // config (default on, mirroring the schema default).
 let gateEnabledCfg = true;
+// Mutable `memory.v3.rareTerm.enabled` switch carried by the mocked config
+// (default on, mirroring the schema default).
+let rareTermEnabledCfg = true;
 let messages: Array<{
   role: string;
   content: string;
@@ -285,6 +288,7 @@ function seedMemoryConfig(): void {
       },
       edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
       entity: { enabled: true, idfFloor: 4, cap: 8 },
+      rareTerm: { enabled: rareTermEnabledCfg, maxDf: 12, perTerm: 2, cap: 24 },
       // Gate tuning (schema defaults) with the mutable `enabled` kill-switch,
       // threaded through to orchestrate as-is.
       gate: { ...GATE_DEFAULTS, enabled: gateEnabledCfg },
@@ -652,6 +656,7 @@ beforeEach(() => {
   extraRealConceptPages = 0;
   selectorEnabledCfg = false;
   gateEnabledCfg = true;
+  rareTermEnabledCfg = true;
   messages = [
     {
       role: "user",
@@ -842,6 +847,47 @@ describe("memory-v3 engine", () => {
       card("page-3", "edge", true),
       card("page-4", "reply", true),
       card("page-5", "learned", true),
+    ]);
+  });
+
+  test("a rare-term selection persists source rare and its pool line's lane", async () => {
+    const pumpkin: Section = {
+      article: "page-rare",
+      title: "Pumpkin",
+      text: "x",
+      ordinal: 1,
+    };
+    orchestrateSpy.mockImplementationOnce(async () => ({
+      selections: [{ slug: "page-rare", sections: [pumpkin] }],
+      lanes: {
+        core: [],
+        hot: [],
+        fresh: [],
+        always: [],
+        finder: [
+          {
+            slug: "page-rare",
+            section: pumpkin,
+            term: "gourd",
+            descriptor: "",
+            lane: "rare",
+          },
+        ],
+      },
+      selectorRan: true,
+    }));
+
+    await observeTurn("conv-1", 2);
+
+    expect(readRows()).toEqual([{ slug: "page-rare", source: "rare" }]);
+    expect(JSON.parse(readPools()[0]!.candidates_json)).toEqual([
+      {
+        slug: "page-rare",
+        lane: "rare",
+        section_title: "Pumpkin",
+        section_ordinal: 1,
+        chosen: true,
+      },
     ]);
   });
 
@@ -1127,6 +1173,43 @@ describe("memory-v3 engine", () => {
     ]);
   });
 
+  test("a selection of a rare-term line records source rare with its section", () => {
+    const pumpkin: Section = {
+      article: "page-1",
+      title: "Pumpkin",
+      text: "x",
+      ordinal: 2,
+    };
+    const rows = attributeSelections({
+      selections: [{ slug: "page-1", sections: [pumpkin] }],
+      lanes: {
+        core: [],
+        hot: [],
+        fresh: [],
+        always: [],
+        finder: [
+          {
+            slug: "page-1",
+            section: pumpkin,
+            term: "gourd",
+            descriptor: "",
+            lane: "rare",
+          },
+        ],
+      },
+      selectorRan: true,
+    });
+    expect(rows).toEqual([
+      {
+        slug: "page-1",
+        source: "rare",
+        sectionOrdinal: 2,
+        sectionTitle: "Pumpkin",
+        sectionKey: "Pumpkin",
+      },
+    ]);
+  });
+
   test("the turn passed to orchestrate carries the latest user message", async () => {
     await observeTurn("conv-1", 0);
     const turn = (
@@ -1291,6 +1374,30 @@ describe("memory-v3 engine", () => {
     // The kill-switch makes the effective `enabled` false, so selection
     // always runs.
     expect(deps.gateConfig).toEqual({ ...GATE_DEFAULTS, enabled: false });
+  });
+
+  test("rareTerm enabled (default) → threads the lane tuning into orchestrate", async () => {
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as { rareTerm?: unknown };
+    expect(deps.rareTerm).toEqual({
+      enabled: true,
+      maxDf: 12,
+      perTerm: 2,
+      cap: 24,
+    });
+  });
+
+  test("rareTerm.enabled:false → the lane threads nothing", async () => {
+    rareTermEnabledCfg = false;
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as { rareTerm?: unknown };
+    expect(deps.rareTerm).toBeUndefined();
   });
 
   test("initLanes filters core to existing pages and excludes core from the hot set", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -291,7 +291,7 @@ function seedMemoryConfig(): void {
       rareTerm: {
         enabled: rareTermEnabledCfg,
         maxDf: 12,
-        maxDfFraction: 0.001,
+        maxDfFraction: 0.002,
         perTerm: 2,
         cap: 24,
       },
@@ -1393,7 +1393,7 @@ describe("memory-v3 engine", () => {
     expect(deps.rareTerm).toEqual({
       enabled: true,
       maxDf: 12,
-      maxDfFraction: 0.001,
+      maxDfFraction: 0.002,
       perTerm: 2,
       cap: 24,
     });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -1191,7 +1191,7 @@ describe("memory-v3 engine", () => {
     ]);
   });
 
-  test("a page selected on several sections logs its first selected section under the lane of its first line", () => {
+  test("a page selected on several sections logs its first selected section under the lane of that section's line", () => {
     const details: Section = {
       article: "page-1",
       title: "Details",
@@ -1218,10 +1218,11 @@ describe("memory-v3 engine", () => {
       },
       selectorRan: true,
     });
+    // "Notes" was selected first and its line came from the span lane.
     expect(rows).toEqual([
       {
         slug: "page-1",
-        source: "needle",
+        source: "span",
         sectionOrdinal: 2,
         sectionTitle: "Notes",
         sectionKey: "Notes",

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -288,7 +288,13 @@ function seedMemoryConfig(): void {
       },
       edge: { hubDegree: 30, seedCount: 6, perSeed: 1, cap: 6 },
       entity: { enabled: true, idfFloor: 4, cap: 8 },
-      rareTerm: { enabled: rareTermEnabledCfg, maxDf: 12, perTerm: 2, cap: 24 },
+      rareTerm: {
+        enabled: rareTermEnabledCfg,
+        maxDf: 12,
+        maxDfFraction: 0.001,
+        perTerm: 2,
+        cap: 24,
+      },
       // Gate tuning (schema defaults) with the mutable `enabled` kill-switch,
       // threaded through to orchestrate as-is.
       gate: { ...GATE_DEFAULTS, enabled: gateEnabledCfg },
@@ -1376,7 +1382,9 @@ describe("memory-v3 engine", () => {
     expect(deps.gateConfig).toEqual({ ...GATE_DEFAULTS, enabled: false });
   });
 
-  test("rareTerm enabled (default) → threads the lane tuning into orchestrate", async () => {
+  test("rareTerm enabled (default) with the selector on → threads the lane tuning into orchestrate", async () => {
+    extraRealConceptPages = MEMORY_V3_FULL_PROFILE_MIN_PAGES;
+    selectorEnabledCfg = true;
     await observeTurn("conv-1", 0);
 
     const deps = (
@@ -1385,12 +1393,15 @@ describe("memory-v3 engine", () => {
     expect(deps.rareTerm).toEqual({
       enabled: true,
       maxDf: 12,
+      maxDfFraction: 0.001,
       perTerm: 2,
       cap: 24,
     });
   });
 
-  test("rareTerm.enabled:false → the lane threads nothing", async () => {
+  test("rareTerm.enabled:false → the lane threads nothing even with the selector on", async () => {
+    extraRealConceptPages = MEMORY_V3_FULL_PROFILE_MIN_PAGES;
+    selectorEnabledCfg = true;
     rareTermEnabledCfg = false;
     await observeTurn("conv-1", 0);
 
@@ -1398,6 +1409,38 @@ describe("memory-v3 engine", () => {
       orchestrateSpy.mock.calls as unknown as unknown[][]
     )[0]![1] as { rareTerm?: unknown };
     expect(deps.rareTerm).toBeUndefined();
+  });
+
+  test("the lean profile's selector-off turns the rare-term lane off with it", async () => {
+    // Sparse corpus: the lean profile disables the selector, and every pooled
+    // line is injected unjudged, so rare lines (judge candidates, not
+    // evidence) stay out of the pool.
+    await observeTurn("conv-1", 0);
+
+    const deps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as { selectorEnabled?: boolean; rareTerm?: unknown };
+    expect(deps.selectorEnabled).toBe(false);
+    expect(deps.rareTerm).toBeUndefined();
+  });
+
+  test("rareTerm follows the configured selector per turn on an established corpus", async () => {
+    extraRealConceptPages = MEMORY_V3_FULL_PROFILE_MIN_PAGES;
+    selectorEnabledCfg = false;
+    await observeTurn("conv-1", 0);
+    const offDeps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![1] as { rareTerm?: unknown };
+    expect(offDeps.rareTerm).toBeUndefined();
+
+    // A live config edit turning the selector on brings the lane with it on
+    // the next turn, with no lane rebuild.
+    selectorEnabledCfg = true;
+    await observeTurn("conv-1", 1);
+    const onDeps = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[1]![1] as { rareTerm?: unknown };
+    expect(onDeps.rareTerm).toBeDefined();
   });
 
   test("initLanes filters core to existing pages and excludes core from the hot set", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -1079,6 +1079,56 @@ describe("memory-v3 engine", () => {
     expect(turn.previousAssistantMessage).toBeUndefined();
   });
 
+  test("a page with lines from two lanes is attributed the lane of the line whose section was selected", () => {
+    const bulk: Section = {
+      article: "page-two",
+      title: "Bulk theme",
+      text: "page-two - Bulk theme\nthe long part",
+      ordinal: 1,
+    };
+    const pumpkin: Section = {
+      article: "page-two",
+      title: "Pumpkin",
+      text: "page-two - Pumpkin\ngourd",
+      ordinal: 4,
+    };
+    const lanes = {
+      core: [],
+      hot: [],
+      fresh: [],
+      always: [],
+      finder: [
+        {
+          slug: "page-two",
+          section: bulk,
+          descriptor: "",
+          lane: "needle" as const,
+        },
+        {
+          slug: "page-two",
+          section: pumpkin,
+          term: "gourd",
+          descriptor: "",
+          lane: "rare" as const,
+        },
+      ],
+    };
+    const sourceOf = (sections: Section[]) =>
+      attributeSelections({
+        selections: [{ slug: "page-two", sections }],
+        lanes,
+        selectorRan: true,
+      })[0]!.source;
+    // Only the rare line was picked: the rare lane is credited.
+    expect(sourceOf([pumpkin])).toBe("rare");
+    // Only the needle line was picked.
+    expect(sourceOf([bulk])).toBe("needle");
+    // Both picked: the first selected section's line decides.
+    expect(sourceOf([pumpkin, bulk])).toBe("rare");
+    // No section (the page's card): the page's first line decides.
+    expect(sourceOf([])).toBe("needle");
+  });
+
   test("a selection of a core page a finder also hit attributes to core (pool position wins)", () => {
     const rows = attributeSelections({
       selections: [{ slug: "page-core", sections: [] }],

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -13,7 +13,13 @@
  *        - the span-query pass — the dense lane re-run over the current
  *          message's clause chunks as separate queries at a small per-chunk
  *          budget (`spanQueryK`), rescuing motifs a long multi-topic message's
- *          single query vector averages away — and
+ *          single query vector averages away,
+ *        - the entity lane (`entityLane`) and the rare-term lane
+ *          (`rareTermLane`), which key on one strong token each (a
+ *          distinctive `## ` heading token the message names; a query word
+ *          that occurs in at most a handful of sections) so the section a
+ *          name or a rare word points at surfaces regardless of the
+ *          message's bulk theme, and
  *        - link-graph edge expansion (`edgeExpand`) over the top
  *          user-message needle+dense article seeds, and
  *        - learned-edge expansion (`edgeExpand` over the co-selection NPMI
@@ -33,7 +39,7 @@
  *      `[...core (file order), ...hot (score order), ...fresh (recency order),
  *      ...always-candidate (skills listed every turn)]`, all computed at lane
  *      init, followed by the finder candidates (needle → dense → reply →
- *      span → entity → edge → learned surfacing order), one line per
+ *      span → entity → rare → edge → learned surfacing order), one line per
  *      distinct (page, matched section) and at most `finderSectionsPerPage`
  *      lines per page, so a page whose sections match different parts of
  *      the message is shown section by section. The stable prefix
@@ -81,6 +87,11 @@ import type {
   StableCandidate,
 } from "./pool-select.js";
 import { selectAllPoolCandidates, selectPool } from "./pool-select.js";
+import {
+  type RareTermHit,
+  rareTermLane,
+  type RareTermLaneOptions,
+} from "./rare-term-lane.js";
 import type { SectionNeedle } from "./section-needle.js";
 import { spanChunksOf } from "./span-query.js";
 import {
@@ -207,8 +218,12 @@ export interface OrchestrateDeps {
   /** Hard cap on entity-lane articles. Defaults to {@link DEFAULT_ENTITY_CAP}.
    *  Ignored when `entityIndex` is omitted (the lane is off). */
   entityCap?: number;
+  /** Rare-term lane tuning (canonical value: `memory.v3.rareTerm`): the df
+   *  ceiling for a query word to count as rare, the sections surfaced per
+   *  rare word, and the per-turn cap. Omitted disables the lane. */
+  rareTerm?: RareTermLaneOptions;
   /** Cap on finder lines one page may carry per turn, applied in surfacing
-   *  order (needle, dense, reply, span, entity); a section-less edge or
+   *  order (needle, dense, reply, span, entity, rare); a section-less edge or
    *  learned line counts as one. Defaults to
    *  {@link DEFAULT_FINDER_SECTIONS_PER_PAGE} (canonical value:
    *  `memory.v3.finderSectionsPerPage`). */
@@ -278,6 +293,9 @@ export interface FinderCandidate {
   slug: Slug;
   section?: Section;
   terms?: string[];
+  /** The one query term the lane keyed the line on (a rare-term hit);
+   *  rendered in the line's lane tag as `(lane: term)`. */
+  term?: string;
   descriptor: string;
   lane: FinderLane;
 }
@@ -438,11 +456,12 @@ export async function orchestrate(
         ),
       ]),
     );
-  // Everything from here to the step-3 selection — finder assembly, the
-  // entity lane, the injection gate, edge + learned-edge expansion, pool
-  // assembly — is synchronous in-memory work, measured as one `v3_expand`
-  // region rather than wrapped calls. Gate-closed early returns skip the
-  // record on purpose: the expansion work didn't happen on those turns.
+  // Everything from here to the step-3 selection (finder assembly, the
+  // entity and rare-term lanes, the injection gate, edge + learned-edge
+  // expansion, pool assembly) is synchronous in-memory work, measured as one
+  // `v3_expand` region rather than wrapped calls. Gate-closed early returns
+  // skip the record on purpose: the expansion work didn't happen on those
+  // turns.
   const expandStartedAt = Date.now();
 
   // Dense hits restricted to pages still in the live section index. A deleted
@@ -456,7 +475,7 @@ export async function orchestrate(
 
   // `finder` accumulates the pool's dynamic tail: one entry per distinct
   // (article, matched section), in the needle → dense → reply → span →
-  // entity call order, so a page whose sections match different parts of
+  // entity → rare call order, so a page whose sections match different parts of
   // the message carries one line per section and the selector sees each
   // section's own text. A hit that resolves to no section (an edge or
   // learned neighbour, a dense ordinal the index no longer holds) is one
@@ -509,6 +528,20 @@ export async function orchestrate(
           }
         : { slug, descriptor: "", lane },
     );
+  };
+
+  // A rare-term hit is keyed on one query word, which is the line's snippet
+  // term and its tag both.
+  const addRareHit = (hit: RareTermHit): void => {
+    const section = sections[hit.section]!;
+    poolLine({
+      slug: hit.article,
+      section,
+      terms: [hit.term],
+      term: hit.term,
+      descriptor: section.text,
+      lane: "rare",
+    });
   };
 
   // A page surfaced by association (an edge or learned neighbour): no
@@ -607,13 +640,34 @@ export async function orchestrate(
     }
   }
 
-  // Step 1b'''': opt-in injection gate. With the CURRENT-message finder lanes in
-  // hand (needle + dense — NOT reply/span/entity/edge, which only add recall), decide
-  // whether retrieval is confident enough to spend the selectPool LLM call this
-  // turn. Default-off via `?.enabled`; pass-open on any throw (a gate bug must
-  // never drop a turn's memory). A closed gate either hard-skips selection
-  // (empty selections) or, when `bypassForCore` is set, runs selectPool over the
-  // stable prefix only — never the finder tail.
+  // Step 1b'''': rare-term lane, the sections a rare query word occurs in. A
+  // word found in at most `maxDf` sections is a near-certain signal on its
+  // own: additive BM25 lets the message's bulk theme pick a page's section,
+  // and a query on the clause alone cannot rank a page whose only
+  // distinctive token is that word. Each rare word's top sections by
+  // single-term score join as their own lines, tagged with the word, which
+  // also centers the selector's snippet; a section a prior lane pooled is a
+  // no-op. Like the entity lane, rare hits feed neither the gate nor the
+  // edge seeds.
+  if (deps.rareTerm) {
+    for (const hit of rareTermLane(
+      deps.needle,
+      deps.sectionIndex,
+      turn.currentMessage,
+      deps.rareTerm,
+    )) {
+      addRareHit(hit);
+    }
+  }
+
+  // Step 1b''''': opt-in injection gate. With the CURRENT-message finder lanes
+  // in hand (needle + dense, NOT reply/span/entity/rare/edge, which only add
+  // recall), decide whether retrieval is confident enough to spend the
+  // selectPool LLM call this turn. Default-off via `?.enabled`; pass-open on
+  // any throw (a gate bug must never drop a turn's memory). A closed gate
+  // either hard-skips selection (empty selections) or, when `bypassForCore`
+  // is set, runs selectPool over the stable prefix only, never the finder
+  // tail.
   //
   // The gate is dense-gated: it only runs when the live dense lane produced hits
   // (`liveDensed.length > 0`). In healthy operation dense returns top-k hits for
@@ -884,6 +938,7 @@ export async function orchestrate(
     lane: c.lane,
     section: c.section,
     terms: c.terms,
+    term: c.term,
     descriptor:
       c.descriptor.trim().length > 0
         ? c.descriptor

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -219,8 +219,11 @@ export interface OrchestrateDeps {
    *  Ignored when `entityIndex` is omitted (the lane is off). */
   entityCap?: number;
   /** Rare-term lane tuning (canonical value: `memory.v3.rareTerm`): the df
-   *  ceiling for a query word to count as rare, the sections surfaced per
-   *  rare word, and the per-turn cap. Omitted disables the lane. */
+   *  ceiling for a query word to count as rare (`maxDf`, lowered on a smaller
+   *  corpus by `maxDfFraction`), the sections surfaced per rare word, and the
+   *  per-turn cap. Omitted disables the lane, which the caller does whenever
+   *  the selector is off: rare lines are candidates for a judge, not evidence
+   *  strong enough to inject unjudged. */
   rareTerm?: RareTermLaneOptions;
   /** Cap on finder lines one page may carry per turn, applied in surfacing
    *  order (needle, dense, reply, span, entity, rare); a section-less edge or

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.ts
@@ -131,14 +131,16 @@ function providerBillingNoticeFromError(
  *  candidate that also carries its matched `section` and the query `terms`
  *  that scored it (best first) renders a keyword-in-context snippet instead:
  *  a window of the section body around the first of those terms that occurs
- *  in it. One page can appear on several lines, one per matched section;
- *  selecting a line selects that section. */
+ *  in it. A candidate keyed on one query `term` (a rare-term hit) tags as
+ *  `(lane: term)`. One page can appear on several lines, one per matched
+ *  section; selecting a line selects that section. */
 export interface PoolCandidate {
   slug: Slug;
   descriptor: string;
   lane?: string;
   section?: Section;
   terms?: string[];
+  term?: string;
 }
 
 /** A stable-prefix candidate: the slug plus its pre-rendered FULL card
@@ -232,7 +234,7 @@ const SELECT_PAGES_TOOL: ToolDefinition = {
 
 const SYSTEM_PROMPT = `You are given the candidate memory pages for an assistant's next reply, in two segments that share one numbering: full page cards first (the curated core, recently-recurring, and recently-modified pages, shown every turn), then this turn's search hits as one-line snippets. Cards carry a \`[lane: …]\` annotation — core is curated, hot recurs by selection frequency, fresh was recently modified (with its last-update time) — and search hits are tagged with the lane that surfaced them.
 
-A page can appear on several search-hit lines, one per matched section, each snippet showing the matched words in context; selecting a line selects that section, so keep every line whose section the reply would draw on.
+A page can appear on several search-hit lines, one per matched section, each snippet showing the matched words in context; selecting a line selects that section, so keep every line whose section the reply would draw on. A line tagged \`(rare: word)\` means the message used a word that occurs in only a handful of sections and this is one of them, a strong signal on its own even when the rest of the message is about something else.
 
 Select EVERY candidate whose content the upcoming reply would draw on. That includes facts the reply needs, current task and event state (open items, deadlines, schedules, recent activity), and equally register, established framing, calibration rules, and relationship/person/project texture — pages that shape HOW to reply, not only what to say. There is no limit on how many you may select; recall matters more than precision, so when a candidate could plausibly inform the reply, keep it. For a list or an "all of X" request, keep EVERY candidate that belongs to X rather than guessing a representative subset.
 
@@ -389,17 +391,31 @@ function renderCardSegment(stable: StableCandidate[]): string {
   return `<candidate_cards>\n${cards.join("\n\n")}\n</candidate_cards>`;
 }
 
+/** A finder line's lane tag: `(lane) `, or `(lane: term) ` for a candidate
+ *  keyed on one query term; empty for a candidate without a lane. */
+function laneTag(candidate: PoolCandidate): string {
+  if (candidate.lane === undefined) {
+    return "";
+  }
+  const keyed =
+    candidate.term === undefined
+      ? candidate.lane
+      : `${candidate.lane}: ${candidate.term}`;
+  return `(${keyed}) `;
+}
+
 /**
  * Render the finder tail: one `[m+i] (lane) slug — snippet` line per
  * candidate, numbered continuing after the `offset` stable-prefix cards. The
- * lane tag is omitted for a candidate without one; a candidate with an empty
- * descriptor renders without the dash.
+ * lane tag is omitted for a candidate without one and names the keyed term
+ * for a candidate that carries one (`(rare: gourd)`); a candidate with an
+ * empty descriptor renders without the dash.
  */
 function renderFinderSegment(finder: PoolCandidate[], offset: number): string {
   const lines = finder.map((c, i) => {
     const snippet = renderSnippet(c);
     const id = offset + i + 1;
-    const lane = c.lane !== undefined ? `(${c.lane}) ` : "";
+    const lane = laneTag(c);
     return snippet.length > 0
       ? `[${id}] ${lane}${c.slug} — ${snippet}`
       : `[${id}] ${lane}${c.slug}`;

--- a/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+
+import { rareTermLane } from "./rare-term-lane.js";
+import { buildSectionNeedle, type SectionNeedle } from "./section-needle.js";
+import { buildSectionIndex } from "./sections.js";
+import type { SectionIndex, Slug } from "./types.js";
+
+/**
+ * A fixture corpus in which "here", "is", "my", and "little" recur
+ * across most sections while "gourd" sits in three sections (two on one
+ * page), "marrow" in two, and "quince" and "0x1f" in one each. All slugs and
+ * content are invented placeholders.
+ */
+const PAGES: Record<Slug, string> = {
+  "silly-lines": [
+    "the list of silly lines: here is my little log of bits, here is the joke",
+    "## Parody",
+    "the parody verse: here is the way it landed, my little friend",
+    "## Pumpkin",
+    "the pumpkin bit: here is my little gourd, gourd of my heart",
+    "## Harvest",
+    "harvest song: the gourd on the porch and the gourd in the pie, here is my little ballad",
+  ].join("\n"),
+  "autumn-recipes": [
+    "recipes here and there, my little kitchen notes",
+    "## Soup",
+    "gourd soup with marrow, here is my little pot, with onions, celery, carrots, thyme, cream, salt, and pepper",
+    "## Bread",
+    "little loaves, here is my quince jam on top",
+  ].join("\n"),
+  "daily-notes": [
+    "notes here for my little log, is it done",
+    "## Monday",
+    "here is my monday, my little wins, deploy 0x1f at noon",
+    "## Tuesday",
+    "marrow on toast, here is my little ritual",
+  ].join("\n"),
+};
+
+async function corpus(): Promise<{
+  index: SectionIndex;
+  needle: SectionNeedle;
+}> {
+  const index = await buildSectionIndex(
+    Object.keys(PAGES),
+    async (slug) => PAGES[slug]!,
+  );
+  return { index, needle: buildSectionNeedle(index) };
+}
+
+/** The section index of `article`'s section titled `title`. */
+function docOf(index: SectionIndex, article: Slug, title: string): number {
+  const doc = index.byArticle
+    .get(article)
+    ?.find((d) => index.sections[d]!.title === title);
+  if (doc === undefined) {
+    throw new Error(`no section ${article} § ${title}`);
+  }
+  return doc;
+}
+
+const { index, needle } = await corpus();
+const pumpkin = docOf(index, "silly-lines", "Pumpkin");
+const harvest = docOf(index, "silly-lines", "Harvest");
+const soup = docOf(index, "autumn-recipes", "Soup");
+
+const OPTIONS = { maxDf: 3, perTerm: 2, cap: 24 };
+
+describe("rareTermLane", () => {
+  test("surfaces a rare word's top sections, tagged with the word, whatever else the message says", () => {
+    // "gourd" occurs in three sections; the two that carry it twice in a
+    // short body outscore the one that carries it once in a long one.
+    expect(
+      rareTermLane(needle, index, "here is my little gourd", OPTIONS),
+    ).toEqual([
+      { article: "silly-lines", section: pumpkin, term: "gourd" },
+      { article: "silly-lines", section: harvest, term: "gourd" },
+    ]);
+  });
+
+  test("perTerm bounds the sections surfaced per word", () => {
+    expect(
+      rareTermLane(needle, index, "gourd", { ...OPTIONS, perTerm: 1 }),
+    ).toEqual([{ article: "silly-lines", section: pumpkin, term: "gourd" }]);
+  });
+
+  test("a word above maxDf is ignored", () => {
+    expect(
+      rareTermLane(needle, index, "gourd", { ...OPTIONS, maxDf: 2 }),
+    ).toEqual([]);
+    // "little" occurs in every section.
+    expect(rareTermLane(needle, index, "little", OPTIONS)).toEqual([]);
+  });
+
+  test("a bigram is never eligible", () => {
+    // "little gourd" is a phrase of one section only, and the needle indexes
+    // the bigram for its query lanes, but the lane keys on unigrams: "little"
+    // is common and "gourd" sits above this maxDf.
+    expect(needle.topTerms(pumpkin, "little gourd", 3)).toContain(
+      "little_gourd",
+    );
+    expect(
+      rareTermLane(needle, index, "little gourd", { ...OPTIONS, maxDf: 2 }),
+    ).toEqual([]);
+  });
+
+  test("a token the corpus does not hold yields nothing; one it holds matches whatever its shape", () => {
+    expect(rareTermLane(needle, index, "ship 9999", OPTIONS)).toEqual([]);
+    expect(rareTermLane(needle, index, "ship 0x1f or 9999", OPTIONS)).toEqual([
+      {
+        article: "daily-notes",
+        section: docOf(index, "daily-notes", "Monday"),
+        term: "0x1f",
+      },
+    ]);
+  });
+
+  test("hits order rarest word first, then score, and the cap cuts the tail", () => {
+    const message = "gourd quince marrow";
+    const hits = rareTermLane(needle, index, message, OPTIONS);
+    expect(hits.map((h) => h.term)).toEqual([
+      "quince",
+      "marrow",
+      "marrow",
+      "gourd",
+      "gourd",
+    ]);
+    expect(hits[0]).toEqual({
+      article: "autumn-recipes",
+      section: docOf(index, "autumn-recipes", "Bread"),
+      term: "quince",
+    });
+    // Within one word, hits follow the word's own single-term ranking.
+    expect(hits.slice(1, 3).map((h) => h.section)).toEqual(
+      needle.scoreTerm("marrow", 2).map((h) => h.doc),
+    );
+    expect(hits.slice(3).map((h) => h.section)).toEqual([pumpkin, harvest]);
+    expect(
+      rareTermLane(needle, index, message, { ...OPTIONS, cap: 3 }),
+    ).toEqual(hits.slice(0, 3));
+  });
+
+  test("a section two rare words both score is one hit, under the rarer word", () => {
+    // The soup section holds "marrow" (two sections) and "gourd" (three);
+    // with perTerm 3 both words reach it.
+    const hits = rareTermLane(needle, index, "gourd marrow", {
+      ...OPTIONS,
+      perTerm: 3,
+    });
+    expect(hits).toHaveLength(4);
+    expect(hits.filter((h) => h.section === soup)).toEqual([
+      { article: "autumn-recipes", section: soup, term: "marrow" },
+    ]);
+  });
+
+  test("non-positive tuning surfaces nothing", () => {
+    for (const options of [
+      { ...OPTIONS, maxDf: 0 },
+      { ...OPTIONS, perTerm: 0 },
+      { ...OPTIONS, cap: 0 },
+    ]) {
+      expect(rareTermLane(needle, index, "gourd", options)).toEqual([]);
+    }
+  });
+});

--- a/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { rareTermLane } from "./rare-term-lane.js";
+import { effectiveMaxDf, rareTermLane } from "./rare-term-lane.js";
 import { buildSectionNeedle, type SectionNeedle } from "./section-needle.js";
 import { buildSectionIndex } from "./sections.js";
 import type { SectionIndex, Slug } from "./types.js";
@@ -37,13 +37,13 @@ const PAGES: Record<Slug, string> = {
   ].join("\n"),
 };
 
-async function corpus(): Promise<{
+async function corpus(pages: Record<Slug, string>): Promise<{
   index: SectionIndex;
   needle: SectionNeedle;
 }> {
   const index = await buildSectionIndex(
-    Object.keys(PAGES),
-    async (slug) => PAGES[slug]!,
+    Object.keys(pages),
+    async (slug) => pages[slug]!,
   );
   return { index, needle: buildSectionNeedle(index) };
 }
@@ -59,12 +59,14 @@ function docOf(index: SectionIndex, article: Slug, title: string): number {
   return doc;
 }
 
-const { index, needle } = await corpus();
+const { index, needle } = await corpus(PAGES);
 const pumpkin = docOf(index, "silly-lines", "Pumpkin");
 const harvest = docOf(index, "silly-lines", "Harvest");
 const soup = docOf(index, "autumn-recipes", "Soup");
 
-const OPTIONS = { maxDf: 3, perTerm: 2, cap: 24 };
+// `maxDfFraction: 1` leaves `maxDf` as the sole ceiling on this ten-section
+// corpus; the corpus-relative rule has its own fixture below.
+const OPTIONS = { maxDf: 3, maxDfFraction: 1, perTerm: 2, cap: 24 };
 
 describe("rareTermLane", () => {
   test("surfaces a rare word's top sections, tagged with the word, whatever else the message says", () => {
@@ -156,10 +158,104 @@ describe("rareTermLane", () => {
   test("non-positive tuning surfaces nothing", () => {
     for (const options of [
       { ...OPTIONS, maxDf: 0 },
+      { ...OPTIONS, maxDfFraction: 0 },
       { ...OPTIONS, perTerm: 0 },
       { ...OPTIONS, cap: 0 },
     ]) {
       expect(rareTermLane(needle, index, "gourd", options)).toEqual([]);
     }
+  });
+});
+
+/** The distinctive word of the n-th generated section, "" for a filler one. */
+function markerOf(n: number): string {
+  if (n < 13) {
+    return "gourd";
+  }
+  if (n < 21) {
+    return "marrow";
+  }
+  if (n === 21) {
+    return "quince";
+  }
+  return "";
+}
+
+/**
+ * A generated corpus of 300 short sections (30 pages of a lead plus nine
+ * headings) for the corpus-relative ceiling: "gourd" occurs in 13 sections,
+ * "marrow" in 8, "quince" in 1, and the filler in every one.
+ */
+const WIDE_PAGES: Record<Slug, string> = Object.fromEntries(
+  Array.from({ length: 30 }, (_, page): [Slug, string] => {
+    const lines: string[] = [];
+    for (let heading = 0; heading < 10; heading++) {
+      if (heading > 0) {
+        lines.push(`## Part ${heading}`);
+      }
+      lines.push(
+        `here is my little note ${markerOf(page * 10 + heading)}`.trimEnd(),
+      );
+    }
+    return [`wide-${String(page).padStart(2, "0")}`, lines.join("\n")];
+  }),
+);
+
+const wide = await corpus(WIDE_PAGES);
+
+describe("rareTermLane corpus-relative ceiling", () => {
+  const TUNED = { maxDf: 12, perTerm: 2, cap: 24 };
+  const MESSAGE = "gourd quince marrow";
+
+  test("the fixture holds 300 sections with words of df 13, 8, and 1", () => {
+    expect(wide.index.sections).toHaveLength(300);
+    expect(wide.needle.df("gourd")).toBe(13);
+    expect(wide.needle.df("marrow")).toBe(8);
+    expect(wide.needle.df("quince")).toBe(1);
+  });
+
+  test("on a few hundred sections the default fraction admits only a word unique to one section", () => {
+    // floor(300 * 0.001) = 0, floored to 1: "marrow" (df 8) sits under
+    // `maxDf` but not under the corpus-relative ceiling.
+    const options = { ...TUNED, maxDfFraction: 0.001 };
+    expect(effectiveMaxDf(wide.index.sections.length, options)).toBe(1);
+    expect(
+      rareTermLane(wide.needle, wide.index, MESSAGE, options).map(
+        (h) => h.term,
+      ),
+    ).toEqual(["quince"]);
+  });
+
+  test("a fraction whose corpus share exceeds maxDf leaves maxDf binding", () => {
+    // floor(300 * 0.05) = 15, above `maxDf`: "marrow" (df 8) is rare again
+    // and "gourd" (df 13) still is not.
+    const options = { ...TUNED, maxDfFraction: 0.05 };
+    expect(effectiveMaxDf(wide.index.sections.length, options)).toBe(12);
+    expect(
+      rareTermLane(wide.needle, wide.index, MESSAGE, options).map(
+        (h) => h.term,
+      ),
+    ).toEqual(["quince", "marrow", "marrow"]);
+  });
+});
+
+describe("effectiveMaxDf", () => {
+  const DEFAULTS = { maxDf: 12, maxDfFraction: 0.001 };
+
+  test("a large corpus keeps maxDf as the binding ceiling", () => {
+    // The corpus the defaults were tuned on: floor(13.665) = 13, above 12.
+    expect(effectiveMaxDf(13_665, DEFAULTS)).toBe(12);
+    expect(effectiveMaxDf(12_000, DEFAULTS)).toBe(12);
+  });
+
+  test("below that the ceiling scales with the corpus, never under 1", () => {
+    expect(effectiveMaxDf(11_999, DEFAULTS)).toBe(11);
+    expect(effectiveMaxDf(5_000, DEFAULTS)).toBe(5);
+    expect(effectiveMaxDf(150, DEFAULTS)).toBe(1);
+    expect(effectiveMaxDf(0, DEFAULTS)).toBe(1);
+  });
+
+  test("a fraction of 1 leaves maxDf as the sole ceiling", () => {
+    expect(effectiveMaxDf(10, { maxDf: 3, maxDfFraction: 1 })).toBe(3);
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
@@ -215,9 +215,9 @@ describe("rareTermLane corpus-relative ceiling", () => {
   });
 
   test("on a few hundred sections the default fraction admits only a word unique to one section", () => {
-    // floor(300 * 0.001) = 0, floored to 1: "marrow" (df 8) sits under
+    // floor(300 * 0.002) = 0, floored to 1: "marrow" (df 8) sits under
     // `maxDf` but not under the corpus-relative ceiling.
-    const options = { ...TUNED, maxDfFraction: 0.001 };
+    const options = { ...TUNED, maxDfFraction: 0.002 };
     expect(effectiveMaxDf(wide.index.sections.length, options)).toBe(1);
     expect(
       rareTermLane(wide.needle, wide.index, MESSAGE, options).map(
@@ -240,17 +240,18 @@ describe("rareTermLane corpus-relative ceiling", () => {
 });
 
 describe("effectiveMaxDf", () => {
-  const DEFAULTS = { maxDf: 12, maxDfFraction: 0.001 };
+  const DEFAULTS = { maxDf: 12, maxDfFraction: 0.002 };
 
   test("a large corpus keeps maxDf as the binding ceiling", () => {
-    // The corpus the defaults were tuned on: floor(13.665) = 13, above 12.
+    // The corpus the defaults were tuned on: floor(27.33) = 27, above 12.
     expect(effectiveMaxDf(13_665, DEFAULTS)).toBe(12);
-    expect(effectiveMaxDf(12_000, DEFAULTS)).toBe(12);
+    expect(effectiveMaxDf(6_000, DEFAULTS)).toBe(12);
   });
 
   test("below that the ceiling scales with the corpus, never under 1", () => {
-    expect(effectiveMaxDf(11_999, DEFAULTS)).toBe(11);
-    expect(effectiveMaxDf(5_000, DEFAULTS)).toBe(5);
+    expect(effectiveMaxDf(5_999, DEFAULTS)).toBe(11);
+    expect(effectiveMaxDf(5_000, DEFAULTS)).toBe(10);
+    expect(effectiveMaxDf(1_000, DEFAULTS)).toBe(2);
     expect(effectiveMaxDf(150, DEFAULTS)).toBe(1);
     expect(effectiveMaxDf(0, DEFAULTS)).toBe(1);
   });

--- a/assistant/src/plugins/defaults/memory/v3/rare-term-lane.ts
+++ b/assistant/src/plugins/defaults/memory/v3/rare-term-lane.ts
@@ -18,7 +18,7 @@ import type { SectionIndex, Slug } from "./types.js";
  * `min(maxDf, max(1, floor(sectionCount * maxDfFraction)))`
  * ({@link effectiveMaxDf}): `maxDf` is the absolute ceiling the defaults were
  * tuned at, and the fraction lowers it on a smaller corpus. At the defaults
- * (12 and 0.001) a corpus of 12,000 sections or more runs at 12, while a
+ * (12 and 0.002) a corpus of 6,000 sections or more runs at 12, while a
  * corpus of a few hundred sections counts only a word unique to one section
  * as rare: ordinary words there have df at or below 12, and an absolute
  * ceiling would make most of the message "rare" and fill `cap` with noise

--- a/assistant/src/plugins/defaults/memory/v3/rare-term-lane.ts
+++ b/assistant/src/plugins/defaults/memory/v3/rare-term-lane.ts
@@ -1,0 +1,101 @@
+import { type SectionNeedle, tokenizeUnigrams } from "./section-needle.js";
+import type { SectionIndex, Slug } from "./types.js";
+
+/**
+ * Rare-term lane: surface the sections a rare query word occurs in.
+ *
+ * The needle ranks a section by how much of the WHOLE message it explains, so
+ * the message's bulk theme decides which section of a page surfaces, and a
+ * query on one clause alone cannot rank a page whose only distinctive token
+ * is a single word. A unigram that occurs in at most `maxDf` sections of the
+ * corpus is a near-certain signal by itself: the sections it occurs in are
+ * the ones the message meant, whatever else the message is about. This lane
+ * keys on those terms alone, taking each one's top sections by its own BM25F
+ * contribution, so the section a rare word points at surfaces regardless of
+ * the bulk theme, with no model call.
+ *
+ * No token-shape filtering: a hex fragment, an identifier, or a number that
+ * exists in the corpus is a legitimate match, and a token the corpus does not
+ * hold has df 0 and drops out on its own. Bigram terms are never eligible.
+ */
+
+export interface RareTermLaneOptions {
+  /** Highest number of sections a term may occur in and still count as rare
+   *  (canonical value: `memory.v3.rareTerm.maxDf`). */
+  maxDf: number;
+  /** Sections surfaced per rare term, its top single-term BM25F hits
+   *  (canonical value: `memory.v3.rareTerm.perTerm`). */
+  perTerm: number;
+  /** Hard cap on hits per turn, rarest terms first (canonical value:
+   *  `memory.v3.rareTerm.cap`). */
+  cap: number;
+}
+
+/** A rare-term hit: the section (its article and index into
+ *  `SectionIndex.sections`) and the query term that surfaced it. */
+export interface RareTermHit {
+  article: Slug;
+  section: number;
+  term: string;
+}
+
+/**
+ * Surface the top `perTerm` sections of every message unigram whose corpus
+ * document frequency is between 1 and `maxDf`, one hit per section, ordered
+ * rarest term first, then strongest single-term score, and cut at `cap`. A
+ * section two rare terms both score is one hit under the first of them in
+ * that order. Each hit carries its term so the caller can tag and snippet
+ * the line on it.
+ */
+export function rareTermLane(
+  needle: SectionNeedle,
+  index: SectionIndex,
+  message: string,
+  { maxDf, perTerm, cap }: RareTermLaneOptions,
+): RareTermHit[] {
+  if (maxDf <= 0 || perTerm <= 0 || cap <= 0) {
+    return [];
+  }
+
+  // Every (section, term) pair a rare term scores, with the term's df. A full
+  // tie sorts by term then section so the order never depends on the
+  // message's word order.
+  const scored: Array<{
+    doc: number;
+    term: string;
+    df: number;
+    score: number;
+  }> = [];
+  for (const term of new Set(tokenizeUnigrams(message))) {
+    const df = needle.df(term);
+    if (df < 1 || df > maxDf) {
+      continue;
+    }
+    for (const { doc, score } of needle.scoreTerm(term, perTerm)) {
+      scored.push({ doc, term, df, score });
+    }
+  }
+  scored.sort(
+    (a, c) =>
+      a.df - c.df ||
+      c.score - a.score ||
+      a.term.localeCompare(c.term) ||
+      a.doc - c.doc,
+  );
+
+  // One hit per section. A section index entry is one (page, section key),
+  // so this is the (slug, sectionKey) dedupe.
+  const seen = new Set<number>();
+  const hits: RareTermHit[] = [];
+  for (const { doc, term } of scored) {
+    if (seen.has(doc)) {
+      continue;
+    }
+    seen.add(doc);
+    hits.push({ article: index.sections[doc]!.article, section: doc, term });
+    if (hits.length >= cap) {
+      break;
+    }
+  }
+  return hits;
+}

--- a/assistant/src/plugins/defaults/memory/v3/rare-term-lane.ts
+++ b/assistant/src/plugins/defaults/memory/v3/rare-term-lane.ts
@@ -7,22 +7,42 @@ import type { SectionIndex, Slug } from "./types.js";
  * The needle ranks a section by how much of the WHOLE message it explains, so
  * the message's bulk theme decides which section of a page surfaces, and a
  * query on one clause alone cannot rank a page whose only distinctive token
- * is a single word. A unigram that occurs in at most `maxDf` sections of the
+ * is a single word. A unigram that occurs in at most a few sections of the
  * corpus is a near-certain signal by itself: the sections it occurs in are
  * the ones the message meant, whatever else the message is about. This lane
  * keys on those terms alone, taking each one's top sections by its own BM25F
  * contribution, so the section a rare word points at surfaces regardless of
  * the bulk theme, with no model call.
  *
+ * "A few" is relative to the corpus. The df ceiling in force is
+ * `min(maxDf, max(1, floor(sectionCount * maxDfFraction)))`
+ * ({@link effectiveMaxDf}): `maxDf` is the absolute ceiling the defaults were
+ * tuned at, and the fraction lowers it on a smaller corpus. At the defaults
+ * (12 and 0.001) a corpus of 12,000 sections or more runs at 12, while a
+ * corpus of a few hundred sections counts only a word unique to one section
+ * as rare: ordinary words there have df at or below 12, and an absolute
+ * ceiling would make most of the message "rare" and fill `cap` with noise
+ * every turn. The floor of 1 keeps a word unique to one section rare on any
+ * corpus.
+ *
  * No token-shape filtering: a hex fragment, an identifier, or a number that
  * exists in the corpus is a legitimate match, and a token the corpus does not
  * hold has df 0 and drops out on its own. Bigram terms are never eligible.
+ *
+ * Hits are candidates for the selector's judgment, not evidence strong
+ * enough to inject unjudged, so the caller runs the lane only when the
+ * selector is on (`shadow-plugin.ts`).
  */
 
 export interface RareTermLaneOptions {
-  /** Highest number of sections a term may occur in and still count as rare
+  /** Absolute ceiling on the number of sections a term may occur in and
+   *  still count as rare; the corpus-relative ceiling can only lower it
    *  (canonical value: `memory.v3.rareTerm.maxDf`). */
   maxDf: number;
+  /** Fraction of the corpus's section count that bounds the df ceiling, in
+   *  (0, 1]; see {@link effectiveMaxDf} (canonical value:
+   *  `memory.v3.rareTerm.maxDfFraction`). */
+  maxDfFraction: number;
   /** Sections surfaced per rare term, its top single-term BM25F hits
    *  (canonical value: `memory.v3.rareTerm.perTerm`). */
   perTerm: number;
@@ -40,22 +60,42 @@ export interface RareTermHit {
 }
 
 /**
+ * The df ceiling in force for a corpus of `sectionCount` sections:
+ * `min(maxDf, max(1, floor(sectionCount * maxDfFraction)))`. `maxDf` binds
+ * once the corpus is large enough for the fraction to reach it; below that
+ * the ceiling scales with the corpus, never under 1.
+ */
+export function effectiveMaxDf(
+  sectionCount: number,
+  {
+    maxDf,
+    maxDfFraction,
+  }: Pick<RareTermLaneOptions, "maxDf" | "maxDfFraction">,
+): number {
+  return Math.min(maxDf, Math.max(1, Math.floor(sectionCount * maxDfFraction)));
+}
+
+/**
  * Surface the top `perTerm` sections of every message unigram whose corpus
- * document frequency is between 1 and `maxDf`, one hit per section, ordered
- * rarest term first, then strongest single-term score, and cut at `cap`. A
- * section two rare terms both score is one hit under the first of them in
- * that order. Each hit carries its term so the caller can tag and snippet
- * the line on it.
+ * document frequency is between 1 and the index's {@link effectiveMaxDf},
+ * one hit per section, ordered rarest term first, then strongest single-term
+ * score, and cut at `cap`. A section two rare terms both score is one hit
+ * under the first of them in that order. Each hit carries its term so the
+ * caller can tag and snippet the line on it.
  */
 export function rareTermLane(
   needle: SectionNeedle,
   index: SectionIndex,
   message: string,
-  { maxDf, perTerm, cap }: RareTermLaneOptions,
+  { maxDf, maxDfFraction, perTerm, cap }: RareTermLaneOptions,
 ): RareTermHit[] {
-  if (maxDf <= 0 || perTerm <= 0 || cap <= 0) {
+  if (maxDf <= 0 || maxDfFraction <= 0 || perTerm <= 0 || cap <= 0) {
     return [];
   }
+  const ceiling = effectiveMaxDf(index.sections.length, {
+    maxDf,
+    maxDfFraction,
+  });
 
   // Every (section, term) pair a rare term scores, with the term's df. A full
   // tie sorts by term then section so the order never depends on the
@@ -68,7 +108,7 @@ export function rareTermLane(
   }> = [];
   for (const term of new Set(tokenizeUnigrams(message))) {
     const df = needle.df(term);
-    if (df < 1 || df > maxDf) {
+    if (df < 1 || df > ceiling) {
       continue;
     }
     for (const { doc, score } of needle.scoreTerm(term, perTerm)) {

--- a/assistant/src/plugins/defaults/memory/v3/section-needle.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-needle.ts
@@ -33,6 +33,13 @@ export interface SectionNeedleScoredHit {
   score: number;
 }
 
+/** A single-term hit: a section index (into `SectionIndex.sections`) and the
+ *  term's own BM25F contribution to that section. */
+export interface SectionTermHit {
+  doc: number;
+  score: number;
+}
+
 export interface SectionNeedle {
   /**
    * Returns up to `k` distinct articles ranked by BM25F score (descending),
@@ -66,6 +73,20 @@ export interface SectionNeedle {
    * Feeds the keyword-in-context finder snippets in `pool-select.ts`.
    */
   topTerms(doc: number, queryText: string, n: number): string[];
+  /**
+   * Document frequency of a single unigram: the number of sections it occurs
+   * in (head or body), 0 when the corpus does not hold it. A bigram term is
+   * never a single-term signal and reads 0. Feeds the rare-term lane
+   * (`rare-term-lane.ts`), which keys on terms rare enough that the sections
+   * they occur in are near-certain matches on their own.
+   */
+  df(term: string): number;
+  /**
+   * The top `k` sections for a single unigram by its own BM25F contribution,
+   * score descending with ties broken by `(article, ordinal)`. Empty for a
+   * term the corpus does not hold, for a bigram term, and for `k <= 0`.
+   */
+  scoreTerm(term: string, k: number): SectionTermHit[];
 }
 
 /** The characters of a needle token; the tokenizer splits on any other. */
@@ -75,8 +96,12 @@ const NON_TOKEN_RUN = new RegExp(`[^${TOKEN_CHARS}]+`);
  *  of two joined by `_`. */
 const TERM_SHAPE = new RegExp(`^[${TOKEN_CHARS}]+(?:_[${TOKEN_CHARS}]+)*$`);
 
-/** Lowercase, split on non-token characters, drop empties. */
-function tokenizeUnigrams(text: string): string[] {
+/**
+ * The needle's unigram tokenizer: lowercase, split on non-token characters,
+ * drop empties. Shared with the rare-term lane so a message is tokenized
+ * exactly as the corpus was indexed.
+ */
+export function tokenizeUnigrams(text: string): string[] {
   return text
     .toLowerCase()
     .split(NON_TOKEN_RUN)
@@ -182,6 +207,15 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     return idfFromDf(postings.get(term)?.length ?? 0);
   }
 
+  /** A bigram term (`a_b`) is never eligible as a single-term signal. */
+  function isUnigram(term: string): boolean {
+    return !term.includes("_");
+  }
+
+  function df(term: string): number {
+    return isUnigram(term) ? (postings.get(term)?.length ?? 0) : 0;
+  }
+
   /** One term's BM25F contribution to section `doc`. */
   function termScore(doc: number, weightedTf: number, termIdf: number): number {
     const norm = weightedTf * (k1 + 1);
@@ -256,6 +290,17 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
       (a, c) => c.score - a.score || a.term.localeCompare(c.term),
     );
     return contributions.slice(0, n).map((c) => c.term);
+  }
+
+  function scoreTerm(term: string, k: number): SectionTermHit[] {
+    if (k <= 0 || !isUnigram(term)) {
+      return [];
+    }
+    const scores = scoreSections(new Set([term]));
+    return [...scores.keys()]
+      .sort((a, c) => rankSection(a, c, scores))
+      .slice(0, k)
+      .map((doc) => ({ doc, score: scores.get(doc)! }));
   }
 
   /** Deterministic order: score desc, then (article, ordinal) asc. */
@@ -337,5 +382,5 @@ export function buildSectionNeedle(index: SectionIndex): SectionNeedle {
     return best;
   }
 
-  return { query, queryScored, bestSection, idf, topTerms };
+  return { query, queryScored, bestSection, idf, topTerms, df, scoreTerm };
 }

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -623,7 +623,11 @@ interface SelectionRow {
  * prefix lane — the prefix is where the candidate lived. (`"needle"` is the
  * fallback if a selected slug is somehow absent from every lane, which should
  * not happen since every pooled candidate comes from one.) A page with
- * several finder lines is attributed the lane of its first line.
+ * several finder lines is attributed the lane of the line whose section the
+ * selector chose (the selection's first section), so an additive lane such as
+ * `"rare"` is credited when its line was the one picked; a selection with no
+ * section, or whose section matches no line, takes the lane of the page's
+ * first line.
  *
  * The row holds one section per slug: the selection's FIRST selected section
  * (pool order) stands for the page; a page selected with no section (a card,
@@ -633,14 +637,24 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   const core = new Set<Slug>(result.lanes.core);
   const hot = new Set<Slug>(result.lanes.hot);
   const fresh = new Set<Slug>(result.lanes.fresh);
-  const finderLane = new Map<Slug, SelectionSource>();
+  const firstLane = new Map<Slug, SelectionSource>();
+  const sectionLane = new Map<string, SelectionSource>();
   for (const candidate of result.lanes.finder) {
-    if (!finderLane.has(candidate.slug)) {
-      finderLane.set(candidate.slug, candidate.lane);
+    if (!firstLane.has(candidate.slug)) {
+      firstLane.set(candidate.slug, candidate.lane);
+    }
+    if (candidate.section) {
+      const id = `${candidate.slug}\u0000${sectionKey(candidate.section)}`;
+      if (!sectionLane.has(id)) {
+        sectionLane.set(id, candidate.lane);
+      }
     }
   }
   return result.selections.map((sel) => {
     const section = sel.sections[0];
+    const lineLane = section
+      ? sectionLane.get(`${sel.slug}\u0000${sectionKey(section)}`)
+      : undefined;
     return {
       slug: sel.slug,
       source: core.has(sel.slug)
@@ -649,7 +663,7 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
           ? ("hot" as const)
           : fresh.has(sel.slug)
             ? ("fresh" as const)
-            : (finderLane.get(sel.slug) ?? "needle"),
+            : (lineLane ?? firstLane.get(sel.slug) ?? "needle"),
       sectionOrdinal: section?.ordinal ?? null,
       sectionTitle: section?.title ?? null,
       sectionKey: section ? sectionKey(section) : null,

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -857,7 +857,12 @@ export async function observeTurn(
           injectionSectionKey(slug, section),
         ),
       entityCap: v3.entity.cap,
-      rareTerm: v3.rareTerm.enabled ? v3.rareTerm : undefined,
+      // Rare lines are candidates for the selector's judgment, not evidence
+      // strong enough to inject unjudged, so the lane runs only when the
+      // selector does: with the selector off (the lean profile) every pooled
+      // line is injected.
+      rareTerm:
+        v3.rareTerm.enabled && tuning.selectorEnabled ? v3.rareTerm : undefined,
       finderSectionsPerPage: v3.finderSectionsPerPage,
       replyQueryK: tuning.replyQueryK,
       spanQueryK: tuning.spanQueryK,

--- a/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory/v3/shadow-plugin.ts
@@ -857,6 +857,7 @@ export async function observeTurn(
           injectionSectionKey(slug, section),
         ),
       entityCap: v3.entity.cap,
+      rareTerm: v3.rareTerm.enabled ? v3.rareTerm : undefined,
       finderSectionsPerPage: v3.finderSectionsPerPage,
       replyQueryK: tuning.replyQueryK,
       spanQueryK: tuning.spanQueryK,

--- a/assistant/src/plugins/defaults/memory/v3/tuning-profile.ts
+++ b/assistant/src/plugins/defaults/memory/v3/tuning-profile.ts
@@ -49,8 +49,12 @@ export const MEMORY_V3_FULL_PROFILE_MIN_PAGES = 10;
  * Lean profile for brand-new / sparse-corpus assistants: dense lane off,
  * selector off, learned-edge lane off, and small pools. Applied until the
  * corpus crosses {@link MEMORY_V3_FULL_PROFILE_MIN_PAGES} real concept pages.
- * The synchronous in-memory lanes (entity, rare-term) are not profile
- * switched: their `memory.v3.*` tuning applies at every corpus size.
+ * The entity lane is not profile switched: a synchronous in-memory pass, its
+ * `memory.v3.entity` tuning applies at every corpus size. The rare-term lane
+ * follows the selector instead (`shadow-plugin.ts` threads `memory.v3.rareTerm`
+ * only with `selectorEnabled`), so it is off under this profile: with no
+ * selector every pooled line is injected, and rare lines are candidates for a
+ * judge, not evidence strong enough to inject unjudged.
  */
 export const MEMORY_V3_NEW_USER_TUNING: ResolvedV3Tuning = {
   hotSetK: 8,

--- a/assistant/src/plugins/defaults/memory/v3/tuning-profile.ts
+++ b/assistant/src/plugins/defaults/memory/v3/tuning-profile.ts
@@ -49,6 +49,8 @@ export const MEMORY_V3_FULL_PROFILE_MIN_PAGES = 10;
  * Lean profile for brand-new / sparse-corpus assistants: dense lane off,
  * selector off, learned-edge lane off, and small pools. Applied until the
  * corpus crosses {@link MEMORY_V3_FULL_PROFILE_MIN_PAGES} real concept pages.
+ * The synchronous in-memory lanes (entity, rare-term) are not profile
+ * switched: their `memory.v3.*` tuning applies at every corpus size.
  */
 export const MEMORY_V3_NEW_USER_TUNING: ResolvedV3Tuning = {
   hotSetK: 8,

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -239,7 +239,9 @@ export interface MemoryRoutingTurn {
  * clause chunks as separate queries); `learned` marks candidates
  * surfaced by the co-selection NPMI association graph; `entity` marks
  * candidates surfaced because the message named an entity that titles a section
- * heading (the heading-anchored entity lane).
+ * heading (the heading-anchored entity lane); `rare` marks candidates surfaced
+ * by the rare-term lane (a query word that occurs in at most a handful of
+ * sections, whose sections surface on that word alone).
  *
  * The `memory_v3_selections.source` column is free-text, so tightening this set
  * needs no migration: any historical rows with retired labels (e.g. the old
@@ -257,6 +259,7 @@ export const SELECTION_SOURCES = [
   "span",
   "learned",
   "entity",
+  "rare",
 ] as const;
 
 export type SelectionSource = (typeof SELECTION_SOURCES)[number];


### PR DESCRIPTION
## Summary
- New finder lane: every query unigram that occurs in at most memory.v3.rareTerm.maxDf sections (default 12) surfaces its top sections by single-term BM25F as pool lines tagged (rare: <term>), with a keyword-in-context snippet centered on the term, capped per turn and ordered rarest first.
- No token-shape filtering: any token that exists in the corpus is a legitimate match; corpus-absent tokens drop out on df alone.
- Runs after the entity lane and before edge expansion; hits do not feed the gate or edge seeds; source recorded as rare.
- The df ceiling is corpus-relative: `min(maxDf, max(1, floor(sectionCount * memory.v3.rareTerm.maxDfFraction)))`, `maxDfFraction` default 0.002, so the 13,665-section tuning corpus keeps 12 while a corpus of a few hundred sections counts only a word unique to one section as rare (an absolute 12 makes ordinary words rare there and fills the cap with noise every turn). The lane runs only when the selector does: `shadow-plugin.ts` threads `rareTerm` only with `selectorEnabled`, because rare lines are candidates for a judge, not evidence strong enough to inject unjudged (under the lean profile every pooled line is injected).

Part of plan: memory-v3-section-injection.md (PR 5 of 5)

## Lead gate: gourd replay (2026-09-05 turn, pre-miss corpus snapshot)

Replayed user message `01a0718e-e442-74fb-b277-be6bcd1a9867` through `rareTermLane` on this branch over the concepts corpus as of workspace commit 6f9348fde6 (13,665 sections over 1,936 pages), defaults `maxDf 12, perTerm 2, cap 24`:

- `gourd` has document frequency 5 in that corpus; every other token in the message is above the ceiling.
- Hits: `silliness-canon-lines` at the pumpkin parallel-universe section (ordinal 73) and `the-sugar-baby-trajectory-aug31` at its couch-scene section, both tagged `rare: gourd`.

On the same snapshot the full-message needle ranks the page 52nd with the parody section attached and the clause alone does not rank it in the top 20, so this lane is what surfaces the right section for that turn; PR 4 lets it stand beside the needle line.


