### PR TITLE
chore(memory-v3): neutral test fixtures, drop dead schema object and re-exports, condense duplicated docs

### DIFF
--- a/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
+++ b/assistant/src/__tests__/cli-memory-v2-reembed-skills.test.ts
@@ -48,7 +48,6 @@ mock.module("../plugins/defaults/memory/substrate/skill-store.js", () => ({
   // The validate route builds the page index, which reads the seeded
   // skill catalog; an empty catalog keeps that walk inert here.
   listSkillEntries: () => [],
-  SKILL_SLUG_PREFIX: "skills/",
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/api/responses/memory-v3-selection-log.ts
+++ b/assistant/src/api/responses/memory-v3-selection-log.ts
@@ -43,8 +43,9 @@ import { z } from "zod";
  * a repeated heading's n-th occurrence and `~<n>` for the n-th chunk of an
  * over-long one), which tells two lines under one heading apart; both null
  * for cards and finder lines with no matched section, and the key null on
- * legacy pool rows that omit `section_key`. `chosen` is whether the selector
- * kept the candidate's page.
+ * legacy pool rows that omit `section_key`. `chosen` is per pool line:
+ * whether the selector kept the section the line names (the page lead, for
+ * a lead line), or the page itself for a line with no matched section.
  */
 export const MemoryV3PoolCandidateSchema = z.object({
   slug: z.string(),

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -163,7 +163,7 @@ function shouldPersistProviderErrorAsAssistantMessage(classified: {
  * and continue. Returns whether the marker is durable, which gates the
  * memory-injection ledger reset ({@link resetInjectionLedgersForStrip}).
  */
-export function markHistoryStrippedBestEffort(conversationId: string): boolean {
+function markHistoryStrippedBestEffort(conversationId: string): boolean {
   try {
     setConversationHistoryStrippedAt(conversationId, Date.now());
     return true;

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -2674,8 +2674,7 @@ export async function applyRuntimeInjections(
   // at the top of the tail with no v2 prefix ahead of it. Historical user
   // messages keep their memory blocks byte-identical: frozen v3 section
   // blocks from prior turns AND pre-cutover v2 blocks both ride the cached
-  // prefix (the old whole-layer `stripAllMemoryInjections` replace is gone).
-  // The strip discriminates v2's dynamic block by IDENTITY ({@link
+  // prefix. The strip discriminates v2's dynamic block by IDENTITY ({@link
   // stripTailV2DynamicMemoryPrefix}): the live graph handle holds the exact
   // text the wiring layer prepended this turn, so a re-entry tail's
   // just-frozen v3 section block (and the `<info>` static block) survive even
@@ -2747,37 +2746,19 @@ export async function applyRuntimeInjections(
   //
   // The v3 frozen section block is captured here, UNWRAPPED (the v2
   // `memoryInjectedBlock` contract; rehydration re-wraps on use), and its
-  // deferred section-store commit runs here, once attachment is certain (a
-  // user tail; on any other tail `applyInjectionBlock` no-ops the block and
-  // a commit would claim sections that never attached, suppressing them
-  // until compaction). Capture and commit go together, and only a block
-  // carrying a commit gets either: the injector attaches one to a turn's
-  // first produce alone, and withholds it when the turn's history is
-  // replaced, so a block without one rides the tail in memory only,
-  // whatever history it lands on, and is never persisted or claimed (a
-  // persisted copy the store never claimed would be rendered and persisted
-  // again on every later turn). A turn re-run onto its original anchor row
-  // (`/conversations/:id/retry`) assembles onto a tail that already carries
-  // the first run's frozen block, rehydrated from the anchor's metadata:
-  // a current-format one takes the rerun's net-new entries
-  // (`mergeIntoAnchorBlock`), so the tail carries one merged block and the
-  // persisted block gives every section the store claims a body that
-  // rehydrates; a legacy-format one (a pre-stamp row) cannot take
-  // current-format entries under one metadata key, so the rerun's block
-  // rides the tail in memory only, uncaptured and uncommitted, the
-  // post-compaction no-claim shape: the next turn injects those sections
-  // net-new onto its own message and the newest-copy rule retires this
-  // copy. A re-injection assembly (`options.reinjection`) never commits:
-  // its block is never persisted, so the store must not claim sections
-  // whose only copy vanishes on restart. A replaced history (Step 1) takes
-  // the in-memory-only shape whatever the block carries: the transcript is
-  // rendered from persisted rows, so a block captured here would never
-  // reach a later prompt; the injector, told of the replacement on its turn
-  // context, rendered every selection afresh for it and attached no
-  // commit, and Step 1 left a retried anchor's frozen block off the
-  // transcript, so the block spliced here is the prompt's only copy. An
-  // empty-text block (all-repeat turn) attaches nothing and captures
-  // nothing.
+  // deferred section-store commit runs here, once attachment is certain: a
+  // user tail (on any other tail `applyInjectionBlock` no-ops the block, and
+  // a commit would claim sections that never attached), a block carrying a
+  // commit, and not a re-injection assembly (`options.reinjection`, whose
+  // block is never persisted). Capture and commit go together: a block
+  // without a commit (a re-entry, or a turn whose history Step 1 replaced)
+  // rides the tail in memory only and is never persisted or claimed. A tail
+  // that already carries a v3 block (a turn re-run onto its original anchor
+  // row, `/conversations/:id/retry`) takes the new entries by merge, or, for
+  // a legacy-format anchor block, carries the new block in memory only
+  // (`AnchorBlockMerge` in `v3/prune.ts`). An empty-text block (all-repeat
+  // turn) attaches nothing and captures nothing. The partition and commit
+  // rules live in `plugins/defaults/memory/v3/injector.ts`.
   for (const block of afterMemory) {
     if (block.id !== MEMORY_V3_BLOCK_ID) {
       result = applyInjectionBlock(result, block);

--- a/assistant/src/persistence/schema/memory-injection.ts
+++ b/assistant/src/persistence/schema/memory-injection.ts
@@ -88,30 +88,3 @@ export const memoryV3Selections = sqliteTable(
     index("idx_memory_v3_selections_conv").on(table.conversationId, table.turn),
   ],
 );
-
-// Per-turn audit record of the memory-v3 selector's candidate pool: every
-// stable-prefix card and finder line the selector saw, in pool order, with its
-// lane, matched section, and verdict (`candidates_json`), and whether the
-// selector judged the pool at all (`selector_ran`; a hard-skipped turn is an
-// empty pool with 0). One row per (conversation, turn); `message_id` is
-// stamped by the turn-end backfill so the inspector can join it to the turn.
-// Lives in the dedicated memory database (`assistant-memory.db`), not main.
-// Access it via the memory connection (`getMemoryDb()` / `getMemorySqlite()`).
-export const memoryV3Pools = sqliteTable(
-  "memory_v3_pools",
-  {
-    conversationId: text("conversation_id").notNull(),
-    turn: integer("turn").notNull(),
-    messageId: text("message_id"),
-    createdAt: integer("created_at").notNull(),
-    poolSize: integer("pool_size").notNull(),
-    selectedCount: integer("selected_count").notNull(),
-    selectorRan: integer("selector_ran").notNull().default(1),
-    candidatesJson: text("candidates_json").notNull(),
-  },
-  (table) => [
-    primaryKey({ columns: [table.conversationId, table.turn] }),
-    index("idx_memory_v3_pools_message").on(table.messageId),
-    index("idx_memory_v3_pools_conv").on(table.conversationId, table.turn),
-  ],
-);

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -154,7 +154,9 @@ not break.
   so page or skill text can never forge one) and parses blocks
   (`parseInjectedSections`). The prune valve, the `loadFromDb` rehydration
   filter, the truncated-fork seed, and the retry anchor merge all read
-  through it; do not add a second header matcher or chunk splitter.
+  through it; do not add a second header matcher or chunk splitter. The one
+  exception is `LEGACY_CARD_HEADER_REGEX` in the same file, the pre-stamp
+  card grammar that `parseLegacyCards` alone reads for legacy blocks.
 - **A block's format is explicit provenance, never inferred from its
   content.** The persisting build stamps `memoryV3InjectedBlockFormat`
   beside `memoryV3InjectedBlock`; a row is current exactly when its stamp

--- a/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
+++ b/assistant/src/plugins/defaults/memory/graph-topology/build-memory-graph.ts
@@ -18,9 +18,9 @@
 import { isV3TierActive } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
 import { getWorkspaceDir } from "../paths.js";
+import { isSkillSlug } from "../substrate/capability-slugs.js";
 import { getPageIndex, type PageIndexEntry } from "../substrate/page-index.js";
 import { readPage, renderPageContent } from "../substrate/page-store.js";
-import { isSkillSlug } from "../substrate/skill-store.js";
 import {
   isCapabilitySlug,
   renderCapabilityContent,

--- a/assistant/src/plugins/defaults/memory/hooks/injection-metadata.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/injection-metadata.ts
@@ -71,19 +71,8 @@ export function injectionMetadataUpdates(
   blocks: RuntimeInjectionResult["blocks"],
   v2BlockPersisted: boolean,
 ): Record<string, unknown> | null {
-  const removeV2Block = Boolean(blocks.memoryV3Active) && v2BlockPersisted;
-  const passthrough = PASSTHROUGH_BLOCKS.filter(([block]) => blocks[block]);
-  if (
-    passthrough.length === 0 &&
-    !blocks.memoryV3InjectedBlock &&
-    !blocks.memoryV3PointerBlock &&
-    !removeV2Block &&
-    !blocks.memoryV3Active
-  ) {
-    return null;
-  }
   const updates: Record<string, unknown> = {};
-  if (removeV2Block) {
+  if (blocks.memoryV3Active && v2BlockPersisted) {
     updates.memoryInjectedBlock = undefined;
   }
   if (blocks.memoryV3InjectedBlock) {
@@ -92,11 +81,20 @@ export function injectionMetadataUpdates(
     updates[MEMORY_V3_INJECTED_BLOCK_FORMAT_METADATA_KEY] =
       MEMORY_V3_INJECTED_BLOCK_FORMAT;
   }
-  updates[MEMORY_V3_POINTER_BLOCK_METADATA_KEY] =
-    blocks.memoryV3PointerBlock || undefined;
-  updates[LEGACY_MEMORY_V3_SPOTLIGHT_BLOCK_METADATA_KEY] = undefined;
-  for (const [block, key] of passthrough) {
-    updates[key] = blocks[block];
+  if (blocks.memoryV3PointerBlock) {
+    updates[MEMORY_V3_POINTER_BLOCK_METADATA_KEY] = blocks.memoryV3PointerBlock;
   }
+  for (const [block, key] of PASSTHROUGH_BLOCKS) {
+    if (blocks[block]) {
+      updates[key] = blocks[block];
+    }
+  }
+  if (Object.keys(updates).length === 0 && !blocks.memoryV3Active) {
+    return null;
+  }
+  if (!blocks.memoryV3PointerBlock) {
+    updates[MEMORY_V3_POINTER_BLOCK_METADATA_KEY] = undefined;
+  }
+  updates[LEGACY_MEMORY_V3_SPOTLIGHT_BLOCK_METADATA_KEY] = undefined;
   return updates;
 }

--- a/assistant/src/plugins/defaults/memory/hooks/injection-metadata.ts
+++ b/assistant/src/plugins/defaults/memory/hooks/injection-metadata.ts
@@ -17,6 +17,22 @@ import {
   MEMORY_V3_POINTER_BLOCK_METADATA_KEY,
 } from "../v3/types.js";
 
+/** The blocks persisted verbatim, each under its own metadata key, in the
+ *  order the update writes them. */
+const PASSTHROUGH_BLOCKS: ReadonlyArray<
+  readonly [block: keyof RuntimeInjectionResult["blocks"], key: string]
+> = [
+  ["unifiedTurnContext", "turnContextBlock"],
+  ["pkbSystemReminder", "pkbSystemReminderBlock"],
+  ["workspaceBlock", "workspaceBlock"],
+  ["nowScratchpadBlock", "nowScratchpadBlock"],
+  ["pkbContextBlock", "pkbContextBlock"],
+  ["memoryV2StaticBlock", "memoryV2StaticBlock"],
+  ["backgroundTurnBlock", "backgroundTurnBlock"],
+  ["channelCapabilitiesBlock", "channelCapabilitiesBlock"],
+  ["nonInteractiveContextBlock", "nonInteractiveContextBlock"],
+];
+
 /**
  * The combined metadata update for a turn's assembled blocks, or `null` when
  * the turn has nothing to persist. Every present block is written under its
@@ -56,18 +72,11 @@ export function injectionMetadataUpdates(
   v2BlockPersisted: boolean,
 ): Record<string, unknown> | null {
   const removeV2Block = Boolean(blocks.memoryV3Active) && v2BlockPersisted;
+  const passthrough = PASSTHROUGH_BLOCKS.filter(([block]) => blocks[block]);
   if (
-    !blocks.unifiedTurnContext &&
-    !blocks.pkbSystemReminder &&
-    !blocks.workspaceBlock &&
-    !blocks.nowScratchpadBlock &&
-    !blocks.pkbContextBlock &&
-    !blocks.memoryV2StaticBlock &&
+    passthrough.length === 0 &&
     !blocks.memoryV3InjectedBlock &&
     !blocks.memoryV3PointerBlock &&
-    !blocks.backgroundTurnBlock &&
-    !blocks.channelCapabilitiesBlock &&
-    !blocks.nonInteractiveContextBlock &&
     !removeV2Block &&
     !blocks.memoryV3Active
   ) {
@@ -86,32 +95,8 @@ export function injectionMetadataUpdates(
   updates[MEMORY_V3_POINTER_BLOCK_METADATA_KEY] =
     blocks.memoryV3PointerBlock || undefined;
   updates[LEGACY_MEMORY_V3_SPOTLIGHT_BLOCK_METADATA_KEY] = undefined;
-  if (blocks.unifiedTurnContext) {
-    updates.turnContextBlock = blocks.unifiedTurnContext;
-  }
-  if (blocks.pkbSystemReminder) {
-    updates.pkbSystemReminderBlock = blocks.pkbSystemReminder;
-  }
-  if (blocks.workspaceBlock) {
-    updates.workspaceBlock = blocks.workspaceBlock;
-  }
-  if (blocks.nowScratchpadBlock) {
-    updates.nowScratchpadBlock = blocks.nowScratchpadBlock;
-  }
-  if (blocks.pkbContextBlock) {
-    updates.pkbContextBlock = blocks.pkbContextBlock;
-  }
-  if (blocks.memoryV2StaticBlock) {
-    updates.memoryV2StaticBlock = blocks.memoryV2StaticBlock;
-  }
-  if (blocks.backgroundTurnBlock) {
-    updates.backgroundTurnBlock = blocks.backgroundTurnBlock;
-  }
-  if (blocks.channelCapabilitiesBlock) {
-    updates.channelCapabilitiesBlock = blocks.channelCapabilitiesBlock;
-  }
-  if (blocks.nonInteractiveContextBlock) {
-    updates.nonInteractiveContextBlock = blocks.nonInteractiveContextBlock;
+  for (const [block, key] of passthrough) {
+    updates[key] = blocks[block];
   }
   return updates;
 }

--- a/assistant/src/plugins/defaults/memory/src/__tests__/memory-v2-simulate-route.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/__tests__/memory-v2-simulate-route.test.ts
@@ -33,7 +33,6 @@ import type { ToolDefinition } from "../../llm-helpers.js";
 
 // Skill store: empty by default so the page index only contains test pages.
 mock.module("../../substrate/skill-store.js", () => ({
-  SKILL_SLUG_PREFIX: "skills/",
   listSkillEntries: () => [],
   listAlwaysCandidateSkillSlugs: () => [],
   seedV2SkillEntries: async () => undefined,

--- a/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-item-routes.test.ts
@@ -69,7 +69,6 @@ mock.module(
 let mockSkillEntries: Array<{ id: string; content: string }> = [];
 
 mock.module("../substrate/skill-store.js", () => ({
-  SKILL_SLUG_PREFIX: "skills/",
   listSkillEntries: () => mockSkillEntries,
 }));
 

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/cli-command-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/cli-command-store.test.ts
@@ -20,6 +20,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { CliCommandHelp } from "../../../../../cli/lib/cli-command-help.js";
+import { isCliCommandSlug } from "../capability-slugs.js";
 
 // ---------------------------------------------------------------------------
 // Programmable test state
@@ -161,7 +162,6 @@ const {
   seedV2CliCommandEntries,
   getCliCommandCapability,
   listCliCommandEntries,
-  isCliCommandSlug,
   _resetCliCommandStoreForTests,
 } = await import("../cli-command-store.js");
 

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/page-index.test.ts
@@ -25,7 +25,6 @@ const skillState: { entries: SkillEntry[] } = { entries: [] };
 const failingSlugs = new Set<string>();
 
 mock.module("../skill-store.js", () => ({
-  SKILL_SLUG_PREFIX: "skills/",
   listSkillEntries: () => skillState.entries,
 }));
 

--- a/assistant/src/plugins/defaults/memory/substrate/cli-command-store.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/cli-command-store.ts
@@ -37,7 +37,6 @@ import { getLogger } from "../logging.js";
 import {
   CLI_COMMAND_SLUG_PREFIX,
   cliCommandSlugFor,
-  isCliCommandSlug,
 } from "./capability-slugs.js";
 import { buildCliCommandHelpContent } from "./cli-command-content.js";
 import { invalidatePageIndex } from "./page-index.js";
@@ -54,10 +53,6 @@ import { resolveSubstrateTuning } from "./tuning.js";
 import type { CliCommandEntry } from "./types.js";
 
 const log = getLogger("memory-v2-cli-command-store");
-
-/** Slug grammar of the CLI-command rows (defined in the dependency-free
- *  `capability-slugs.ts` leaf; re-exported here for the store's callers). */
-export { CLI_COMMAND_SLUG_PREFIX, cliCommandSlugFor, isCliCommandSlug };
 
 /**
  * Payload discriminator written on every CLI-command-seeded Qdrant point.

--- a/assistant/src/plugins/defaults/memory/substrate/ingest.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/ingest.ts
@@ -24,6 +24,10 @@ import {
 } from "../../../../persistence/jobs-store.js";
 import { getLogger } from "../logging.js";
 import {
+  CLI_COMMAND_SLUG_PREFIX,
+  SKILL_SLUG_PREFIX,
+} from "./capability-slugs.js";
+import {
   getConsolidationLockPath,
   releaseLock,
   tryAcquireLock,
@@ -73,16 +77,14 @@ export interface IngestSummary {
 export const MAX_INGEST_PAGES_PER_CALL = 200;
 
 /**
- * Slug prefixes owned by synthetic capability entries. Mirrors
- * `SKILL_SLUG_PREFIX` (`substrate/skill-store.ts`) and
- * `CLI_COMMAND_SLUG_PREFIX` (`substrate/cli-command-store.ts`); the literals
- * are duplicated here because importing those modules would pull the
- * embedding-backend chain into every ingest caller (the page index lazy
- * imports them for the same reason). The page index drops concept pages
- * whose slugs collide with synthetic entries, so ingesting one would
- * persist an unreachable file.
+ * Slug prefixes owned by synthetic capability entries. The page index drops
+ * concept pages whose slugs collide with synthetic entries, so ingesting one
+ * would persist an unreachable file.
  */
-const RESERVED_SLUG_PREFIXES = ["skills/", "cli-commands/"] as const;
+const RESERVED_SLUG_PREFIXES = [
+  SKILL_SLUG_PREFIX,
+  CLI_COMMAND_SLUG_PREFIX,
+] as const;
 
 /** Thrown when the consolidation lock is held by another writer. */
 export class IngestLockedError extends Error {

--- a/assistant/src/plugins/defaults/memory/substrate/injected-block-slugs.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/injected-block-slugs.ts
@@ -98,7 +98,7 @@ const SECTION_PATH_SOURCE = `memory\\/concepts\\/(.+?)\\.md(?:${RegExp.escape(IN
  * spec and so never mutates this shared instance's `lastIndex`. Do NOT call
  * `exec`/`test` on it directly, a `g`-flagged regex is stateful under those.
  */
-export const INJECTED_CONCEPT_HEADER_REGEX = new RegExp(
+const INJECTED_CONCEPT_HEADER_REGEX = new RegExp(
   `^# ${SECTION_PATH_SOURCE}$`,
   "gm",
 );
@@ -370,10 +370,13 @@ export function parseInjectedSections(inner: string): {
 
 /**
  * Header line of a legacy card: the bare page header, one compact card per
- * page, as the builds before the format stamp rendered a block. Greedy in
- * the slug (no section key existed to bleed into it). Flagged `gm` for
- * `matchAll` like {@link INJECTED_CONCEPT_HEADER_REGEX}: never `exec`/`test`
- * it.
+ * page, the grammar the builds before the format stamp rendered a block
+ * with. The one sanctioned second header matcher beside
+ * {@link INJECTED_CONCEPT_HEADER_REGEX}: {@link parseLegacyCards} alone
+ * reads it, it is never applied to a current-format block, and it stays
+ * byte-identical to the pre-stamp build's regex rather than being derived
+ * from the section-path source. Greedy in the slug (no section key existed
+ * to bleed into it). Flagged `gm` for `matchAll`: never `exec`/`test` it.
  */
 const LEGACY_CARD_HEADER_REGEX = /^# memory\/concepts\/(.+)\.md$/gm;
 
@@ -386,7 +389,7 @@ type LegacyCardRef = { kind: "card"; slug: string } | { kind: "other" };
 /** One ordered chunk of a parsed legacy card block: a page's card (owned by
  *  `slug`) or any other `\n\n`-joined chunk (capability content under its
  *  own header, the skills hint; never dropped). */
-export type LegacyCardPiece = LegacyCardRef & { text: string };
+type LegacyCardPiece = LegacyCardRef & { text: string };
 
 /**
  * Split an UNWRAPPED legacy card block (a `memoryV3InjectedBlock` persisted

--- a/assistant/src/plugins/defaults/memory/substrate/page-index.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/page-index.ts
@@ -20,6 +20,10 @@
  */
 
 import { getLogger } from "../logging.js";
+import {
+  CLI_COMMAND_SLUG_PREFIX,
+  SKILL_SLUG_PREFIX,
+} from "./capability-slugs.js";
 import { type DanglingLink, findDanglingLinks } from "./page-links.js";
 import {
   getPageMtimeMs,
@@ -171,10 +175,7 @@ export async function getPageIndex(workspaceDir: string): Promise<PageIndex> {
     freshAt: number | null;
   }
 
-  const [
-    { listSkillEntries, SKILL_SLUG_PREFIX },
-    { listCliCommandEntries, CLI_COMMAND_SLUG_PREFIX },
-  ] = await Promise.all([
+  const [{ listSkillEntries }, { listCliCommandEntries }] = await Promise.all([
     import("./skill-store.js"),
     import("./cli-command-store.js"),
   ]);

--- a/assistant/src/plugins/defaults/memory/substrate/skill-store.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/skill-store.ts
@@ -38,11 +38,7 @@ import { generateSparseEmbedding } from "../../../../persistence/embeddings/embe
 import { applyCorrectionIfCalibrated } from "../anisotropy.js";
 import { embedWithBackend } from "../embeddings.js";
 import { getLogger } from "../logging.js";
-import {
-  isSkillSlug,
-  SKILL_SLUG_PREFIX,
-  skillSlugFor,
-} from "./capability-slugs.js";
+import { SKILL_SLUG_PREFIX, skillSlugFor } from "./capability-slugs.js";
 import { invalidatePageIndex } from "./page-index.js";
 import {
   backfillKindOnPointsWithPrefix,
@@ -62,10 +58,6 @@ import { resolveSubstrateTuning } from "./tuning.js";
 import type { SkillEntry } from "./types.js";
 
 const log = getLogger("memory-v2-skill-store");
-
-/** Slug grammar of the skill rows (defined in the dependency-free
- *  `capability-slugs.ts` leaf; re-exported here for the store's callers). */
-export { isSkillSlug, SKILL_SLUG_PREFIX, skillSlugFor };
 
 /**
  * Payload discriminator written on every skill-seeded Qdrant point. Keeps

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/injection.test.ts
@@ -16,8 +16,8 @@
  *
  * Hermetic by design: the embedding backend, qdrant client, and `getConfig`
  * are mocked at the module level so the suite never reaches a real backend.
- * The skill-store cache (`getSkillCapability`, `isSkillSlug`) is mocked so
- * each test can stage skill content without touching the real catalog.
+ * The skill-store cache (`getSkillCapability`) is mocked so each test can
+ * stage skill content without touching the real catalog.
  * The activation-store uses an in-memory SQLite database so writes are
  * real but contained.
  *
@@ -140,9 +140,6 @@ mock.module("../../substrate/skill-store.js", () => ({
       : idOrSlug;
     return skillState.entries.get(id) ?? null;
   },
-  isSkillSlug: (slug: string) => slug.startsWith("skills/"),
-  SKILL_SLUG_PREFIX: "skills/",
-  skillSlugFor: (id: string) => `skills/${id}`,
   // PR 4 added `listSkillEntries`; `page-index.ts` (transitively imported
   // via `page-store.ts` and `skill-store.ts`) consumes it at module-init
   // time. Tests stage skill content via `skillState.entries`; expose them
@@ -181,9 +178,6 @@ mock.module("../../substrate/cli-command-store.js", () => ({
       : idOrSlug;
     return cliCommandState.entries.get(id) ?? null;
   },
-  isCliCommandSlug: (slug: string) => slug.startsWith("cli-commands/"),
-  CLI_COMMAND_SLUG_PREFIX: "cli-commands/",
-  cliCommandSlugFor: (name: string) => `cli-commands/${name}`,
   listCliCommandEntries: () => Array.from(cliCommandState.entries.values()),
 }));
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/router.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/router.test.ts
@@ -71,7 +71,6 @@ mock.module("../../../../../util/logger.js", () => ({
 }));
 
 mock.module("../../substrate/skill-store.js", () => ({
-  SKILL_SLUG_PREFIX: "skills/",
   listSkillEntries: () => skillState.entries,
   listAlwaysCandidateSkillSlugs: () => [],
 }));

--- a/assistant/src/plugins/defaults/memory/v2/injection.ts
+++ b/assistant/src/plugins/defaults/memory/v2/injection.ts
@@ -27,15 +27,15 @@ import type { AssistantConfig } from "../../../../config/types.js";
 import { getLogger } from "../logging.js";
 import { getWorkspaceDir } from "../paths.js";
 import {
-  getCliCommandCapability,
   isCliCommandSlug,
-} from "../substrate/cli-command-store.js";
+  isSkillSlug,
+} from "../substrate/capability-slugs.js";
+import { getCliCommandCapability } from "../substrate/cli-command-store.js";
 import { getEdgeIndex } from "../substrate/edge-index.js";
 import { getPageIndex } from "../substrate/page-index.js";
 import { readPage, renderPageContent } from "../substrate/page-store.js";
 import {
   getSkillCapability,
-  isSkillSlug,
   listAlwaysCandidateSkillSlugs,
 } from "../substrate/skill-store.js";
 import { spreadActivation } from "../substrate/spread.js";

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/live-integration.test.ts
@@ -18,8 +18,7 @@
  * That is the behavioral contract the live path wires together: the injector
  * renders only the turn's NET-NEW sections, records them, and the resulting
  * block is FROZEN into history, prior turns' blocks are never re-rendered or
- * stripped (the cache contract; the old `stripAllMemoryInjections`
- * whole-layer replace is gone). The provider is stubbed (no network).
+ * stripped (the cache contract). The provider is stubbed (no network).
  */
 
 import { Database } from "bun:sqlite";

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
@@ -7,7 +7,7 @@ import { EmbeddingBackendUnavailableError } from "../../../../../persistence/emb
 import { EmbeddingBillingBlockError } from "../../../../../persistence/embeddings/embedding-billing-breaker.js";
 import type { MemoryJob } from "../../../../../persistence/jobs-store.js";
 import type { SkillInstallMeta } from "../../../../../skills/install-meta.js";
-import { skillSlugFor } from "../../substrate/skill-store.js";
+import { skillSlugFor } from "../../substrate/capability-slugs.js";
 import { renderCapabilityBody } from "../capabilities.js";
 import {
   backfillAllSections,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -2099,30 +2099,30 @@ describe("orchestrate — span-query pass", () => {
 
 describe("orchestrate: multi-section finder lines", () => {
   // A page whose `## Parody` section matches the message's bulk and whose
-  // `## Pumpkin` section matches only its last clause, deep in its body. The
-  // slug shares no token with the queries: its last segment heads every
+  // `## Inventory` section matches only its last clause, deep in its body.
+  // The slug shares no token with the queries: its last segment heads every
   // section's text, so a query term in it would score every section.
   const FILLER = "filler words to push the match deep into the section ";
-  const GOURD_PAGES: Record<Slug, string> = {
+  const BULK_AND_CLAUSE_PAGES: Record<Slug, string> = {
     "autumn-notes": [
-      "lead for the squash page",
+      "lead for the page",
       "## Parody",
-      "the parody verse everyone laughed at, a hilarious pumpkin patch skit",
-      "## Pumpkin",
-      `${FILLER.repeat(8)}the gourd loves the pumpkin song`,
+      "the parody verse everyone laughed at, a hilarious skit",
+      "## Inventory",
+      `${FILLER.repeat(8)}the turnip crates are counted here`,
     ].join("\n"),
   };
   const BULK = "the parody verse was hilarious and everyone laughed.";
-  const CLAUSE = "please remind me about the gourd.";
+  const CLAUSE = "please remind me about the turnip.";
 
   test("a page whose sections match the bulk and the last clause carries both lines, and keeping both selects both sections", async () => {
-    const lanes = await customLanes(GOURD_PAGES);
-    const [, parodyDoc, pumpkinDoc] =
+    const lanes = await customLanes(BULK_AND_CLAUSE_PAGES);
+    const [, parodyDoc, inventoryDoc] =
       lanes.sectionIndex.byArticle.get("autumn-notes")!;
     const parody = lanes.sectionIndex.sections[parodyDoc!]!;
-    const pumpkin = lanes.sectionIndex.sections[pumpkinDoc!]!;
+    const inventory = lanes.sectionIndex.sections[inventoryDoc!]!;
     // The needle scores the bulk theme (`## Parody`); the span pass over the
-    // last clause reaches `## Pumpkin`.
+    // last clause reaches `## Inventory`.
     denseHits = [];
     denseHitsByQuery.set(CLAUSE, [{ article: "autumn-notes", section: 2 }]);
     providerStub = selectProvider(["autumn-notes"]);
@@ -2135,35 +2135,35 @@ describe("orchestrate: multi-section finder lines", () => {
     const lines = result.lanes.finder.filter((c) => c.slug === "autumn-notes");
     expect(lines.map((c) => [c.lane, c.section])).toEqual([
       ["needle", parody],
-      ["span", pumpkin],
+      ["span", inventory],
     ]);
     // Two pool lines, each a keyword-in-context snippet of its own section.
     const poolLines = lastPoolLines.filter((l) => l.includes(" autumn-notes "));
     expect(poolLines).toHaveLength(2);
     expect(poolLines[0]).toContain("§Parody: ");
     expect(poolLines[0]).toContain("parody");
-    expect(poolLines[1]).toContain("§Pumpkin: ");
-    expect(poolLines[1]).toContain("gourd");
+    expect(poolLines[1]).toContain("§Inventory: ");
+    expect(poolLines[1]).toContain("turnip");
     // Keeping both ids selects both sections.
     expect(result.selections).toEqual([
-      { slug: "autumn-notes", sections: [parody, pumpkin] },
+      { slug: "autumn-notes", sections: [parody, inventory] },
     ]);
   });
 
   test("a needle line's snippet is a window around its top contributing term, not the section head", async () => {
-    const lanes = await customLanes(GOURD_PAGES);
+    const lanes = await customLanes(BULK_AND_CLAUSE_PAGES);
     providerStub = selectProvider([]);
 
-    const result = await orchestrate(makeTurn(1, "gourd"), depsOf(lanes));
+    const result = await orchestrate(makeTurn(1, "turnip"), depsOf(lanes));
 
-    expect(result.lanes.finder[0]?.terms).toEqual(["gourd"]);
+    expect(result.lanes.finder[0]?.terms).toEqual(["turnip"]);
     const line = lastPoolLines.find((l) => l.includes(" autumn-notes "))!;
-    // "gourd" sits past the first 300 characters of `## Pumpkin`, so a
+    // "turnip" sits past the first 300 characters of `## Inventory`, so a
     // section-head snippet would not show it; the window is centered on it
     // and the synthetic head line is not shown.
-    expect(line).toContain("§Pumpkin: … ");
-    expect(line).toContain("the gourd loves the pumpkin song");
-    expect(line).not.toContain("autumn-notes - Pumpkin");
+    expect(line).toContain("§Inventory: … ");
+    expect(line).toContain("the turnip crates are counted here");
+    expect(line).not.toContain("autumn-notes - Inventory");
   });
 
   test("finderSectionsPerPage caps a page's lines in surfacing order", async () => {
@@ -2221,53 +2221,53 @@ describe("orchestrate: multi-section finder lines", () => {
 
 describe("orchestrate: rare-term lane", () => {
   // The message's bulk theme (the parody) matches `## Parody`; its last
-  // clause's one distinctive word, "gourd", sits twice each in two other
+  // clause's one distinctive word, "turnip", sits twice each in two other
   // sections of the page and once, in a longer body, on a second page. The
   // common words recur in every section, so among the message's words only
-  // the parody words (which hit `## Parody` alone) and "gourd" are rare.
-  const GOURD_PAGES: Record<Slug, string> = {
-    "silly-lines": [
-      "here is my little log of silly lines",
+  // the parody words (which hit `## Parody` alone) and "turnip" are rare.
+  const RARE_TERM_PAGES: Record<Slug, string> = {
+    "sample-notes": [
+      "the weekly report lists the sample notes",
       "## Parody",
-      "parody verse: everyone laughed, hilarious skit, roast, encore, standing ovation, crowd; here is my little friend",
-      "## Pumpkin",
-      "pumpkin bit: here is my little gourd, gourd of my heart",
+      "parody verse: everyone laughed, hilarious skit, roast, encore, standing ovation, crowd; the weekly report lists the rest",
+      "## Inventory",
+      "inventory: the weekly report lists the turnip crates and the turnip totals",
       "## Harvest",
-      "harvest song: gourd on the porch, gourd in the pie; here is my little ballad",
+      "harvest: the weekly report lists the turnip deliveries and the turnip receipts, with the dates of each",
     ].join("\n"),
     "autumn-recipes": [
       "## Soup",
-      "gourd soup: here is my little pot; onions, celery, carrots, thyme, cream, salt, pepper, and a long simmer",
+      "turnip soup: the weekly report lists onions, celery, carrots, thyme, cream, salt, pepper, and a long simmer",
     ].join("\n"),
   };
   const MESSAGE =
-    "parody verse hilarious, everyone laughed: skit, roast, encore, standing ovation, crowd. Here is my little gourd";
+    "parody verse hilarious, everyone laughed: skit, roast, encore, standing ovation, crowd. The weekly report lists the turnip";
   const RARE = { maxDf: 3, maxDfFraction: 1, perTerm: 2, cap: 24 };
 
   test("a rare word's top sections join as lines tagged with the word beside the bulk-theme line, and selecting them selects the sections", async () => {
-    const lanes = await customLanes(GOURD_PAGES);
-    const [, parodyDoc, pumpkinDoc, harvestDoc] =
-      lanes.sectionIndex.byArticle.get("silly-lines")!;
+    const lanes = await customLanes(RARE_TERM_PAGES);
+    const [, parodyDoc, inventoryDoc, harvestDoc] =
+      lanes.sectionIndex.byArticle.get("sample-notes")!;
     const parody = lanes.sectionIndex.sections[parodyDoc!]!;
-    const pumpkin = lanes.sectionIndex.sections[pumpkinDoc!]!;
+    const inventory = lanes.sectionIndex.sections[inventoryDoc!]!;
     const harvest = lanes.sectionIndex.sections[harvestDoc!]!;
-    providerStub = selectProvider(["silly-lines"]);
+    providerStub = selectProvider(["sample-notes"]);
 
     const result = await orchestrate(
       makeTurn(1, MESSAGE),
       depsOf(lanes, { rareTerm: RARE }),
     );
 
-    const lines = result.lanes.finder.filter((c) => c.slug === "silly-lines");
+    const lines = result.lanes.finder.filter((c) => c.slug === "sample-notes");
     expect(lines.map((c) => [c.lane, c.section])).toEqual([
       ["needle", parody],
-      ["rare", pumpkin],
+      ["rare", inventory],
       ["rare", harvest],
     ]);
-    expect(lines[1]!.terms).toEqual(["gourd"]);
-    expect(lines[2]!.terms).toEqual(["gourd"]);
-    // The second page's only "gourd" section is the needle's own line for
-    // it, and the third-ranked "gourd" section is past perTerm anyway.
+    expect(lines[1]!.terms).toEqual(["turnip"]);
+    expect(lines[2]!.terms).toEqual(["turnip"]);
+    // The second page's only "turnip" section is the needle's own line for
+    // it, and the third-ranked "turnip" section is past perTerm anyway.
     expect(
       result.lanes.finder
         .filter((c) => c.slug === "autumn-recipes")
@@ -2275,35 +2275,37 @@ describe("orchestrate: rare-term lane", () => {
     ).toEqual(["needle"]);
     // Each rare line is tagged with the word and snippets the section
     // around it.
-    const rareLines = lastPoolLines.filter((l) => l.includes("(rare: gourd) "));
+    const rareLines = lastPoolLines.filter((l) =>
+      l.includes("(rare: turnip) "),
+    );
     expect(rareLines).toHaveLength(2);
-    expect(rareLines[0]).toContain("(rare: gourd) silly-lines ");
+    expect(rareLines[0]).toContain("(rare: turnip) sample-notes ");
     expect(rareLines[0]).toContain(
-      "§Pumpkin: pumpkin bit: here is my little gourd",
+      "§Inventory: inventory: the weekly report lists the turnip",
     );
     expect(rareLines[1]).toContain("§Harvest: ");
-    expect(rareLines[1]).toContain("gourd");
+    expect(rareLines[1]).toContain("turnip");
     expect(result.selections).toContainEqual({
-      slug: "silly-lines",
-      sections: [parody, pumpkin, harvest],
+      slug: "sample-notes",
+      sections: [parody, inventory, harvest],
     });
   });
 
   test("a rare hit on a section the needle already pooled is a no-op", async () => {
-    const lanes = await customLanes(GOURD_PAGES);
-    const [, , pumpkinDoc, harvestDoc] =
-      lanes.sectionIndex.byArticle.get("silly-lines")!;
-    const pumpkin = lanes.sectionIndex.sections[pumpkinDoc!]!;
+    const lanes = await customLanes(RARE_TERM_PAGES);
+    const [, , inventoryDoc, harvestDoc] =
+      lanes.sectionIndex.byArticle.get("sample-notes")!;
+    const inventory = lanes.sectionIndex.sections[inventoryDoc!]!;
     const harvest = lanes.sectionIndex.sections[harvestDoc!]!;
     providerStub = selectProvider([]);
 
     const result = await orchestrate(
-      makeTurn(1, "gourd"),
+      makeTurn(1, "turnip"),
       depsOf(lanes, {
         needle: {
           ...lanes.needle,
           queryScored: () => [
-            { article: "silly-lines", section: pumpkinDoc!, score: 1 },
+            { article: "sample-notes", section: inventoryDoc!, score: 1 },
           ],
         },
         rareTerm: RARE,
@@ -2312,8 +2314,8 @@ describe("orchestrate: rare-term lane", () => {
 
     expect(result.lanes.finder.map((c) => [c.slug, c.lane, c.section])).toEqual(
       [
-        ["silly-lines", "needle", pumpkin],
-        ["silly-lines", "rare", harvest],
+        ["sample-notes", "needle", inventory],
+        ["sample-notes", "rare", harvest],
       ],
     );
   });
@@ -2322,8 +2324,8 @@ describe("orchestrate: rare-term lane", () => {
   // before the rare lane runs: the needle pools `## Alpha` (ordinal 1), the
   // full-message dense pass `## Bravo` (2), and the reply pass `## Charlie`
   // (3). `alpha` is the Alpha section's text, `tail` the page's further
-  // sections. Of the message's words only "gourd" occurs in the corpus.
-  const CAPPED_MESSAGE = "here is my little gourd";
+  // sections. Of the message's words only "turnip" occurs in the corpus.
+  const CAPPED_MESSAGE = "any turnip news";
   const REPLY = "the previous reply";
   async function cappedPageDeps(
     alpha: string,
@@ -2360,12 +2362,12 @@ describe("orchestrate: rare-term lane", () => {
   }
 
   test("a rare hit joins a page the prior lanes filled to the per-page cap, bounded by the lane's own cap", async () => {
-    // "gourd" is held by `## Delta` (ordinal 4) and `## Echo` (5) alone.
+    // "turnip" is held by `## Delta` (ordinal 4) and `## Echo` (5) alone.
     const tail = [
       "## Delta",
-      "delta text, and the gourd",
+      "delta text, and the turnip",
       "## Echo",
-      "echo text, and the gourd",
+      "echo text, and the turnip",
     ];
     providerStub = selectProvider([]);
 
@@ -2384,7 +2386,7 @@ describe("orchestrate: rare-term lane", () => {
     ]);
     expect(
       result.lanes.finder.filter((c) => c.lane === "rare").map((c) => c.terms),
-    ).toEqual([["gourd"], ["gourd"]]);
+    ).toEqual([["turnip"], ["turnip"]]);
 
     // The lane's own cap is what bounds the lines past the page cap, so a
     // page carries at most `finderSectionsPerPage + rareTerm.cap` lines.
@@ -2403,15 +2405,15 @@ describe("orchestrate: rare-term lane", () => {
   });
 
   test("a rare hit on a section a capped page already carries is still a no-op", async () => {
-    // "gourd" is held by `## Alpha`, which the needle pooled, and by
+    // "turnip" is held by `## Alpha`, which the needle pooled, and by
     // `## Delta` (ordinal 4).
     providerStub = selectProvider([]);
 
     const result = await orchestrate(
       makeTurn(1, CAPPED_MESSAGE, REPLY),
-      await cappedPageDeps("alpha text, and the gourd", [
+      await cappedPageDeps("alpha text, and the turnip", [
         "## Delta",
-        "delta text, and the gourd",
+        "delta text, and the turnip",
       ]),
     );
     expect(
@@ -2424,18 +2426,18 @@ describe("orchestrate: rare-term lane", () => {
     ]);
     expect(
       result.lanes.finder.filter((c) => c.lane === "rare").map((c) => c.terms),
-    ).toEqual([["gourd"]]);
+    ).toEqual([["turnip"]]);
   });
 
   test("omitting the rare-term tuning disables the lane", async () => {
-    const lanes = await customLanes(GOURD_PAGES);
+    const lanes = await customLanes(RARE_TERM_PAGES);
     providerStub = selectProvider([]);
 
-    const without = await orchestrate(makeTurn(1, "gourd"), depsOf(lanes));
+    const without = await orchestrate(makeTurn(1, "turnip"), depsOf(lanes));
     expect(without.lanes.finder.some((c) => c.lane === "rare")).toBe(false);
 
     const withLane = await orchestrate(
-      makeTurn(2, "gourd"),
+      makeTurn(2, "turnip"),
       depsOf(lanes, { rareTerm: RARE }),
     );
     expect(withLane.lanes.finder.some((c) => c.lane === "rare")).toBe(true);

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/pool-select.test.ts
@@ -716,17 +716,17 @@ describe("selectPool: sections and keyword-in-context snippets", () => {
     const deep = sectionOf(
       "page-a",
       "Rollout",
-      `${filler.repeat(6)}the Gourd milestone slipped a week ${filler.repeat(3)}`,
+      `${filler.repeat(6)}the Turnip milestone slipped a week ${filler.repeat(3)}`,
     );
     await selectPool(
       finderOnly({
         slug: "page-a",
         descriptor: deep.text,
         section: deep,
-        terms: ["absent", "gourd"],
+        terms: ["absent", "turnip"],
         lane: "needle",
       }),
-      makeTurn("gourd?"),
+      makeTurn("turnip?"),
     );
     const [block] = sentBlocks();
     const line = block.text
@@ -735,7 +735,7 @@ describe("selectPool: sections and keyword-in-context snippets", () => {
     // The first term that occurs in the body (not `absent`) centers the
     // window; the match is case-insensitive and the head line is not shown.
     expect(line).toContain("§Rollout: … ");
-    expect(line).toContain("Gourd milestone");
+    expect(line).toContain("Turnip milestone");
     expect(line).not.toContain("page-a - Rollout");
     expect(line.endsWith(" …")).toBe(true);
     // The window itself stays at the snippet cap (plus its ellipses).
@@ -793,27 +793,27 @@ describe("selectPool: sections and keyword-in-context snippets", () => {
     providerStub = makeProvider(toolUseResponse({ ids: [] }));
     const filler =
       "filler words that push the match well past the head of the section ";
-    const pumpkin = sectionOf(
-      "silly-lines",
-      "Pumpkin",
-      `${filler.repeat(6)}the pumpkin bit: my little gourd ${filler.repeat(3)}`,
+    const inventory = sectionOf(
+      "sample-notes",
+      "Inventory",
+      `${filler.repeat(6)}the weekly turnip totals ${filler.repeat(3)}`,
     );
     await selectPool(
       finderOnly({
-        slug: "silly-lines",
-        descriptor: pumpkin.text,
-        section: pumpkin,
-        terms: ["gourd"],
+        slug: "sample-notes",
+        descriptor: inventory.text,
+        section: inventory,
+        terms: ["turnip"],
         lane: "rare",
       }),
-      makeTurn("here is my little gourd"),
+      makeTurn("the weekly report lists the turnip"),
     );
     const [block] = sentBlocks();
     const line = block.text
       .split("\n")
-      .find((l) => l.startsWith("[1] (rare: gourd) silly-lines "))!;
-    expect(line).toContain("§Pumpkin: … ");
-    expect(line).toContain("my little gourd");
+      .find((l) => l.startsWith("[1] (rare: turnip) sample-notes "))!;
+    expect(line).toContain("§Inventory: … ");
+    expect(line).toContain("weekly turnip totals");
     // The selector is told what the tag means.
     expect(providerCalls[0]!.options?.systemPrompt).toContain("(rare: word)");
   });
@@ -823,14 +823,14 @@ describe("selectPool: sections and keyword-in-context snippets", () => {
     const notes = sectionOf(
       "page-a",
       "Notes",
-      "we said: little, gourd is the nickname",
+      "we said: weekly, turnip is the label",
     );
     await selectPool(
       finderOnly({
         slug: "page-a",
         descriptor: notes.text,
         section: notes,
-        terms: ["little_gourd"],
+        terms: ["weekly_turnip"],
       }),
       makeTurn("x"),
     );
@@ -838,8 +838,8 @@ describe("selectPool: sections and keyword-in-context snippets", () => {
     const line = block.text
       .split("\n")
       .find((l) => l.startsWith("[1] page-a "))!;
-    expect(
-      line.endsWith("§Notes: we said: little, gourd is the nickname"),
-    ).toBe(true);
+    expect(line.endsWith("§Notes: we said: weekly, turnip is the label")).toBe(
+      true,
+    );
   });
 });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-needle.test.ts
@@ -242,20 +242,20 @@ describe("queryScored", () => {
   });
 
   test("findTerm locates a term as a whole token, case-insensitively, and a bigram across punctuation", () => {
-    expect(findTerm("The Gourd sits here", "gourd")).toEqual({
+    expect(findTerm("The Turnip sits here", "turnip")).toEqual({
       start: 4,
-      end: 9,
+      end: 10,
     });
     // A substring inside a longer token is not an occurrence.
-    expect(findTerm("gourds and gourd", "gourd")).toEqual({
-      start: 11,
-      end: 16,
+    expect(findTerm("turnips and turnip", "turnip")).toEqual({
+      start: 12,
+      end: 18,
     });
-    expect(findTerm("we said: little, gourd", "little_gourd")).toEqual({
+    expect(findTerm("we said: weekly, turnip", "weekly_turnip")).toEqual({
       start: 9,
-      end: 22,
+      end: 23,
     });
-    expect(findTerm("nothing here", "gourd")).toBeUndefined();
+    expect(findTerm("nothing here", "turnip")).toBeUndefined();
     // Only tokenizer-shaped terms are searched.
     expect(findTerm("a (b) c", "(b)")).toBeUndefined();
   });

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/sections.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/sections.test.ts
@@ -95,9 +95,6 @@ describe("buildSectionIndex", () => {
           `${sectionHeadLine(section.article, section.title)}\n`,
         ),
       ).toBe(true);
-      if (section.title === "Big" || section.article === "page-lead") {
-        expect(sectionBody(section).length).toBeGreaterThan(0);
-      }
     }
     const big = index.sections.filter((s) => s.title === "Big");
     expect(big.length).toBeGreaterThan(1);
@@ -105,6 +102,10 @@ describe("buildSectionIndex", () => {
     const leadChunks = index.sections.filter((s) => s.article === "page-lead");
     expect(leadChunks.length).toBeGreaterThan(1);
     expect(leadChunks.map(sectionBody).join("")).toBe(unbroken);
+    // Every chunk of both carries body text past its head line.
+    for (const chunk of [...big, ...leadChunks]) {
+      expect(sectionBody(chunk).length).toBeGreaterThan(0);
+    }
   });
 
   test("a heading longer than the window still chunks by near-window bodies; the key keeps the full title", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/shadow-plugin.test.ts
@@ -419,9 +419,9 @@ mock.module("../../../../../util/platform.js", () => ({
 
 // Capability stores: `renderCapabilityBody` (reached from `initLanes`' pageBody)
 // and `renderCapabilityContent` (the live injector's short form) resolve
-// synthetic slugs through these. Spread the real module so the prefix
-// predicates (`isSkillSlug`/`isCliCommandSlug`) stay intact; override only the
-// content lookup so the capability slug resolves.
+// synthetic slugs through these. Spread the real module so its other exports
+// stay intact; override only the content lookup so the capability slug
+// resolves.
 mock.module("../../substrate/skill-store.js", () => ({
   ...realSkillStore,
   getSkillCapability: (idOrSlug: string) =>
@@ -861,14 +861,14 @@ describe("memory-v3 engine", () => {
   });
 
   test("a rare-term selection persists source rare and its pool line's lane", async () => {
-    const pumpkin: Section = {
+    const inventory: Section = {
       article: "page-rare",
-      title: "Pumpkin",
+      title: "Inventory",
       text: "x",
       ordinal: 1,
     };
     orchestrateSpy.mockImplementationOnce(async () => ({
-      selections: [{ slug: "page-rare", sections: [pumpkin] }],
+      selections: [{ slug: "page-rare", sections: [inventory] }],
       lanes: {
         core: [],
         hot: [],
@@ -877,8 +877,8 @@ describe("memory-v3 engine", () => {
         finder: [
           {
             slug: "page-rare",
-            section: pumpkin,
-            terms: ["gourd"],
+            section: inventory,
+            terms: ["turnip"],
             descriptor: "",
             lane: "rare",
           },
@@ -894,8 +894,8 @@ describe("memory-v3 engine", () => {
       {
         slug: "page-rare",
         lane: "rare",
-        section_title: "Pumpkin",
-        section_key: "Pumpkin",
+        section_title: "Inventory",
+        section_key: "Inventory",
         chosen: true,
       },
     ]);
@@ -1090,10 +1090,10 @@ describe("memory-v3 engine", () => {
       text: "page-two - Bulk theme\nthe long part",
       ordinal: 1,
     };
-    const pumpkin: Section = {
+    const inventory: Section = {
       article: "page-two",
-      title: "Pumpkin",
-      text: "page-two - Pumpkin\ngourd",
+      title: "Inventory",
+      text: "page-two - Inventory\nturnip",
       ordinal: 4,
     };
     const lanes = {
@@ -1110,8 +1110,8 @@ describe("memory-v3 engine", () => {
         },
         {
           slug: "page-two",
-          section: pumpkin,
-          terms: ["gourd"],
+          section: inventory,
+          terms: ["turnip"],
           descriptor: "",
           lane: "rare" as const,
         },
@@ -1124,11 +1124,11 @@ describe("memory-v3 engine", () => {
         selectorRan: true,
       })[0]!.source;
     // Only the rare line was picked: the rare lane is credited.
-    expect(sourceOf([pumpkin])).toBe("rare");
+    expect(sourceOf([inventory])).toBe("rare");
     // Only the needle line was picked.
     expect(sourceOf([bulk])).toBe("needle");
     // Both picked: the first selected section's line decides.
-    expect(sourceOf([pumpkin, bulk])).toBe("rare");
+    expect(sourceOf([inventory, bulk])).toBe("rare");
     // No section (the page's card): the page's first line decides.
     expect(sourceOf([])).toBe("needle");
   });
@@ -1235,14 +1235,14 @@ describe("memory-v3 engine", () => {
   });
 
   test("a selection of a rare-term line records source rare with its section", () => {
-    const pumpkin: Section = {
+    const inventory: Section = {
       article: "page-1",
-      title: "Pumpkin",
+      title: "Inventory",
       text: "x",
       ordinal: 2,
     };
     const rows = attributeSelections({
-      selections: [{ slug: "page-1", sections: [pumpkin] }],
+      selections: [{ slug: "page-1", sections: [inventory] }],
       lanes: {
         core: [],
         hot: [],
@@ -1251,8 +1251,8 @@ describe("memory-v3 engine", () => {
         finder: [
           {
             slug: "page-1",
-            section: pumpkin,
-            terms: ["gourd"],
+            section: inventory,
+            terms: ["turnip"],
             descriptor: "",
             lane: "rare",
           },
@@ -1265,8 +1265,8 @@ describe("memory-v3 engine", () => {
         slug: "page-1",
         source: "rare",
         sectionOrdinal: 2,
-        sectionTitle: "Pumpkin",
-        sectionKey: "Pumpkin",
+        sectionTitle: "Inventory",
+        sectionKey: "Inventory",
       },
     ]);
   });

--- a/assistant/src/plugins/defaults/memory/v3/candidate-match.ts
+++ b/assistant/src/plugins/defaults/memory/v3/candidate-match.ts
@@ -31,8 +31,8 @@ import {
 } from "../../../../persistence/embeddings/embed.js";
 import { abortableSleep, computeRetryDelay } from "../host-utils.js";
 import { getLogger } from "../logging.js";
+import { skillSlugFor } from "../substrate/capability-slugs.js";
 import { simBatch } from "../substrate/sim.js";
-import { skillSlugFor } from "../substrate/skill-store.js";
 
 const log = getLogger("memory-v3-candidate-match");
 

--- a/assistant/src/plugins/defaults/memory/v3/capabilities.ts
+++ b/assistant/src/plugins/defaults/memory/v3/capabilities.ts
@@ -48,10 +48,7 @@ export function isCapabilitySlug(slug: Slug): boolean {
  * section injects that section under its {@link sectionKey}, and a page
  * selected without a match injects its lead (`""`).
  */
-export function injectionSectionKey(
-  slug: Slug,
-  section: Section | undefined,
-): string {
+function injectionSectionKey(slug: Slug, section: Section | undefined): string {
   if (isCapabilitySlug(slug) || !section) {
     return "";
   }

--- a/assistant/src/plugins/defaults/memory/v3/injector.ts
+++ b/assistant/src/plugins/defaults/memory/v3/injector.ts
@@ -2,113 +2,63 @@
  * The memory-v3 {@link Injector}s: frozen net-new sections + per-turn pointer.
  *
  * Two injectors share one orchestration result per turn (memoized via
- * {@link observeTurnOnce} so re-entry assemblies — overflow convergence,
- * post-compaction re-injection — reuse the turn's selections instead of
+ * {@link observeTurnOnce}, so re-entry assemblies, overflow convergence and
+ * post-compaction re-injection, reuse the turn's selections instead of
  * re-running the selector):
  *
  *  - {@link memoryV3Injector} (id `memory-v3`, `after-memory-prefix`): the
  *    PERSISTENT layer. The injection unit is the SECTION: each selected page
  *    contributes every section selected for it, or its lead when it was
  *    selected with none (a capability slug contributes its whole capability
- *    content). Renders only this turn's NET-NEW sections, pairs
+ *    content). It renders only this turn's NET-NEW units, the pairs
  *    `(slug, section key)` not already active in the section store, inside
- *    one `<memory>` block and returns the block. The resident pairs are
- *    stamped with the turn's selection time (`touchSelected`, the prune
- *    valve's recency) synchronously at classification, before the page reads
- *    yield: a valve queued by an earlier turn's commit fires on a timer and
- *    can run while those reads are awaited, so it ranks this turn's recency
- *    rather than the stale one, and a turn whose net-new pairs all render
- *    empty (no block, no commit) still stamps them. The stamp is a recency
- *    bump, never a claim, so a turn whose block does not attach bumps
- *    harmlessly. The net-new record (`recordInjected`) and the prune-valve
- *    schedule are DEFERRED to a commit callback the block carries
- *    (`meta[MEMORY_V3_COMMIT_META_KEY]`): runtime assembly invokes it only
- *    when the turn's tail is a user message (the same gate as metadata
- *    capture), so a turn whose block silently fails to attach never claims
- *    its sections in the store (which would suppress them until compaction).
- *    Runtime assembly splices the block onto the
- *    current user message and the user-prompt-submit hook persists the
- *    unwrapped inner text under `metadata.memoryV3InjectedBlock`;
- *    `conversation.ts` rehydrates it on load. The block is FROZEN thereafter:
- *    prior turns' section blocks stay byte-identical in history, so they ride
- *    the provider's cached prefix and survive restarts, mirroring v2's
- *    `memoryInjectedBlock` mechanism. An all-repeat turn returns an
- *    EMPTY-TEXT block: assembly attaches nothing, but the block's presence
- *    still keys v2 suppression (v3 ran and owns the `<memory>` layer this
- *    turn). A `null` return (failure / empty selection / every net-new
- *    section rendered empty) attaches no v3 block: under `memory-v3-live` the
- *    user-prompt-submit hook skips v2 retrieval entirely, so a null return
- *    leaves the turn with no NEW injected memory (prior turns' frozen
- *    sections still ride history).
+ *    one `<memory>` block. The resident pairs are stamped with the turn's
+ *    selection time (`touchSelected`, the prune valve's recency); the
+ *    net-new record (`recordInjected`) and the valve schedule are DEFERRED
+ *    to a commit callback the block carries
+ *    (`meta[MEMORY_V3_COMMIT_META_KEY]`), which runtime assembly invokes
+ *    only when the block attached to a user tail, so a block that fails to
+ *    attach never claims its sections (which would suppress them until
+ *    compaction). The user-prompt-submit hook persists the unwrapped text
+ *    under `metadata.memoryV3InjectedBlock` and `conversation.ts` rehydrates
+ *    it on load. The block is FROZEN thereafter: prior turns' blocks stay
+ *    byte-identical in history, ride the provider's cached prefix, and
+ *    survive restarts, mirroring v2's `memoryInjectedBlock`. An all-repeat
+ *    turn returns an EMPTY-TEXT block: assembly attaches nothing, but its
+ *    presence keys v2 suppression. A `null` return (failure, empty
+ *    selection, every net-new section rendered empty) attaches no v3 block,
+ *    and since the hook skips v2 retrieval under `memory-v3-live` the turn
+ *    gets no NEW injected memory (prior turns' frozen sections still ride
+ *    history).
  *
  *  - {@link memoryV3PointerInjector} (id `memory-v3-pointer`,
  *    `after-memory-prefix`): the per-turn pointer layer. Lists this turn's
- *    selected sections that are ALREADY resident in history (selected again,
- *    not injected net-new this turn) as a `<memory_pointer>` block of
- *    `memory/concepts/<slug>.md § <key>` lines, no bodies, so the model knows
- *    which frozen sections the turn is about. The entries are re-validated
- *    against the section store at render time: a pair the valve tombstoned
- *    since the sections injector classified it (its body stripped from the
- *    live history) is dropped rather than pointed at, and with nothing left
- *    no block is emitted. Such a section is simply absent this turn and
- *    re-injects on its next selection. Runtime assembly splices the
- *    block onto the current user message immediately after any frozen
- *    `<memory>` sections; the user-prompt-submit hook persists the wrapped
- *    text under `metadata.memoryV3PointerBlock` and `conversation.ts`
- *    rehydrates it on load. Historical user messages keep the pointer they
- *    were sent with, so the provider prefix through those messages stays
- *    byte-identical; mid-turn re-entry and post-compact tail-strip the
- *    current tail before splicing a fresh pointer so the block does not
- *    double-stack.
+ *    selected sections that are ALREADY resident in history as a
+ *    `<memory_pointer>` block of `memory/concepts/<slug>.md § <key>` lines,
+ *    no bodies, so the model knows which frozen sections the turn is about.
+ *    The entries are re-validated against the section store at render time:
+ *    a pair the valve tombstoned since classification is dropped (it
+ *    re-injects on its next selection), and with nothing left no block is
+ *    emitted. Runtime assembly splices the block right after any frozen
+ *    `<memory>` sections; the hook persists the wrapped text under
+ *    `metadata.memoryV3PointerBlock` and `conversation.ts` rehydrates it.
+ *    Historical user messages keep the pointer they were sent with, so the
+ *    prefix through them stays byte-identical; re-entry and post-compaction
+ *    assemblies tail-strip the current pointer before splicing a fresh one.
  *
  * Gating: `memory.v3.live` (config) runs orchestration and attaches blocks;
- * with it off, no orchestration runs and nothing is attached.
+ * with it off, nothing runs and nothing is attached. Both injectors apply
+ * the personal-memory trust gate ({@link isPersonalMemoryAllowed}): an
+ * untrusted remote actor's turn produces, records, and persists nothing,
+ * since v3 blocks are persisted to message metadata and rehydrated forever.
  *
- * Both injectors apply the same personal-memory trust gate as v2
- * ({@link isPersonalMemoryAllowed}): an untrusted remote actor's turn
- * produces nothing, no orchestration, no sections, no pointer, and nothing
- * recorded or persisted. Memory pages, skill/CLI capability content, and
- * matched sections all surface private user content, and because v3 blocks
- * are persisted to message metadata and rehydrated forever, the gate must
- * also keep an untrusted turn from recording or persisting anything.
- *
- * Re-entry assemblies (the post-compaction hook, which also serves the
- * overflow ladder's rungs) attach their blocks in memory only: metadata is
+ * A re-entry assembly (the post-compaction hook, which also serves the
+ * overflow ladder's rungs) attaches its blocks in memory only: metadata is
  * persisted at the first-call site alone, and every message a re-entry
  * attaches to predates a compaction's `historyStrippedAt` marker, which
- * keeps `loadFromDb` from rehydrating it. The turn memo remembers what the
- * first produce rendered, and a re-entry re-emits those entries byte for
- * byte: the hook's tail strip cleared their only copy while the store still
- * counts them active, so partitioning against the store alone would read
- * them as resident and drop them for the rest of the turn. Around them it
- * points at the pairs still active, renders anew any pair a compaction's
- * store reset left unclaimed, and skips any pair tombstoned since (the
- * Step-0 strip's verdict stands). A re-entry block carries no commit, and
- * runtime assembly withholds the commit on a `reinjection` assembly
- * besides, so a turn's sections are recorded exactly once, at the
- * first-call site that persists them. After a compaction the re-rendered
- * sections stay unclaimed: the next turn injects them net-new onto its own
- * persisted user message, and the re-entry copy still in the live history
- * is superseded by the newest-copy rule at the assembly after that
- * (`stripPrunedSectionsFromMessages`).
- *
- * An assembly that replaces the run messages with a transcript rendered
- * from persisted rows (`TurnContext.replacesRunMessages`, set by the chain
- * walker once the replacing injector has produced its block: the Slack
- * chronological transcript) carries no frozen block from any earlier turn,
- * because those blocks live only in message metadata. Residency means
- * nothing in that prompt, so the sections injector renders every selection
- * afresh, whether the store counts it active or not, the pointer injector
- * has nothing to point at, and the block carries no commit: nothing is
- * recorded, the valve is not scheduled, and runtime assembly attaches the
- * block to the transcript's tail in memory only (it persists and claims a
- * block only when the block carries a commit), leaving a retried anchor's
- * rehydrated frozen block off the transcript so the fresh render is the
- * single copy. A Slack conversation whose transcript injector is absent
- * (the channel plugin disabled) is not replaced, and its turn is an
- * ordinary committed injection. The turn memo still remembers what the
- * first produce rendered, so a re-entry of such a turn re-emits the same
- * bytes.
+ * keeps `loadFromDb` from rehydrating it. How a re-entry, and an assembly
+ * whose run messages a transcript replaces, classify the turn's units is
+ * documented at the partition in {@link memoryV3Injector}.
  */
 
 import { getConfig } from "../../../../config/loader.js";
@@ -398,25 +348,38 @@ export const memoryV3Injector: Injector = {
     const result = observed;
 
     try {
-      // Partition this turn's injection units. Each selected section injects
-      // under its own key, and a page selected with none under `""` (its
-      // lead; capability content injects whole under `""` too). A resident
-      // pair (active in the section store) is a pointer entry and is stamped
-      // with the turn's selection time below; capability slugs are stamped
-      // too but left out of the pointer because they have no
-      // `memory/concepts/` path to point at. On a re-entry assembly
-      // (`rendered` set by the turn's first produce) an entry the first
-      // produce rendered is re-emitted from the
-      // memo byte for byte: the store counts it active, but its only copy
-      // rode the tail the re-injection strip cleared, so the store alone
-      // would read it as resident and drop it for the rest of the turn. A
-      // pair tombstoned since the first produce is skipped outright (a
-      // re-entry never revives what the valve pruned), and a pair the first
-      // produce saw resident whose copy a compaction's store reset has since
-      // unclaimed (neither active nor tombstoned) renders anew, in memory
-      // only. Under a run-messages replacement no earlier block is in the
-      // prompt at all, so the store's active set is not consulted: every
-      // pair renders (or re-emits) and none is pointed at.
+      // Partition this turn's injection units: each selected section under
+      // its own key, a page selected with none under `""` (its lead;
+      // capability content injects whole under `""` too).
+      //  - A pair tombstoned since the turn's first produce is skipped: a
+      //    re-entry never revives what the valve pruned.
+      //  - On a re-entry assembly (`rendered` set by the first produce) an
+      //    entry the first produce rendered is re-emitted from the memo byte
+      //    for byte: the store counts it active, but its only copy rode the
+      //    tail the re-injection strip cleared, so the store alone would
+      //    read it as resident and drop it for the rest of the turn. A
+      //    re-entry block carries no commit (and runtime assembly withholds
+      //    one on a `reinjection` assembly besides), so a turn's sections
+      //    are recorded once, at the first-call site; after a compaction they
+      //    stay unclaimed until the next turn injects them net-new onto its
+      //    own persisted message, and the newest-copy rule
+      //    (`stripPrunedSectionsFromMessages`) retires the re-entry copy.
+      //  - A pair active in the store is resident: a pointer entry, stamped
+      //    with the turn's selection time below. Capability slugs are
+      //    stamped too but left out of the pointer (no `memory/concepts/`
+      //    path to point at).
+      //  - Every other pair renders net-new, including one the first produce
+      //    saw resident whose copy a compaction's store reset has since
+      //    unclaimed (neither active nor tombstoned), in memory only.
+      // Under a run-messages replacement (`ctx.replacesRunMessages`: the
+      // Slack chronological transcript, rendered from persisted rows, so it
+      // carries no earlier turn's block) residency means nothing. The
+      // store's active set is not consulted, every pair renders or
+      // re-emits, none is pointed at, and the block carries no commit, so
+      // nothing is recorded or scheduled and runtime assembly attaches the
+      // block in memory only as the prompt's single copy. A Slack
+      // conversation whose transcript injector is absent is not replaced and
+      // injects as an ordinary committed turn.
       const rendered = observedTurn(
         ctx.conversationId,
         ctx.turnIndex,

--- a/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
@@ -93,9 +93,9 @@ import { executeDeleteManagedSkill } from "../../../../tools/skills/delete-manag
 import { embedWithBackend } from "../embeddings.js";
 import { getLogger } from "../logging.js";
 import { getWorkspaceDir } from "../paths.js";
+import { skillSlugFor } from "../substrate/capability-slugs.js";
 import { getPageIndex } from "../substrate/page-index.js";
 import { readPage } from "../substrate/page-store.js";
-import { skillSlugFor } from "../substrate/skill-store.js";
 import { capabilityOrDiskBody, isCapabilitySlug } from "./capabilities.js";
 import { loadCoreSet as realLoadCoreSet } from "./core-set.js";
 import {

--- a/assistant/src/plugins/defaults/memory/v3/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory/v3/pool-select.ts
@@ -408,7 +408,7 @@ function laneTag(candidate: PoolCandidate): string {
  * Render the finder tail: one `[m+i] (lane) slug — snippet` line per
  * candidate, numbered continuing after the `offset` stable-prefix cards. The
  * lane tag is omitted for a candidate without one and names the keyed word
- * for a rare-term line (`(rare: gourd)`); a candidate with an empty
+ * for a rare-term line (`(rare: turnip)`); a candidate with an empty
  * descriptor renders without the dash.
  */
 function renderFinderSegment(finder: PoolCandidate[], offset: number): string {

--- a/assistant/src/plugins/defaults/memory/v3/prune.ts
+++ b/assistant/src/plugins/defaults/memory/v3/prune.ts
@@ -3,101 +3,67 @@
  * footprint.
  *
  * Frozen sections accumulate in history with no per-turn bound (the injector
- * renders net-new only and never strips prior blocks — the cache contract).
+ * renders net-new only and never strips prior blocks, the cache contract).
  * The valve is the backstop: when the resident (non-pruned) section bytes
  * exceed `memory.v3.prune.maxResidentBytes`, the least-recently-selected
  * sections are pruned, oldest first, until the footprint is at
- * `targetResidentBytes`. Every section is a candidate: core and hot pages
- * are evicted by recency like any other.
+ * `targetResidentBytes` ({@link planPrune}). Every section is a candidate:
+ * core and hot pages are evicted by recency like any other.
  *
  * Pruning is `markPruned` (the store's audit-preserving tombstone) plus two
- * FILTER points — never a metadata rewrite, so the persisted
+ * FILTER points, never a metadata rewrite, so the persisted
  * `metadata.memoryV3InjectedBlock` / `memoryV3PointerBlock` rows stay intact
- * (auditable, and a re-selected section re-injects as a fresh entry because
- * `recordInjected` clears `pruned_at`):
+ * and a re-selected section re-injects as a fresh entry (`recordInjected`
+ * clears `pruned_at`):
  *
- *   (a) a strip of the pruned sections from the `<memory>` blocks riding
- *       the LIVE in-memory history, and of their lines from the
- *       `<memory_pointer>` blocks that named them
- *       ({@link stripPrunedSectionsFromMessages}; per-section boundaries are
- *       the `# memory/concepts/<slug>.md` / `# memory/concepts/<slug>.md § <key>`
- *       headers within a block, terminated at the next header or at a
- *       non-section chunk such as capability content; see
- *       `parseInjectedSections` in `substrate/injected-block-slugs.ts`). The
- *       strip mutates the shared message objects in place so the agent
- *       loop's end-of-turn history fold-back keeps the stripped content. It
- *       runs with the conversation's full tombstone set at two points: in
- *       the valve itself, and at runtime assembly Step 0 on every turn
- *       (`applyRuntimeInjections`). The valve fires on a timer while the
- *       turn that scheduled it may still be in flight, against a history
- *       that turn's block has not folded back into, so a section pruned on
- *       the turn that injected it can ride back in; the assembly strip
- *       catches it on the next turn, and the live history converges to the
- *       store no matter when the valve ran;
- *   (b) the `loadFromDb` rehydration splice in `daemon/conversation.ts`
- *       re-applies {@link filterResidentSections} and
+ *   (a) a strip of the pruned sections, and of the pointer lines naming
+ *       them, from the LIVE in-memory history
+ *       ({@link stripPrunedSectionsFromMessages}; section boundaries are
+ *       the `# memory/concepts/<slug>.md` / `... § <key>` headers read by
+ *       `parseInjectedSections` in `substrate/injected-block-slugs.ts`). It
+ *       runs with the conversation's full tombstone set in the valve itself
+ *       and at runtime assembly Step 0 on every turn, so a section the valve
+ *       pruned before its own turn's block folded back into the history is
+ *       caught on the next turn ({@link runPruneValve});
+ *   (b) the `loadFromDb` rehydration splice in `daemon/conversation.ts`,
+ *       which re-applies {@link filterResidentSections} and
  *       {@link filterResidentPointerEntries} on every load, so prunes persist
  *       across daemon restarts without touching the metadata.
  *
- * A pruned section that is re-selected re-injects as a fresh entry on a
- * later message, and `recordInjected` clears its tombstone. Its older copies
- * still sit in earlier messages' persisted metadata, so both filter points
- * also keep only each section's NEWEST persisted copy
- * ({@link newestCopyIndexes}): the live conversation holds exactly that one,
- * every earlier copy having been stripped when the section was pruned, and
- * rehydrating an earlier copy beside it would double the section and change
- * the cached prefix. Pointer entries follow the same rule: a line naming a
- * section whose newest copy sits further down predates its re-injection and
- * is dropped.
+ * Both points also keep only each section's NEWEST persisted copy
+ * ({@link newestCopyIndexes}), since a re-injected section's older copies
+ * still sit in earlier messages' metadata. The first post-prune request
+ * loses the provider prefix cache from the earliest affected message, ONE
+ * amortized bust per prune, logged with `prunedSections` / `bytesFreed`; a
+ * pointer always sits after the block of every section it names, so
+ * filtering it never widens that bust.
  *
- * The first post-prune request loses the provider prefix cache from the
- * earliest affected message — ONE amortized bust per prune, logged with
- * `prunedSections` / `bytesFreed`. A pointer always sits after the block of
- * every section it names, so filtering it never widens that bust.
+ * Ownership: v2's dynamic `<memory>` blocks share the exact wrapper and
+ * `# memory/concepts/<slug>.md` header convention, and a pre-cutover v2
+ * block can be byte-identical to a v3 lead entry, so the live strip never
+ * decides ownership by text. It owns a block by object identity
+ * (`isV3LiveBlock` in `types.ts`: the blocks runtime assembly attaches for
+ * the `memory-v3` injector, `loadFromDb` splices from persisted metadata,
+ * and the strip writes back in their place) and leaves every other
+ * `<memory>` block untouched. The `<memory_pointer>` wrapper is v3-only, so
+ * pointer blocks need no ownership test.
  *
- * v2-coexistence note: v2's dynamic `<memory>` blocks share the exact wrapper
- * and `# memory/concepts/<slug>.md` header convention, and a pre-cutover v2
- * block can even be byte-identical to a v3 lead entry (v2's full-page
- * fallback on a headingless page), so the live strip never decides ownership
- * by text. It owns a block by object identity (`isV3LiveBlock` in
- * `types.ts`): the blocks runtime assembly attaches for the `memory-v3`
- * injector, `loadFromDb` splices from persisted metadata, and the strip
- * writes back in their place. Every other `<memory>` block is left untouched,
- * keeping v2 blocks' unfiltered rehydration byte-identical. The
- * `<memory_pointer>` wrapper is v3-only, so pointer blocks need no ownership
- * test.
+ * Capability content (skill / CLI-command chunks under their own `# Skill:`
+ * / `# CLI command:` header) is recorded at `bytes: 0`, which keeps it out
+ * of the resident measure and out of candidacy, so it survives the prune of
+ * its neighboring sections; both filter points still supersede an older
+ * copy of it under the identity the store records it by (its capability
+ * slug, empty key). A legacy-format block (no format stamp,
+ * `InjectedBlockFormat` in `types.ts`) is filtered with that build's card
+ * grammar under each card's lead ref; see {@link filterSections} and
+ * {@link newestCopyIndexes}.
  *
- * Capability note: skill / CLI-command content renders under its own
- * `# Skill:` / `# CLI command:` header, not a section header. The injector
- * records capability slugs at `bytes: 0`, which keeps them out of the resident
- * measure AND out of candidacy (zero-byte rows are skipped — pruning them
- * frees nothing), so capability content riding a block survives the prune of
- * its neighboring sections. Both filter points still reach it under the
- * identity the store records it by (its capability slug, empty key): a copy
- * a later block renders again (a post-compaction re-entry copy, once the
- * next turn persists the capability anew) is superseded like a section's.
- *
- * Legacy-format note: a v3 block persisted without the format stamp
- * (`InjectedBlockFormat` in `types.ts`) was rendered as compact cards by a
- * build before body escaping, and both filter points read it with that
- * build's card grammar (`filterLegacyCards` in
- * `substrate/injected-block-slugs.ts`), each card under its lead ref
- * `(slug, "")`: a card whose lead is tombstoned leaves, so a prune that
- * predates the upgrade holds across restarts, and one whose lead a
- * current-format block re-injected after such a prune (clearing the
- * tombstone) is superseded by that copy. The block is never indexed by
- * {@link newestCopyIndexes} (its cards retire no current copy), the section
- * store carries its slugs at zero bytes (`plugin-schema.ts`) so nothing in
- * it is ever planned, and it leaves with the compaction that strips memory
- * blocks and clears the store.
- *
- * Accounting-drift note: a section whose recorded bytes have no locatable
- * persisted text (e.g. its metadata row was lost) can be planned and
- * tombstoned — the strip/rehydration filter simply finds nothing to remove,
- * its content (if any) stays in context, and its bytes leave the resident
- * accounting with the tombstone. That self-heals in ONE pass: the next valve
- * run measures the corrected footprint, so the valve never loop-fires against
- * bytes it cannot free.
+ * Accounting drift: a section whose recorded bytes have no locatable
+ * persisted text (its metadata row was lost) can be planned and tombstoned;
+ * the filters find nothing to remove and its bytes leave the resident
+ * accounting with the tombstone, so the next valve run measures the
+ * corrected footprint and the valve never loop-fires against bytes it
+ * cannot free.
  */
 
 import type { ContentBlock, Message } from "@vellumai/plugin-api";

--- a/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/rare-term-lane.test.ts
@@ -6,34 +6,34 @@ import { buildSectionIndex } from "./sections.js";
 import type { SectionIndex, Slug } from "./types.js";
 
 /**
- * A fixture corpus in which "here", "is", "my", and "little" recur
- * across most sections while "gourd" sits in three sections (two on one
- * page), "marrow" in two, and "quince" and "0x1f" in one each. All slugs and
+ * A fixture corpus in which "the", "weekly", "report", and "lists" recur in
+ * every section while "turnip" sits in three sections (two on one page),
+ * "marrow" in two, and "quince" and "0x1f" in one each. All slugs and
  * content are invented placeholders.
  */
 const PAGES: Record<Slug, string> = {
-  "silly-lines": [
-    "the list of silly lines: here is my little log of bits, here is the joke",
+  "sample-notes": [
+    "the weekly report lists the sample notes and the open items",
     "## Parody",
-    "the parody verse: here is the way it landed, my little friend",
-    "## Pumpkin",
-    "the pumpkin bit: here is my little gourd, gourd of my heart",
+    "the parody report lists the weekly skit and the encore",
+    "## Inventory",
+    "the weekly turnip report lists the turnip totals",
     "## Harvest",
-    "harvest song: the gourd on the porch and the gourd in the pie, here is my little ballad",
+    "the weekly harvest report lists the turnip crates and the turnip deliveries",
   ].join("\n"),
   "autumn-recipes": [
-    "recipes here and there, my little kitchen notes",
+    "the weekly recipe report lists the kitchen items",
     "## Soup",
-    "gourd soup with marrow, here is my little pot, with onions, celery, carrots, thyme, cream, salt, and pepper",
+    "turnip soup with marrow: the weekly report lists onions, celery, carrots, thyme, cream, salt, and pepper",
     "## Bread",
-    "little loaves, here is my quince jam on top",
+    "the weekly bread report lists the quince jam on top",
   ].join("\n"),
   "daily-notes": [
-    "notes here for my little log, is it done",
+    "the weekly notes report lists the open items",
     "## Monday",
-    "here is my monday, my little wins, deploy 0x1f at noon",
+    "the monday report lists the weekly wins and the deploy of 0x1f at noon",
     "## Tuesday",
-    "marrow on toast, here is my little ritual",
+    "the tuesday report lists marrow on toast as the weekly ritual",
   ].join("\n"),
 };
 
@@ -60,8 +60,8 @@ function docOf(index: SectionIndex, article: Slug, title: string): number {
 }
 
 const { index, needle } = await corpus(PAGES);
-const pumpkin = docOf(index, "silly-lines", "Pumpkin");
-const harvest = docOf(index, "silly-lines", "Harvest");
+const inventory = docOf(index, "sample-notes", "Inventory");
+const harvest = docOf(index, "sample-notes", "Harvest");
 const soup = docOf(index, "autumn-recipes", "Soup");
 
 // `maxDfFraction: 1` leaves `maxDf` as the sole ceiling on this ten-section
@@ -70,39 +70,46 @@ const OPTIONS = { maxDf: 3, maxDfFraction: 1, perTerm: 2, cap: 24 };
 
 describe("rareTermLane", () => {
   test("surfaces a rare word's top sections, tagged with the word, whatever else the message says", () => {
-    // "gourd" occurs in three sections; the two that carry it twice in a
+    // "turnip" occurs in three sections; the two that carry it twice in a
     // short body outscore the one that carries it once in a long one.
     expect(
-      rareTermLane(needle, index, "here is my little gourd", OPTIONS),
+      rareTermLane(
+        needle,
+        index,
+        "the weekly report lists the turnip",
+        OPTIONS,
+      ),
     ).toEqual([
-      { article: "silly-lines", section: pumpkin, term: "gourd" },
-      { article: "silly-lines", section: harvest, term: "gourd" },
+      { article: "sample-notes", section: inventory, term: "turnip" },
+      { article: "sample-notes", section: harvest, term: "turnip" },
     ]);
   });
 
   test("perTerm bounds the sections surfaced per word", () => {
     expect(
-      rareTermLane(needle, index, "gourd", { ...OPTIONS, perTerm: 1 }),
-    ).toEqual([{ article: "silly-lines", section: pumpkin, term: "gourd" }]);
+      rareTermLane(needle, index, "turnip", { ...OPTIONS, perTerm: 1 }),
+    ).toEqual([
+      { article: "sample-notes", section: inventory, term: "turnip" },
+    ]);
   });
 
   test("a word above maxDf is ignored", () => {
     expect(
-      rareTermLane(needle, index, "gourd", { ...OPTIONS, maxDf: 2 }),
+      rareTermLane(needle, index, "turnip", { ...OPTIONS, maxDf: 2 }),
     ).toEqual([]);
-    // "little" occurs in every section.
-    expect(rareTermLane(needle, index, "little", OPTIONS)).toEqual([]);
+    // "weekly" occurs in every section.
+    expect(rareTermLane(needle, index, "weekly", OPTIONS)).toEqual([]);
   });
 
   test("a bigram is never eligible", () => {
-    // "little gourd" is a phrase of one section only, and the needle indexes
-    // the bigram for its query lanes, but the lane keys on unigrams: "little"
-    // is common and "gourd" sits above this maxDf.
-    expect(needle.topTerms(pumpkin, "little gourd", 3)).toContain(
-      "little_gourd",
+    // "weekly turnip" is a phrase of one section only, and the needle indexes
+    // the bigram for its query lanes, but the lane keys on unigrams: "weekly"
+    // is common and "turnip" sits above this maxDf.
+    expect(needle.topTerms(inventory, "weekly turnip", 3)).toContain(
+      "weekly_turnip",
     );
     expect(
-      rareTermLane(needle, index, "little gourd", { ...OPTIONS, maxDf: 2 }),
+      rareTermLane(needle, index, "weekly turnip", { ...OPTIONS, maxDf: 2 }),
     ).toEqual([]);
   });
 
@@ -118,14 +125,14 @@ describe("rareTermLane", () => {
   });
 
   test("hits order rarest word first, then score, and the cap cuts the tail", () => {
-    const message = "gourd quince marrow";
+    const message = "turnip quince marrow";
     const hits = rareTermLane(needle, index, message, OPTIONS);
     expect(hits.map((h) => h.term)).toEqual([
       "quince",
       "marrow",
       "marrow",
-      "gourd",
-      "gourd",
+      "turnip",
+      "turnip",
     ]);
     expect(hits[0]).toEqual({
       article: "autumn-recipes",
@@ -136,16 +143,16 @@ describe("rareTermLane", () => {
     expect(hits.slice(1, 3).map((h) => h.section)).toEqual(
       needle.scoreTerm("marrow", 2).map((h) => h.doc),
     );
-    expect(hits.slice(3).map((h) => h.section)).toEqual([pumpkin, harvest]);
+    expect(hits.slice(3).map((h) => h.section)).toEqual([inventory, harvest]);
     expect(
       rareTermLane(needle, index, message, { ...OPTIONS, cap: 3 }),
     ).toEqual(hits.slice(0, 3));
   });
 
   test("a section two rare words both score is one hit, under the rarer word", () => {
-    // The soup section holds "marrow" (two sections) and "gourd" (three);
+    // The soup section holds "marrow" (two sections) and "turnip" (three);
     // with perTerm 3 both words reach it.
-    const hits = rareTermLane(needle, index, "gourd marrow", {
+    const hits = rareTermLane(needle, index, "turnip marrow", {
       ...OPTIONS,
       perTerm: 3,
     });
@@ -162,7 +169,7 @@ describe("rareTermLane", () => {
       { ...OPTIONS, perTerm: 0 },
       { ...OPTIONS, cap: 0 },
     ]) {
-      expect(rareTermLane(needle, index, "gourd", options)).toEqual([]);
+      expect(rareTermLane(needle, index, "turnip", options)).toEqual([]);
     }
   });
 });
@@ -170,7 +177,7 @@ describe("rareTermLane", () => {
 /** The distinctive word of the n-th generated section, "" for a filler one. */
 function markerOf(n: number): string {
   if (n < 13) {
-    return "gourd";
+    return "turnip";
   }
   if (n < 21) {
     return "marrow";
@@ -183,7 +190,7 @@ function markerOf(n: number): string {
 
 /**
  * A generated corpus of 300 short sections (30 pages of a lead plus nine
- * headings) for the corpus-relative ceiling: "gourd" occurs in 13 sections,
+ * headings) for the corpus-relative ceiling: "turnip" occurs in 13 sections,
  * "marrow" in 8, "quince" in 1, and the filler in every one.
  */
 const WIDE_PAGES: Record<Slug, string> = Object.fromEntries(
@@ -194,7 +201,7 @@ const WIDE_PAGES: Record<Slug, string> = Object.fromEntries(
         lines.push(`## Part ${heading}`);
       }
       lines.push(
-        `here is my little note ${markerOf(page * 10 + heading)}`.trimEnd(),
+        `the weekly report lists ${markerOf(page * 10 + heading)}`.trimEnd(),
       );
     }
     return [`wide-${String(page).padStart(2, "0")}`, lines.join("\n")];
@@ -205,11 +212,11 @@ const wide = await corpus(WIDE_PAGES);
 
 describe("rareTermLane corpus-relative ceiling", () => {
   const TUNED = { maxDf: 12, perTerm: 2, cap: 24 };
-  const MESSAGE = "gourd quince marrow";
+  const MESSAGE = "turnip quince marrow";
 
   test("the fixture holds 300 sections with words of df 13, 8, and 1", () => {
     expect(wide.index.sections).toHaveLength(300);
-    expect(wide.needle.df("gourd")).toBe(13);
+    expect(wide.needle.df("turnip")).toBe(13);
     expect(wide.needle.df("marrow")).toBe(8);
     expect(wide.needle.df("quince")).toBe(1);
   });
@@ -228,7 +235,7 @@ describe("rareTermLane corpus-relative ceiling", () => {
 
   test("a fraction whose corpus share exceeds maxDf leaves maxDf binding", () => {
     // floor(300 * 0.05) = 15, above `maxDf`: "marrow" (df 8) is rare again
-    // and "gourd" (df 13) still is not.
+    // and "turnip" (df 13) still is not.
     const options = { ...TUNED, maxDfFraction: 0.05 };
     expect(effectiveMaxDf(wide.index.sections.length, options)).toBe(12);
     expect(

--- a/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
@@ -190,7 +190,7 @@ let _onRebuildPending: (() => void) | undefined;
  * retrying it, so an outage draws one collection probe a minute rather than
  * one per read.
  */
-export const SECTION_VERSION_CHECK_RETRY_MS = 60_000;
+const SECTION_VERSION_CHECK_RETRY_MS = 60_000;
 
 /**
  * Hold dense reads while the section store awaits its chunker rebuild, or

--- a/assistant/src/plugins/defaults/memory/v3/section-needle.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-needle.ts
@@ -2,9 +2,10 @@ import type { SectionIndex, Slug } from "./types.js";
 
 /**
  * Section-grain "needle" lane for memory-v3 retrieval: a lexical BM25F search
- * over a {@link SectionIndex}. Each section is a tiny two-field document — a
- * weighted `head` line (`${lastSlugSegment} — ${title}`) and the remaining
- * `body` text — so a literal term in a heading outranks the same term buried in
+ * over a {@link SectionIndex}. Each section is a tiny two-field document, a
+ * weighted `head` line (`${lastSlugSegment} - ${title}`, the title capped, as
+ * `sectionHeadLine` in `sections.ts` renders it) and the remaining `body`
+ * text, so a literal term in a heading outranks the same term buried in
  * prose. Scoring happens at section grain; results are deduped to distinct
  * articles, each tagged with its best-scoring section.
  *

--- a/assistant/src/plugins/defaults/memory/v3/types.ts
+++ b/assistant/src/plugins/defaults/memory/v3/types.ts
@@ -128,7 +128,9 @@ export function isV3LiveBlock(block: object): boolean {
  * ordinal 0) or a heading-delimited block. Over-long sections are split into
  * multiple ordered `Section`s, each with its own consecutive `ordinal`, so each
  * fits a typical embedding window. `text` is prefixed with a
- * `${lastSlugSegment} — ${title}` head line for lexical/dense matching.
+ * `${lastSlugSegment} - ${title}` head line (`sectionHeadLine` in
+ * `sections.ts`, which caps the title at `SECTION_HEAD_TITLE_CHARS`) for
+ * lexical/dense matching.
  *
  * `occurrence` is this heading's 0-based index among the article's headings
  * that share its title (a repeated `## Topic`); `chunk` is this section's


### PR DESCRIPTION
## Summary

Cleanup from the read-only re-review of the memory-v3 section-injection branch. No behavior changes.

- **Test fixtures**: replace the private-corpus vocabulary and lyric-shaped filler this branch introduced in the rare-term and snippet fixtures (`orchestrate`, `rare-term-lane`, `shadow-plugin`, `pool-select`, `section-needle` tests, plus the `pool-select.ts` docstring) with neutral placeholders (`sample-notes`, `## Inventory`, `turnip`, "the weekly report lists ..."). Every document-frequency and ranking assumption is preserved (rare word at df 3 and df 13, the filler in every section, the bigram in exactly one section); the `findTerm` offsets follow the new word length. `quince` was not used as the rare word because it is already the df-1 word in `rare-term-lane.test.ts`.
- **Dead code**: drop the unreferenced Drizzle object `memoryV3Pools` from `persistence/schema/memory-injection.ts` (the table is created by DDL in `v3/plugin-schema.ts` and read through raw SQL in `v3/pool-log-store.ts`).
- **Re-exports**: remove the slug-grammar re-exports from `skill-store.ts` / `cli-command-store.ts`. Every importer (`build-memory-graph`, `maintain-job`, `candidate-match`, `v2/injection`, the dynamic destructuring in `page-index.ts`, and the tests) imports from the `capability-slugs.ts` leaf. `ingest.ts` imports the prefixes from the leaf instead of duplicating the literals. The `SKILL_SLUG_PREFIX` / predicate keys in the store test mocks that only existed to satisfy the re-exports are removed.
- **Docs**: condense the duplicated module docs in `v3/injector.ts` (module doc and partition comment) and `v3/prune.ts`, cut the runtime-assembly Step 2 comment to a pointer at `v3/injector.ts` and `AnchorBlockMerge`, and drop the temporal "whole-layer replace is gone" parentheticals. `injection-metadata.ts` derives its empty-update guard and the pass-through assignments from one block list.

## Validation

- `bun run typecheck:fast`: exit 0.
- Every `v3/__tests__` file, `rare-term-lane.test.ts`, and `skill-boundary-guard.test.ts`, run individually: 27 files, 555 pass, 0 fail.
- Touched non-v3 tests and the store tests (8 files): 280 pass, 0 fail.
- Memory-plugin guard tests plus the tests covering the other changed modules (51 files): 1242 pass, 0 fail.
- Running the whole `v3/__tests__/` directory in one bun process reports 7 failures from cross-file `mock.module` leakage; the base branch reports the identical 7 with the same command.
- The flagged-vocabulary scan over `assistant` and `clients` is empty; no em dashes on added lines; eslint and prettier clean on every changed file.

Part of plan: memory-v3-section-injection.md (re-review cleanup)

## Round 2 (slop-report tail and integration pass)

- `injection-metadata.ts`: `injectionMetadataUpdates` builds `updates` first from the one block list and returns `null` when it is empty and `!blocks.memoryV3Active`; the pointer and legacy spotlight deletions are appended after that gate. Same keys, same values, same serialized key order (undefined-valued keys are dropped by `JSON.stringify`).
- `injected-block-slugs.ts`: `LEGACY_CARD_HEADER_REGEX` is documented as the one sanctioned second header matcher (pre-stamp card grammar, read only by `parseLegacyCards`, never applied to a current-format block, kept byte-identical rather than derived from the section-path source), and the memory `AGENTS.md` "block grammar has one owner" bullet names that exception.
- Dropped `export` on file-local symbols after confirming no importer in `assistant/src` (tests included): `injectionSectionKey`, `markHistoryStrippedBestEffort`, `SECTION_VERSION_CHECK_RETRY_MS`, `LegacyCardPiece`, `INJECTED_CONCEPT_HEADER_REGEX`. Declaration emit (`tsc --emitDeclarationOnly`) still succeeds with the un-exported `LegacyCardPiece` in `parseLegacyCards`' return type.
- `sections.test.ts`: the conditional `expect` inside the chunk loop is gone; every `Big` chunk and every `page-lead` chunk is asserted to carry body text unconditionally, after the existing `length > 1` guards that keep the loop non-vacuous (both split into several chunks, so a single `find` would only cover the first).
- Stale head-line docs in `v3/types.ts` and `v3/section-needle.ts` describe the present `${lastSlugSegment} - ${title}` rendering with the title capped (`sectionHeadLine` in `sections.ts`); the em dashes on those lines are gone.
- `memory-v3-selection-log.ts`: `chosen` is documented per pool line (the section the line names, the page lead for a lead line, or the page for a line with no matched section). `bun run generate:openapi` re-run and `--check` reports up to date; the JSDoc is not emitted into the spec, so `openapi.yaml` is unchanged and no generated web client is committed.
- `skills/catalog.json` untouched.

Round 2 validation: `typecheck:fast` exit 0; declaration emit exit 0; eslint and prettier clean; 10 test files run individually (`sections`, `injected-block-slugs`, `prune`, `capabilities`, `section-dense-store`, `conversation-lifecycle`, `carry-integration`, `post-compaction-reinjection-idempotency`, `post-compact`, `plugin-import-boundary-guard`): 218 pass, 0 fail; zero em dashes on added lines.
