### PR TITLE
fix(memory-v3): honor pre-upgrade card tombstones when rehydrating legacy blocks

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -677,14 +677,11 @@ describe("loadFromDb metadata injection rehydration", () => {
     ]);
   });
 
-  test("the same block persisted without the format stamp is a legacy block: rehydrated verbatim with every slug it holds tombstoned, where a current block leaves", async () => {
+  test("the same block persisted without the format stamp is a legacy card block: the card whose lead was tombstoned before the upgrade leaves and the other rehydrates byte-identical", async () => {
     mockConversation = defaultConv();
     const leadA = "# memory/concepts/page-a.md\nlead a";
     const leadB = "# memory/concepts/page-b.md\nlead b";
-    mockPrunedSections = new Map([
-      ["page-a", new Set([""])],
-      ["page-b", new Set([""])],
-    ]);
+    mockPrunedSections = new Map([["page-b", new Set([""])]]);
     mockDbMessages = [
       {
         id: "m1",
@@ -699,8 +696,38 @@ describe("loadFromDb metadata injection rehydration", () => {
         role: "assistant",
         content: [{ type: "text", text: "Reply" }],
       },
-      // page-a's lead re-injected later under the current format: pruned
-      // like any current section, and a block left with nothing is skipped.
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    expect(conversation.getMessages()[0].content).toEqual([
+      { type: "text", text: `<memory>\nheader line\n\n${leadA}\n</memory>` },
+      { type: "text", text: "First turn" },
+    ]);
+  });
+
+  test("a legacy card whose lead a later row re-injected under the current format is superseded by that copy; a card with no such copy stays", async () => {
+    mockConversation = defaultConv();
+    const leadA = "# memory/concepts/page-a.md\nlead a";
+    const leadB = "# memory/concepts/page-b.md\nlead b";
+    // page-a was pruned before the upgrade and re-selected after it: the
+    // re-injection cleared its tombstone, so neither lead is pruned now.
+    mockPrunedSections = new Map();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "First turn" }],
+        metadata: JSON.stringify({
+          memoryV3InjectedBlock: `header line\n\n${leadA}\n\n${leadB}`,
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: [{ type: "text", text: "Reply" }],
+      },
       {
         id: "m3",
         role: "user",
@@ -717,13 +744,11 @@ describe("loadFromDb metadata injection rehydration", () => {
 
     const messages = conversation.getMessages();
     expect(messages[0].content).toEqual([
-      {
-        type: "text",
-        text: `<memory>\nheader line\n\n${leadA}\n\n${leadB}\n</memory>`,
-      },
+      { type: "text", text: `<memory>\nheader line\n\n${leadB}\n</memory>` },
       { type: "text", text: "First turn" },
     ]);
     expect(messages[2].content).toEqual([
+      { type: "text", text: `<memory>\nheader line\n\n${leadA}\n</memory>` },
       { type: "text", text: "Second turn" },
     ]);
   });

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1466,7 +1466,7 @@ export class Conversation {
             // The block's rendering format is the row's own provenance (the
             // persisting build's stamp, absent on pre-stamp rows), never
             // read off the block's content: a current block is filtered by
-            // section, a legacy block is opaque and rehydrates verbatim.
+            // section, a legacy block by card under each card's lead ref.
             const v3Format = v3BlockFormatOf(meta);
             const v3Resident = filterResidentSections(
               unwrapMemoryBlock(v3Block),

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -159,17 +159,25 @@ carrying the block without the stamp is legacy (exactly the pre-stamp rows;
 fork copies carry the stamp with the metadata), `persistedV3Block` reads both
 for rehydration and the fork seeder, and the identity registry records the
 format of every block in live history (the injector's own blocks are current;
-a spliced block keeps its row's). A legacy block is opaque: rehydrated
-verbatim, never parsed for sections, never pruned or stripped by the valve,
-never indexed by the newest-copy pass, and never fork-seeded (a later
-re-selection of a section it holds injects that section afresh beside it);
-its `memory_v3_ever_injected` rows are copied into the section store at zero
-bytes, once per database (`memory_v3_injected_sections:legacy_copy_done` in
+a spliced block keeps its row's). A legacy block is read with the card
+grammar of the build that rendered it (`filterLegacyCards` in
+`substrate/injected-block-slugs.ts`: one compact card per page header,
+bodies unescaped), at rehydration and in the live strip, each card under its
+lead ref `(slug, "")`: a card whose lead is tombstoned leaves, so a prune
+that predates the upgrade holds across restarts, and a card whose lead a
+current-format block re-injected after such a prune (clearing the tombstone)
+is superseded by that copy; a block with nothing to drop rehydrates byte for
+byte. A legacy block is never re-pruned: its `memory_v3_ever_injected` rows,
+`pruned_at` included, are copied into the section store at zero bytes, once
+per database (`memory_v3_injected_sections:legacy_copy_done` in
 `memory_checkpoints`), dedup-only like capability rows, so nothing in it is
-ever planned or counted, and it ages out at compaction, which strips memory
-blocks and clears the store, the conversation's legacy rows included
-(`clearConversation`, as the conversation purge does), so no later copy
-re-imports leads whose blocks are gone. A page's lead injection carries its
+ever planned or counted. It is never indexed by the newest-copy pass (its
+cards retire no current copy) and never fork-seeded (a truncated fork
+re-injects a section it holds afresh, superseding the card), and it ages out
+at compaction, which strips memory blocks and clears the store, the
+conversation's legacy rows included (`clearConversation`, as the
+conversation purge does), so no later copy re-imports leads whose blocks
+are gone. A page's lead injection carries its
 `[current: …]` annotation under the header, as the selector card does. The valve strips a pruned section
 by exactly its header span, in live history and at rehydration, drops the
 section's line from any `<memory_pointer>` that named it (a pointer left empty

--- a/assistant/src/plugins/defaults/memory/fork-conversation-memory.ts
+++ b/assistant/src/plugins/defaults/memory/fork-conversation-memory.ts
@@ -110,7 +110,7 @@ export function forkConversationMemory(
       }
       // Each inherited block carries the format its row's metadata records
       // (the copied metadata keeps the persisting build's stamp): the seeder
-      // scans the current ones and skips the legacy ones, which are opaque.
+      // scans the current ones and skips the legacy ones, which seed nothing.
       const v3Block = persistedV3Block(message.metadata);
       if (v3Block) {
         inheritedV3Blocks.push(v3Block);

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/injected-block-slugs.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/injected-block-slugs.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, test } from "bun:test";
 import {
   escapeInjectedBody,
   extractInjectedConceptSlugs,
+  filterLegacyCards,
   injectedConceptHeader,
   injectedSectionHeader,
   injectedSectionPath,
   parseInjectedSectionPath,
   parseInjectedSections,
+  parseLegacyCards,
   readInjectedBlock,
   unescapeInjectedBody,
 } from "../injected-block-slugs.js";
@@ -296,6 +298,106 @@ describe("escapeInjectedBody / unescapeInjectedBody", () => {
     ]);
     expect(parsed.pieces).toHaveLength(1);
     expect(extractInjectedConceptSlugs(entry)).toEqual(["topics/page-a"]);
+  });
+});
+
+describe("parseLegacyCards / filterLegacyCards", () => {
+  const PREAMBLE = "Memory cards. Read a page with file_read.";
+  const CAPABILITY_CHUNK =
+    "# Skill: meet-join\nJoin a video meeting on request.";
+  /** A card as the pre-stamp builds rendered one: page header, the page's
+   *  own `# Title` line, head, one-line TOC. */
+  const card = (slug: string): string =>
+    `${injectedConceptHeader(slug)}\n# ${slug}\nhead of ${slug}\n\n[sections: §One · §Two]`;
+  const block = (...chunks: string[]): string =>
+    [PREAMBLE, ...chunks].join("\n\n");
+  const inner = block(card("page-a"), card("page-b"), card("page-c"));
+  const is = (slugs: string[]) => (slug: string) => slugs.includes(slug);
+
+  test("parses the preamble and one card piece per page header; a card head's own # Title line stays inside it", () => {
+    const parsed = parseLegacyCards(inner);
+    expect(parsed.preamble).toBe(PREAMBLE);
+    expect(parsed.pieces).toEqual([
+      { kind: "card", slug: "page-a", text: card("page-a") },
+      { kind: "card", slug: "page-b", text: card("page-b") },
+      { kind: "card", slug: "page-c", text: card("page-c") },
+    ]);
+  });
+
+  test("a page header opens a card wherever it sits: bodies were not escaped", () => {
+    const head = `${injectedConceptHeader("page-a")}\nlead\n${injectedConceptHeader("quoted")}\nquoted line`;
+    expect(parseLegacyCards(block(head)).pieces).toEqual([
+      {
+        kind: "card",
+        slug: "page-a",
+        text: `${injectedConceptHeader("page-a")}\nlead`,
+      },
+      {
+        kind: "card",
+        slug: "quoted",
+        text: `${injectedConceptHeader("quoted")}\nquoted line`,
+      },
+    ]);
+    // The current grammar receives the same line escaped by the renderer
+    // (the body under the header) and keeps it inside the section.
+    const body = `lead\n${injectedConceptHeader("quoted")}\nquoted line`;
+    expect(
+      parseInjectedSections(
+        block(
+          `${injectedConceptHeader("page-a")}\n${escapeInjectedBody(body)}`,
+        ),
+      ).sections.map(refOf),
+    ).toEqual([{ slug: "page-a", key: "" }]);
+  });
+
+  test("a foreign top-level header on a seam ends the card and is its own piece; off a seam it stays inside", () => {
+    const parsed = parseLegacyCards(
+      block(card("page-a"), CAPABILITY_CHUNK, card("page-b")),
+    );
+    expect(parsed.pieces).toEqual([
+      { kind: "card", slug: "page-a", text: card("page-a") },
+      { kind: "other", text: CAPABILITY_CHUNK },
+      { kind: "card", slug: "page-b", text: card("page-b") },
+    ]);
+    const inline = `${injectedConceptHeader("page-a")}\n# Skill: not-a-chunk\nstill the head`;
+    expect(parseLegacyCards(block(inline)).pieces).toEqual([
+      { kind: "card", slug: "page-a", text: inline },
+    ]);
+  });
+
+  test("text with no page header is all preamble and passes the filter unchanged", () => {
+    const plain = "remember: user prefers tea";
+    expect(parseLegacyCards(plain)).toEqual({ preamble: plain, pieces: [] });
+    expect(filterLegacyCards(plain, () => true)).toBe(plain);
+  });
+
+  test("nothing dropped: the same reference; every card dropped: empty", () => {
+    expect(filterLegacyCards(inner, () => false)).toBe(inner);
+    expect(filterLegacyCards(inner, is(["page-z"]))).toBe(inner);
+    expect(filterLegacyCards(inner, () => true)).toBe("");
+  });
+
+  test("a dropped card leaves the remainder byte-identical to a fresh render", () => {
+    expect(filterLegacyCards(inner, is(["page-b"]))).toBe(
+      block(card("page-a"), card("page-c")),
+    );
+    expect(filterLegacyCards(inner, is(["page-a", "page-c"]))).toBe(
+      block(card("page-b")),
+    );
+  });
+
+  test("dropping a card never swallows a capability chunk, and a block left with only capability content keeps it", () => {
+    const mixed = block(card("page-a"), CAPABILITY_CHUNK, card("page-b"));
+    expect(filterLegacyCards(mixed, is(["page-a"]))).toBe(
+      block(CAPABILITY_CHUNK, card("page-b")),
+    );
+    const trailing = block(card("page-a"), CAPABILITY_CHUNK);
+    expect(filterLegacyCards(trailing, is(["page-a"]))).toBe(
+      block(CAPABILITY_CHUNK),
+    );
+    expect(filterLegacyCards(trailing, () => true)).toBe(
+      block(CAPABILITY_CHUNK),
+    );
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/substrate/injected-block-slugs.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/injected-block-slugs.ts
@@ -21,9 +21,11 @@
  *
  * The parser reads this escaped grammar only. A v3 block persisted without
  * the format stamp (`memoryV3InjectedBlockFormat`; `InjectedBlockFormat` in
- * `plugins/defaults/memory/v3/types.ts`) was rendered by a build before body
- * escaping and is opaque to every reader: rehydrated verbatim and never
- * handed to the parser.
+ * `plugins/defaults/memory/v3/types.ts`) was rendered as compact cards by a
+ * build before body escaping and is never handed to the parser: the legacy
+ * card grammar below ({@link parseLegacyCards}, {@link filterLegacyCards})
+ * reads it exactly as that build did, so a card pruned before the upgrade
+ * is filtered out of it at rehydration and in the live strip.
  *
  * Skill and CLI-command chunks carry no recoverable slug, so the slug
  * extractor intentionally skips them.
@@ -239,9 +241,63 @@ type BoundaryRef =
   | { kind: "capability"; capability: "skill" | "cli-command"; id: string }
   | { kind: "other" };
 
-interface Boundary {
+/** A chunk boundary: the offset of the header line that opens a piece, with
+ *  the piece's classification. */
+interface Boundary<Ref> {
   index: number;
-  ref: BoundaryRef;
+  ref: Ref;
+}
+
+/**
+ * Cut `inner` at `boundaries` (sorted in place) into the preamble before the
+ * first one and one piece per boundary: its `ref` plus the text from its
+ * header up to the next boundary, `trimEnd()`ed so re-joining pieces with
+ * `\n\n` reproduces the renderer's exact bytes. With no boundary the whole
+ * text is the preamble.
+ */
+function cutAtBoundaries<Ref extends object>(
+  inner: string,
+  boundaries: Array<Boundary<Ref>>,
+): { preamble: string; pieces: Array<Ref & { text: string }> } {
+  if (boundaries.length === 0) {
+    return { preamble: inner, pieces: [] };
+  }
+  boundaries.sort((a, b) => a.index - b.index);
+  const preamble = inner.slice(0, boundaries[0]!.index).trimEnd();
+  const pieces = boundaries.map((boundary, i) => {
+    const end =
+      i + 1 < boundaries.length ? boundaries[i + 1]!.index : undefined;
+    return {
+      ...boundary.ref,
+      text: inner.slice(boundary.index, end).trimEnd(),
+    };
+  });
+  return { preamble, pieces };
+}
+
+/**
+ * Re-join the pieces kept from a parsed block behind its preamble on the
+ * renderer's `\n\n` seams, byte-identical to a fresh render of those chunks.
+ * Returns `inner` UNCHANGED (same reference) when every piece is kept, so a
+ * caller detects a no-op by identity, and `""` when none is (a bare preamble
+ * carries no content; the caller drops the block).
+ */
+export function rejoinKeptPieces(
+  inner: string,
+  parsed: { preamble: string; pieces: ReadonlyArray<{ text: string }> },
+  kept: ReadonlyArray<{ text: string }>,
+): string {
+  if (kept.length === parsed.pieces.length) {
+    return inner;
+  }
+  if (kept.length === 0) {
+    return "";
+  }
+  const texts = kept.map((piece) => piece.text);
+  if (parsed.preamble.length > 0) {
+    texts.unshift(parsed.preamble);
+  }
+  return texts.join("\n\n");
 }
 
 /** Whether a header match at `index` opens its own `\n\n`-joined chunk: it
@@ -297,14 +353,14 @@ function classifyNonSectionHeader(line: string): BoundaryRef {
  *
  * Only a block rendered under this grammar is handed to the parser (a
  * persisted block carrying the format stamp, or one rendered in-process); a
- * pre-stamp block is opaque, see the module doc.
+ * pre-stamp block is read by {@link parseLegacyCards}.
  */
 export function parseInjectedSections(inner: string): {
   preamble: string;
   sections: ParsedInjectedSection[];
   pieces: InjectionBlockPiece[];
 } {
-  const boundaries: Boundary[] = [];
+  const boundaries: Array<Boundary<BoundaryRef>> = [];
   for (const match of inner.matchAll(INJECTED_CONCEPT_HEADER_REGEX)) {
     if (onChunkSeam(inner, match.index!)) {
       boundaries.push({
@@ -323,23 +379,89 @@ export function parseInjectedSections(inner: string): {
       });
     }
   }
-  boundaries.sort((a, b) => a.index - b.index);
-  if (boundaries.length === 0) {
-    return { preamble: inner, sections: [], pieces: [] };
-  }
-
-  const preamble = inner.slice(0, boundaries[0]!.index).trimEnd();
-  const pieces = boundaries.map((boundary, i): InjectionBlockPiece => {
-    const end =
-      i + 1 < boundaries.length ? boundaries[i + 1]!.index : undefined;
-    const text = inner.slice(boundary.index, end).trimEnd();
-    return { ...boundary.ref, text };
-  });
+  const { preamble, pieces } = cutAtBoundaries(inner, boundaries);
   const sections = pieces.filter(
     (piece): piece is Extract<InjectionBlockPiece, { kind: "section" }> =>
       piece.kind === "section",
   );
   return { preamble, sections, pieces };
+}
+
+// ─── legacy card grammar ─────────────────────────────────────────────────────
+
+/**
+ * Header line of a legacy card: the bare page header, one compact card per
+ * page, as the builds before the format stamp rendered a block. Greedy in
+ * the slug (no section key existed to bleed into it). Flagged `gm` for
+ * `matchAll` like {@link INJECTED_CONCEPT_HEADER_REGEX}: never `exec`/`test`
+ * it.
+ */
+const LEGACY_CARD_HEADER_REGEX = /^# memory\/concepts\/(.+)\.md$/gm;
+
+/** Any top-level `# ` line: a card header or a foreign one (a capability
+ *  chunk's `# Skill:` / `# CLI command:` line, the `# Skills` hint). */
+const TOP_LEVEL_HEADER_REGEX = /^# /gm;
+
+type LegacyCardRef = { kind: "card"; slug: string } | { kind: "other" };
+
+/** One ordered chunk of a parsed legacy card block: a page's card (owned by
+ *  `slug`) or any other `\n\n`-joined chunk (capability content under its
+ *  own header, the skills hint; never dropped). */
+export type LegacyCardPiece = LegacyCardRef & { text: string };
+
+/**
+ * Split an UNWRAPPED legacy card block (a `memoryV3InjectedBlock` persisted
+ * without the format stamp) into its preamble and ordered chunk pieces,
+ * under the grammar the build that rendered it read: a card opens at every
+ * page header wherever it sits (bodies were not escaped, so a page line
+ * shaped like one splits here exactly as it did for that build's valve) and
+ * ends at the next page header or at any other top-level `# ` line on a
+ * `\n\n` seam, so a capability chunk trailing a card is its own piece and
+ * dropping the card never deletes it. The seam requirement keeps a card
+ * head's own `# Title` line, which follows the path header with a single
+ * `\n`, inside the card. With no page header the whole text is the
+ * preamble.
+ */
+export function parseLegacyCards(inner: string): {
+  preamble: string;
+  pieces: LegacyCardPiece[];
+} {
+  const boundaries: Array<Boundary<LegacyCardRef>> = [];
+  const cardStarts = new Set<number>();
+  for (const match of inner.matchAll(LEGACY_CARD_HEADER_REGEX)) {
+    cardStarts.add(match.index!);
+    boundaries.push({
+      index: match.index!,
+      ref: { kind: "card", slug: match[1]! },
+    });
+  }
+  if (boundaries.length === 0) {
+    return { preamble: inner, pieces: [] };
+  }
+  for (const match of inner.matchAll(TOP_LEVEL_HEADER_REGEX)) {
+    if (!cardStarts.has(match.index!) && onChunkSeam(inner, match.index!)) {
+      boundaries.push({ index: match.index!, ref: { kind: "other" } });
+    }
+  }
+  return cutAtBoundaries(inner, boundaries);
+}
+
+/**
+ * Remove from an unwrapped legacy card block every card whose page slug
+ * `drop` names; non-card chunks are always kept. Same contract as
+ * {@link rejoinKeptPieces}: the input UNCHANGED (same reference) when
+ * nothing is removed, `""` when every chunk is, and a remainder
+ * byte-identical to a fresh render of the kept chunks.
+ */
+export function filterLegacyCards(
+  inner: string,
+  drop: (slug: string) => boolean,
+): string {
+  const parsed = parseLegacyCards(inner);
+  const kept = parsed.pieces.filter(
+    (piece) => piece.kind !== "card" || !drop(piece.slug),
+  );
+  return rejoinKeptPieces(inner, parsed, kept);
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.test.ts
@@ -601,7 +601,7 @@ describe("seedEverInjectedFromBlocks", () => {
     expect(residentBytes("conv-child")).toBe(renderedBytes(leadA));
   });
 
-  test("a legacy block (a pre-stamp row's) is opaque and seeds nothing; the current blocks beside it seed as usual", () => {
+  test("a legacy block (a pre-stamp row's) seeds nothing; the current blocks beside it seed as usual", () => {
     const card = [
       injectedSectionHeader("topics/page-a", ""),
       "# Page A",

--- a/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/ever-injected-store.ts
@@ -106,8 +106,8 @@ export const MEMORY_V3_INJECTED_BLOCK_METADATA_KEY = "memoryV3InjectedBlock";
  * Message-metadata key the persisting build stamps beside
  * `MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`: the block's rendering format
  * ({@link MEMORY_V3_INJECTED_BLOCK_FORMAT}). A row carrying the section block
- * without it was persisted before the stamp existed and holds a legacy
- * block, opaque to every reader (`InjectedBlockFormat` in `./types.ts`).
+ * without it was persisted before the stamp existed and holds a legacy card
+ * block (`InjectedBlockFormat` in `./types.ts`).
  */
 export const MEMORY_V3_INJECTED_BLOCK_FORMAT_METADATA_KEY =
   "memoryV3InjectedBlockFormat";
@@ -590,9 +590,10 @@ export function forkEverInjected(
  * live view at fork time; re-selection clears the tombstone and re-injects,
  * same as in the parent.
  *
- * A legacy-format block (a pre-stamp row's) is opaque and seeds nothing: the
- * child rehydrates it verbatim, and a later selection of a section it holds
- * injects that section afresh beside it, accepted for the one-time window
+ * A legacy-format block (a pre-stamp row's) seeds nothing: the child
+ * rehydrates it with no tombstone of its own for the cards it holds, and a
+ * later selection of a section it holds injects that section afresh, which
+ * supersedes the card at the next strip; accepted for the one-time window
  * such rows live in (they leave with the child's first compaction).
  *
  * No-op when the child inherited no current-format blocks. The rows live on

--- a/assistant/src/plugins/defaults/memory/v3/plugin-schema.ts
+++ b/assistant/src/plugins/defaults/memory/v3/plugin-schema.ts
@@ -149,10 +149,12 @@ function legacyCardsTableExists(memoryRaw: MemorySqlite): boolean {
  * its `injected_at` and `pruned_at`, so in-flight conversations keep their
  * dedup state across the cutover (a frozen card in history is the page's
  * lead plus a TOC, and the lead is what a re-selection of that page without
- * a matched section would inject again). Zero bytes because the card's
- * block is opaque to the section readers (rehydrated verbatim, never parsed
- * or stripped): like a capability row, the entry is dedup-only, never a
- * prune candidate, and never counted in the resident footprint.
+ * a matched section would inject again). Zero bytes because a legacy block
+ * is never re-pruned (its cards leave only under the `pruned_at` carried
+ * here, or when a current block re-injects a lead; `filterLegacyCards` in
+ * `substrate/injected-block-slugs.ts`): like a capability row, the entry is
+ * dedup-only, never a prune candidate, and never counted in the resident
+ * footprint.
  *
  * The copy runs once per database. The first ensure that finds the legacy
  * table copies its rows and records {@link SECTIONS_LEGACY_COPY_DONE_KEY} in

--- a/assistant/src/plugins/defaults/memory/v3/prune.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.test.ts
@@ -5,8 +5,10 @@
  *     byte-identical remainders, all-pruned → `""`, no-op → same reference,
  *     non-section chunks (`# Skills`, `# Skill:` / `# CLI command:` headers)
  *     terminating a section and surviving its prune, arbitrary `# ` lines
- *     inside a section body staying inside it, and a body line that would
- *     read as a header arriving escaped from the renderer;
+ *     inside a section body staying inside it, a body line that would
+ *     read as a header arriving escaped from the renderer, and a legacy
+ *     (pre-stamp) block filtered by card under each card's lead ref, never
+ *     indexed;
  *   - `filterResidentPointerEntries`: a pruned section's line, or one whose
  *     section was re-injected further down, leaves the `<memory_pointer>`
  *     block; an emptied pointer collapses to `""`;
@@ -135,7 +137,7 @@ const {
   seedEverInjectedFromBlocks,
   touchSelected,
 } = await import("./ever-injected-store.js");
-const { markV3LiveBlock } = await import("./types.js");
+const { markV3LiveBlock, v3LiveBlockFormat } = await import("./types.js");
 const { V3_INJECTION_HEADER, renderInjectionBlockInner, renderPointerInner } =
   await import("./render-injection.js");
 const { renderV3SectionInjection } = await import("./page-content.js");
@@ -151,6 +153,12 @@ function lead(slug: string): string {
 /** A heading-section entry: `§ key` header plus body. */
 function section(slug: string, key: string): string {
   return `${injectedSectionHeader(slug, key)}\nbody of ${slug} ${key}`;
+}
+
+/** A card exactly as the pre-stamp builds' card renderer shaped one: page
+ *  header, the page's own `# Title` line, head, one-line section TOC. */
+function legacyCard(slug: string): string {
+  return `${injectedSectionHeader(slug, "")}\n# ${slug}\nhead of ${slug}\n\n[sections: §One · §Two]`;
 }
 
 /** A capability chunk exactly as `renderCapabilityContent` shapes it: its own
@@ -173,7 +181,7 @@ function refSet(
 }
 
 /** A persisted block with its row's provenance: current (this build's
- *  render, stamped) or legacy (a pre-stamp row, opaque). */
+ *  render, stamped) or legacy (a pre-stamp row, read by card). */
 const current = (inner: string): InjectedBlock => ({
   inner,
   format: "current",
@@ -420,7 +428,61 @@ describe("parseInjectedSections / filterPrunedSections", () => {
     );
   });
 
-  test("a legacy block (a pre-stamp row's) is opaque: the filter returns it as is whatever the tombstones name, and the newest-copy index skips it", () => {
+  test("a legacy block (a pre-stamp row's) is filtered by card under each lead ref: a tombstoned card leaves, the rest stays byte-identical, and the block is never indexed", () => {
+    const cardA = legacyCard("page-a");
+    const cardB = legacyCard("page-b");
+    const legacyInner = [V3_INJECTION_HEADER, cardA, cardB].join("\n\n");
+
+    // Nothing it holds tombstoned: the same reference back. A heading
+    // section's tombstone names no card.
+    expect(filterPrunedSections(legacyInner, "legacy", refSet())).toBe(
+      legacyInner,
+    );
+    expect(
+      filterPrunedSections(legacyInner, "legacy", refSet(["page-a", "One"])),
+    ).toBe(legacyInner);
+    // page-b's lead tombstoned before the upgrade: its card leaves and
+    // page-a's rehydrates byte for byte.
+    expect(
+      filterPrunedSections(legacyInner, "legacy", refSet(["page-b", ""])),
+    ).toBe([V3_INJECTION_HEADER, cardA].join("\n\n"));
+    // Every card tombstoned: nothing left, the caller drops the block.
+    expect(
+      filterPrunedSections(
+        legacyInner,
+        "legacy",
+        refSet(["page-a", ""], ["page-b", ""]),
+      ),
+    ).toBe("");
+
+    // page-a's lead re-injected by a current block after that prune (which
+    // cleared its tombstone): the current copy supersedes the card. The
+    // legacy block contributes nothing to the index, so a legacy copy
+    // sitting after a current one never retires it.
+    const reinjected = renderInjectionBlockInner([lead("page-a")]);
+    const newest = newestCopyIndexes([
+      legacy(legacyInner),
+      current(reinjected),
+    ]);
+    expect(newest.size).toBe(1);
+    expect(
+      filterResidentSections(legacyInner, "legacy", 0, refSet(), newest),
+    ).toBe([V3_INJECTION_HEADER, cardB].join("\n\n"));
+    expect(
+      filterResidentSections(reinjected, "current", 1, refSet(), newest),
+    ).toBe(reinjected);
+    expect(
+      filterResidentSections(
+        reinjected,
+        "current",
+        0,
+        refSet(),
+        newestCopyIndexes([current(reinjected), legacy(legacyInner)]),
+      ),
+    ).toBe(reinjected);
+  });
+
+  test("a legacy block is read with its build's card grammar: an unescaped head line shaped like a page header opens a card, as it did for that build's valve", () => {
     const cardA = [
       injectedSectionHeader("page-a", ""),
       "# Page A",
@@ -434,43 +496,24 @@ describe("parseInjectedSections / filterPrunedSections", () => {
     const legacyInner = [V3_INJECTION_HEADER, cardA, lead("page-b")].join(
       "\n\n",
     );
-    // The same reference back, every slug it holds tombstoned or not.
+    const forgedCard =
+      "# memory/concepts/example.md\nmore lead prose\n\n[sections: §Notes · §Design]";
     expect(
-      filterPrunedSections(
-        legacyInner,
-        "legacy",
-        refSet(["page-a", ""], ["page-b", ""], ["example", ""]),
-      ),
-    ).toBe(legacyInner);
+      filterPrunedSections(legacyInner, "legacy", refSet(["page-a", ""])),
+    ).toBe([V3_INJECTION_HEADER, forgedCard, lead("page-b")].join("\n\n"));
+    expect(
+      filterPrunedSections(legacyInner, "legacy", refSet(["example", ""])),
+    ).toBe(
+      [
+        V3_INJECTION_HEADER,
+        cardA.slice(0, cardA.indexOf(forgedCard)).trimEnd(),
+        lead("page-b"),
+      ].join("\n\n"),
+    );
     // The same bytes under the current format are filtered by section.
     expect(
       filterPrunedSections(legacyInner, "current", refSet(["page-b", ""])),
     ).toBe([V3_INJECTION_HEADER, cardA].join("\n\n"));
-
-    // A later current copy of page-a's lead retires nothing in the legacy
-    // block, and the legacy block contributes nothing to the index: a legacy
-    // copy sitting after a current one never retires it either.
-    const reinjected = renderInjectionBlockInner([lead("page-a")]);
-    const newest = newestCopyIndexes([
-      legacy(legacyInner),
-      current(reinjected),
-    ]);
-    expect(newest.size).toBe(1);
-    expect(
-      filterResidentSections(legacyInner, "legacy", 0, refSet(), newest),
-    ).toBe(legacyInner);
-    expect(
-      filterResidentSections(reinjected, "current", 1, refSet(), newest),
-    ).toBe(reinjected);
-    expect(
-      filterResidentSections(
-        reinjected,
-        "current",
-        0,
-        refSet(),
-        newestCopyIndexes([current(reinjected), legacy(legacyInner)]),
-      ),
-    ).toBe(reinjected);
   });
 
   test("all sections pruned keeps the preamble + capability chunks", () => {
@@ -1265,21 +1308,24 @@ describe("runPruneValve", () => {
     expect(await runPruneValve("conv-1")).toBeNull();
   });
 
-  test("the valve never strips a legacy block: it stays the same object while a current block beside it is stripped, and rehydration agrees", async () => {
-    const card = [
-      injectedSectionHeader("stub", ""),
-      "# Stub",
-      "just a lead, no sections",
-      "",
-      "[sections: §One]",
-    ].join("\n");
-    const legacyInner = [V3_INJECTION_HEADER, card].join("\n\n");
+  test("the valve never plans a legacy card; the live strip drops a card tombstoned before the upgrade from a legacy block, re-marked legacy, and rehydration agrees", async () => {
+    const stubCard = legacyCard("stub");
+    const keptCard = legacyCard("kept");
+    const legacyInner = [V3_INJECTION_HEADER, stubCard, keptCard].join("\n\n");
     const currentInner = renderInjectionBlockInner([lead("page-a")]);
     insertUserRowWithV3Block("conv-1", "m1", legacyInner, "legacy");
     insertUserRowWithV3Block("conv-1", "m2", currentInner);
-    // The card's row is dedup-only (zero bytes, as the schema ensure copies
-    // it in) and already tombstoned; the current lead carries its bytes.
-    recordInjected("conv-1", [{ slug: "stub", key: "", bytes: 0 }], 1_000);
+    // The cards' rows are dedup-only (zero bytes, as the schema ensure copies
+    // them in), stub's tombstoned before the upgrade; the current lead
+    // carries its bytes.
+    recordInjected(
+      "conv-1",
+      [
+        { slug: "stub", key: "", bytes: 0 },
+        { slug: "kept", key: "", bytes: 0 },
+      ],
+      1_000,
+    );
     markPruned("conv-1", [{ slug: "stub", key: "" }], 1_500);
     recordInjected("conv-1", [{ slug: "page-a", key: "", bytes: 300 }], 2_000);
 
@@ -1308,15 +1354,22 @@ describe("runPruneValve", () => {
       sections: [{ slug: "page-a", key: "" }],
       bytesFreed: 300,
     });
-    expect(liveMessages[0]!.content[0]).toBe(legacyBlock);
+    // The legacy block lost stub's card, kept the other byte for byte, and
+    // is owned in its place under its own format for the next strip.
+    const remainder = [V3_INJECTION_HEADER, keptCard].join("\n\n");
+    const stripped = liveMessages[0]!.content[0]!;
+    expect(stripped).not.toBe(legacyBlock);
+    expect(stripped).toEqual({
+      type: "text",
+      text: wrapMemoryBlock(remainder),
+    });
+    expect(v3LiveBlockFormat(stripped)).toBe("legacy");
     expect(liveMessages[2]!.content).toEqual([
       { type: "text", text: "turn 2" },
     ]);
     const pruned = getPrunedSections("conv-1");
     expect(pruned).toEqual(refSet(["stub", ""], ["page-a", ""]));
-    expect(filterPrunedSections(legacyInner, "legacy", pruned)).toBe(
-      legacyInner,
-    );
+    expect(filterPrunedSections(legacyInner, "legacy", pruned)).toBe(remainder);
     expect(filterPrunedSections(currentInner, "current", pruned)).toBe("");
   });
 

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -78,12 +78,18 @@
  * next turn persists the capability anew) is superseded like a section's.
  *
  * Legacy-format note: a v3 block persisted without the format stamp
- * (`InjectedBlockFormat` in `types.ts`) is opaque at both filter points and
- * in the newest-copy index: rehydrated verbatim, never parsed, stripped, or
- * superseded, and never retiring a later current copy of a section it holds.
- * The section store carries its slugs at zero bytes (`plugin-schema.ts`), so
- * nothing in it is ever planned, and it leaves with the compaction that
- * strips memory blocks and clears the store.
+ * (`InjectedBlockFormat` in `types.ts`) was rendered as compact cards by a
+ * build before body escaping, and both filter points read it with that
+ * build's card grammar (`filterLegacyCards` in
+ * `substrate/injected-block-slugs.ts`), each card under its lead ref
+ * `(slug, "")`: a card whose lead is tombstoned leaves, so a prune that
+ * predates the upgrade holds across restarts, and one whose lead a
+ * current-format block re-injected after such a prune (clearing the
+ * tombstone) is superseded by that copy. The block is never indexed by
+ * {@link newestCopyIndexes} (its cards retire no current copy), the section
+ * store carries its slugs at zero bytes (`plugin-schema.ts`) so nothing in
+ * it is ever planned, and it leaves with the compaction that strips memory
+ * blocks and clears the store.
  *
  * Accounting-drift note: a section whose recorded bytes have no locatable
  * persisted text (e.g. its metadata row was lost) can be planned and
@@ -106,10 +112,12 @@ import {
 } from "../memory-marker.js";
 import { capabilitySlugOf } from "../substrate/capability-slugs.js";
 import {
+  filterLegacyCards,
   type InjectionBlockPiece,
   parseInjectedSectionPath,
   parseInjectedSections,
   readInjectedMetadata,
+  rejoinKeptPieces,
 } from "../substrate/injected-block-slugs.js";
 import {
   getActiveEntries,
@@ -134,8 +142,9 @@ const log = getLogger("memory-v3-shadow");
 // ─── pruned-section filtering ────────────────────────────────────────────────
 
 /**
- * Remove pruned sections from an unwrapped block body of the given format; a
- * legacy-format block is opaque and comes back unchanged.
+ * Remove pruned sections from an unwrapped block body of the given format: a
+ * current-format block by section, a legacy-format block by card under each
+ * card's lead ref (see {@link filterSections}).
  *
  * Returns the input string UNCHANGED (same reference) when nothing is
  * removed (callers use identity to detect a no-op) and `""` when every
@@ -212,9 +221,9 @@ export function persistedV3Block(
  * re-entry rendered in memory gets a persisted copy again when a later turn
  * selects it against the reset store; the live conversation holds only the
  * newest, so rehydration and the live strip keep exactly that copy and treat
- * every earlier one as superseded. A legacy-format block is opaque and is
- * not indexed: its copies neither retire a later current copy nor are
- * retired by one.
+ * every earlier one as superseded. A legacy-format block is not indexed:
+ * its cards retire no current copy, while a current copy of a card's lead
+ * does retire the card (see {@link filterSections}).
  */
 export function newestCopyIndexes(
   blocks: ReadonlyArray<InjectedBlock | null>,
@@ -237,7 +246,8 @@ export function newestCopyIndexes(
 /**
  * Remove from block `index` of that sequence every section that is pruned or
  * whose newest copy lives on a later block (`newest` from
- * {@link newestCopyIndexes}). Same contract as {@link filterPrunedSections}.
+ * {@link newestCopyIndexes}); a legacy block's cards are tested under their
+ * lead refs. Same contract as {@link filterPrunedSections}.
  */
 export function filterResidentSections(
   inner: string,
@@ -255,43 +265,36 @@ export function filterResidentSections(
   );
 }
 
-/** The shared filter: a legacy-format block is opaque and returned as is; a
- *  current one loses the chunks `drop` names. */
+/**
+ * The shared filter: a current-format block loses the chunks `drop` names;
+ * a legacy-format block, read with the card grammar of the build that
+ * rendered it, loses every card `drop` names under the card's lead ref
+ * `(slug, "")`, the identity the section store carries it by. A legacy
+ * block is never indexed by {@link newestCopyIndexes}, so for its cards the
+ * newest-copy test a caller folds into `drop` reads as: a current-format
+ * block holds a copy of this lead, which means the card was pruned before
+ * the upgrade and its lead re-selected after it.
+ */
 function filterSections(
   inner: string,
   format: InjectedBlockFormat,
   drop: (slug: string, key: string) => boolean,
 ): string {
   if (format === "legacy") {
-    return inner;
+    return filterLegacyCards(inner, (slug) => drop(slug, ""));
   }
-  const { preamble, pieces } = parseInjectedSections(inner);
-  if (pieces.length === 0) {
-    return inner;
-  }
-
-  const survivors = pieces.filter((piece) => {
+  const parsed = parseInjectedSections(inner);
+  const survivors = parsed.pieces.filter((piece) => {
     const identity = pieceIdentity(piece);
     return identity === null || !drop(identity.slug, identity.key);
   });
   // The renderer adds the skills hint chunk only beside skill chunks, so a
   // block that loses its last one loses the hint with it.
   const kept =
-    pieces.some(isSkillChunk) && !survivors.some(isSkillChunk)
+    parsed.pieces.some(isSkillChunk) && !survivors.some(isSkillChunk)
       ? survivors.filter((piece) => piece.kind !== "other")
       : survivors;
-  if (kept.length === pieces.length) {
-    return inner;
-  }
-  if (kept.length === 0) {
-    return "";
-  }
-
-  const texts = kept.map((piece) => piece.text);
-  if (preamble.length > 0) {
-    texts.unshift(preamble);
-  }
-  return texts.join("\n\n");
+  return rejoinKeptPieces(inner, parsed, kept);
 }
 
 /**
@@ -510,10 +513,10 @@ export function mergeIntoAnchorBlock(
 
 /**
  * Strip pruned sections from the live in-memory history: for every
- * current-format `<memory>` text block memory-v3 owns (by object identity,
- * see the module doc; a legacy-format owned block is left as is), drop the
- * pruned sections and any copy superseded by a newer one later in the
- * history, and for every `<memory_pointer>` block drop the
+ * `<memory>` text block memory-v3 owns (by object identity, see the module
+ * doc; a legacy-format owned block is filtered by card and re-marked
+ * legacy), drop the pruned sections and any copy superseded by a newer one
+ * later in the history, and for every `<memory_pointer>` block drop the
  * lines naming pruned sections; a block left with no sections (or no pointer
  * entries) is removed outright (matching the rehydration splice, which skips
  * such a block). A rewritten block is registered in the owner's place.

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -53,17 +53,21 @@ export const LEGACY_MEMORY_V3_SPOTLIGHT_BLOCK_METADATA_KEY =
   "memoryV3SpotlightBlock" as const;
 
 /**
- * How a persisted memory-v3 section block was rendered, which decides whether
- * a reader parses it. `"current"`: rendered by a build that stamps
- * `memoryV3InjectedBlockFormat` (`MEMORY_V3_INJECTED_BLOCK_FORMAT` in
+ * How a persisted memory-v3 section block was rendered, which decides the
+ * grammar a reader parses it with. `"current"`: rendered by a build that
+ * stamps `memoryV3InjectedBlockFormat` (`MEMORY_V3_INJECTED_BLOCK_FORMAT` in
  * `ever-injected-store.ts`) beside the block, so its inner text follows the
  * escaped grammar of `substrate/injected-block-slugs.ts` and is parsed,
  * pruned, superseded by newer copies, and fork-seeded at section grain.
  * `"legacy"`: persisted by a build before the stamp existed (a row carrying
- * the block without it), which is opaque: rehydrated verbatim, never parsed,
- * stripped, superseded, or fork-seeded, and gone with the compaction that
- * strips memory blocks and clears the section store. Provenance is explicit,
- * never inferred from a block's content.
+ * the block without it), rendered as compact cards, which the rehydration
+ * filter and the live strip read with that build's card grammar
+ * (`filterLegacyCards` in `substrate/injected-block-slugs.ts`) under each
+ * card's lead ref: a card whose lead is tombstoned, or re-injected by a
+ * current block after a prune, leaves. The block itself is never pruned,
+ * indexed, or fork-seeded, and is gone with the compaction that strips
+ * memory blocks and clears the section store. Provenance is explicit, never
+ * inferred from a block's content.
  */
 export type InjectedBlockFormat = "legacy" | "current";
 


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for memory-v3-section-injection.md.

**Gap:** opaque pre-stamp blocks resurrected every card pruned before the upgrade, with no way to evict them until compaction.
**Fix:** legacy (pre-stamp) blocks are filtered on load and in the live strip with the card grammar the previous build used (`filterLegacyCards` in `substrate/injected-block-slugs.ts`, main's `parseCardSections` / `filterPrunedCardSections` relocated into the grammar module), each card under its lead ref `(slug, "")`: a card whose lead was tombstoned before the upgrade stays out across restarts, and a card whose lead a current-format block re-injected after such a prune (which clears the tombstone) is superseded by that copy instead of resurrecting beside it. They stay otherwise opaque (never re-pruned, never fork-seeded, never newest-copy indexed). Both parsers now share the seam cut and the `\n\n` re-join (`rejoinKeptPieces`).

**Not covered:** a truncated fork still seeds nothing for a legacy block, so the parent's pre-upgrade tombstones do not reach the child's store (full forks copy the store rows, tombstones included); unchanged from the feature branch.

**Tests:** the three pins of the opaque rule are flipped (`prune.test.ts` x2, `conversation-lifecycle.test.ts`), a two-cards-one-tombstone rehydration case is added at both the unit level and through `loadFromDb`, a supersession case through `loadFromDb`, and the legacy grammar's edge cases (unescaped header-shaped body lines, `# Title` lines, capability chunks on and off seams) in `injected-block-slugs.test.ts`.
