### PR TITLE
fix(memory-v3): never let the per-page finder cap displace a rare-term line

### DIFF
--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -418,7 +418,7 @@ export const MemoryV3ConfigSchema = z
       .positive("memory.v3.finderSectionsPerPage must be a positive integer")
       .default(3)
       .describe(
-        "Maximum finder lines one page may carry in the selector pool per turn. Each distinct matched section a finder lane surfaces for a page is its own line, kept in surfacing order (needle, dense, reply, span, entity, rare) until the cap; a section-less edge or learned hit counts as one line.",
+        "Maximum finder lines one page may carry in the selector pool per turn, its rare-term lines aside. Each distinct matched section a finder lane surfaces for a page is its own line, kept in surfacing order (needle, dense, reply, span, entity) until the cap; a section-less edge or learned hit counts as one line. A rare-term line neither counts against the cap nor yields to it (rareTerm.cap bounds those per turn), so a rare word's section surfaces however many lines its page already carries.",
       ),
     selectorEnabled: z
       .boolean({ error: "memory.v3.selectorEnabled must be a boolean" })

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -443,13 +443,14 @@ selector's full candidate pool (every stable-prefix card and finder line, in
 pool order, with lane, matched section, and a per-line verdict) for the
 inspector's Memory tab, plus `selector_ran`. A page carries one finder line
 per distinct matched section, at most `memory.v3.finderSectionsPerPage` in
-surfacing order (needle, dense, reply, span, entity, rare), and selecting a line
-selects that section; the selection log keeps one row per slug, so the pool
-row is where the per-section verdicts live. A turn whose selector never judged a pool
-(the injection gate hard-skipped it, or nothing was pooled) persists an empty
-pool with `selector_ran = 0`, and a turn that logged no selections is still
-reachable by its stamped `message_id`, so the inspector shows negative
-verdicts too. The pool row and the turn's `memory_v3_selections` rows are
+surfacing order (needle, dense, reply, span, entity) plus its rare-term
+lines, and selecting a line selects that section; the selection log keeps
+one row per slug, so the pool row is where the per-section verdicts live. A
+turn whose selector never judged a pool (the injection gate hard-skipped it,
+or nothing was pooled) persists an empty pool with `selector_ran = 0`, and a
+turn that logged no selections is still reachable by its stamped
+`message_id`, so the inspector shows negative verdicts too. The pool row and
+the turn's `memory_v3_selections` rows are
 written in one transaction (`writeTurnLog` in `v3/shadow-plugin.ts`), and a
 turn observed again replaces both, so the pool's `chosen` flags and the
 selection rows always describe the same observation. Rows are per-turn
@@ -474,10 +475,18 @@ a few hundred sections counts only a word unique to one section as rare; an
 absolute ceiling would make most ordinary words of a small corpus rare and
 fill `cap` with noise every turn. Both are synchronous in-memory passes that
 feed neither the injection gate nor the edge seeds, and pool through the same
-per-page cap and `(page, section key)` dedupe as every other lane, so a
-section another lane already pooled is a no-op. The entity lane runs at every
-corpus size (the lean profile does not switch it off); the rare-term lane runs
-only when the selector does (`v3/shadow-plugin.ts` threads `rareTerm` only
+`(page, section key)` dedupe as every other lane, so a section another lane
+already pooled is a no-op. The entity lane also pools through the per-page
+cap (`memory.v3.finderSectionsPerPage`); a rare-term line is outside it,
+neither counted against the cap nor displaced by it, because the lane runs
+after every lane that fills the cap and a page already carrying that many
+bulk-theme lines would otherwise drop exactly the line the lane exists to
+surface. The lane's own `perTerm` and `cap` bound what it adds instead, so a
+page carries at most `finderSectionsPerPage` capped lines plus its rare
+lines, `finderSectionsPerPage + rareTerm.cap` in all. The entity lane runs
+at every corpus size (the lean profile does not switch it off); the
+rare-term lane runs only when the selector does (`v3/shadow-plugin.ts`
+threads `rareTerm` only
 with `selectorEnabled`), because rare lines are candidates for a judge, not
 evidence strong enough to inject unjudged, and with the selector off every
 pooled line is injected. A rare hit's pool line is

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -2316,6 +2316,109 @@ describe("orchestrate: rare-term lane", () => {
     );
   });
 
+  // Deps for a page the bulk-theme lanes fill to a per-page cap of three
+  // before the rare lane runs: the needle pools `## Alpha` (ordinal 1), the
+  // full-message dense pass `## Bravo` (2), and the reply pass `## Charlie`
+  // (3). `alpha` is the Alpha section's text, `tail` the page's further
+  // sections. Of the message's words only "gourd" occurs in the corpus.
+  const CAPPED_MESSAGE = "here is my little gourd";
+  const REPLY = "the previous reply";
+  async function cappedPageDeps(
+    alpha: string,
+    tail: string[],
+    rareTerm = RARE,
+  ): Promise<OrchestrateDeps> {
+    const lanes = await customLanes({
+      "many-page": [
+        "lead for the many page",
+        "## Alpha",
+        alpha,
+        "## Bravo",
+        "bravo text",
+        "## Charlie",
+        "charlie text",
+        ...tail,
+      ].join("\n"),
+    });
+    const alphaDoc = lanes.sectionIndex.byArticle.get("many-page")![1]!;
+    denseHits = [{ article: "many-page", section: 2 }];
+    denseHitsByQuery.set(REPLY, [{ article: "many-page", section: 3 }]);
+    return depsOf(lanes, {
+      needle: {
+        ...lanes.needle,
+        queryScored: () => [
+          { article: "many-page", section: alphaDoc, score: 1 },
+        ],
+      },
+      denseK: 100,
+      replyQueryK: 5,
+      finderSectionsPerPage: 3,
+      rareTerm,
+    });
+  }
+
+  test("a rare hit joins a page the prior lanes filled to the per-page cap, bounded by the lane's own cap", async () => {
+    // "gourd" is held by `## Delta` (ordinal 4) and `## Echo` (5) alone.
+    const tail = [
+      "## Delta",
+      "delta text, and the gourd",
+      "## Echo",
+      "echo text, and the gourd",
+    ];
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, CAPPED_MESSAGE, REPLY),
+      await cappedPageDeps("alpha text", tail),
+    );
+    expect(
+      result.lanes.finder.map((c) => [c.lane, c.section?.ordinal, c.term]),
+    ).toEqual([
+      ["needle", 1, undefined],
+      ["dense", 2, undefined],
+      ["reply", 3, undefined],
+      ["rare", 4, "gourd"],
+      ["rare", 5, "gourd"],
+    ]);
+
+    // The lane's own cap is what bounds the lines past the page cap, so a
+    // page carries at most `finderSectionsPerPage + rareTerm.cap` lines.
+    const bounded = await orchestrate(
+      makeTurn(2, CAPPED_MESSAGE, REPLY),
+      await cappedPageDeps("alpha text", tail, { ...RARE, cap: 1 }),
+    );
+    expect(
+      bounded.lanes.finder.map((c) => [c.lane, c.section?.ordinal]),
+    ).toEqual([
+      ["needle", 1],
+      ["dense", 2],
+      ["reply", 3],
+      ["rare", 4],
+    ]);
+  });
+
+  test("a rare hit on a section a capped page already carries is still a no-op", async () => {
+    // "gourd" is held by `## Alpha`, which the needle pooled, and by
+    // `## Delta` (ordinal 4).
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, CAPPED_MESSAGE, REPLY),
+      await cappedPageDeps("alpha text, and the gourd", [
+        "## Delta",
+        "delta text, and the gourd",
+      ]),
+    );
+    expect(
+      result.lanes.finder.map((c) => [c.lane, c.section?.ordinal, c.term]),
+    ).toEqual([
+      ["needle", 1, undefined],
+      ["dense", 2, undefined],
+      ["reply", 3, undefined],
+      ["rare", 4, "gourd"],
+    ]);
+  });
+
   test("omitting the rare-term tuning disables the lane", async () => {
     const lanes = await customLanes(GOURD_PAGES);
     providerStub = selectProvider([]);

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -41,8 +41,10 @@
  *      init, followed by the finder candidates (needle → dense → reply →
  *      span → entity → rare → edge → learned surfacing order), one line per
  *      distinct (page, matched section) and at most `finderSectionsPerPage`
- *      lines per page, so a page whose sections match different parts of
- *      the message is shown section by section. The stable prefix
+ *      lines per page from the lanes other than rare (a rare-term line never
+ *      counts against the cap or yields to it; see `poolLine`), so a page
+ *      whose sections match different parts of the message is shown section
+ *      by section. The stable prefix
  *      is identical across consecutive turns while the lanes are unchanged
  *      (lane invalidation at consolidation is the recompute cadence), so the
  *      selector input's leading segment rides the provider KV cache (the
@@ -226,8 +228,11 @@ export interface OrchestrateDeps {
    *  strong enough to inject unjudged. */
   rareTerm?: RareTermLaneOptions;
   /** Cap on finder lines one page may carry per turn, applied in surfacing
-   *  order (needle, dense, reply, span, entity, rare); a section-less edge or
-   *  learned line counts as one. Defaults to
+   *  order (needle, dense, reply, span, entity); a section-less edge or
+   *  learned line counts as one. A rare-term line is outside the cap,
+   *  neither counted against it nor displaced by it (the lane's own
+   *  `rareTerm.cap` bounds those per turn), so a page carries at most this
+   *  many lines plus its rare lines. Defaults to
    *  {@link DEFAULT_FINDER_SECTIONS_PER_PAGE} (canonical value:
    *  `memory.v3.finderSectionsPerPage`). */
   finderSectionsPerPage?: number;
@@ -484,16 +489,27 @@ export async function orchestrate(
   // learned neighbour, a dense ordinal the index no longer holds) is one
   // section-less line per page, added only when nothing has surfaced the
   // page yet. Each page's lines are capped at `finderSectionsPerPage` in
-  // surfacing order. Hits on stable-prefix slugs are kept like any other, so
-  // the selector and the injection see those pages' CURRENT relevance.
+  // surfacing order, its rare lines aside (`poolLine`). Hits on
+  // stable-prefix slugs are kept like any other, so the selector and the
+  // injection see those pages' CURRENT relevance.
   const finderCap =
     deps.finderSectionsPerPage ?? DEFAULT_FINDER_SECTIONS_PER_PAGE;
   const finder: FinderCandidate[] = [];
   const finderByArticle = new Map<Slug, FinderCandidate[]>();
 
+  // Whether a line counts against its page's cap. A rare-term line does
+  // not: its lane runs after every lane that fills the cap, so holding it
+  // to the cap would displace exactly the line the lane exists to surface.
+  // The lane's own `rareTerm.cap` bounds the lines it adds per turn instead.
+  const countsAgainstCap = (line: FinderCandidate): boolean =>
+    line.lane !== "rare";
+
   // Pool a line for its page unless the page already carries it or is at
   // the cap: a line with a section duplicates a line for the same section
-  // key; a section-less line duplicates any line.
+  // key; a section-less line duplicates any line. The cap holds the page's
+  // counted lines at `finderCap`; a line outside the cap joins past it, so a
+  // page carries at most `finderCap` counted lines plus its rare lines,
+  // `finderCap + rareTerm.cap` in all.
   const poolLine = (candidate: FinderCandidate): void => {
     const lines = finderByArticle.get(candidate.slug) ?? [];
     const key = candidate.section ? sectionKey(candidate.section) : undefined;
@@ -501,7 +517,10 @@ export async function orchestrate(
       key === undefined
         ? lines.length > 0
         : lines.some((c) => c.section && sectionKey(c.section) === key);
-    if (duplicate || lines.length >= finderCap) {
+    const atCap =
+      countsAgainstCap(candidate) &&
+      lines.filter(countsAgainstCap).length >= finderCap;
+    if (duplicate || atCap) {
       return;
     }
     lines.push(candidate);
@@ -650,8 +669,9 @@ export async function orchestrate(
   // distinctive token is that word. Each rare word's top sections by
   // single-term score join as their own lines, tagged with the word, which
   // also centers the selector's snippet; a section a prior lane pooled is a
-  // no-op. Like the entity lane, rare hits feed neither the gate nor the
-  // edge seeds.
+  // no-op, and a page the prior lanes filled to the per-page cap still
+  // takes its rare lines (`poolLine`). Like the entity lane, rare hits feed
+  // neither the gate nor the edge seeds.
   if (deps.rareTerm) {
     for (const hit of rareTermLane(
       deps.needle,


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for memory-v3-section-injection.md.

**Gap:** the rare-term lane runs last, so a page already carrying three bulk-theme finder lines dropped its rare line at the per-page cap.
**Fix:** the per-page cap is lane-aware; a rare-term line is never displaced (see the poolLine doc for the bound).