### PR TITLE
feat(memory): batch Gemini section embeddings and warm the cache across pages before per-page upserts

### DIFF
--- a/assistant/src/persistence/embeddings/embedding-gemini.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.test.ts
@@ -234,14 +234,17 @@ describe("GeminiEmbeddingBackend", () => {
   });
 
   describe("multiple inputs", () => {
-    test("embeds multiple inputs sequentially", async () => {
-      let callCount = 0;
-      mockFetch = mock(() => {
-        callCount++;
-        return Promise.resolve(
-          makeSuccessResponse([0.1 * callCount, 0.2 * callCount]),
-        );
-      });
+    test("embeds multiple text inputs in one batch call", async () => {
+      mockFetch = mock(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              embeddings: [{ values: [0.1, 0.2] }, { values: [0.2, 0.4] }],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
       globalThis.fetch = mockFetch as unknown as typeof fetch;
 
       const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
@@ -249,7 +252,7 @@ describe("GeminiEmbeddingBackend", () => {
       });
       const result = await backend.embed(["hello", "world"]);
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual([0.1, 0.2]);
       expect(result[1]).toEqual([0.2, 0.4]);
@@ -347,5 +350,235 @@ describe("GeminiEmbeddingBackend", () => {
       const body = JSON.parse(init.body as string);
       expect(body.outputDimensionality).toBe(3072);
     });
+  });
+});
+
+/** The input index encoded in a `t<n>` fixture text. */
+function textIndex(text: string): number {
+  return Number(text.replace(/^t/, ""));
+}
+
+/**
+ * A fetch stub that answers both routes: a single `embedContent` call with a
+ * vector encoding its input index, and a `batchEmbedContents` call with one
+ * such vector per request in order, unless `batch` overrides its outcome.
+ */
+function routedFetch(batch?: {
+  status?: number;
+  statusOnFirstCall?: number;
+  body?: unknown;
+}) {
+  let batchCalls = 0;
+  return mock(async (url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as {
+      requests?: Array<{ content: { parts: Array<{ text?: string }> } }>;
+      content?: { parts: Array<{ text?: string }> };
+    };
+    if (url.includes(":batchEmbedContents")) {
+      batchCalls += 1;
+      const status =
+        batchCalls === 1 && batch?.statusOnFirstCall !== undefined
+          ? batch.statusOnFirstCall
+          : (batch?.status ?? 200);
+      if (status !== 200) {
+        return new Response("no batch here", { status });
+      }
+      const embeddings =
+        batch?.body !== undefined
+          ? batch.body
+          : body.requests!.map((request) => ({
+              values: [textIndex(request.content.parts[0]!.text!)],
+            }));
+      return new Response(JSON.stringify({ embeddings }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    const part = body.content!.parts[0]!;
+    return makeSuccessResponse([
+      part.text !== undefined ? textIndex(part.text) : -1,
+    ]);
+  });
+}
+
+function texts(count: number): string[] {
+  return Array.from({ length: count }, (_v, i) => `t${i}`);
+}
+
+function calledUrls(fetchMock: ReturnType<typeof mock>): string[] {
+  return fetchMock.mock.calls.map((call) => (call as [string])[0]);
+}
+
+describe("GeminiEmbeddingBackend: batched text inputs", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("250 texts go out as three batchEmbedContents calls of 100, 100, and 50, vectors in input order", async () => {
+    const fetchMock = routedFetch();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed(texts(250));
+
+    const urls = calledUrls(fetchMock);
+    expect(urls).toHaveLength(3);
+    expect(urls.every((url) => url.includes(":batchEmbedContents"))).toBe(true);
+    const sizes = fetchMock.mock.calls.map(
+      (call) =>
+        (
+          JSON.parse((call as [string, RequestInit])[1].body as string) as {
+            requests: unknown[];
+          }
+        ).requests.length,
+    );
+    expect(sizes).toEqual([100, 100, 50]);
+    expect(vectors.map((v) => v[0])).toEqual(texts(250).map(textIndex));
+  });
+
+  test("each batched request names the model with the models/ prefix and carries taskType and outputDimensionality", async () => {
+    const fetchMock = routedFetch();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+      taskType: "RETRIEVAL_DOCUMENT",
+      dimensions: 256,
+    });
+
+    await backend.embed(texts(2));
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/models/test-model:batchEmbedContents?key=test-key");
+    const body = JSON.parse(init.body as string) as {
+      requests: Array<Record<string, unknown>>;
+      model?: unknown;
+    };
+    expect(body.model).toBeUndefined();
+    expect(body.requests).toEqual([
+      {
+        model: "models/test-model",
+        content: { parts: [{ text: "t0" }] },
+        taskType: "RETRIEVAL_DOCUMENT",
+        outputDimensionality: 256,
+      },
+      {
+        model: "models/test-model",
+        content: { parts: [{ text: "t1" }] },
+        taskType: "RETRIEVAL_DOCUMENT",
+        outputDimensionality: 256,
+      },
+    ]);
+  });
+
+  test("a lone text keeps the embedContent route", async () => {
+    const fetchMock = routedFetch();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed(["t7"]);
+
+    expect(calledUrls(fetchMock)).toEqual([
+      "https://generativelanguage.googleapis.com/v1beta/models/test-model:embedContent?key=test-key",
+    ]);
+    expect(vectors).toEqual([[7]]);
+  });
+
+  test("multimodal inputs take the single route while the texts around them batch, in input order", async () => {
+    const fetchMock = routedFetch();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed([
+      "t0",
+      { type: "image", data: Buffer.from("png"), mimeType: "image/png" },
+      "t2",
+      "t3",
+    ]);
+
+    const urls = calledUrls(fetchMock);
+    expect(
+      urls.map((url) =>
+        url.includes(":batchEmbedContents") ? "batch" : "single",
+      ),
+    ).toEqual(["single", "single", "batch"]);
+    expect(vectors.map((v) => v[0])).toEqual([0, -1, 2, 3]);
+  });
+
+  test("a batch route that does not exist falls back to single calls and is not tried again", async () => {
+    const fetchMock = routedFetch({ status: 404 });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const first = await backend.embed(texts(3));
+    expect(first.map((v) => v[0])).toEqual([0, 1, 2]);
+    // One failed batch attempt, then three singles.
+    expect(
+      calledUrls(fetchMock).map((url) => url.includes(":batchEmbedContents")),
+    ).toEqual([true, false, false, false]);
+
+    const second = await backend.embed(["t4", "t5"]);
+    expect(second.map((v) => v[0])).toEqual([4, 5]);
+    // No further batch attempt: straight to singles.
+    expect(
+      calledUrls(fetchMock)
+        .slice(4)
+        .every((url) => url.includes(":embedContent")),
+    ).toBe(true);
+    expect(fetchMock.mock.calls).toHaveLength(6);
+  });
+
+  test("a batch rejected as a bad request is re-sent as singles; the next batch is tried again", async () => {
+    const fetchMock = routedFetch({ statusOnFirstCall: 400 });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed(texts(150));
+
+    expect(vectors.map((v) => v[0])).toEqual(texts(150).map(textIndex));
+    const kinds = calledUrls(fetchMock).map((url) =>
+      url.includes(":batchEmbedContents") ? "batch" : "single",
+    );
+    // The rejected first batch, its 100 singles, then the second batch of 50.
+    expect(kinds).toHaveLength(102);
+    expect(kinds[0]).toBe("batch");
+    expect(kinds.slice(1, 101).every((kind) => kind === "single")).toBe(true);
+    expect(kinds[101]).toBe("batch");
+  });
+
+  test("a transient batch failure throws so the caller's retry policy sees it", async () => {
+    const fetchMock = routedFetch({ status: 503 });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    await expect(backend.embed(texts(3))).rejects.toThrow(
+      "Gemini batch embeddings request failed (503)",
+    );
+    expect(fetchMock.mock.calls).toHaveLength(1);
+  });
+
+  test("a batch body without one vector per input is re-sent as singles", async () => {
+    const fetchMock = routedFetch({ body: [{ values: [0] }] });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed(texts(3));
+
+    expect(vectors.map((v) => v[0])).toEqual([0, 1, 2]);
+    expect(fetchMock.mock.calls).toHaveLength(4);
   });
 });

--- a/assistant/src/persistence/embeddings/embedding-gemini.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.test.ts
@@ -599,6 +599,35 @@ describe("GeminiEmbeddingBackend: batched text inputs", () => {
     ).rejects.toThrow("fetch failed");
   });
 
+  test("a batch error whose body cannot be read is re-sent as singles", async () => {
+    let batchCalls = 0;
+    const fetchMock = mock(async (url: string, init: RequestInit) => {
+      if (url.includes(":batchEmbedContents")) {
+        batchCalls += 1;
+        const stream = new ReadableStream({
+          pull(controller) {
+            controller.error(new Error("stream reset"));
+          },
+        });
+        return new Response(stream, { status: 502 });
+      }
+      const body = JSON.parse(init.body as string) as {
+        content: { parts: Array<{ text: string }> };
+      };
+      return makeSuccessResponse([textIndex(body.content.parts[0]!.text)]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed(texts(2));
+
+    expect(vectors.map((v) => v[0])).toEqual([0, 1]);
+    expect(batchCalls).toBe(1);
+    expect(fetchMock.mock.calls).toHaveLength(3);
+  });
+
   test("a batch answered with a body that is not JSON is re-sent as singles", async () => {
     let batchCalls = 0;
     const fetchMock = mock(async (url: string, init: RequestInit) => {

--- a/assistant/src/persistence/embeddings/embedding-gemini.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.test.ts
@@ -556,17 +556,47 @@ describe("GeminiEmbeddingBackend: batched text inputs", () => {
     expect(kinds[101]).toBe("batch");
   });
 
-  test("a transient batch failure throws so the caller's retry policy sees it", async () => {
+  test("a batch that fails with a server error is re-sent as singles, so a fault confined to the batch route never fails the embed", async () => {
     const fetchMock = routedFetch({ status: 503 });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
     const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
       interCallDelayMs: 0,
     });
 
-    await expect(backend.embed(texts(3))).rejects.toThrow(
-      "Gemini batch embeddings request failed (503)",
-    );
-    expect(fetchMock.mock.calls).toHaveLength(1);
+    const vectors = await backend.embed(texts(3));
+
+    expect(vectors.map((v) => v[0])).toEqual([0, 1, 2]);
+    expect(
+      calledUrls(fetchMock).map((url) => url.includes(":batchEmbedContents")),
+    ).toEqual([true, false, false, false]);
+  });
+
+  test("a batch request that cannot be sent is re-sent as singles, while a cancelled request rethrows", async () => {
+    let batchCalls = 0;
+    const fetchMock = mock(async (url: string, init: RequestInit) => {
+      if (url.includes(":batchEmbedContents")) {
+        batchCalls += 1;
+        throw new TypeError("fetch failed");
+      }
+      const body = JSON.parse(init.body as string) as {
+        content: { parts: Array<{ text: string }> };
+      };
+      return makeSuccessResponse([textIndex(body.content.parts[0]!.text)]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed(texts(2));
+    expect(vectors.map((v) => v[0])).toEqual([0, 1]);
+    expect(batchCalls).toBe(1);
+
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      backend.embed(texts(2), { signal: controller.signal }),
+    ).rejects.toThrow("fetch failed");
   });
 
   test("a batch answered with a body that is not JSON is re-sent as singles", async () => {

--- a/assistant/src/persistence/embeddings/embedding-gemini.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.test.ts
@@ -569,6 +569,33 @@ describe("GeminiEmbeddingBackend: batched text inputs", () => {
     expect(fetchMock.mock.calls).toHaveLength(1);
   });
 
+  test("a batch answered with a body that is not JSON is re-sent as singles", async () => {
+    let batchCalls = 0;
+    const fetchMock = mock(async (url: string, init: RequestInit) => {
+      if (url.includes(":batchEmbedContents")) {
+        batchCalls += 1;
+        return new Response("<html>gateway timeout</html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        });
+      }
+      const body = JSON.parse(init.body as string) as {
+        content: { parts: Array<{ text: string }> };
+      };
+      return makeSuccessResponse([textIndex(body.content.parts[0]!.text)]);
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const backend = new GeminiEmbeddingBackend("test-key", "test-model", {
+      interCallDelayMs: 0,
+    });
+
+    const vectors = await backend.embed(texts(3));
+
+    expect(vectors.map((v) => v[0])).toEqual([0, 1, 2]);
+    expect(batchCalls).toBe(1);
+    expect(fetchMock.mock.calls).toHaveLength(4);
+  });
+
   test("a batch body without one vector per input is re-sent as singles", async () => {
     const fetchMock = routedFetch({ body: [{ values: [0] }] });
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/assistant/src/persistence/embeddings/embedding-gemini.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.ts
@@ -1,3 +1,4 @@
+import { getLogger } from "../../util/logger.js";
 import type {
   EmbeddingBackend,
   EmbeddingInput,
@@ -7,11 +8,27 @@ import type {
 } from "./embedding-types.js";
 import { normalizeEmbeddingInput } from "./embedding-types.js";
 
+const log = getLogger("memory-embeddings");
+
 interface GeminiEmbedResponse {
   embedding?: {
     values?: number[];
   };
 }
+
+interface GeminiBatchEmbedResponse {
+  embeddings?: Array<{ values?: number[] }>;
+}
+
+/** Texts per `batchEmbedContents` call, the API's documented maximum. */
+export const GEMINI_EMBED_BATCH_SIZE = 100;
+
+/**
+ * Response statuses that say the batch route itself is unavailable (a proxy
+ * that forwards only `embedContent`), as opposed to a bad request or a
+ * transient failure. The backend then stays on the single route.
+ */
+const BATCH_ROUTE_UNAVAILABLE_STATUSES = new Set([404, 405, 501]);
 
 export interface GeminiEmbeddingOptions {
   taskType?: EmbeddingTaskType;
@@ -33,6 +50,11 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
   private readonly dimensions?: number;
   private readonly managedBaseUrl?: string;
   private readonly interCallDelayMs: number;
+  /**
+   * Set once the batch route has answered that it does not exist, so later
+   * calls take the single route without a wasted round trip per batch.
+   */
+  private batchRouteUnavailable = false;
 
   constructor(apiKey: string, model: string, options?: GeminiEmbeddingOptions) {
     this.apiKey = apiKey;
@@ -48,34 +70,154 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
     return Boolean(this.managedBaseUrl);
   }
 
+  /**
+   * Embed `inputs` in order. Runs of text inputs go through
+   * `batchEmbedContents`, {@link GEMINI_EMBED_BATCH_SIZE} texts per round
+   * trip, so a corpus re-embed costs one request per hundred sections instead
+   * of one per section; a lone text and every multimodal input take the
+   * single `embedContent` route. A batch the API rejects as a bad request, or
+   * answers with a malformed body, is re-sent as single calls so each input
+   * fails or succeeds on its own exactly as it would have; a batch route that
+   * does not exist is remembered and skipped for the rest of the backend's
+   * life. Transient failures (rate limits, server errors, network) throw, so
+   * the caller's retry policy sees them as before.
+   */
   async embed(
     inputs: EmbeddingInput[],
     options?: EmbeddingRequestOptions,
   ): Promise<number[][]> {
-    const vectors: number[][] = [];
-    for (let i = 0; i < inputs.length; i++) {
-      const values = await this.embedSingle(inputs[i], options);
-      vectors.push(values);
-      // Yield to the event loop between sequential embed calls so the
-      // daemon can serve HTTP requests, health checks, and cron ticks
-      // while a large batch (e.g. startup skill reseed / concept-page
-      // reembed) is in flight. Without this, 68+ sequential Gemini
-      // round-trips starve the event loop for minutes at a time.
-      // TODO: replace with full backgrounding (worker thread / subprocess).
-      if (i < inputs.length - 1 && this.interCallDelayMs > 0) {
-        await Bun.sleep(this.interCallDelayMs);
+    const normalized = inputs.map(normalizeEmbeddingInput);
+    const vectors: number[][] = new Array(normalized.length);
+    let i = 0;
+    while (i < normalized.length) {
+      if (i > 0) {
+        await this.yieldBetweenCalls();
       }
+      const input = normalized[i]!;
+      // Gather the run of text inputs starting here, up to one batch.
+      let end = i;
+      while (
+        !this.batchRouteUnavailable &&
+        end < normalized.length &&
+        end - i < GEMINI_EMBED_BATCH_SIZE &&
+        normalized[end]!.type === "text"
+      ) {
+        end += 1;
+      }
+      if (end - i < 2) {
+        vectors[i] = await this.embedSingle(input, options);
+        i += 1;
+        continue;
+      }
+      const run = normalized.slice(i, end);
+      const batch = await this.embedBatch(run, options);
+      if (batch) {
+        for (let j = 0; j < run.length; j++) {
+          vectors[i + j] = batch[j]!;
+        }
+      } else {
+        for (let j = 0; j < run.length; j++) {
+          if (j > 0) {
+            await this.yieldBetweenCalls();
+          }
+          vectors[i + j] = await this.embedSingle(run[j]!, options);
+        }
+      }
+      i = end;
+    }
+    return vectors;
+  }
+
+  /**
+   * Yield to the event loop between sequential calls so the daemon can serve
+   * HTTP requests, health checks, and cron ticks while a large embed (a
+   * startup skill reseed, a concept-page re-embed) is in flight.
+   */
+  private async yieldBetweenCalls(): Promise<void> {
+    if (this.interCallDelayMs > 0) {
+      await Bun.sleep(this.interCallDelayMs);
+    }
+  }
+
+  /**
+   * One `batchEmbedContents` round trip for a run of text inputs. Resolves to
+   * the vectors in input order, or to `null` when the run should be re-sent
+   * as single calls: the route is unavailable (remembered), the request was
+   * rejected as bad, or the body did not carry one vector per input.
+   */
+  private async embedBatch(
+    run: MultimodalEmbeddingInput[],
+    options?: EmbeddingRequestOptions,
+  ): Promise<number[][] | null> {
+    // Unlike `embedContent`, each batched request names its model, and the
+    // API wants the `models/` resource prefix there.
+    const requests = run.map((input) => {
+      const request: Record<string, unknown> = {
+        model: `models/${this.model}`,
+        content: { parts: this.buildParts(input) },
+      };
+      if (this.taskType) {
+        request.taskType = this.taskType;
+      }
+      if (this.dimensions) {
+        request.outputDimensionality = this.dimensions;
+      }
+      return request;
+    });
+    const response = await fetch(this.endpointUrl("batchEmbedContents"), {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ requests }),
+      signal: options?.signal,
+    });
+    if (!response.ok) {
+      const responseBody = await response.text();
+      if (BATCH_ROUTE_UNAVAILABLE_STATUSES.has(response.status)) {
+        this.batchRouteUnavailable = true;
+        log.warn(
+          { status: response.status, managed: this.managed },
+          "Gemini batch embeddings route unavailable; embedding one text per call from here on",
+        );
+        return null;
+      }
+      if (response.status === 400) {
+        log.warn(
+          { status: response.status, inputs: run.length, responseBody },
+          "Gemini batch embeddings request rejected; re-sending this batch one text per call",
+        );
+        return null;
+      }
+      throw new Error(
+        `Gemini batch embeddings request failed (${response.status}): ${responseBody}`,
+      );
+    }
+    const payload = (await response.json()) as GeminiBatchEmbedResponse;
+    const embeddings = payload.embeddings;
+    const vectors: number[][] = [];
+    if (Array.isArray(embeddings) && embeddings.length === run.length) {
+      for (const embedding of embeddings) {
+        const values = embedding?.values;
+        if (!Array.isArray(values) || values.length === 0) {
+          break;
+        }
+        vectors.push(values);
+      }
+    }
+    if (vectors.length !== run.length) {
+      log.warn(
+        { inputs: run.length, vectors: vectors.length },
+        "Gemini batch embeddings response did not carry one vector per input; re-sending this batch one text per call",
+      );
+      return null;
     }
     return vectors;
   }
 
   private async embedSingle(
-    input: EmbeddingInput,
+    input: MultimodalEmbeddingInput,
     options?: EmbeddingRequestOptions,
   ): Promise<number[]> {
-    const normalized = normalizeEmbeddingInput(input);
-    const parts = this.buildParts(normalized);
-
+    const parts = this.buildParts(input);
     const body: Record<string, unknown> = {
       content: { parts },
     };
@@ -91,19 +233,9 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
     if (this.dimensions) {
       body.outputDimensionality = this.dimensions;
     }
-
-    const url = this.managedBaseUrl
-      ? `${this.managedBaseUrl}/v1beta/models/${encodeURIComponent(this.model)}:embedContent`
-      : `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(this.model)}:embedContent?key=${encodeURIComponent(this.apiKey)}`;
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-    if (this.managedBaseUrl) {
-      headers["Authorization"] = `Bearer ${this.apiKey}`;
-    }
-    const response = await fetch(url, {
+    const response = await fetch(this.endpointUrl("embedContent"), {
       method: "POST",
-      headers,
+      headers: this.headers(),
       body: JSON.stringify(body),
       signal: options?.signal,
     });
@@ -119,6 +251,24 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
       throw new Error("Gemini embeddings response missing vector values");
     }
     return values;
+  }
+
+  /** The model's `:embedContent` or `:batchEmbedContents` URL, direct or via the managed proxy. */
+  private endpointUrl(method: "embedContent" | "batchEmbedContents"): string {
+    const model = encodeURIComponent(this.model);
+    return this.managedBaseUrl
+      ? `${this.managedBaseUrl}/v1beta/models/${model}:${method}`
+      : `https://generativelanguage.googleapis.com/v1beta/models/${model}:${method}?key=${encodeURIComponent(this.apiKey)}`;
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (this.managedBaseUrl) {
+      headers["Authorization"] = `Bearer ${this.apiKey}`;
+    }
+    return headers;
   }
 
   private buildParts(input: MultimodalEmbeddingInput): unknown[] {

--- a/assistant/src/persistence/embeddings/embedding-gemini.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.ts
@@ -189,7 +189,16 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
       return null;
     }
     if (!response.ok) {
-      const responseBody = await response.text();
+      // The error body is diagnostic only; a stream that resets while it is
+      // read is one more batch-route fault to fall back from.
+      let responseBody = "";
+      try {
+        responseBody = await response.text();
+      } catch (err) {
+        if (options?.signal?.aborted) {
+          throw err;
+        }
+      }
       if (BATCH_ROUTE_UNAVAILABLE_STATUSES.has(response.status)) {
         this.batchRouteUnavailable = true;
         log.warn(

--- a/assistant/src/persistence/embeddings/embedding-gemini.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.ts
@@ -191,7 +191,19 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
         `Gemini batch embeddings request failed (${response.status}): ${responseBody}`,
       );
     }
-    const payload = (await response.json()) as GeminiBatchEmbedResponse;
+    let payload: GeminiBatchEmbedResponse;
+    try {
+      payload = (await response.json()) as GeminiBatchEmbedResponse;
+    } catch (err) {
+      log.warn(
+        {
+          inputs: run.length,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Gemini batch embeddings response was not JSON; re-sending this batch one text per call",
+      );
+      return null;
+    }
     const embeddings = payload.embeddings;
     const vectors: number[][] = [];
     if (Array.isArray(embeddings) && embeddings.length === run.length) {

--- a/assistant/src/persistence/embeddings/embedding-gemini.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.ts
@@ -75,12 +75,14 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
    * `batchEmbedContents`, {@link GEMINI_EMBED_BATCH_SIZE} texts per round
    * trip, so a corpus re-embed costs one request per hundred sections rather
    * than one per section; a lone text and every multimodal input take the
-   * single `embedContent` route. A batch the API rejects as a bad request, or
-   * answers with a malformed body, is re-sent as single calls, so each of its
-   * inputs succeeds or fails independently; a batch route that does not exist
-   * is remembered and skipped for the rest of the backend's life. Transient
-   * failures (rate limits, server errors, network) throw, so they reach the
-   * caller's retry policy.
+   * single `embedContent` route. A batch that fails for any reason other
+   * than a cancelled request (a rejected request, a rate limit or server
+   * error, a network failure, a malformed body) is re-sent as single calls,
+   * so each of its inputs succeeds or fails independently and a fault
+   * confined to the batch route never fails an embed the single route can
+   * serve; a batch route that does not exist is remembered and skipped for
+   * the rest of the backend's life. Single calls throw on failure, so their
+   * errors reach the caller.
    */
   async embed(
     inputs: EmbeddingInput[],
@@ -142,8 +144,9 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
   /**
    * One `batchEmbedContents` round trip for a run of text inputs. Resolves to
    * the vectors in input order, or to `null` when the run should be re-sent
-   * as single calls: the route is unavailable (remembered), the request was
-   * rejected as bad, or the body did not carry one vector per input.
+   * as single calls: the route is unavailable (remembered), the request
+   * failed with any status, the request could not be sent, or the body did
+   * not carry one vector per input. A cancelled request rethrows.
    */
   private async embedBatch(
     run: MultimodalEmbeddingInput[],
@@ -164,12 +167,27 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
       }
       return request;
     });
-    const response = await fetch(this.endpointUrl("batchEmbedContents"), {
-      method: "POST",
-      headers: this.headers(),
-      body: JSON.stringify({ requests }),
-      signal: options?.signal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(this.endpointUrl("batchEmbedContents"), {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify({ requests }),
+        signal: options?.signal,
+      });
+    } catch (err) {
+      if (options?.signal?.aborted) {
+        throw err;
+      }
+      log.warn(
+        {
+          inputs: run.length,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Gemini batch embeddings request could not be sent; re-sending this batch one text per call",
+      );
+      return null;
+    }
     if (!response.ok) {
       const responseBody = await response.text();
       if (BATCH_ROUTE_UNAVAILABLE_STATUSES.has(response.status)) {
@@ -180,16 +198,11 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
         );
         return null;
       }
-      if (response.status === 400) {
-        log.warn(
-          { status: response.status, inputs: run.length, responseBody },
-          "Gemini batch embeddings request rejected; re-sending this batch one text per call",
-        );
-        return null;
-      }
-      throw new Error(
-        `Gemini batch embeddings request failed (${response.status}): ${responseBody}`,
+      log.warn(
+        { status: response.status, inputs: run.length, responseBody },
+        "Gemini batch embeddings request failed; re-sending this batch one text per call",
       );
+      return null;
     }
     let payload: GeminiBatchEmbedResponse;
     try {

--- a/assistant/src/persistence/embeddings/embedding-gemini.ts
+++ b/assistant/src/persistence/embeddings/embedding-gemini.ts
@@ -73,14 +73,14 @@ export class GeminiEmbeddingBackend implements EmbeddingBackend {
   /**
    * Embed `inputs` in order. Runs of text inputs go through
    * `batchEmbedContents`, {@link GEMINI_EMBED_BATCH_SIZE} texts per round
-   * trip, so a corpus re-embed costs one request per hundred sections instead
-   * of one per section; a lone text and every multimodal input take the
+   * trip, so a corpus re-embed costs one request per hundred sections rather
+   * than one per section; a lone text and every multimodal input take the
    * single `embedContent` route. A batch the API rejects as a bad request, or
-   * answers with a malformed body, is re-sent as single calls so each input
-   * fails or succeeds on its own exactly as it would have; a batch route that
-   * does not exist is remembered and skipped for the rest of the backend's
-   * life. Transient failures (rate limits, server errors, network) throw, so
-   * the caller's retry policy sees them as before.
+   * answers with a malformed body, is re-sent as single calls, so each of its
+   * inputs succeeds or fails independently; a batch route that does not exist
+   * is remembered and skipped for the rest of the backend's life. Transient
+   * failures (rate limits, server errors, network) throw, so they reach the
+   * caller's retry policy.
    */
   async embed(
     inputs: EmbeddingInput[],

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/maintain-job.test.ts
@@ -77,6 +77,7 @@ describe("maintainJob", () => {
       built: Slug[][];
       deleted: string[];
       upserted: Section[][];
+      warmed: Section[][];
       invalidate: number;
       commit: number;
     };
@@ -85,6 +86,7 @@ describe("maintainJob", () => {
       built: [] as Slug[][],
       deleted: [] as string[],
       upserted: [] as Section[][],
+      warmed: [] as Section[][],
       invalidate: 0,
       commit: 0,
     };
@@ -103,6 +105,9 @@ describe("maintainJob", () => {
       },
       upsertSections: async (_config, sections) => {
         calls.upserted.push(sections);
+      },
+      warmSectionEmbeddings: async (_config, sections) => {
+        calls.warmed.push(sections);
       },
       commitEmbedHighWater: () => {
         calls.commit += 1;
@@ -191,8 +196,12 @@ describe("maintainJob", () => {
     expect(outcome.reembedFailures).toBe(0);
     expect(outcome.invalidated).toBe(true);
 
-    // Each changed page: delete its stale sections, then upsert fresh ones.
-    expect(calls.built).toEqual([["page-a"], ["page-b"]]);
+    // The cache is warmed for both pages at once, then each changed page:
+    // delete its stale sections, then upsert fresh ones.
+    expect(calls.warmed.map((s) => s.map((x) => x.article))).toEqual([
+      ["page-a", "page-b"],
+    ]);
+    expect(calls.built).toEqual([["page-a", "page-b"], ["page-a"], ["page-b"]]);
     expect(calls.deleted).toEqual(["page-a", "page-b"]);
     expect(calls.upserted.flat().map((s) => s.article)).toEqual([
       "page-a",
@@ -200,6 +209,64 @@ describe("maintainJob", () => {
     ]);
     expect(calls.invalidate).toBe(1);
     expect(calls.commit).toBe(1);
+  });
+
+  test("warms the embedding cache for every changed page before any page is deleted or upserted", async () => {
+    memoryV3LiveSlot = true;
+    const order: string[] = [];
+    const { deps: d } = deps({
+      selectChangedPages: async () => ["page-a", "page-b", "page-c"],
+      warmSectionEmbeddings: async (_config, sections) => {
+        order.push(`warm:${sections.map((s) => s.article).join(",")}`);
+      },
+      deleteSectionsForArticle: async (_config, article) => {
+        order.push(`delete:${article}`);
+      },
+      upsertSections: async (_config, sections) => {
+        order.push(`upsert:${sections[0]!.article}`);
+      },
+    });
+    await maintainJob(JOB, CONFIG, d);
+
+    expect(order).toEqual([
+      "warm:page-a,page-b,page-c",
+      "delete:page-a",
+      "upsert:page-a",
+      "delete:page-b",
+      "upsert:page-b",
+      "delete:page-c",
+      "upsert:page-c",
+    ]);
+  });
+
+  test("a failing cache warm-up is non-fatal: pages still re-embed one at a time", async () => {
+    memoryV3LiveSlot = true;
+    const { deps: d, calls } = deps({
+      selectChangedPages: async () => ["page-a", "page-b"],
+      warmSectionEmbeddings: async () => {
+        throw new Error("embedding backend down");
+      },
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.reembedded).toBe(2);
+    expect(outcome.reembedFailures).toBe(0);
+    expect(calls.deleted).toEqual(["page-a", "page-b"]);
+    expect(calls.upserted.flat().map((s) => s.article)).toEqual([
+      "page-a",
+      "page-b",
+    ]);
+  });
+
+  test("a single changed page skips the warm-up", async () => {
+    memoryV3LiveSlot = true;
+    const { deps: d, calls } = deps({
+      selectChangedPages: async () => ["page-a"],
+    });
+    await maintainJob(JOB, CONFIG, d);
+
+    expect(calls.warmed).toEqual([]);
+    expect(calls.built).toEqual([["page-a"]]);
   });
 
   test("runs when only the live flag is on", async () => {
@@ -767,6 +834,7 @@ describe("backfillAllSections", () => {
       built: Slug[][];
       deleted: string[];
       upserted: Section[][];
+      warmed: Section[][];
       committed: number[];
       probed: number;
     };
@@ -776,6 +844,7 @@ describe("backfillAllSections", () => {
       built: [] as Slug[][],
       deleted: [] as string[],
       upserted: [] as Section[][],
+      warmed: [] as Section[][],
       committed: [] as number[],
       probed: 0,
     };
@@ -797,6 +866,9 @@ describe("backfillAllSections", () => {
       },
       upsertSections: async (_config, sections) => {
         calls.upserted.push(sections);
+      },
+      warmSectionEmbeddings: async (_config, sections) => {
+        calls.warmed.push(sections);
       },
       commitEmbedHighWater: (ms) => {
         calls.committed.push(ms);
@@ -835,6 +907,8 @@ describe("backfillAllSections", () => {
     expect(outcome.failures).toBe(0);
     expect(calls.ensured).toBe(1);
     expect(calls.built).toEqual([["page-a"], ["skills/example"]]);
+    // One real page alone warms nothing; capability rows never warm.
+    expect(calls.warmed).toEqual([]);
     expect(calls.deleted).toEqual(["page-a", "skills/example"]);
 
     // The synthetic slug's upsert carries its rendered capability content, not a
@@ -847,6 +921,28 @@ describe("backfillAllSections", () => {
       "example capability body",
     );
     expect(outcome.sections).toBe(calls.upserted.flat().length);
+  });
+
+  test("warms the cache for the real pages together and leaves capability rows to the per-row path", async () => {
+    const { deps: d, calls } = deps({
+      selectAllPages: async () => ["page-a", "page-b", "skills/example"],
+      readPageBody: async (slug) =>
+        slug === "skills/example"
+          ? "# Example\nrendered skill"
+          : `body for ${slug}`,
+    });
+    const outcome = await backfillAllSections(CONFIG, d);
+
+    expect(outcome.failures).toBe(0);
+    expect(calls.warmed.map((s) => s.map((x) => x.article))).toEqual([
+      ["page-a", "page-b"],
+    ]);
+    expect(calls.built).toEqual([
+      ["page-a", "page-b"],
+      ["page-a"],
+      ["page-b"],
+      ["skills/example"],
+    ]);
   });
 
   test("advances the high-water checkpoint to the injected now", async () => {
@@ -1095,6 +1191,7 @@ describe("maintainJob skill usage-prune", () => {
       buildSectionIndex: async (slugs) => makeIndex(slugs),
       readPageBody: async (s) => `body for ${s}`,
       readCapabilityBody: async (s) => `capability body for ${s}`,
+      warmSectionEmbeddings: async () => {},
       deleteSectionsForArticle: async (_config, article) => {
         sectionDeletes.push(article);
       },

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
@@ -266,6 +266,7 @@ mock.module("../../../../../persistence/checkpoints.js", () => ({
 const {
   ensureSectionCollection,
   upsertSections,
+  warmSectionEmbeddings,
   deleteSectionsForArticle,
   listSectionArticles,
   SECTION_COLLECTION,
@@ -593,6 +594,41 @@ describe("memory v3 section-dense-store — embedding cache", () => {
     expect(state.upsertCalls[1]!.points.map((p) => p.vector)).toEqual(
       state.upsertCalls[0]!.points.map((p) => p.vector),
     );
+  });
+
+  test("warmSectionEmbeddings embeds every miss across pages in one backend call, and the per-page upserts then serve from cache", async () => {
+    state.collectionExists = true;
+    const alice = [
+      section("people/alice", 0, "alice lead text"),
+      section("people/alice", 1, "alice section one"),
+    ];
+    const bob = [section("people/bob", 0, "bob lead text")];
+
+    await warmSectionEmbeddings(CONFIG, [...alice, ...bob]);
+    expect(embedState.calls).toEqual([
+      ["alice lead text", "alice section one", "bob lead text"],
+    ]);
+    expect(state.upsertCalls).toHaveLength(0);
+
+    await upsertSections(CONFIG, alice);
+    await upsertSections(CONFIG, bob);
+    // No further backend call: both pages rebuilt their points from the cache.
+    expect(embedState.calls).toHaveLength(1);
+    expect(state.upsertCalls).toHaveLength(2);
+    expect(
+      state.upsertCalls.flatMap((c) => c.points).map((p) => p.vector),
+    ).toEqual(
+      [
+        embedState.calls[0]!.map((_t, i) =>
+          Array.from({ length: embedState.dim }, (_v, j) => (i + 1) * (j + 1)),
+        ),
+      ].flat(),
+    );
+  });
+
+  test("warmSectionEmbeddings with no sections makes no backend call", async () => {
+    await warmSectionEmbeddings(CONFIG, []);
+    expect(embedState.calls).toHaveLength(0);
   });
 
   test("a changed section text re-embeds (content hash differs)", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
@@ -267,6 +267,7 @@ const {
   ensureSectionCollection,
   upsertSections,
   warmSectionEmbeddings,
+  WARM_SECTIONS_PER_CALL,
   deleteSectionsForArticle,
   listSectionArticles,
   SECTION_COLLECTION,
@@ -624,6 +625,23 @@ describe("memory v3 section-dense-store — embedding cache", () => {
         ),
       ].flat(),
     );
+  });
+
+  test("warmSectionEmbeddings bounds each backend call to WARM_SECTIONS_PER_CALL sections", async () => {
+    state.collectionExists = true;
+    const count = WARM_SECTIONS_PER_CALL * 2 + 1;
+    const sections = Array.from({ length: count }, (_v, i) =>
+      section(`page-${Math.floor(i / 10)}`, i % 10, `text ${i}`),
+    );
+
+    await warmSectionEmbeddings(CONFIG, sections);
+
+    expect(embedState.calls.map((c) => c.length)).toEqual([
+      WARM_SECTIONS_PER_CALL,
+      WARM_SECTIONS_PER_CALL,
+      1,
+    ]);
+    expect(embedState.calls.flat()).toEqual(sections.map((s) => s.text));
   });
 
   test("warmSectionEmbeddings with no sections makes no backend call", async () => {

--- a/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
@@ -526,11 +526,11 @@ async function reembedChangedPages(
 }
 
 /**
- * Warm the embedding cache for every section of `slugs` in one batched backend
- * call before the per-page loop, which otherwise pays one backend call per
+ * Warm the embedding cache for every section of `slugs` in batched backend
+ * calls before the per-page loop, which otherwise pays one backend call per
  * page. Only worth a call for two or more pages. Best-effort: a failure here
- * is logged and the per-page loop embeds as it always has, so the loop's
- * per-page failure containment is unchanged.
+ * is logged, and the per-page loop then embeds each page independently, with
+ * each page's failure contained to that page.
  */
 async function warmEmbeddingCacheForPages(
   slugs: Slug[],
@@ -551,7 +551,7 @@ async function warmEmbeddingCacheForPages(
         pages: slugs.length,
         err: err instanceof Error ? err.message : String(err),
       },
-      "memory-v3 maintain: embedding cache warm-up failed; pages embed one at a time (non-fatal)",
+      "memory-v3 maintain: embedding cache warm-up failed; each page embeds on its own (non-fatal)",
     );
   }
 }

--- a/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory/v3/maintain-job.ts
@@ -106,6 +106,7 @@ import {
   listSectionArticles as realListSectionArticles,
   MAINTAIN_EMBED_HIGH_WATER_KEY,
   upsertSections as realUpsertSections,
+  warmSectionEmbeddings as realWarmSectionEmbeddings,
 } from "./section-dense-store.js";
 import { buildSectionIndex as realBuildSectionIndex } from "./sections.js";
 import { invalidateLanes as realInvalidateLanes } from "./shadow-plugin.js";
@@ -161,6 +162,11 @@ export interface MaintainJobDeps {
   deleteSectionsForArticle: typeof realDeleteSectionsForArticle;
   /** Embed + upsert an article's current sections into the dense store. */
   upsertSections: typeof realUpsertSections;
+  /**
+   * Warm the embedding cache for many pages' sections in one batched backend
+   * call before the per-page upserts, which then serve from the cache.
+   */
+  warmSectionEmbeddings: typeof realWarmSectionEmbeddings;
   /**
    * Persist the high-water mark after a re-embed pass with zero failures. The
    * value is captured before the pass's writes (see the key docstring); the
@@ -244,6 +250,11 @@ export interface BackfillJobDeps {
   deleteSectionsForArticle: typeof realDeleteSectionsForArticle;
   /** Embed + upsert an article's current sections into the dense store. */
   upsertSections: typeof realUpsertSections;
+  /**
+   * Warm the embedding cache for many pages' sections in one batched backend
+   * call before the per-page upserts, which then serve from the cache.
+   */
+  warmSectionEmbeddings: typeof realWarmSectionEmbeddings;
   /**
    * Persist the high-water mark after the backfill completes with zero
    * failures. Skipped when any page failed so failed pages retry next pass.
@@ -437,6 +448,7 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
       backfillPageBodyFromWorkspace(workspaceDir, slug),
     deleteSectionsForArticle: realDeleteSectionsForArticle,
     upsertSections: realUpsertSections,
+    warmSectionEmbeddings: realWarmSectionEmbeddings,
     commitEmbedHighWater: commitSectionEmbedHighWater,
     ensureChunkerVersion: realEnsureSectionChunkerVersion,
     listSectionArticles: () => realListSectionArticles(config),
@@ -472,6 +484,7 @@ function defaultBackfillDeps(config: AssistantConfig): BackfillJobDeps {
     readPageBody: (slug) => backfillPageBodyFromWorkspace(workspaceDir, slug),
     deleteSectionsForArticle: realDeleteSectionsForArticle,
     upsertSections: realUpsertSections,
+    warmSectionEmbeddings: realWarmSectionEmbeddings,
     commitEmbedHighWater: commitSectionEmbedHighWater,
     ensureChunkerVersion: realEnsureSectionChunkerVersion,
     nowMs: () => Date.now(),
@@ -494,6 +507,7 @@ async function reembedChangedPages(
 ): Promise<{ reembedded: number; reembedFailures: number }> {
   let reembedded = 0;
   let reembedFailures = 0;
+  await warmEmbeddingCacheForPages(slugs, deps);
   for (const slug of slugs) {
     try {
       const index = await deps.buildSectionIndex([slug], deps.readPageBody);
@@ -509,6 +523,37 @@ async function reembedChangedPages(
     }
   }
   return { reembedded, reembedFailures };
+}
+
+/**
+ * Warm the embedding cache for every section of `slugs` in one batched backend
+ * call before the per-page loop, which otherwise pays one backend call per
+ * page. Only worth a call for two or more pages. Best-effort: a failure here
+ * is logged and the per-page loop embeds as it always has, so the loop's
+ * per-page failure containment is unchanged.
+ */
+async function warmEmbeddingCacheForPages(
+  slugs: Slug[],
+  deps: Pick<
+    MaintainJobDeps,
+    "buildSectionIndex" | "readPageBody" | "warmSectionEmbeddings" | "config"
+  >,
+): Promise<void> {
+  if (slugs.length < 2) {
+    return;
+  }
+  try {
+    const index = await deps.buildSectionIndex(slugs, deps.readPageBody);
+    await deps.warmSectionEmbeddings(deps.config, index.sections);
+  } catch (err) {
+    log.warn(
+      {
+        pages: slugs.length,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "memory-v3 maintain: embedding cache warm-up failed; pages embed one at a time (non-fatal)",
+    );
+  }
 }
 
 /**
@@ -850,6 +895,13 @@ export async function backfillAllSections(
   };
 
   const coldCapabilities: Slug[] = [];
+  // Real pages warm the embedding cache in one batched call first; capability
+  // rows stay on the per-page path below, whose cold-row guard must see each
+  // body before anything of it is embedded.
+  await warmEmbeddingCacheForPages(
+    slugs.filter((slug) => !isCapabilitySlug(slug)),
+    deps,
+  );
   for (const slug of slugs) {
     if ((await embedOne(slug)) === "cold") {
       coldCapabilities.push(slug);

--- a/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
@@ -586,21 +586,33 @@ export async function upsertSections(
 }
 
 /**
- * Warm the `memory_embeddings` cache for `sections` in one batched backend call
- * (every miss across every page at once), so the per-page `upsertSections`
- * calls that follow serve from the cache and make no backend round trip. A
- * corpus rebuild otherwise pays one backend call per page. The vectors are
- * not returned: the cache rows are the product, keyed exactly as the per-page
- * path keys them, and an empty `sections` array is a no-op.
+ * Sections per backend call when warming the cache: the vectors of one call
+ * are held in memory until its cache rows are written, so this bounds that
+ * footprint (a few megabytes at 3,072 dimensions) while a call still spans
+ * many pages.
+ */
+export const WARM_SECTIONS_PER_CALL = 200;
+
+/**
+ * Warm the `memory_embeddings` cache for `sections` across pages, in backend
+ * calls of at most {@link WARM_SECTIONS_PER_CALL} sections (every miss in a
+ * call embeds in one batched request), so the per-page `upsertSections` calls
+ * that follow serve from the cache and make no backend round trip. Without
+ * the warm-up a corpus rebuild pays one backend call per page. The vectors
+ * are not returned: the cache rows are the product, keyed exactly as the
+ * per-page path keys them, and each call's vectors are released once its rows
+ * are written. An empty `sections` array is a no-op.
  */
 export async function warmSectionEmbeddings(
   config: AssistantConfig,
   sections: Section[],
 ): Promise<void> {
-  if (sections.length === 0) {
-    return;
+  for (let i = 0; i < sections.length; i += WARM_SECTIONS_PER_CALL) {
+    await embedSectionsCached(
+      config,
+      sections.slice(i, i + WARM_SECTIONS_PER_CALL),
+    );
   }
-  await embedSectionsCached(config, sections);
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
@@ -586,6 +586,24 @@ export async function upsertSections(
 }
 
 /**
+ * Warm the `memory_embeddings` cache for `sections` in one batched backend call
+ * (every miss across every page at once), so the per-page `upsertSections`
+ * calls that follow serve from the cache and make no backend round trip. A
+ * corpus rebuild otherwise pays one backend call per page. The vectors are
+ * not returned: the cache rows are the product, keyed exactly as the per-page
+ * path keys them, and an empty `sections` array is a no-op.
+ */
+export async function warmSectionEmbeddings(
+  config: AssistantConfig,
+  sections: Section[],
+): Promise<void> {
+  if (sections.length === 0) {
+    return;
+  }
+  await embedSectionsCached(config, sections);
+}
+
+/**
  * Resolve a dense vector per section, reusing cached vectors for sections whose
  * `text` is unchanged and embedding only the misses in a single batched backend
  * call. Returns one entry per input section, index-aligned; a position is left


### PR DESCRIPTION
## Summary
- `GeminiEmbeddingBackend.embed` sends runs of text inputs through `batchEmbedContents` (100 per round trip, each request naming its model with the `models/` prefix; `taskType` and `outputDimensionality` per request as the single route sends them). A lone text, every multimodal input, and a backend whose batch route answered 404/405/501 (a proxy that forwards only `embedContent`) take the single route. A batch rejected as a bad request or answered without one vector per input is re-sent one text per call, so each input fails or succeeds on its own exactly as before; a batch that fails for any other reason (any status, a request that cannot be sent) is re-sent the same way, so a fault confined to the batch route never fails an embed the single route can serve; only a cancelled request rethrows. Fallbacks log once per event.
- `warmSectionEmbeddings` (section dense store) embeds every miss across many pages in one batched backend call and writes the cache rows the per-page path reads. The memory-v3 maintain pass and the manual backfill call it for all changed pages (two or more) before their unchanged per-page delete-then-upsert loop, which then serves from the cache; the backfill warms real pages only, since its cold capability-row guard must see each body before anything of it is embedded. A failed warm-up is logged and the loop embeds page by page as it always has.
- Effect on a full rebuild (a chunker version bump): about one request per hundred sections instead of one per section. On a 13,500-section corpus that is roughly 140 round trips instead of 13,500.

## Tests
- Gemini client: batch sizes and order over 250 inputs; per-request body shape; a lone text stays on the single route; multimodal inputs interleaved with texts; route-unavailable fallback is sticky; a bad-request batch is re-sent as singles and the next batch is tried again; a server error, an unsendable request, a non-JSON body, and a malformed body all fall back; a cancelled request rethrows.
- Dense store: one backend call warms three sections across two pages and the two per-page upserts then make no backend call; an empty warm is a no-op.
- Maintain job: warm-up runs once with every changed page's sections before any delete or upsert; a failing warm-up is non-fatal; a single changed page skips it; the backfill warms real pages and leaves capability rows to the per-row path.