### PR TITLE
fix(memory-v3): keep entity-lane lines outside the per-page finder cap

### DIFF
--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -415,7 +415,7 @@ export const MemoryV3ConfigSchema = z
       .positive("memory.v3.finderSectionsPerPage must be a positive integer")
       .default(3)
       .describe(
-        "Maximum finder lines one page may carry in the selector pool per turn, its rare-term lines aside. Each distinct matched section a finder lane surfaces for a page is its own line, kept in surfacing order (needle, dense, reply, span, entity) until the cap; a section-less edge or learned hit counts as one line. A rare-term line neither counts against the cap nor yields to it (rareTerm.cap bounds those per turn), so a rare word's section surfaces however many lines its page already carries.",
+        "Maximum finder lines one page may carry in the selector pool per turn, its entity and rare-term lines aside. Each distinct matched section a finder lane surfaces for a page is its own line, kept in surfacing order (needle, dense, reply, span) until the cap; a section-less edge or learned hit counts as one line. An entity line and a rare-term line neither count against the cap nor yield to it (the entity lane's own cap and rareTerm.cap bound those per turn), so a heading the message names and a rare word's section both surface however many lines their page already carries.",
       ),
     selectorEnabled: z
       .boolean({ error: "memory.v3.selectorEnabled must be a boolean" })

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -437,14 +437,15 @@ absolute ceiling would make most ordinary words of a small corpus rare and
 fill `cap` with noise every turn. Both are synchronous in-memory passes that
 feed neither the injection gate nor the edge seeds, and pool through the same
 `(page, section key)` dedupe as every other lane, so a section another lane
-already pooled is a no-op. The entity lane also pools through the per-page
-cap (`memory.v3.finderSectionsPerPage`); a rare-term line is outside it,
-neither counted against the cap nor displaced by it, because the lane runs
-after every lane that fills the cap and a page already carrying that many
-bulk-theme lines would otherwise drop exactly the line the lane exists to
-surface. The lane's own `perTerm` and `cap` bound what it adds instead, so a
-page carries at most `finderSectionsPerPage` capped lines plus its rare
-lines, `finderSectionsPerPage + rareTerm.cap` in all. The entity lane runs
+already pooled is a no-op. Both lanes' lines are outside the per-page cap
+(`memory.v3.finderSectionsPerPage`), neither counted against it nor
+displaced by it, because each lane runs after every lane that fills the cap
+and a page already carrying that many bulk-theme lines would otherwise drop
+exactly the line the lane exists to surface. The lanes' own caps bound what
+they add instead (`entityCap` articles per turn for the entity lane,
+`perTerm` and `cap` for the rare-term lane), so a page carries at most
+`finderSectionsPerPage` capped lines plus its entity and rare lines,
+`finderSectionsPerPage + entityCap + rareTerm.cap` in all. The entity lane runs
 at every corpus size (the lean profile does not switch it off); the
 rare-term lane runs only when the selector does (`v3/shadow-plugin.ts`
 threads `rareTerm` only

--- a/assistant/src/plugins/defaults/memory/AGENTS.md
+++ b/assistant/src/plugins/defaults/memory/AGENTS.md
@@ -227,8 +227,8 @@ not break.
   re-imports leads whose blocks are gone.
 - **Lanes and caps.** The finder lanes surface in a fixed order and only ever
   add lines; a page carries at most `memory.v3.finderSectionsPerPage` capped
-  lines plus its rare-term lines (the lane rules are under `memory_v3_pools`
-  below).
+  lines plus its entity and rare-term lines (the lane rules are under
+  `memory_v3_pools` below).
 
 Both rules are enforced by `__tests__/memory-tier-boundary-guard.test.ts`, which
 also carries a reverse stale-exemption test: an allowlist entry whose multi-tier
@@ -404,7 +404,7 @@ selector's full candidate pool (every stable-prefix card and finder line, in
 pool order, with lane, matched section, and a per-line verdict) for the
 inspector's Memory tab, plus `selector_ran`. A page carries one finder line
 per distinct matched section, at most `memory.v3.finderSectionsPerPage` in
-surfacing order (needle, dense, reply, span, entity) plus its rare-term
+surfacing order (needle, dense, reply, span) plus its entity and rare-term
 lines, and selecting a line selects that section; the selection log keeps
 one row per slug, so the pool row is where the per-section verdicts live. A
 turn whose selector never judged a pool (the injection gate hard-skipped it,

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/orchestrate.test.ts
@@ -2331,6 +2331,7 @@ describe("orchestrate: rare-term lane", () => {
     alpha: string,
     tail: string[],
     rareTerm = RARE,
+    entity?: { token: string; ordinal: number },
   ): Promise<OrchestrateDeps> {
     const lanes = await customLanes({
       "many-page": [
@@ -2344,7 +2345,8 @@ describe("orchestrate: rare-term lane", () => {
         ...tail,
       ].join("\n"),
     });
-    const alphaDoc = lanes.sectionIndex.byArticle.get("many-page")![1]!;
+    const docs = lanes.sectionIndex.byArticle.get("many-page")!;
+    const alphaDoc = docs[1]!;
     denseHits = [{ article: "many-page", section: 2 }];
     denseHitsByQuery.set(REPLY, [{ article: "many-page", section: 3 }]);
     return depsOf(lanes, {
@@ -2358,8 +2360,36 @@ describe("orchestrate: rare-term lane", () => {
       replyQueryK: 5,
       finderSectionsPerPage: 3,
       rareTerm,
+      ...(entity
+        ? { entityIndex: new Map([[entity.token, [docs[entity.ordinal]!]]]) }
+        : {}),
     });
   }
+
+  test("an entity hit joins a page the prior lanes filled to the per-page cap", async () => {
+    // The message names the `## Delta` heading (ordinal 4) of a page whose
+    // first three sections the bulk-theme lanes already pooled. Of the
+    // message's words only "delta" occurs in the corpus, so the rare lane's
+    // hit on the same section is a no-op behind the entity line.
+    const tail = ["## Delta", "delta text"];
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, `${CAPPED_MESSAGE} and delta`, REPLY),
+      await cappedPageDeps("alpha text", tail, RARE, {
+        token: "delta",
+        ordinal: 4,
+      }),
+    );
+    expect(
+      result.lanes.finder.map((c) => [c.lane, c.section?.ordinal]),
+    ).toEqual([
+      ["needle", 1],
+      ["dense", 2],
+      ["reply", 3],
+      ["entity", 4],
+    ]);
+  });
 
   test("a rare hit joins a page the prior lanes filled to the per-page cap, bounded by the lane's own cap", async () => {
     // "turnip" is held by `## Delta` (ordinal 4) and `## Echo` (5) alone.

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -41,10 +41,10 @@
  *      init, followed by the finder candidates (needle → dense → reply →
  *      span → entity → rare → edge → learned surfacing order), one line per
  *      distinct (page, matched section) and at most `finderSectionsPerPage`
- *      lines per page from the lanes other than rare (a rare-term line never
- *      counts against the cap or yields to it; see `poolLine`), so a page
- *      whose sections match different parts of the message is shown section
- *      by section. The stable prefix
+ *      lines per page from the lanes other than entity and rare (an entity
+ *      line and a rare-term line never count against the cap or yield to it;
+ *      see `poolLine`), so a page whose sections match different parts of
+ *      the message is shown section by section. The stable prefix
  *      is identical across consecutive turns while the lanes are unchanged
  *      (lane invalidation at consolidation is the recompute cadence), so the
  *      selector input's leading segment rides the provider KV cache (the

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -227,12 +227,12 @@ export interface OrchestrateDeps {
    *  strong enough to inject unjudged. */
   rareTerm?: RareTermLaneOptions;
   /** Cap on finder lines one page may carry per turn, applied in surfacing
-   *  order (needle, dense, reply, span, entity); a section-less edge or
-   *  learned line counts as one. A rare-term line is outside the cap,
-   *  neither counted against it nor displaced by it (the lane's own
-   *  `rareTerm.cap` bounds those per turn), so a page carries at most this
-   *  many lines plus its rare lines (canonical value, default included:
-   *  `memory.v3.finderSectionsPerPage`). */
+   *  order (needle, dense, reply, span); a section-less edge or learned line
+   *  counts as one. An entity line and a rare-term line are outside the cap,
+   *  neither counted against it nor displaced by it (the lanes' own
+   *  `entityCap` and `rareTerm.cap` bound those per turn), so a page carries
+   *  at most this many lines plus its entity and rare lines (canonical
+   *  value, default included: `memory.v3.finderSectionsPerPage`). */
   finderSectionsPerPage: number;
   /** Per-lane article budget for the reply-query pass (needle + dense re-run
    *  over `turn.previousAssistantMessage` as separate queries). `0` or

--- a/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory/v3/orchestrate.ts
@@ -487,26 +487,28 @@ export async function orchestrate(
   // learned neighbour, a dense ordinal the index no longer holds) is one
   // section-less line per page, added only when nothing has surfaced the
   // page yet. Each page's lines are capped at `finderSectionsPerPage` in
-  // surfacing order, its rare lines aside (`poolLine`). Hits on
+  // surfacing order, its entity and rare lines aside (`poolLine`). Hits on
   // stable-prefix slugs are kept like any other, so the selector and the
   // injection see those pages' CURRENT relevance.
   const finderCap = deps.finderSectionsPerPage;
   const finder: FinderCandidate[] = [];
   const finderByArticle = new Map<Slug, FinderCandidate[]>();
 
-  // Whether a line counts against its page's cap. A rare-term line does
-  // not: its lane runs after every lane that fills the cap, so holding it
-  // to the cap would displace exactly the line the lane exists to surface.
-  // The lane's own `rareTerm.cap` bounds the lines it adds per turn instead.
+  // Whether a line counts against its page's cap. An entity line and a
+  // rare-term line do not: both lanes key on one strong token the message
+  // names and run after every lane that fills the cap, so holding them to
+  // the cap would displace exactly the line each lane exists to surface.
+  // The lanes' own caps (`entityCap`, `rareTerm.cap`) bound the lines they
+  // add per turn instead.
   const countsAgainstCap = (line: FinderCandidate): boolean =>
-    line.lane !== "rare";
+    line.lane !== "entity" && line.lane !== "rare";
 
   // Pool a line for its page unless the page already carries it or is at
   // the cap: a line with a section duplicates a line for the same section
   // key; a section-less line duplicates any line. The cap holds the page's
   // counted lines at `finderCap`; a line outside the cap joins past it, so a
-  // page carries at most `finderCap` counted lines plus its rare lines,
-  // `finderCap + rareTerm.cap` in all.
+  // page carries at most `finderCap` counted lines plus its entity and rare
+  // lines, `finderCap + entityCap + rareTerm.cap` in all.
   const poolLine = (candidate: FinderCandidate): void => {
     const lines = finderByArticle.get(candidate.slug) ?? [];
     const key = candidate.section ? sectionKey(candidate.section) : undefined;


### PR DESCRIPTION
## Summary
- `countsAgainstCap` in `v3/orchestrate.ts` exempts entity-lane lines as it already exempts rare-term lines: both lanes key on one strong token the message names and run after every lane that fills the cap, so a page already carrying `finderSectionsPerPage` bulk-theme lines no longer drops the heading the user named.
- Bound stays the lane's own `entityCap` (8 articles per turn), so a page carries at most `finderSectionsPerPage + entityCap + rareTerm.cap` lines.
- Test: an entity hit joins a page the prior lanes filled to the cap (fails without the change). Memory AGENTS.md lanes paragraph updated.

Raised by Codex on #42213; Closes #42211.

Part of plan: memory-v3-section-injection.md (feature-branch review fix)