### PR TITLE
fix(memory-v3): persist a frozen block only when it carries a commit, and key the projection mode on the real replacement

### DIFF
--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -152,8 +152,13 @@ import { conversations, messages } from "../persistence/schema/index.js";
 import { registerDefaultPluginInjectors } from "../plugins/defaults/index.js";
 import { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import postCompact from "../plugins/defaults/memory/hooks/post-compact.js";
+import { wrapMemoryPointerBlock } from "../plugins/defaults/memory/memory-marker.js";
 import { getPkbRoot } from "../plugins/defaults/memory/v1/pkb/types.js";
-import { MEMORY_V3_COMMIT_META_KEY } from "../plugins/defaults/memory/v3/types.js";
+import {
+  MEMORY_V3_BLOCK_ID,
+  MEMORY_V3_COMMIT_META_KEY,
+  MEMORY_V3_POINTER_BLOCK_ID,
+} from "../plugins/defaults/memory/v3/types.js";
 import {
   buildUnifiedTurnContextBlock,
   type UnifiedTurnContextOptions,
@@ -171,7 +176,10 @@ import type { Message } from "../providers/types.js";
 import { wrapUntrustedContent } from "../security/untrusted-content.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { SubagentState } from "../subagent/types.js";
-import { getWorkspacePromptPath } from "../util/platform.js";
+import {
+  getWorkspacePluginsDir,
+  getWorkspacePromptPath,
+} from "../util/platform.js";
 import { asConversation } from "./helpers/mock-conversation.js";
 
 // `applyRuntimeInjections` self-resolves the Slack active-thread focus block by
@@ -3965,14 +3973,39 @@ describe("Slack channel chronological rendering — multi-thread", () => {
 
   // ── memory-v3 block under the replacement ──────────────────────────────
   // The transcript is rendered from persisted rows, so the frozen memory-v3
-  // blocks that live in message metadata never reach it. Assembly states the
-  // replacement on the turn context ahead of the chain (the sections
-  // injector renders every selection afresh for it) and attaches the block
-  // to the transcript's tail in memory only: uncaptured and uncommitted.
-  // The probe mirrors the real injector's block id, placement, and commit
-  // meta under its own name (the real one is registered by the memory
-  // plugin and stays inert with memory-v3 off).
+  // blocks that live in message metadata never reach it. The chain walker
+  // states the replacement on the turn context of every injector after the
+  // transcript injector (the sections injector renders every selection
+  // afresh for it) and assembly attaches the block to the transcript's tail
+  // in memory only: uncaptured and uncommitted. The probe mirrors the real
+  // injector's block id, placement, and commit meta under its own name (the
+  // real one is registered by the memory plugin and stays inert with
+  // memory-v3 off).
   const V3_PROBE_PLUGIN = "memory-v3-replacement-probe";
+
+  /** A Slack DM conversation with one persisted transcript row, the live
+   *  conversation the assembly under test resolves. */
+  function seedSlackImConversation(): void {
+    seedSlackChannelConversationWithRows(
+      {
+        channel: "slack",
+        dashboardCapable: false,
+        supportsDynamicUi: false,
+        supportsVoiceInput: false,
+        chatType: "im",
+      },
+      [
+        userRow({
+          id: "v3-replaced-1",
+          createdAt: 1700000000_000,
+          text: "transcript line",
+          slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
+          extraOuterMetadata: { provenanceTrustClass: "guardian" },
+        }),
+      ],
+    );
+  }
+
   function probeMemoryV3Injector(seen: {
     ctx: TurnContext | null;
     commits: number;
@@ -3983,7 +4016,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
       async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
         seen.ctx = ctx;
         return {
-          id: "memory-v3",
+          id: MEMORY_V3_BLOCK_ID,
           text: "<memory>\nrendered sections\n</memory>",
           placement: "after-memory-prefix",
           meta: {
@@ -4000,25 +4033,7 @@ describe("Slack channel chronological rendering — multi-thread", () => {
     const seen = { ctx: null as TurnContext | null, commits: 0 };
     registerPluginInjectors(V3_PROBE_PLUGIN, [probeMemoryV3Injector(seen)]);
     try {
-      const rows: MessageRow[] = [
-        userRow({
-          id: "v3-replaced-1",
-          createdAt: 1700000000_000,
-          text: "transcript line",
-          slackMeta: buildSlackMeta({ channelTs: T0, displayName: "alice" }),
-          extraOuterMetadata: { provenanceTrustClass: "guardian" },
-        }),
-      ];
-      seedSlackChannelConversationWithRows(
-        {
-          channel: "slack",
-          dashboardCapable: false,
-          supportsDynamicUi: false,
-          supportsVoiceInput: false,
-          chatType: "im",
-        },
-        rows,
-      );
+      seedSlackImConversation();
 
       const { messages: result, blocks } = await applyRuntimeInjections(
         [{ role: "user", content: [{ type: "text", text: "inbound" }] }],
@@ -4055,11 +4070,173 @@ describe("Slack channel chronological rendering — multi-thread", () => {
         { conversationId: FALLBACK_CONVERSATION_ID },
       );
 
-      expect(seen.ctx?.replacesRunMessages).toBe(false);
+      // No injector ahead of the probe produced a replacement, so the walker
+      // never states one.
+      expect(seen.ctx?.replacesRunMessages).toBeUndefined();
       expect(blocks.memoryV3InjectedBlock).toBe("rendered sections");
       expect(seen.commits).toBe(1);
     } finally {
       unregisterPluginInjectors(V3_PROBE_PLUGIN);
+    }
+  });
+
+  // ── the transcript injector absent: the channel plugin disabled ────────
+  // `getRegisteredInjectors` drops a plugin's injectors while its
+  // `.disabled` sentinel exists, so a Slack conversation is then assembled
+  // onto its own history, frozen blocks included, and residency means what
+  // it does on any other channel: the turn is an ordinary committed
+  // injection. The probes mirror the real memory-v3 pair's projection rule
+  // over one selected section, with the section store reduced to `claimed`:
+  // under a replacement the section renders afresh and the block carries no
+  // commit; otherwise it renders only while unclaimed, with a commit that
+  // claims it, and is pointed at once claimed.
+  const V3_MIRROR_PLUGIN = "memory-v3-residency-probe";
+  const MIRROR_SECTION_PATH = "memory/concepts/page-a.md";
+  const MIRROR_SECTION_INNER = `# ${MIRROR_SECTION_PATH}\nhead a`;
+  function mirrorMemoryV3Injectors(
+    claimed: Set<string>,
+    seen: { replaced: boolean[] },
+  ): Injector[] {
+    const sectionBlock = (meta?: InjectionBlock["meta"]): InjectionBlock => ({
+      id: MEMORY_V3_BLOCK_ID,
+      text: `<memory>\n${MIRROR_SECTION_INNER}\n</memory>`,
+      placement: "after-memory-prefix",
+      ...(meta ? { meta } : {}),
+    });
+    return [
+      {
+        name: V3_MIRROR_PLUGIN,
+        order: 1000,
+        async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+          const replaced = ctx.replacesRunMessages === true;
+          seen.replaced.push(replaced);
+          if (replaced) {
+            return sectionBlock();
+          }
+          if (claimed.has(MIRROR_SECTION_PATH)) {
+            return {
+              id: MEMORY_V3_BLOCK_ID,
+              text: "",
+              placement: "after-memory-prefix",
+            };
+          }
+          return sectionBlock({
+            [MEMORY_V3_COMMIT_META_KEY]: () => {
+              claimed.add(MIRROR_SECTION_PATH);
+            },
+          });
+        },
+      },
+      {
+        name: `${V3_MIRROR_PLUGIN}-pointer`,
+        order: 1001,
+        async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+          if (
+            ctx.replacesRunMessages === true ||
+            !claimed.has(MIRROR_SECTION_PATH)
+          ) {
+            return null;
+          }
+          return {
+            id: MEMORY_V3_POINTER_BLOCK_ID,
+            text: wrapMemoryPointerBlock(MIRROR_SECTION_PATH),
+            placement: "after-memory-prefix",
+          };
+        },
+      },
+    ];
+  }
+
+  /** Write the `default-channel` plugin's `.disabled` sentinel; returns its
+   *  directory for removal. */
+  function disableChannelPlugin(): string {
+    const dir = join(getWorkspacePluginsDir(), "default-channel");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ".disabled"), "");
+    return dir;
+  }
+
+  test("with the channel plugin disabled a Slack conversation is not replaced: the block is captured and claimed once, and the next turn points at it", async () => {
+    const claimed = new Set<string>();
+    const seen = { replaced: [] as boolean[] };
+    registerPluginInjectors(
+      V3_MIRROR_PLUGIN,
+      mirrorMemoryV3Injectors(claimed, seen),
+    );
+    const pluginDir = disableChannelPlugin();
+    try {
+      seedSlackImConversation();
+
+      const first = await applyRuntimeInjections(
+        [{ role: "user", content: [{ type: "text", text: "inbound" }] }],
+        { conversationId: FALLBACK_CONVERSATION_ID, turnIndex: 0 },
+      );
+      // The transcript injector is out of the chain, so the history is the
+      // turn's own and no injector is told of a replacement.
+      expect(seen.replaced).toEqual([false]);
+      const firstTexts = first.messages[
+        first.messages.length - 1
+      ]!.content.filter(
+        (b): b is { type: "text"; text: string } => b.type === "text",
+      ).map((b) => b.text);
+      expect(firstTexts).toContain("inbound");
+      expect(firstTexts.join("\n")).not.toContain("transcript line");
+      // An ordinary committed injection: persisted and claimed.
+      expect(first.blocks.memoryV3InjectedBlock).toBe(MIRROR_SECTION_INNER);
+      expect(first.blocks.memoryV3PointerBlock).toBeUndefined();
+      expect(claimed).toEqual(new Set([MIRROR_SECTION_PATH]));
+
+      const second = await applyRuntimeInjections(
+        [
+          ...first.messages,
+          { role: "assistant", content: [{ type: "text", text: "reply" }] },
+          { role: "user", content: [{ type: "text", text: "follow-up" }] },
+        ],
+        { conversationId: FALLBACK_CONVERSATION_ID, turnIndex: 1 },
+      );
+      // The section is resident in the history the turn is assembled onto,
+      // so it is pointed at rather than rendered and persisted again.
+      expect(seen.replaced).toEqual([false, false]);
+      expect(second.blocks.memoryV3InjectedBlock).toBeUndefined();
+      expect(second.blocks.memoryV3PointerBlock).toBe(
+        wrapMemoryPointerBlock(MIRROR_SECTION_PATH),
+      );
+      expect(claimed).toEqual(new Set([MIRROR_SECTION_PATH]));
+    } finally {
+      rmSync(pluginDir, { recursive: true, force: true });
+      unregisterPluginInjectors(V3_MIRROR_PLUGIN);
+    }
+  });
+
+  test("with the channel plugin enabled the same conversation is replaced every turn: rendered afresh, nothing captured or claimed", async () => {
+    const claimed = new Set<string>();
+    const seen = { replaced: [] as boolean[] };
+    registerPluginInjectors(
+      V3_MIRROR_PLUGIN,
+      mirrorMemoryV3Injectors(claimed, seen),
+    );
+    try {
+      seedSlackImConversation();
+
+      for (const turnIndex of [0, 1]) {
+        const { messages: result, blocks } = await applyRuntimeInjections(
+          [{ role: "user", content: [{ type: "text", text: "inbound" }] }],
+          { conversationId: FALLBACK_CONVERSATION_ID, turnIndex },
+        );
+        const tailTexts = result[result.length - 1]!.content.filter(
+          (b): b is { type: "text"; text: string } => b.type === "text",
+        ).map((b) => b.text);
+        expect(tailTexts).toContain(
+          `<memory>\n${MIRROR_SECTION_INNER}\n</memory>`,
+        );
+        expect(tailTexts.join("\n")).toContain("transcript line");
+        expect(blocks.memoryV3InjectedBlock).toBeUndefined();
+        expect(blocks.memoryV3PointerBlock).toBeUndefined();
+      }
+      expect(seen.replaced).toEqual([true, true]);
+      expect(claimed.size).toBe(0);
+    } finally {
+      unregisterPluginInjectors(V3_MIRROR_PLUGIN);
     }
   });
 

--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -131,6 +131,9 @@ function seedV2Identity(text: string | null): void {
  * does too. `inner === null` means the injector produced nothing this turn
  * (error/empty selection); `inner === ""` mirrors an all-repeat turn (block
  * produced, empty text — nothing attached, but v2 is still suppressed).
+ * `commit` is the residency commit the real injector attaches to a turn's
+ * first produce outside a run-messages replacement; a block without one is
+ * attached in memory only and never captured for persistence.
  */
 function v3Injector(inner: string | null, commit?: () => void): Injector {
   return {
@@ -222,7 +225,7 @@ describe("memory-v3-live v2 suppression", () => {
 
   test("flag ON + v3 produced a block → TAIL v2 stripped, historical memory blocks frozen in place", async () => {
     memoryV3LiveSlot = true;
-    injectorChainSlot.push(v3Injector("net-new cards"));
+    injectorChainSlot.push(v3Injector("net-new cards", () => {}));
     seedV2Identity("fresh recalled fact");
 
     // History: a prior user turn carrying a frozen memory block (a v3 card
@@ -256,8 +259,9 @@ describe("memory-v3-live v2 suppression", () => {
     expect(texts[1]).toBe("current question");
     expect(texts).toHaveLength(2);
 
-    // The v3 block is captured for metadata persistence (UNWRAPPED) and the
-    // turn is marked v3-active so the hook skips v2's metadata write.
+    // The committed v3 block is captured for metadata persistence
+    // (UNWRAPPED) and the turn is marked v3-active so the hook skips v2's
+    // metadata write.
     expect(result.blocks.memoryV3InjectedBlock).toBe("net-new cards");
     expect(result.blocks.memoryV3Active).toBe(true);
   });
@@ -610,6 +614,29 @@ describe("memory-v3-live v2 suppression", () => {
     expect(commit).toHaveBeenCalledTimes(1);
   });
 
+  test("a v3 block carrying no commit is attached in memory only: never captured, so nothing persists it", async () => {
+    memoryV3LiveSlot = true;
+    injectorChainSlot.push(v3Injector("uncommitted sections"));
+    seedV2Identity(null);
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+    ];
+
+    const result = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    // The block reaches the model, and v3 still owns the turn's `<memory>`
+    // layer, but a block the store will never claim must not be persisted:
+    // a persisted, unclaimed copy would render again on every later turn.
+    expect(tailTexts(result.messages)).toEqual([
+      "<memory>\nuncommitted sections\n</memory>",
+      "question",
+    ]);
+    expect(result.blocks.memoryV3InjectedBlock).toBeUndefined();
+    expect(result.blocks.memoryV3Active).toBe(true);
+  });
+
   test("the commit callback is SKIPPED when the tail is not a user message (block never attaches)", async () => {
     memoryV3LiveSlot = true;
     const commit = mock(() => {});
@@ -925,6 +952,64 @@ describe("memory-v3-live v2 suppression", () => {
     ]);
     expect(result.blocks.memoryV3InjectedBlock).toBeUndefined();
     expect(commits).toBe(0);
+  });
+
+  /** An injector that records the `replacesRunMessages` it was handed and
+   *  contributes nothing. */
+  function replacementProbe(
+    name: string,
+    order: number,
+    seen: Map<string, boolean | undefined>,
+  ): Injector {
+    return {
+      name,
+      order,
+      async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
+        seen.set(name, ctx.replacesRunMessages);
+        return null;
+      },
+    };
+  }
+
+  test("the run-messages replacement is stated on the turn context of every injector after the replacing one, and of none when no injector replaces", async () => {
+    const seen = new Map<string, boolean | undefined>();
+    const transcript: Message[] = [
+      { role: "user", content: [{ type: "text", text: "transcript line" }] },
+    ];
+    const runMessages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "question" }] },
+    ];
+    injectorChainSlot.push(
+      replacementProbe("before-replace", 10, seen),
+      replaceInjector(transcript),
+      replacementProbe("after-replace", 1000, seen),
+    );
+
+    const replaced = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    expect(seen.get("before-replace")).toBeUndefined();
+    expect(seen.get("after-replace")).toBe(true);
+    expect(tailTexts(replaced.messages)).toEqual(["transcript line"]);
+
+    // The replacing injector out of the chain (its plugin disabled or never
+    // registered): the flag follows the replacement, so nobody is told of
+    // one and the history stays the turn's own.
+    injectorChainSlot.length = 0;
+    seen.clear();
+    injectorChainSlot.push(
+      replacementProbe("before-replace", 10, seen),
+      replacementProbe("after-replace", 1000, seen),
+    );
+
+    const kept = await applyRuntimeInjections(runMessages, {
+      ...makeTurnContext(),
+    });
+
+    expect(seen.get("before-replace")).toBeUndefined();
+    expect(seen.get("after-replace")).toBeUndefined();
+    expect(tailTexts(kept.messages)).toEqual(["question"]);
   });
 
   test("a retry assembled onto a run-messages replacement leaves the anchor's frozen block off the transcript: the fresh render is the single copy, uncaptured, commit withheld", async () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1871,8 +1871,11 @@ export interface RuntimeInjectionBlocks {
    * UNWRAPPED inner text of the memory-v3 frozen net-new section block the v3
    * injector attached this turn, mirroring v2's unwrapped `memoryInjectedBlock`
    * contract (rehydration re-wraps on use). Undefined when v3 attached no new
-   * sections (all-repeat turn, v3 off, or v3 failure). Persisted by the
-   * user-prompt-submit hook under `metadata.memoryV3InjectedBlock`
+   * sections (all-repeat turn, v3 off, or v3 failure) and when the block
+   * attached in memory only, carrying no residency commit (a replaced
+   * history, a re-entry): what is captured here is persisted, and only a
+   * block the store claims may be. Persisted by the user-prompt-submit hook
+   * under `metadata.memoryV3InjectedBlock`
    * (`MEMORY_V3_INJECTED_BLOCK_METADATA_KEY`).
    */
   memoryV3InjectedBlock?: string;
@@ -1922,6 +1925,21 @@ export interface RuntimeInjectionResult {
 const SELF_INSTRUMENTED_INJECTORS = new Set(["memory-v3-shadow"]);
 
 /**
+ * Whether `block` replaces the turn's run messages: a
+ * `"replace-run-messages"` placement carrying the override that
+ * {@link applyInjectionBlock} swaps in (a replace block without one is a
+ * no-op there).
+ */
+function replacesRunMessages(
+  block: InjectionBlock,
+): block is InjectionBlock & { messagesOverride: Message[] } {
+  return (
+    block.placement === "replace-run-messages" &&
+    block.messagesOverride !== undefined
+  );
+}
+
+/**
  * Run every {@link Injector} in the chain ({@link getRegisteredInjectors},
  * already sorted by ascending `order`) and return every non-null block it
  * produced, timing each non-self-instrumented injector as a latency
@@ -1933,6 +1951,15 @@ const SELF_INSTRUMENTED_INJECTORS = new Set(["memory-v3-shadow"]);
  * callers ({@link composeInjectorChain}) that drive the chain without a
  * message array.
  *
+ * `ctx` is handed to each injector as given, except that once an injector
+ * has produced the run-messages replacement ({@link replacesRunMessages}),
+ * every injector after it in the chain is told so on its context
+ * (`TurnContext.replacesRunMessages`, read by the memory-v3 sections
+ * injector). The flag follows the block Step 1 of
+ * {@link applyRuntimeInjections} swaps in, so it is set exactly when the
+ * replacement fires: never for a replacing injector that is unregistered,
+ * disabled with its plugin, or gated off for the turn.
+ *
  * Injectors returning `null` are omitted from the result. The returned array
  * preserves ascending-`order` sort so downstream callers (notably
  * {@link applyRuntimeInjections}) can group blocks by `placement` and apply
@@ -1943,16 +1970,21 @@ async function collectInjectorBlocks(
   runMessages?: Message[],
 ): Promise<InjectionBlock[]> {
   const out: InjectionBlock[] = [];
+  let injectorCtx = ctx;
   for (const injector of getRegisteredInjectors()) {
     const block = SELF_INSTRUMENTED_INJECTORS.has(injector.name)
-      ? await injector.produce(ctx, runMessages)
+      ? await injector.produce(injectorCtx, runMessages)
       : await timeLatencySubSpan(
           `injector:${injector.name}`,
           `Injector: ${injector.name}`,
-          () => injector.produce(ctx, runMessages),
+          () => injector.produce(injectorCtx, runMessages),
         );
-    if (block) {
-      out.push(block);
+    if (!block) {
+      continue;
+    }
+    out.push(block);
+    if (replacesRunMessages(block)) {
+      injectorCtx = { ...injectorCtx, replacesRunMessages: true };
     }
   }
   return out;
@@ -2297,9 +2329,10 @@ function fallbackTurnTrust(
  *     tail. When replacement fires, re-prepend any memory-prefix blocks
  *     that `graphMemory.prepareMemory` had attached to the original tail —
  *     the Slack transcript is rendered fresh from persisted rows and
- *     carries no memory prefix of its own. The chain is told ahead of time
- *     that the replacement will fire (`replacesRunMessages` on the turn
- *     context, resolved with the transcript in step 1), and the memory-v3
+ *     carries no memory prefix of its own. Every injector after the
+ *     replacing one was told that the replacement will fire
+ *     (`replacesRunMessages` on its turn context, set by the chain walker
+ *     in step 2 as the replacing block is produced), and the memory-v3
  *     block then attaches to the replaced tail in memory only (step 4); a
  *     memory-v3 block the original tail already carried (a retry's anchor)
  *     is left off the transcript in that case, so the fresh render is the
@@ -2457,17 +2490,6 @@ export async function applyRuntimeInjections(
           liveConversation?.slackContextCompactionWatermarkTs,
       })
     : null;
-  // The `slack-messages` injector replaces the run messages with that
-  // transcript whenever it has at least one entry. Stated on the turn
-  // context ahead of the chain (the transcript is loaded here, before any
-  // injector runs) so an injector whose output depends on what history
-  // carries renders for the transcript rather than for `runMessages`: the
-  // transcript is rendered from raw persisted content, so the frozen memory
-  // blocks that live in message metadata never reach it.
-  const replacesRunMessages =
-    slackChronologicalMessages !== null &&
-    slackChronologicalMessages.length > 0;
-
   // Assemble the per-turn TurnContext handed to the injector chain. The
   // turn-identity fields come from `options` when supplied; `requestId` is the
   // only one the caller must provide, since the other three are recovered from
@@ -2481,7 +2503,6 @@ export async function applyRuntimeInjections(
     channelCapabilities,
     slackChronologicalMessages,
     slackActiveThreadFocusBlock,
-    replacesRunMessages,
     isNonInteractive: options.isNonInteractive,
     isBackgroundConversation,
     activeDocuments,
@@ -2679,7 +2700,7 @@ export async function applyRuntimeInjections(
 
   // ── Step 1: Slack chronological replacement (chain "replace" block) ──
   let historyReplaced = false;
-  if (replaceBlock && replaceBlock.messagesOverride) {
+  if (replaceBlock && replacesRunMessages(replaceBlock)) {
     historyReplaced = true;
     // `graphMemory.prepareMemory` prepends a `<memory __injected>` block
     // (and any memory-image groups) to the last user message before
@@ -2729,7 +2750,13 @@ export async function applyRuntimeInjections(
   // deferred section-store commit runs here, once attachment is certain (a
   // user tail; on any other tail `applyInjectionBlock` no-ops the block and
   // a commit would claim sections that never attached, suppressing them
-  // until compaction). A turn re-run onto its original anchor row
+  // until compaction). Capture and commit go together, and only a block
+  // carrying a commit gets either: the injector attaches one to a turn's
+  // first produce alone, and withholds it when the turn's history is
+  // replaced, so a block without one rides the tail in memory only,
+  // whatever history it lands on, and is never persisted or claimed (a
+  // persisted copy the store never claimed would be rendered and persisted
+  // again on every later turn). A turn re-run onto its original anchor row
   // (`/conversations/:id/retry`) assembles onto a tail that already carries
   // the first run's frozen block, rehydrated from the anchor's metadata:
   // a current-format one takes the rerun's net-new entries
@@ -2743,11 +2770,11 @@ export async function applyRuntimeInjections(
   // copy. A re-injection assembly (`options.reinjection`) never commits:
   // its block is never persisted, so the store must not claim sections
   // whose only copy vanishes on restart. A replaced history (Step 1) takes
-  // the same in-memory-only shape: the transcript is rendered from
-  // persisted rows, so a block captured here would never reach a later
-  // prompt, and the injector rendered every selection afresh for the
-  // replacement (`replacesRunMessages` on the turn context) and attached
-  // no commit; Step 1 left a retried anchor's frozen block off the
+  // the in-memory-only shape whatever the block carries: the transcript is
+  // rendered from persisted rows, so a block captured here would never
+  // reach a later prompt; the injector, told of the replacement on its turn
+  // context, rendered every selection afresh for it and attached no
+  // commit, and Step 1 left a retried anchor's frozen block off the
   // transcript, so the block spliced here is the prompt's only copy. An
   // empty-text block (all-repeat turn) attaches nothing and captures
   // nothing.
@@ -2760,7 +2787,8 @@ export async function applyRuntimeInjections(
     if (!tail || tail.role !== "user") {
       continue;
     }
-    if (historyReplaced) {
+    const commit = block.meta?.[MEMORY_V3_COMMIT_META_KEY];
+    if (historyReplaced || typeof commit !== "function") {
       result = applyInjectionBlock(result, block);
       continue;
     }
@@ -2778,8 +2806,7 @@ export async function applyRuntimeInjections(
         memoryV3Captured = unwrapMemoryBlock(block.text);
       }
     }
-    const commit = block.meta?.[MEMORY_V3_COMMIT_META_KEY];
-    if (typeof commit === "function" && !options.reinjection) {
+    if (!options.reinjection) {
       (commit as () => void)();
     }
   }

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -208,12 +208,17 @@ between the sections injector's classification and the pointer's render is
 dropped from it (absent this turn, it re-injects on its next selection), and
 a pointer left with nothing is not emitted.
 Under a run-messages replacement (the Slack chronological transcript,
-`TurnContext.replacesRunMessages`, stated by runtime assembly ahead of the
-chain) no frozen block from an earlier turn is in the prompt, so the sections
-injector renders every selection afresh, the pointer injector emits nothing,
-and assembly attaches the block to the transcript's tail in memory only,
-uncaptured and uncommitted: the store claims nothing and the valve is not
-scheduled. The memory-prefix blocks assembly carries from the original tail
+`TurnContext.replacesRunMessages`, set by the chain walker on the context of
+every injector after the one that produced the replacing block, so it is set
+exactly when the replacement fires and never when the channel plugin is
+disabled or its injector gated off) no frozen block from an earlier turn is
+in the prompt, so the sections injector renders every selection afresh, the
+pointer injector emits nothing, and assembly attaches the block to the
+transcript's tail in memory only, uncaptured and uncommitted: the store
+claims nothing and the valve is not scheduled. Assembly captures a block for
+persistence only when it carries a commit, so a block rendered without one is
+never persisted or claimed whatever history it lands on. The memory-prefix
+blocks assembly carries from the original tail
 onto the transcript leave out any v3-owned block whenever the injector
 produced one (a retry's anchor carries the first run's rehydrated frozen
 block), so each re-selected section reaches the model once, in the fresh

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/injection.test.ts
@@ -1224,8 +1224,8 @@ describe("memoryV3Injector: run-messages replacement (Slack transcript)", () => 
   const gamma = section("page-c", "Gamma", "gamma section text");
 
   /** Produce for an assembly that replaces the run messages with a
-   *  transcript rendered from persisted rows, which runtime assembly states
-   *  on the turn context for every Slack conversation. */
+   *  transcript rendered from persisted rows, which the chain walker states
+   *  on the turn context once the transcript injector has produced it. */
   function produceReplaced(conversationId: string, turnIndex: number) {
     seedMemoryConfig();
     return memoryV3Injector.produce({

--- a/assistant/src/plugins/defaults/memory/v3/injector.ts
+++ b/assistant/src/plugins/defaults/memory/v3/injector.ts
@@ -93,18 +93,22 @@
  * (`stripPrunedSectionsFromMessages`).
  *
  * An assembly that replaces the run messages with a transcript rendered
- * from persisted rows (`TurnContext.replacesRunMessages`: the Slack
- * chronological transcript, on every Slack conversation) carries no frozen
- * block from any earlier turn, because those blocks live only in message
- * metadata. Residency means nothing in that prompt, so the sections
- * injector renders every selection afresh, whether the store counts it
- * active or not, the pointer injector has nothing to point at, and the
- * block carries no commit: nothing is recorded, the valve is not scheduled,
- * and runtime assembly attaches the block to the transcript's tail in
- * memory only, leaving a retried anchor's rehydrated frozen block off the
- * transcript so the fresh render is the single copy. The turn memo still
- * remembers what the first produce rendered, so a re-entry of such a turn
- * re-emits the same bytes.
+ * from persisted rows (`TurnContext.replacesRunMessages`, set by the chain
+ * walker once the replacing injector has produced its block: the Slack
+ * chronological transcript) carries no frozen block from any earlier turn,
+ * because those blocks live only in message metadata. Residency means
+ * nothing in that prompt, so the sections injector renders every selection
+ * afresh, whether the store counts it active or not, the pointer injector
+ * has nothing to point at, and the block carries no commit: nothing is
+ * recorded, the valve is not scheduled, and runtime assembly attaches the
+ * block to the transcript's tail in memory only (it persists and claims a
+ * block only when the block carries a commit), leaving a retried anchor's
+ * rehydrated frozen block off the transcript so the fresh render is the
+ * single copy. A Slack conversation whose transcript injector is absent
+ * (the channel plugin disabled) is not replaced, and its turn is an
+ * ordinary committed injection. The turn memo still remembers what the
+ * first produce rendered, so a re-entry of such a turn re-emits the same
+ * bytes.
  */
 
 import { getConfig } from "../../../../config/loader.js";

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -213,13 +213,17 @@ export interface TurnContext {
    */
   readonly slackActiveThreadFocusBlock?: string | null;
   /**
-   * True when this assembly replaces `runMessages` with a transcript
-   * rendered from persisted rows (the default chain's Slack chronological
-   * transcript, on every Slack conversation with at least one transcript
-   * entry). Content that lives only in message metadata, such as frozen
-   * memory blocks rehydrated onto earlier messages, is absent from that
-   * prompt, so an injector that would otherwise point at content already
-   * resident in history renders it again instead.
+   * True when an injector earlier in the chain has produced the
+   * `"replace-run-messages"` block this assembly swaps `runMessages` for: a
+   * transcript rendered from persisted rows (the default chain's Slack
+   * chronological transcript). The chain walker sets it on the context of
+   * every injector that runs after the replacing one, so it is set exactly
+   * when the replacement fires and never for a replacing injector that is
+   * absent, disabled with its plugin, or gated off for the turn. Content
+   * that lives only in message metadata, such as frozen memory blocks
+   * rehydrated onto earlier messages, is absent from that prompt, so an
+   * injector that would otherwise point at content already resident in
+   * history renders it again instead.
    */
   readonly replacesRunMessages?: boolean;
   /**


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for memory-v3-section-injection.md.

**Gap:** the injector's projection mode was keyed on a Slack transcript being present while assembly's capture path was keyed on the replacement actually firing; with the channel plugin disabled the two disagreed and an uncommitted block was persisted every turn.
**Fix:** assembly captures a frozen block only when it carries a commit, and the projection flag is derived from the same condition the injector chain applies.