### PR TITLE
Expose window-scoped capture on computer_use_observe

### DIFF
--- a/assistant/src/__tests__/assistant-event-hub-machine-name.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub-machine-name.test.ts
@@ -124,3 +124,43 @@ describe("AssistantEventHub — machineName", () => {
     expect(entry?.machineName).toBeUndefined();
   });
 });
+
+describe("window capture negotiation", () => {
+  test.each([
+    ["macos", undefined, false],
+    ["macos", "0", false],
+    ["macos", "unknown", false],
+    ["macos", "1", true],
+    ["windows", "1", false],
+    ["linux", "1", false],
+    ["chrome-extension", "1", false],
+  ] as const)(
+    "%s advertising %s negotiates support=%s",
+    (interfaceId, advertised, supported) => {
+      const ac = new AbortController();
+      const hub = new AssistantEventHub();
+      try {
+        handleSubscribeAssistantEvents(
+          {
+            headers: {
+              "x-vellum-client-id": "client-1",
+              "x-vellum-interface-id": interfaceId,
+              ...(advertised
+                ? { "x-vellum-cu-window-capture": advertised }
+                : {}),
+            },
+            abortSignal: ac.signal,
+          },
+          { hub },
+        );
+        expect(
+          hub
+            .getClientById("client-1")
+            ?.capabilities.includes("host_cu_window_capture"),
+        ).toBe(supported);
+      } finally {
+        ac.abort();
+      }
+    },
+  );
+});

--- a/assistant/src/__tests__/assistant-event-hub.test.ts
+++ b/assistant/src/__tests__/assistant-event-hub.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import type { AssistantEventEnvelope } from "../api/index.js";
 import {
   AssistantEventHub,
+  assistantEventHub,
   broadcastMessage,
   capabilityForMessageType,
 } from "../runtime/assistant-event-hub.js";
@@ -644,4 +645,48 @@ describe("broadcastMessage — replay ring", () => {
       "assistant_text_delta",
     ]);
   });
+});
+
+test("window requests never reach an older overlapping connection with the same device ID", async () => {
+  const receivedLegacy: unknown[] = [];
+  const receivedSupported: unknown[] = [];
+  const legacy = assistantEventHub.subscribe({
+    type: "client",
+    clientId: "window-client",
+    interfaceId: "macos",
+    capabilities: ["host_cu"],
+    callback: (event) => {
+      receivedLegacy.push(event);
+    },
+  });
+  const supported = assistantEventHub.subscribe({
+    type: "client",
+    clientId: "window-client",
+    interfaceId: "macos",
+    capabilities: ["host_cu", "host_cu_window_capture"],
+    callback: (event) => {
+      receivedSupported.push(event);
+    },
+  });
+  try {
+    broadcastMessage(
+      {
+        type: "host_cu_request",
+        requestId: "window-request",
+        conversationId: "window-session",
+        toolName: "computer_use_observe",
+        input: { capture_window_id: 12 },
+        stepNumber: 1,
+        targetClientId: "window-client",
+      },
+      "window-session",
+      { targetClientId: "window-client" },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(receivedLegacy).toHaveLength(0);
+    expect(receivedSupported).toHaveLength(1);
+  } finally {
+    legacy.dispose();
+    supported.dispose();
+  }
 });

--- a/assistant/src/__tests__/computer-use-native-history.test.ts
+++ b/assistant/src/__tests__/computer-use-native-history.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+
+// Source contract for the macOS-only implementation; native capture itself is
+// exercised on macOS, not by this cross-platform guard.
+test("native targeted observations reset but never overwrite desktop history", () => {
+  const source = readFileSync(
+    new URL(
+      "../../../clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const builder = source.slice(
+    source.indexOf("private static func buildObservation("),
+    source.indexOf("/// Package observation data"),
+  );
+  expect(builder).toContain(
+    "if captureTarget != nil {\n            previousAXElements.removeValue(forKey: conversationId)\n        }",
+  );
+  expect(builder.indexOf("previousAXElements.removeValue")).toBeLessThan(
+    builder.indexOf("switch captureTarget"),
+  );
+  expect(builder).toContain(
+    "currentElements = captureTarget == nil ? flat : nil",
+  );
+  expect(builder).toContain(
+    "if captureTarget == nil, let previousFlat = previousAXElements[conversationId]",
+  );
+});

--- a/assistant/src/__tests__/computer-use-window-schema.test.ts
+++ b/assistant/src/__tests__/computer-use-window-schema.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { computerUseObserveTool } from "../tools/computer-use/definitions";
+
+test("window observation schema matches the skill manifest", () => {
+  const manifest = JSON.parse(readFileSync(new URL("../config/bundled-skills/computer-use/TOOLS.json", import.meta.url), "utf8"));
+  expect(manifest.tools.find((tool: { name: string }) => tool.name === "computer_use_observe").input_schema).toEqual(computerUseObserveTool.input_schema);
+  expect(computerUseObserveTool.input_schema.properties.capture_window_id).toMatchObject({ type: "integer", minimum: 1, maximum: 4294967295 });
+});

--- a/assistant/src/__tests__/computer-use-window-schema.test.ts
+++ b/assistant/src/__tests__/computer-use-window-schema.test.ts
@@ -1,9 +1,24 @@
-import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { computerUseObserveTool } from "../tools/computer-use/definitions";
+import { expect, test } from "bun:test";
+
+import { computerUseObserveTool } from "../tools/computer-use/definitions.js";
 
 test("window observation schema matches the skill manifest", () => {
-  const manifest = JSON.parse(readFileSync(new URL("../config/bundled-skills/computer-use/TOOLS.json", import.meta.url), "utf8"));
-  expect(manifest.tools.find((tool: { name: string }) => tool.name === "computer_use_observe").input_schema).toEqual(computerUseObserveTool.input_schema);
-  expect(computerUseObserveTool.input_schema.properties.capture_window_id).toMatchObject({ type: "integer", minimum: 1, maximum: 4294967295 });
+  const manifest = JSON.parse(
+    readFileSync(
+      new URL(
+        "../config/bundled-skills/computer-use/TOOLS.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  );
+  expect(
+    manifest.tools.find(
+      (tool: { name: string }) => tool.name === "computer_use_observe",
+    ).input_schema,
+  ).toEqual(computerUseObserveTool.input_schema);
+  expect(
+    computerUseObserveTool.input_schema.properties.capture_window_id,
+  ).toMatchObject({ type: "integer", minimum: 1, maximum: 4294967295 });
 });

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 
 const sentMessages: unknown[] = [];
+const sentOptions: unknown[] = [];
 let mockHasClient = false;
 type MockClient = {
   clientId: string;
@@ -10,13 +11,18 @@ type MockClient = {
 let mockClients: MockClient[] = [];
 
 mock.module("../runtime/assistant-event-hub.js", () => ({
-  broadcastMessage: (msg: unknown) => {
+  broadcastMessage: (
+    msg: unknown,
+    _conversationId: unknown,
+    options: unknown,
+  ) => {
     // Skip `interaction_resolved` envelopes — pending-interactions emits one
     // on every resolve and these tests assert on host-proxy wire messages.
     if ((msg as { type?: string } | null)?.type === "interaction_resolved") {
       return;
     }
     sentMessages.push(msg);
+    sentOptions.push(options);
   },
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
@@ -39,6 +45,7 @@ describe("HostCuProxy", () => {
 
   function setup(maxSteps?: number) {
     sentMessages.length = 0;
+    sentOptions.length = 0;
     mockHasClient = false;
     mockClients = [];
     pendingInteractions.clear();
@@ -1492,6 +1499,157 @@ describe("HostCuProxy", () => {
       proxy.processObservation(sent.requestId as string, { axTree: "ok" });
       const result = await resultPromise;
       expect(result.isError).toBe(false);
+    });
+  });
+
+  describe("window capture privacy and observation history", () => {
+    function connect(supported = true) {
+      mockClients = [
+        {
+          clientId: "mac-1",
+          actorPrincipalId: "user-1",
+          capabilities: supported
+            ? ["host_cu", "host_cu_window_capture"]
+            : ["host_cu"],
+        },
+      ];
+    }
+    function observe(input: Record<string, unknown>, targetClientId?: string) {
+      return proxy.request(
+        "computer_use_observe",
+        input,
+        "session-1",
+        1,
+        undefined,
+        undefined,
+        targetClientId,
+        "user-1",
+      );
+    }
+    async function finish(
+      input: Record<string, unknown>,
+      observation: Record<string, string>,
+    ) {
+      proxy.recordAction("computer_use_observe", input);
+      const pending = observe(input);
+      const sent = sentMessages.at(-1) as { requestId: string };
+      proxy.processObservation(sent.requestId, observation);
+      return await pending;
+    }
+
+    test("old clients fail closed for both explicit and automatic targeting", async () => {
+      setup();
+      connect(false);
+      for (const target of [undefined, "mac-1"]) {
+        expect((await observe({ capture_window_id: 12 }, target)).isError).toBe(
+          true,
+        );
+      }
+      expect(sentMessages).toHaveLength(0);
+    });
+    test("unknown support never falls back to an untargeted broadcast", async () => {
+      setup();
+      expect((await observe({ capture_window_id: 12 })).isError).toBe(true);
+      expect(sentMessages).toHaveLength(0);
+    });
+    test("supported clients receive explicitly targeted dispatch", async () => {
+      setup();
+      connect();
+      for (const target of [undefined, "mac-1"]) {
+        const pending = observe({ capture_window_id: 12 }, target);
+        const sent = sentMessages.at(-1) as {
+          requestId: string;
+          targetClientId: string;
+        };
+        expect(sent.targetClientId).toBe("mac-1");
+        expect(sentOptions.at(-1)).toEqual({
+          targetClientId: "mac-1",
+        });
+        proxy.processObservation(sent.requestId, { axTree: "Window" });
+        expect((await pending).isError).toBe(false);
+      }
+    });
+    test("invalid targets and scoped actions are rejected before dispatch", async () => {
+      setup();
+      connect();
+      for (const id of [0, -1, 1.5, "12", null, NaN, Infinity, 4294967296]) {
+        expect((await observe({ capture_window_id: id })).isError).toBe(true);
+      }
+      expect(
+        (await observe({ capture_window_id: 12, captureDisplayId: 2 })).isError,
+      ).toBe(true);
+      expect(
+        (await observe({ capture_window_id: 12, captureWindowId: 2 })).isError,
+      ).toBe(true);
+      expect(
+        (
+          await proxy.request(
+            "computer_use_click",
+            { capture_window_id: 12 },
+            "session-1",
+            1,
+            undefined,
+            undefined,
+            "mac-1",
+            "user-1",
+          )
+        ).isError,
+      ).toBe(true);
+      expect(sentMessages).toHaveLength(0);
+    });
+    test("targeted snapshots reset history without no-effect warnings or cross-window diffs", async () => {
+      setup();
+      connect();
+      await finish({}, { axTree: "Private desktop" });
+      await finish({}, { axTree: "Private desktop" });
+      expect(proxy.consecutiveUnchangedSteps).toBe(1);
+      for (const id of [12, 12, 13]) {
+        const result = await finish(
+          { capture_window_id: id },
+          {
+            axTree: "Chosen window",
+            axDiff: "Removed Private desktop",
+            secondaryWindows: "Private secondary window",
+          },
+        );
+        expect(result.content).not.toContain("NO VISIBLE EFFECT");
+        expect(result.content).not.toContain("Private");
+        expect(proxy.previousAXTree).toBeUndefined();
+        expect(proxy.consecutiveUnchangedSteps).toBe(0);
+      }
+      const desktop = await finish({}, { axTree: "Returned desktop" });
+      expect(desktop.content).not.toContain("NO VISIBLE EFFECT");
+      expect(proxy.previousAXTree).toBe("Returned desktop");
+      expect(proxy.consecutiveUnchangedSteps).toBe(0);
+      await finish({}, { axTree: "Returned desktop" });
+      expect(proxy.consecutiveUnchangedSteps).toBe(1);
+    });
+    test("failed targeted captures also break the desktop comparison baseline", async () => {
+      setup();
+      connect();
+      await finish({}, { axTree: "Desktop" });
+      expect(
+        (
+          await finish(
+            { capture_window_id: 99 },
+            { executionError: "Window not found" },
+          )
+        ).isError,
+      ).toBe(true);
+      expect(proxy.previousAXTree).toBeUndefined();
+      const result = await finish({}, { axTree: "Desktop" });
+      expect(result.content).not.toContain("NO VISIBLE EFFECT");
+    });
+    test("legacy camel-case companion targets also reset observation history", async () => {
+      setup();
+      connect();
+      await finish({}, { axTree: "Desktop" });
+      const result = await finish(
+        { captureDisplayId: 1 },
+        { axTree: "Display" },
+      );
+      expect(result.content).not.toContain("NO VISIBLE EFFECT");
+      expect(proxy.previousAXTree).toBeUndefined();
     });
   });
 });

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -307,6 +307,7 @@ export const HOST_PROXY_CAPABILITIES = [
   "host_bash",
   "host_file",
   "host_cu",
+  "host_cu_window_capture",
   "host_browser",
   "host_app_control",
   "host_ui_snapshot",
@@ -347,6 +348,10 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
+  // Window capture is additionally negotiated on each client connection.
+  if (capability === "host_cu_window_capture") {
+    return id === "macos";
+  }
   // macOS supports every host proxy capability including host_browser
   // and host_app_control. The host_browser proxy is provisioned via the
   // assistant event hub. When no extension is connected, browser tools fall

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -35,8 +35,9 @@ A missing window must not be replaced with a desktop capture.
 This is a **single observation**, not a session-wide privacy boundary: normal
 click/type/scroll and other action tools still return their normal desktop
 observations. Do not promise app-only capture for a whole control session.
-The helper must support targeted capture; older installed desktop versions
-must not be assumed to enforce this option. Other desktop platforms reject it.
+The desktop must explicitly advertise `host_cu_window_capture` support on its
+connection; the daemon rejects older or unsupported clients before requesting
+any capture. Other desktop platforms reject this option.
 
 The screenshot is window-relative, while action coordinates are screen points;
 do not scale it using full-display dimensions. Prefer accessibility element IDs

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -22,3 +22,23 @@ The skill is internally preactivated for conversations with a connected desktop 
 
 Tools in this skill are proxy tools. Execution is forwarded to a connected
 desktop client and is never handled locally by the assistant.
+
+## Window-scoped observation (macOS)
+
+`computer_use_observe` accepts optional `capture_window_id`, a native macOS
+CGWindowID (not a browser tab ID or accessibility element ID). Obtain the ID
+from a current native window inventory before using it; never guess one.
+The native helper captures that window and its accessibility tree without
+including secondary windows, even when another app covers the selected window.
+A missing window must not be replaced with a desktop capture.
+
+This is a **single observation**, not a session-wide privacy boundary: normal
+click/type/scroll and other action tools still return their normal desktop
+observations. Do not promise app-only capture for a whole control session.
+The helper must support targeted capture; older installed desktop versions
+must not be assumed to enforce this option. Other desktop platforms reject it.
+
+The screenshot is window-relative, while action coordinates are screen points;
+do not scale it using full-display dimensions. Prefer accessibility element IDs
+and ensure the intended window is focused before a later action. Window-scoped
+observation does not focus the window or confine subsequent input to that app.

--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -9,6 +9,12 @@
       "input_schema": {
         "type": "object",
         "properties": {
+          "capture_window_id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4294967295,
+            "description": "macOS only: capture this native CGWindowID instead of the desktop, including only its accessibility tree. Obtain a current native window ID first; do not guess or use a browser tab ID. Applies to this observation only, not subsequent actions. Requires a desktop helper with window-capture support. Screenshot coordinates are window-relative; use accessibility element IDs for later actions, not desktop scaling."
+          },
           "target_client_id": {
             "type": "string",
             "description": "ID of the specific client to target. Required when multiple clients support host_cu; omit when only one is connected. Obtain IDs from `assistant clients list --capability host_cu`."

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -174,8 +174,8 @@ export class HostCuProxy {
   private _previousAXTree: string | undefined;
   private _consecutiveUnchangedSteps = 0;
   private _actionHistory: ActionRecord[] = [];
-  /** Request IDs owned by this instance — used to scope dispose(). */
-  private _ownedRequests = new Set<string>();
+  /** Owned request IDs mapped to whether their observation is scoped. */
+  private _ownedRequests = new Map<string, boolean>();
 
   constructor(maxSteps = loadConfig().maxStepsPerSession) {
     this._maxSteps = maxSteps;
@@ -303,6 +303,46 @@ export class HostCuProxy {
       }
     }
 
+    const hasWindowTarget = Object.hasOwn(input, "capture_window_id");
+    if (hasWindowTarget) {
+      const id = input.capture_window_id;
+      if (
+        toolName !== "computer_use_observe" ||
+        typeof id !== "number" ||
+        !Number.isInteger(id) ||
+        id < 1 ||
+        id > 0xffffffff ||
+        Object.hasOwn(input, "captureWindowId") ||
+        Object.hasOwn(input, "captureDisplayId")
+      ) {
+        return Promise.resolve({
+          content:
+            "capture_window_id requires a valid CGWindowID on computer_use_observe with no conflicting capture target.",
+          isError: true,
+        });
+      }
+      // Never dispatch this option to a legacy executor: it would forward the
+      // unknown snake-case key and silently capture the entire desktop.
+      const client =
+        resolvedTargetClientId == null
+          ? undefined
+          : assistantEventHub.getClientById(resolvedTargetClientId);
+      if (!client?.capabilities.includes("host_cu_window_capture")) {
+        return Promise.resolve({
+          content:
+            "Window-only observation requires a connected client advertising host_cu_window_capture; update the desktop app before retrying. No capture was requested.",
+          isError: true,
+        });
+      }
+    }
+    const scopedObservation =
+      hasWindowTarget ||
+      Object.hasOwn(input, "captureWindowId") ||
+      Object.hasOwn(input, "captureDisplayId");
+    if (scopedObservation) {
+      this._previousAXTree = undefined;
+      this._consecutiveUnchangedSteps = 0;
+    }
     const requestId = uuid();
 
     return new Promise<ToolExecutionResult>((resolve, reject) => {
@@ -346,7 +386,7 @@ export class HostCuProxy {
         detachAbort = () => signal.removeEventListener("abort", onAbort);
       }
 
-      this._ownedRequests.add(requestId);
+      this._ownedRequests.set(requestId, scopedObservation);
 
       pendingInteractions.register(requestId, {
         conversationId,
@@ -399,6 +439,7 @@ export class HostCuProxy {
     requestId: string,
     observation: CuObservationResult,
   ): ToolExecutionResult | undefined {
+    const scopedObservation = this._ownedRequests.get(requestId) ?? false;
     this._ownedRequests.delete(requestId);
     const interaction = pendingInteractions.resolve(requestId, "answered");
     if (!interaction?.rpcResolve) {
@@ -406,9 +447,20 @@ export class HostCuProxy {
       return undefined;
     }
 
+    // A targeted snapshot has no comparable action/diff baseline; neither it
+    // nor the first desktop observation after it can imply "no visible effect".
+    if (scopedObservation) {
+      this._previousAXTree = undefined;
+      this._consecutiveUnchangedSteps = 0;
+    }
     const prevAXTree = this._previousAXTree;
-    this.updateStateFromObservation(observation);
-    const result = this.formatObservation(observation, prevAXTree);
+    const comparableObservation = scopedObservation
+      ? { ...observation, axDiff: undefined, secondaryWindows: undefined }
+      : observation;
+    if (!scopedObservation) {
+      this.updateStateFromObservation(comparableObservation);
+    }
+    const result = this.formatObservation(comparableObservation, prevAXTree);
     interaction.rpcResolve(result);
     return result;
   }
@@ -566,7 +618,7 @@ export class HostCuProxy {
   // ---------------------------------------------------------------------------
 
   dispose(): void {
-    for (const requestId of this._ownedRequests) {
+    for (const requestId of this._ownedRequests.keys()) {
       const entry = pendingInteractions.resolve(requestId, "cancelled");
       if (!entry) {
         continue;

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -742,7 +742,13 @@ export function broadcastMessage(
   const targetInterfaceId = options?.targetInterfaceId;
 
   const event = buildAssistantEvent(msg, resolvedConversationId);
-  const targetCapability = capabilityForMessageType(msg.type);
+  // A reconnect can overlap an older executor with the same device ID.
+  // Filter at delivery too, not only when HostCuProxy resolves its target.
+  const targetCapability =
+    msg.type === "host_cu_request" &&
+    Object.hasOwn(msg.input, "capture_window_id")
+      ? "host_cu_window_capture"
+      : capabilityForMessageType(msg.type);
   // Self-echo suppression: a `sync_changed` carrying an `originClientId`
   // means a specific client just mutated the resource. The hub must not
   // re-deliver the invalidation to that client — it already updated its

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -436,9 +436,15 @@ export function handleSubscribeAssistantEvents(
             type: "client" as const,
             clientId,
             interfaceId,
-            capabilities: ALL_CAPABILITIES.filter((cap) =>
-              supportsHostProxy(interfaceId, cap),
-            ),
+            capabilities: [
+              ...ALL_CAPABILITIES.filter((cap) =>
+                supportsHostProxy(interfaceId, cap),
+              ),
+              ...(interfaceId === "macos" &&
+              headers?.["x-vellum-cu-window-capture"] === "1"
+                ? ["host_cu_window_capture" as const]
+                : []),
+            ],
             machineName: rawMachineName?.trim() || undefined,
             actorPrincipalId,
           })

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -452,6 +452,12 @@ export const computerUseObserveTool = {
   input_schema: {
     type: "object",
     properties: {
+      capture_window_id: {
+        type: "integer",
+        minimum: 1,
+        maximum: 4294967295,
+        description: "macOS only: capture this native CGWindowID instead of the desktop, including only its accessibility tree. Obtain a current native window ID first; do not guess or use a browser tab ID. Applies to this observation only, not subsequent actions. Requires a desktop helper with window-capture support. Screenshot coordinates are window-relative; use accessibility element IDs for later actions, not desktop scaling.",
+      },
       target_client_id: {
         type: "string",
         description:

--- a/clients/docs/src/app/docs/_components/skills-reference-computer-use-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-computer-use-content.tsx
@@ -155,6 +155,22 @@ export function SkillsReferenceComputerUseContent() {
               unsupported tools are not offered to the assistant.
             </li>
             <li>
+              <strong>Single-window observations on macOS.</strong> The observe tool accepts
+              <code> capture_window_id</code>, a current native CGWindowID, not a browser tab
+              or accessibility element ID. It captures only that window and its accessibility
+              tree, even behind another app, without secondary windows or a desktop fallback.
+              A compatible desktop app must explicitly advertise window-capture support;
+              older or unsupported clients are rejected before capture.
+            </li>
+            <li>
+              <strong>Observation-only scope.</strong> Window selection applies to one observe
+              call, not the whole session: later click, type, and scroll actions still return
+              normal desktop observations. Selection does not focus the window or restrict
+              later input to it. Cropped screenshot coordinates are window-relative, not
+              full-display coordinates; prefer accessibility element IDs and focus the
+              intended window before acting.
+            </li>
+            <li>
               <strong>Screen visibility.</strong> Be mindful of what&apos;s visible on screen.
               Screenshots are sent to the AI model.
             </li>

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -411,7 +411,7 @@ enum HostCuActionRunner {
             log.info("[\(stepNumber)] AX tree: \(result.appName) — \"\(result.windowTitle)\" — \(flat.count) elements (\(interactiveCount) interactive)")
 
             // Compute AX diff against previous step's elements
-            if let previousFlat = previousAXElements[conversationId] {
+            if captureTarget == nil, let previousFlat = previousAXElements[conversationId] {
                 axDiffText = AXTreeDiff.diff(previousFlat: previousFlat, currentFlat: flat)
             }
 

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -379,6 +379,13 @@ enum HostCuActionRunner {
         var screenHeightPt: Int?
         var secondaryWindowsText: String?
 
+        // Targeted reads are standalone snapshots, never a desktop diff baseline.
+        // Clear before enumeration, including failed/missing-window captures, so
+        // the next ordinary observation also starts with a fresh baseline.
+        if captureTarget != nil {
+            previousAXElements.removeValue(forKey: conversationId)
+        }
+
         // The tree stays inside what the screenshot shows. A window target
         // reads that window's tree, focused or not; a display target reads
         // the frontmost window on that display. Neither falls back to the
@@ -406,7 +413,7 @@ enum HostCuActionRunner {
                 appName: result.appName
             )
             let flat = AccessibilityTreeEnumerator.flattenElements(result.elements)
-            currentElements = flat
+            currentElements = captureTarget == nil ? flat : nil
             let interactiveCount = flat.filter { AccessibilityTreeEnumerator.interactiveRoles.contains($0.role) }.count
             log.info("[\(stepNumber)] AX tree: \(result.appName) — \"\(result.windowTitle)\" — \(flat.count) elements (\(interactiveCount) interactive)")
 

--- a/clients/macos/src/main/executors/host-cu-executor.ts
+++ b/clients/macos/src/main/executors/host-cu-executor.ts
@@ -20,6 +20,7 @@ export function createHostCuExecutor(
   const { helper } = deps;
   return createCuHelperProxyExecutor({
     logger: log,
+    supportsWindowCapture: true,
     resolveHelper: helper ? () => helper : getSharedCuHelper,
   });
 }

--- a/clients/macos/src/main/host-proxy-adapter.ts
+++ b/clients/macos/src/main/host-proxy-adapter.ts
@@ -79,6 +79,7 @@ export const installHostProxyBridge = (
       getClientId: getDeviceId,
       getMachineName: hostname,
       interfaceId: "macos",
+      supportsWindowCapture: true,
     }),
     executors: {
       host_bash: hostBashExecutor,

--- a/packages/electron-desktop/src/host-proxy/cu-capability.test.ts
+++ b/packages/electron-desktop/src/host-proxy/cu-capability.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { createHostProxyClientHeaders } from "./router";
+
+const identity = { getClientId: () => "mac-1", getMachineName: () => "Test Mac", interfaceId: "macos" };
+
+test("window capture is explicitly advertised by updated clients only", () => {
+  expect(createHostProxyClientHeaders(identity).sseClientHeaders()).not.toHaveProperty("X-Vellum-Cu-Window-Capture");
+  expect(createHostProxyClientHeaders({ ...identity, supportsWindowCapture: true }).sseClientHeaders()).toHaveProperty("X-Vellum-Cu-Window-Capture", "1");
+});

--- a/packages/electron-desktop/src/host-proxy/cu-executor.ts
+++ b/packages/electron-desktop/src/host-proxy/cu-executor.ts
@@ -41,6 +41,8 @@ export type CuResult = z.infer<typeof CU_RESULT_SCHEMA>;
 export interface CuExecutorDeps {
   logger: HostProxyLogger;
   resolveHelper: () => CuHelperClient;
+  /** Only enable on hosts whose native helper supports CGWindowID capture. */
+  supportsWindowCapture?: boolean;
 }
 
 export function cuExecutorConfig(
@@ -57,12 +59,30 @@ export function cuExecutorConfig(
       if (!toolName) {
         return { error: "Missing toolName" };
       }
+      const input = { ...((message.input as Record<string, unknown> | undefined) ?? {}) };
+      if (input.capture_window_id !== undefined) {
+        if (!deps.supportsWindowCapture) {
+          return { error: "Window-scoped observation is not supported by this desktop client." };
+        }
+        if (toolName !== "computer_use_observe") {
+          return { error: "capture_window_id is only supported for computer_use_observe." };
+        }
+        const windowId = input.capture_window_id;
+        if (typeof windowId !== "number" || !Number.isInteger(windowId) || windowId < 1 || windowId > 0xffffffff) {
+          return { error: "capture_window_id must be a positive 32-bit native window ID." };
+        }
+        if (input.captureWindowId !== undefined || input.captureDisplayId !== undefined) {
+          return { error: "Specify only one capture target." };
+        }
+        input.captureWindowId = windowId;
+        delete input.capture_window_id;
+      }
       return {
         params: {
           requestId,
           conversationId: (message.conversationId as string | undefined) ?? "",
           toolName,
-          input: (message.input as Record<string, unknown> | undefined) ?? {},
+          input,
           stepNumber: (message.stepNumber as number | undefined) ?? 1,
           ...(typeof message.reasoning === "string"
             ? { reasoning: message.reasoning }

--- a/packages/electron-desktop/src/host-proxy/cu-window-capture.test.ts
+++ b/packages/electron-desktop/src/host-proxy/cu-window-capture.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { cuExecutorConfig } from "./cu-executor";
+
+const config = (supported = true) => cuExecutorConfig({
+  logger: { info() {}, warn() {}, error() {} },
+  resolveHelper: () => { throw new Error("not called"); },
+  supportsWindowCapture: supported,
+});
+const build = (input: Record<string, unknown>, supported = true, toolName = "computer_use_observe") =>
+  config(supported).buildParams({ type: "host_cu_request", toolName, input }, "req");
+
+describe("window-scoped observations", () => {
+  test("maps public ID to the existing native key without mutating input", () => {
+    const input = { capture_window_id: 4211 };
+    expect(build(input)).toMatchObject({ params: { input: { captureWindowId: 4211 } } });
+    expect(input).toEqual({ capture_window_id: 4211 });
+  });
+  test("leaves legacy requests unchanged", () => {
+    expect(build({})).toMatchObject({ params: { input: {} } });
+  });
+  test("fails closed on unsupported clients", () => {
+    expect(build({ capture_window_id: 1 }, false)).toHaveProperty("error");
+  });
+  test("rejects invalid native IDs", () => {
+    for (const id of [0, -1, 1.5, "123", null, NaN, Infinity, 4294967296]) {
+      expect(build({ capture_window_id: id })).toHaveProperty("error");
+    }
+  });
+  test("rejects conflicting targets and action scope claims", () => {
+    expect(build({ capture_window_id: 1, captureDisplayId: 2 })).toHaveProperty("error");
+    expect(build({ capture_window_id: 1, captureWindowId: 2 })).toHaveProperty("error");
+    expect(build({ capture_window_id: 1 }, true, "computer_use_click")).toHaveProperty("error");
+  });
+});

--- a/packages/electron-desktop/src/host-proxy/router.ts
+++ b/packages/electron-desktop/src/host-proxy/router.ts
@@ -65,6 +65,8 @@ export interface HostProxyClientIdentity {
   getClientId: () => string;
   getMachineName: () => string;
   interfaceId: string;
+  /** Opt in only when the bundled CU executor supports window-only observations. */
+  supportsWindowCapture?: boolean;
 }
 
 export function createHostProxyClientHeaders(
@@ -79,6 +81,9 @@ export function createHostProxyClientHeaders(
       ...posterClientHeaders(),
       "X-Vellum-Interface-Id": identity.interfaceId,
       "X-Vellum-Machine-Name": identity.getMachineName(),
+      ...(identity.supportsWindowCapture
+        ? { "X-Vellum-Cu-Window-Capture": "1" }
+        : {}),
     }),
   };
 }

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -11,7 +11,7 @@
     },
     "computer-use": {
       "docsSlug": "computer-use",
-      "sha256": "0389441d5383647e5de61798c7ed322056b7208b50bddea035ce81af1013741d"
+      "sha256": "b2dc092dca6ff1bc6f3e941940a1855d7853dc7d25ef7f9ad5f4aa694f4a807a"
     },
     "contacts": {
       "docsSlug": "contacts",


### PR DESCRIPTION
## Summary
- Expose optional `capture_window_id` on `computer_use_observe` in both the core definition and bundled skill manifest.
- Map validated native CGWindowIDs to the existing macOS helper `captureWindowId` input; reject unsupported hosts, invalid IDs, conflicting targets, and use on action tools.
- Suppress previous-window accessibility diffs for targeted observations so unrelated historical text is not returned.
- Document that this is observation-only, not a session-wide privacy boundary; action screenshots remain unchanged, and cropped screenshot coordinates must not be scaled as desktop coordinates.

## Validation
- Assistant schema + manifest suites: 11 passed.
- Shared host window-scope tests: 5 passed.
- macOS executor tests: 4 passed.
- `git diff --check` passed.
- Native Swift build and live window capture not tested in this Linux environment; no full repository typecheck performed.

## Scope / limitations
Uses the existing native window-capture implementation. Requires a supporting desktop helper; older installed builds must not be assumed to honor targeting. A current native window ID must be obtained separately; no new window-picker or discovery tool is introduced. Subsequent click/type/scroll tools are deliberately not scoped by this parameter.
