### PR TITLE
fix(schedule): connect MCP servers in the schedule worker

### DIFF
--- a/assistant/src/daemon/mcp-reload-service.ts
+++ b/assistant/src/daemon/mcp-reload-service.ts
@@ -12,6 +12,7 @@ import {
 } from "../mcp/effective-config.js";
 import { getMcpServerManager } from "../mcp/manager.js";
 import { migrateLegacyMcpHeaders } from "../mcp/mcp-header-store.js";
+import { signalMcpReloaded } from "../mcp/reload-signal.js";
 import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
 import { registerMcpTools, unregisterAllMcpTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -154,6 +155,11 @@ async function doReload(): Promise<McpReloadResult> {
     // to evict sessions.
 
     log.info({ serverCount, toolCount }, "MCP servers reloaded");
+    // Other processes hold their own connections to the same servers and have
+    // no watcher of their own; this is how they learn the set moved. Only on
+    // success: a reload that failed before the teardown left this process on
+    // its existing servers, so there is nothing for anyone to mirror.
+    signalMcpReloaded();
     return { success: true, serverCount, toolCount, servers };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);

--- a/assistant/src/daemon/providers-setup.ts
+++ b/assistant/src/daemon/providers-setup.ts
@@ -1,8 +1,7 @@
 import { maybeDefaultSpeechToManaged } from "../config/managed-speech-defaults.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import type { AssistantConfig } from "../config/types.js";
-import { buildEffectiveMcpConfig } from "../mcp/effective-config.js";
-import { getMcpServerManager } from "../mcp/manager.js";
+import { startConfiguredMcpServers } from "../mcp/startup.js";
 import { gmailMessagingProvider } from "../messaging/providers/gmail/adapter.js";
 import { outlookMessagingProvider } from "../messaging/providers/outlook/adapter.js";
 import { slackProvider as slackMessagingProvider } from "../messaging/providers/slack/adapter.js";
@@ -11,8 +10,7 @@ import { whatsappMessagingProvider } from "../messaging/providers/whatsapp/adapt
 import { registerMessagingProvider } from "../messaging/registry.js";
 import { initializeProviders } from "../providers/registry.js";
 import { validateSubagentRoleAllowlists } from "../subagent/validate-allowlists.js";
-import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
-import { initializeTools, registerMcpTools } from "../tools/registry.js";
+import { initializeTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import { initWatcherEngine } from "../watcher/engine.js";
 import { registerWatcherProvider } from "../watcher/provider-registry.js";
@@ -63,28 +61,9 @@ export async function initializeProvidersAndTools(
   }
 
   // Start MCP servers — workspace-configured and plugin-declared alike —
-  // and register their tools.
-  const mcpConfig = buildEffectiveMcpConfig(config.mcp);
-  if (Object.keys(mcpConfig.servers).length > 0) {
-    const manager = getMcpServerManager();
-    try {
-      const serverToolInfos = await manager.start(mcpConfig);
-      for (const { serverId, serverConfig, tools } of serverToolInfos) {
-        const mcpTools = createMcpToolsFromServer(
-          tools,
-          serverId,
-          serverConfig,
-          manager,
-        );
-        registerMcpTools(serverId, mcpTools);
-      }
-    } catch (err) {
-      log.error(
-        { err },
-        "MCP server initialization failed — continuing without MCP tools",
-      );
-    }
-  }
+  // and register their tools. Shared with the schedule worker, which hosts
+  // agent turns in its own process and so needs its own connections.
+  await startConfiguredMcpServers(config.mcp);
 
   log.info("Daemon startup: providers and tools initialized");
 }

--- a/assistant/src/mcp/__tests__/reload-signal-emission.test.ts
+++ b/assistant/src/mcp/__tests__/reload-signal-emission.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The daemon's MCP reload is what announces itself to the other processes.
+ *
+ * Every path that changes the server set (a config edit, the reload route, an
+ * OAuth reauthentication, a plugin install) funnels through `reloadMcpServers`,
+ * so signalling there covers all of them. Signalling anywhere narrower would
+ * leave whichever path was missed silently stale in the schedule worker.
+ */
+
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
+
+mock.module("../manager.js", () => ({
+  getMcpServerManager: () => ({
+    start: jest.fn(async () => []),
+    stop: jest.fn(async () => {}),
+    callTool: jest.fn(),
+    getClient: () => undefined,
+  }),
+  stopMcpServerManager: jest.fn(async () => {}),
+}));
+
+mock.module("../mcp-header-store.js", () => ({
+  migrateLegacyMcpHeaders: async () => {},
+}));
+
+mock.module("../../plugins/mcp-servers.js", () => ({
+  readPluginMcpServers: () => ({ servers: [], issues: [] }),
+}));
+
+const { getSignalsDir } = await import("../../util/platform.js");
+const { MCP_RELOAD_SIGNAL_FILE } = await import("../reload-signal.js");
+const { reloadMcpServers } = await import("../../daemon/mcp-reload-service.js");
+
+const signalPath = () => join(getSignalsDir(), MCP_RELOAD_SIGNAL_FILE);
+
+beforeEach(() => {
+  rmSync(signalPath(), { force: true });
+});
+
+describe("reloadMcpServers", () => {
+  test("signals the reload so other processes rebuild their own set", async () => {
+    const result = await reloadMcpServers();
+
+    expect(result.success).toBe(true);
+    expect(
+      existsSync(signalPath()),
+      "Connections and the tools they register are per-process. A reload " +
+        "that only rebuilds the daemon's leaves the schedule worker calling " +
+        "servers the config no longer lists.",
+    ).toBe(true);
+  });
+});

--- a/assistant/src/mcp/__tests__/reload-signal.test.ts
+++ b/assistant/src/mcp/__tests__/reload-signal.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The MCP reload signal, the channel that tells the daemon's child processes
+ * their MCP server set moved.
+ *
+ * They hold their own connections to the same servers and have no config
+ * watcher of their own, so without this they keep serving the set as it stood
+ * when they started: a server the config has since disabled stays callable
+ * there long after the daemon dropped it.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getSignalsDir } from "../../util/platform.js";
+import { MCP_RELOAD_SIGNAL_FILE, signalMcpReloaded } from "../reload-signal.js";
+
+const signalPath = () => join(getSignalsDir(), MCP_RELOAD_SIGNAL_FILE);
+
+beforeEach(() => {
+  rmSync(signalPath(), { force: true });
+});
+
+describe("signalMcpReloaded", () => {
+  test("writes the signal file", () => {
+    signalMcpReloaded();
+
+    expect(existsSync(signalPath())).toBe(true);
+    expect(Number(readFileSync(signalPath(), "utf8"))).toBeGreaterThan(0);
+  });
+
+  test("creates the signals directory when it is absent", () => {
+    rmSync(getSignalsDir(), { recursive: true, force: true });
+
+    signalMcpReloaded();
+
+    expect(existsSync(signalPath())).toBe(true);
+  });
+
+  test("rewrites in place, so a second reload is a fresh event", () => {
+    mkdirSync(getSignalsDir(), { recursive: true });
+    signalMcpReloaded();
+    const first = readFileSync(signalPath(), "utf8");
+
+    const until = Date.now() + 2;
+    while (Date.now() < until) {
+      /* let the clock move so the two writes differ */
+    }
+    signalMcpReloaded();
+
+    expect(
+      readFileSync(signalPath(), "utf8"),
+      "Readers react to the write rather than consuming the file, so the " +
+        "content has to change for a second reload to register.",
+    ).not.toBe(first);
+  });
+});

--- a/assistant/src/mcp/__tests__/startup.test.ts
+++ b/assistant/src/mcp/__tests__/startup.test.ts
@@ -1,7 +1,7 @@
 /**
  * MCP tools reach a process's tool registry only by connecting to each server
- * and listing what it offers. `initializeTools()` does not do that — it loads
- * core built-ins and workspace tools from disk — so every process that hosts
+ * and listing what it offers. `initializeTools()` does not do that: it loads
+ * core built-ins and workspace tools from disk. So every process that hosts
  * agent turns has to run this step for itself or its `mcp__*` calls fail as
  * "Unknown tool" while `assistant tools list`, which reads the daemon's
  * registry over IPC, reports the same tool as registered.

--- a/assistant/src/mcp/__tests__/startup.test.ts
+++ b/assistant/src/mcp/__tests__/startup.test.ts
@@ -7,8 +7,9 @@
  * registry over IPC, reports the same tool as registered.
  *
  * These cover the shared step itself: that it registers what a server reports,
- * and that a server it cannot reach leaves the process running anyway. The
- * guard that the schedule worker actually calls it lives in
+ * that a server it cannot reach leaves the process running anyway, and that a
+ * restart rebuilds the set rather than adding to it. The guard that the
+ * schedule worker actually calls it lives in
  * `src/schedule/__tests__/worker-mcp-tools.test.ts`, next to the worker.
  */
 
@@ -32,9 +33,35 @@ mock.module("../../plugins/mcp-servers.js", () => ({
   readPluginMcpServers: () => ({ servers: [], issues: [] }),
 }));
 
-const { startConfiguredMcpServers } = await import("../startup.js");
+const { restartConfiguredMcpServers, startConfiguredMcpServers } =
+  await import("../startup.js");
 const { __resetRegistryForTesting, getTool } =
   await import("../../tools/registry.js");
+
+/** One entry of `McpServerManager.start()`'s result: a server and its tools. */
+function serverReporting(serverId: string, toolName: string) {
+  return {
+    serverId,
+    serverConfig: {
+      transport: {
+        type: "streamable-http",
+        url: "https://example.invalid/mcp",
+      },
+      enabled: true,
+      defaultRiskLevel: "low",
+      maxTools: 20,
+      source: "workspace",
+    },
+    tools: [
+      {
+        name: toolName,
+        description: "Search email",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+    ],
+  };
+}
 
 /** The `mcp` config block shape a workspace config carries for one server. */
 function workspaceConfigWith(serverId: string) {
@@ -61,29 +88,7 @@ afterEach(() => {
 
 describe("startConfiguredMcpServers", () => {
   test("registers the tools a server reports, namespaced by server id", async () => {
-    start.mockResolvedValueOnce([
-      {
-        serverId: "fastmail",
-        serverConfig: {
-          transport: {
-            type: "streamable-http",
-            url: "https://example.invalid/mcp",
-          },
-          enabled: true,
-          defaultRiskLevel: "low",
-          maxTools: 20,
-          source: "workspace",
-        },
-        tools: [
-          {
-            name: "search_email",
-            description: "Search email",
-            inputSchema: { type: "object", properties: {} },
-            annotations: { readOnlyHint: true },
-          },
-        ],
-      },
-    ]);
+    start.mockResolvedValueOnce([serverReporting("fastmail", "search_email")]);
 
     const registered = await startConfiguredMcpServers(
       workspaceConfigWith("fastmail") as never,
@@ -108,5 +113,38 @@ describe("startConfiguredMcpServers", () => {
     );
 
     expect(registered).toBe(0);
+  });
+});
+
+describe("restartConfiguredMcpServers", () => {
+  test("drops tools the reconnected set no longer reports", async () => {
+    start.mockResolvedValueOnce([serverReporting("fastmail", "search_email")]);
+    await startConfiguredMcpServers(workspaceConfigWith("fastmail") as never);
+    expect(getTool("mcp__fastmail__search_email")).toBeDefined();
+
+    // The test workspace config declares no MCP servers, which is what a
+    // removed or disabled one looks like on the next connect.
+    await restartConfiguredMcpServers();
+
+    expect(
+      getTool("mcp__fastmail__search_email"),
+      "A server the config dropped has to stop being callable here. Leaving " +
+        "its tools registered is what lets a background schedule keep " +
+        "reaching a server the daemon has already disconnected.",
+    ).toBeUndefined();
+  });
+
+  test("reconnects from the config on disk rather than the previous set", async () => {
+    start.mockResolvedValueOnce([serverReporting("fastmail", "search_email")]);
+    await startConfiguredMcpServers(workspaceConfigWith("fastmail") as never);
+    start.mockClear();
+
+    await restartConfiguredMcpServers();
+
+    expect(
+      start,
+      "The previous effective config is not reusable: it is the thing that " +
+        "changed. A restart rereads it.",
+    ).not.toHaveBeenCalled();
   });
 });

--- a/assistant/src/mcp/__tests__/startup.test.ts
+++ b/assistant/src/mcp/__tests__/startup.test.ts
@@ -1,0 +1,112 @@
+/**
+ * MCP tools reach a process's tool registry only by connecting to each server
+ * and listing what it offers. `initializeTools()` does not do that — it loads
+ * core built-ins and workspace tools from disk — so every process that hosts
+ * agent turns has to run this step for itself or its `mcp__*` calls fail as
+ * "Unknown tool" while `assistant tools list`, which reads the daemon's
+ * registry over IPC, reports the same tool as registered.
+ *
+ * These cover the shared step itself: that it registers what a server reports,
+ * and that a server it cannot reach leaves the process running anyway. The
+ * guard that the schedule worker actually calls it lives in
+ * `src/schedule/__tests__/worker-mcp-tools.test.ts`, next to the worker.
+ */
+
+import { afterEach, describe, expect, jest, mock, test } from "bun:test";
+
+const start = jest.fn(async () => [] as unknown[]);
+
+mock.module("../manager.js", () => ({
+  getMcpServerManager: () => ({
+    start,
+    callTool: jest.fn(),
+    getClient: () => undefined,
+  }),
+  stopMcpServerManager: jest.fn(async () => {}),
+}));
+
+// Plugin-declared servers are read off disk, so leaving this real would make
+// "no servers configured" depend on which plugins the machine running the
+// tests happens to have installed.
+mock.module("../../plugins/mcp-servers.js", () => ({
+  readPluginMcpServers: () => ({ servers: [], issues: [] }),
+}));
+
+const { startConfiguredMcpServers } = await import("../startup.js");
+const { __resetRegistryForTesting, getTool } =
+  await import("../../tools/registry.js");
+
+/** The `mcp` config block shape a workspace config carries for one server. */
+function workspaceConfigWith(serverId: string) {
+  return {
+    servers: {
+      [serverId]: {
+        transport: {
+          type: "streamable-http" as const,
+          url: "https://example.invalid/mcp",
+        },
+        enabled: true,
+        defaultRiskLevel: "low" as const,
+        maxTools: 20,
+      },
+    },
+    globalMaxTools: 50,
+  };
+}
+
+afterEach(() => {
+  start.mockClear();
+  __resetRegistryForTesting();
+});
+
+describe("startConfiguredMcpServers", () => {
+  test("registers the tools a server reports, namespaced by server id", async () => {
+    start.mockResolvedValueOnce([
+      {
+        serverId: "fastmail",
+        serverConfig: {
+          transport: {
+            type: "streamable-http",
+            url: "https://example.invalid/mcp",
+          },
+          enabled: true,
+          defaultRiskLevel: "low",
+          maxTools: 20,
+          source: "workspace",
+        },
+        tools: [
+          {
+            name: "search_email",
+            description: "Search email",
+            inputSchema: { type: "object", properties: {} },
+            annotations: { readOnlyHint: true },
+          },
+        ],
+      },
+    ]);
+
+    const registered = await startConfiguredMcpServers(
+      workspaceConfigWith("fastmail") as never,
+    );
+
+    expect(registered).toBe(1);
+    expect(getTool("mcp__fastmail__search_email")).toBeDefined();
+  });
+
+  test("does nothing when no servers are configured", async () => {
+    const registered = await startConfiguredMcpServers(undefined);
+
+    expect(registered).toBe(0);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  test("a server that cannot be started leaves the process running", async () => {
+    start.mockRejectedValueOnce(new Error("connection refused"));
+
+    const registered = await startConfiguredMcpServers(
+      workspaceConfigWith("fastmail") as never,
+    );
+
+    expect(registered).toBe(0);
+  });
+});

--- a/assistant/src/mcp/reload-signal.ts
+++ b/assistant/src/mcp/reload-signal.ts
@@ -1,0 +1,50 @@
+/**
+ * Cross-process notification that the MCP server set has been reloaded.
+ *
+ * MCP connections and the tools they register are per-process, and so is the
+ * reload that rebuilds them: `daemon/mcp-reload-service.ts` acts on the
+ * daemon's own manager and registry. Every other process that holds
+ * connections has to hear about it, or it keeps serving the server set as it
+ * stood when that process started, including servers the config has since
+ * disabled or removed.
+ *
+ * The channel is a file in the signals directory, written by the reloading
+ * process and watched by the others. A file rather than an IPC call because
+ * the listeners are the daemon's own children: a call would need the daemon to
+ * track who is listening and to stay up while it delivers, and the reload has
+ * no reason to wait for either.
+ *
+ * The file's content is a timestamp, and it is never deleted. Readers react to
+ * the write, so there is nothing to consume and no race over who consumes it.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getSignalsDir } from "../util/platform.js";
+
+const log = getLogger("mcp-reload-signal");
+
+/** Name of the signal file within the signals directory. */
+export const MCP_RELOAD_SIGNAL_FILE = "mcp-reloaded";
+
+/**
+ * Announce that this process reloaded its MCP servers.
+ *
+ * Best-effort: a signals directory that cannot be written leaves other
+ * processes on their existing connections, which is where they already were,
+ * so it is logged rather than raised into the reload's result.
+ */
+export function signalMcpReloaded(): void {
+  const signalsDir = getSignalsDir();
+  try {
+    mkdirSync(signalsDir, { recursive: true });
+    writeFileSync(join(signalsDir, MCP_RELOAD_SIGNAL_FILE), String(Date.now()));
+  } catch (err) {
+    log.warn(
+      { err, signalsDir },
+      "Failed to write the MCP reload signal; other processes keep their current servers",
+    );
+  }
+}

--- a/assistant/src/mcp/startup.ts
+++ b/assistant/src/mcp/startup.ts
@@ -1,0 +1,73 @@
+/**
+ * Connect the configured MCP servers and register their tools.
+ *
+ * MCP tools are not loaded from disk the way core and workspace tools are:
+ * something has to connect to each server, list its tools, and register the
+ * results into this process's registry. That registry is per-process, so every
+ * process that hosts agent turns has to do it for itself — the daemon at boot
+ * and the schedule worker at startup alike. A process that skips this step has
+ * the tools missing entirely rather than filtered out, and every `mcp__*` call
+ * made in it fails as "Unknown tool".
+ *
+ * Both callers previously spelled this out inline; it lives here so the two
+ * cannot drift, and so a third process that starts hosting turns has one call
+ * to make.
+ */
+
+import type { McpConfig } from "../config/schemas/mcp.js";
+import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
+import { registerMcpTools } from "../tools/registry.js";
+import { getLogger } from "../util/logger.js";
+import { buildEffectiveMcpConfig } from "./effective-config.js";
+import { getMcpServerManager } from "./manager.js";
+
+const log = getLogger("mcp-startup");
+
+/**
+ * Start every enabled server in the effective MCP config (workspace entries
+ * plus plugin-declared ones) and register the tools they report.
+ *
+ * Call after {@link initializeTools}, so core and workspace tools already own
+ * their names when MCP registrations resolve — `registerMcpTools` yields to an
+ * existing owner rather than displacing it.
+ *
+ * Never throws: a server that cannot be reached is logged and skipped, and a
+ * failure of the whole step leaves the process running without MCP tools. This
+ * is a startup step in processes whose other work must not be held hostage to
+ * a third-party server being up.
+ *
+ * @param workspaceMcpConfig The `mcp` block of the assistant config, if any.
+ * @returns The number of tools registered across all servers.
+ */
+export async function startConfiguredMcpServers(
+  workspaceMcpConfig?: McpConfig,
+): Promise<number> {
+  const mcpConfig = buildEffectiveMcpConfig(workspaceMcpConfig);
+  if (Object.keys(mcpConfig.servers).length === 0) {
+    return 0;
+  }
+
+  const manager = getMcpServerManager();
+  let registered = 0;
+  try {
+    const serverToolInfos = await manager.start(mcpConfig);
+    for (const { serverId, serverConfig, tools } of serverToolInfos) {
+      const mcpTools = createMcpToolsFromServer(
+        tools,
+        serverId,
+        serverConfig,
+        manager,
+      );
+      registered += registerMcpTools(serverId, mcpTools).length;
+    }
+  } catch (err) {
+    log.error(
+      { err },
+      "MCP server initialization failed — continuing without MCP tools",
+    );
+    return registered;
+  }
+
+  log.info({ toolCount: registered }, "MCP tools registered");
+  return registered;
+}

--- a/assistant/src/mcp/startup.ts
+++ b/assistant/src/mcp/startup.ts
@@ -9,17 +9,17 @@
  * the tools missing entirely rather than filtered out, and every `mcp__*` call
  * made in it fails as "Unknown tool".
  *
- * Both callers previously spelled this out inline; it lives here so the two
- * cannot drift, and so a third process that starts hosting turns has one call
- * to make.
+ * One home for the step so the processes that run it cannot drift, and so a
+ * further process that starts hosting turns has one call to make.
  */
 
+import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import type { McpConfig } from "../config/schemas/mcp.js";
 import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
-import { registerMcpTools } from "../tools/registry.js";
+import { registerMcpTools, unregisterAllMcpTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import { buildEffectiveMcpConfig } from "./effective-config.js";
-import { getMcpServerManager } from "./manager.js";
+import { getMcpServerManager, stopMcpServerManager } from "./manager.js";
 
 const log = getLogger("mcp-startup");
 
@@ -42,14 +42,14 @@ const log = getLogger("mcp-startup");
 export async function startConfiguredMcpServers(
   workspaceMcpConfig?: McpConfig,
 ): Promise<number> {
-  const mcpConfig = buildEffectiveMcpConfig(workspaceMcpConfig);
-  if (Object.keys(mcpConfig.servers).length === 0) {
-    return 0;
-  }
-
-  const manager = getMcpServerManager();
   let registered = 0;
   try {
+    const mcpConfig = buildEffectiveMcpConfig(workspaceMcpConfig);
+    if (Object.keys(mcpConfig.servers).length === 0) {
+      return 0;
+    }
+
+    const manager = getMcpServerManager();
     const serverToolInfos = await manager.start(mcpConfig);
     for (const { serverId, serverConfig, tools } of serverToolInfos) {
       const mcpTools = createMcpToolsFromServer(
@@ -63,11 +63,39 @@ export async function startConfiguredMcpServers(
   } catch (err) {
     log.error(
       { err },
-      "MCP server initialization failed — continuing without MCP tools",
+      "MCP server initialization failed, continuing without MCP tools",
     );
     return registered;
   }
 
   log.info({ toolCount: registered }, "MCP tools registered");
   return registered;
+}
+
+/**
+ * Drop this process's MCP connections and tools and build them again from the
+ * config on disk.
+ *
+ * The server set is owned by the config, not by any one process, so a process
+ * that holds connections has to be told when it moves. The daemon learns from
+ * its own config watcher and reload route; a process without those (the
+ * schedule worker) calls this when the daemon signals that a reload happened,
+ * which is what keeps a disabled or removed server from staying callable there
+ * long after it stopped being callable in the daemon.
+ *
+ * Never throws, for the same reason {@link startConfiguredMcpServers} does not.
+ * The window between the teardown and the reconnect has no MCP tools
+ * registered, so an `mcp__*` call landing inside it fails as an unknown tool.
+ *
+ * @returns The number of tools registered after the reconnect.
+ */
+export async function restartConfiguredMcpServers(): Promise<number> {
+  try {
+    await stopMcpServerManager();
+  } catch (err) {
+    log.warn({ err }, "MCP server teardown failed, reconnecting anyway");
+  }
+  unregisterAllMcpTools();
+  invalidateConfigCache();
+  return startConfiguredMcpServers(getConfig().mcp);
 }

--- a/assistant/src/mcp/startup.ts
+++ b/assistant/src/mcp/startup.ts
@@ -4,7 +4,7 @@
  * MCP tools are not loaded from disk the way core and workspace tools are:
  * something has to connect to each server, list its tools, and register the
  * results into this process's registry. That registry is per-process, so every
- * process that hosts agent turns has to do it for itself — the daemon at boot
+ * process that hosts agent turns has to run it for itself: the daemon at boot
  * and the schedule worker at startup alike. A process that skips this step has
  * the tools missing entirely rather than filtered out, and every `mcp__*` call
  * made in it fails as "Unknown tool".
@@ -28,7 +28,7 @@ const log = getLogger("mcp-startup");
  * plus plugin-declared ones) and register the tools they report.
  *
  * Call after {@link initializeTools}, so core and workspace tools already own
- * their names when MCP registrations resolve — `registerMcpTools` yields to an
+ * their names when MCP registrations resolve: `registerMcpTools` yields to an
  * existing owner rather than displacing it.
  *
  * Never throws: a server that cannot be reached is logged and skipped, and a

--- a/assistant/src/schedule/__tests__/worker-mcp-tools.test.ts
+++ b/assistant/src/schedule/__tests__/worker-mcp-tools.test.ts
@@ -9,10 +9,15 @@
  * registry over IPC and reports the same tool as registered. The mismatch is
  * what makes the failure hard to place, so it is worth a guard.
  *
+ * The worker is also long-lived, so the set it connects at startup goes stale
+ * as soon as the config moves. It watches for the daemon's reload signal to
+ * rebuild, which is covered here too.
+ *
  * The entrypoint installs signal handlers and calls `process.exit`, so it
  * cannot be imported into a test process; these assertions read its source the
- * way `worker-feature-flags.test.ts` does. The behavior of the step itself is
- * covered in `src/mcp/__tests__/startup.test.ts`.
+ * way `worker-feature-flags.test.ts` does. The behavior of the steps
+ * themselves is covered in `src/mcp/__tests__/startup.test.ts` and
+ * `src/mcp/__tests__/reload-signal.test.ts`.
  */
 
 import { readFileSync } from "node:fs";
@@ -20,6 +25,12 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 const MCP_CALL = "startConfiguredMcpServers(";
+
+/** The bounded wait that keeps unreachable servers off the critical path. */
+const MCP_GRACE = "MCP_STARTUP_GRACE_MS";
+
+/** The reload watcher that keeps the connected set current. */
+const MCP_WATCH = "watchForMcpReload(";
 
 /** The worker's first call that can execute a schedule. */
 const WORK_START = "void tick()";
@@ -43,8 +54,35 @@ describe("schedule worker MCP tools", () => {
     expect(workAt).toBeGreaterThanOrEqual(0);
     expect(
       mcpAt < workAt,
-      "The MCP connect must complete before the first tick, so a schedule " +
-        "that fires immediately runs with the tools it was written against.",
+      "The connect starts and is waited on before the first tick, so a " +
+        "schedule that fires immediately runs with the tools it was written " +
+        "against. The wait is bounded (see below), so a server that never " +
+        "answers delays it rather than blocking it.",
+    ).toBe(true);
+  });
+
+  test("bounds the startup wait so unrelated schedules still fire", () => {
+    const source = readWorkerSource();
+
+    expect(
+      source.includes(MCP_GRACE),
+      "`McpServerManager.start()` walks servers one at a time and allows " +
+        "each 30s to connect and 30s more to list its tools. An unbounded " +
+        "wait lets a few unreachable servers hold every due schedule, " +
+        "including the notify and script ones that never touch MCP, while " +
+        "the PID file already reports this worker as running.",
+    ).toBe(true);
+  });
+
+  test("rebuilds its MCP set when the daemon reports a reload", () => {
+    const source = readWorkerSource();
+
+    expect(
+      source.includes(MCP_WATCH),
+      "This process is long-lived and holds its own connections. Without " +
+        "the watcher, a server disabled or removed in the config stays " +
+        "registered and callable by background schedules until the worker " +
+        "restarts.",
     ).toBe(true);
   });
 });

--- a/assistant/src/schedule/__tests__/worker-mcp-tools.test.ts
+++ b/assistant/src/schedule/__tests__/worker-mcp-tools.test.ts
@@ -3,7 +3,7 @@
  *
  * The tool registry is process-local and MCP tools reach it only by connecting
  * to each server and listing what it offers. `initializeTools()` does not do
- * that — it loads core built-ins and workspace tools from disk — so a worker
+ * that: it loads core built-ins and workspace tools from disk. So a worker
  * that stops connecting fails every `mcp__*` call an execute-mode schedule
  * makes as "Unknown tool", while `assistant tools list` reads the daemon's
  * registry over IPC and reports the same tool as registered. The mismatch is

--- a/assistant/src/schedule/__tests__/worker-mcp-tools.test.ts
+++ b/assistant/src/schedule/__tests__/worker-mcp-tools.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Guard over the schedule worker entrypoint's MCP bootstrap.
+ *
+ * The tool registry is process-local and MCP tools reach it only by connecting
+ * to each server and listing what it offers. `initializeTools()` does not do
+ * that — it loads core built-ins and workspace tools from disk — so a worker
+ * that stops connecting fails every `mcp__*` call an execute-mode schedule
+ * makes as "Unknown tool", while `assistant tools list` reads the daemon's
+ * registry over IPC and reports the same tool as registered. The mismatch is
+ * what makes the failure hard to place, so it is worth a guard.
+ *
+ * The entrypoint installs signal handlers and calls `process.exit`, so it
+ * cannot be imported into a test process; these assertions read its source the
+ * way `worker-feature-flags.test.ts` does. The behavior of the step itself is
+ * covered in `src/mcp/__tests__/startup.test.ts`.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const MCP_CALL = "startConfiguredMcpServers(";
+
+/** The worker's first call that can execute a schedule. */
+const WORK_START = "void tick()";
+
+function readWorkerSource(): string {
+  return readFileSync(join(process.cwd(), "src/schedule/worker.ts"), "utf8");
+}
+
+describe("schedule worker MCP tools", () => {
+  test("connects its own MCP servers before the first schedule tick", () => {
+    const source = readWorkerSource();
+    const mcpAt = source.indexOf(MCP_CALL);
+    const workAt = source.indexOf(WORK_START);
+
+    expect(
+      mcpAt,
+      `The schedule worker must call \`${MCP_CALL})\` at startup. This ` +
+        "process hosts execute-mode schedule turns, and its tool registry is " +
+        "its own: without the call it has no mcp__* tools at all.",
+    ).toBeGreaterThanOrEqual(0);
+    expect(workAt).toBeGreaterThanOrEqual(0);
+    expect(
+      mcpAt < workAt,
+      "The MCP connect must complete before the first tick, so a schedule " +
+        "that fires immediately runs with the tools it was written against.",
+    ).toBe(true);
+  });
+});

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -11,7 +11,7 @@
  * user-facing traffic, and keep running during a main-thread freeze in the
  * daemon.
  */
-import { writeFileSync } from "node:fs";
+import { watch, writeFileSync } from "node:fs";
 
 import {
   initFeatureFlagOverrides,
@@ -21,13 +21,17 @@ import { getConfig } from "../config/loader.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import { startConversationEvictor } from "../daemon/conversation-evictor.js";
 import { stopMcpServerManager } from "../mcp/manager.js";
-import { startConfiguredMcpServers } from "../mcp/startup.js";
+import { MCP_RELOAD_SIGNAL_FILE } from "../mcp/reload-signal.js";
+import {
+  restartConfiguredMcpServers,
+  startConfiguredMcpServers,
+} from "../mcp/startup.js";
 import { resetDb } from "../persistence/db-connection.js";
 import { registerWorkerPluginSurface } from "../plugins/worker-plugin-surface.js";
 import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
 import { initializeTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
-import { getScheduleWorkerPidPath } from "../util/platform.js";
+import { getScheduleWorkerPidPath, getSignalsDir } from "../util/platform.js";
 import {
   cleanupWorkerPidFile,
   startWorkerPidFileGuard,
@@ -41,6 +45,80 @@ const TICK_INTERVAL_MS = 15_000;
 
 /** How often this process re-reads flag overrides from the gateway. */
 const FLAG_REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * How long startup waits for MCP servers before arming the tick.
+ *
+ * Connecting is worth waiting for: a schedule that fires first would fail its
+ * `mcp__*` calls as unknown tools. It is not worth waiting for without limit.
+ * `McpServerManager.start()` walks servers one at a time and allows each 30s to
+ * connect and 30s more to list its tools, so a handful of unreachable ones can
+ * hold the first tick for minutes, including the notify and script schedules
+ * that never touch MCP. Past this deadline the connect continues in the
+ * background and the tick starts without it.
+ */
+const MCP_STARTUP_GRACE_MS = 20_000;
+
+/**
+ * Rebuild this process's MCP connections whenever the daemon reports a reload.
+ *
+ * Watches the signals directory rather than config.json: a reload also follows
+ * an OAuth reauthentication and a plugin install, neither of which edits that
+ * file, and the daemon already funnels all of them through one reload that
+ * writes this signal. Restarts are serialized and coalesced, so a burst of
+ * writes (an editor saving config.json, several servers reauthenticating)
+ * rebuilds once rather than once per event.
+ *
+ * Never throws: a signals directory that cannot be watched leaves this process
+ * on the servers it connected at startup, which is where it already was.
+ */
+function watchForMcpReload(): void {
+  const signalsDir = getSignalsDir();
+  let restarting: Promise<unknown> | null = null;
+  let restartQueued = false;
+
+  const restart = (): void => {
+    if (restarting) {
+      // A reload landed mid-rebuild, so the rebuild in flight may have read
+      // the config as it stood before. Run once more after it, not once per
+      // event that arrived while it ran.
+      restartQueued = true;
+      return;
+    }
+    restarting = restartConfiguredMcpServers()
+      .then((toolCount) => {
+        log.info({ toolCount }, "MCP servers reloaded in schedule worker");
+      })
+      .catch((err: unknown) => {
+        log.warn({ err }, "MCP reload failed in schedule worker");
+      })
+      .finally(() => {
+        restarting = null;
+        if (restartQueued) {
+          restartQueued = false;
+          restart();
+        }
+      });
+  };
+
+  try {
+    const watcher = watch(signalsDir, (_eventType, filename) => {
+      if (String(filename ?? "") === MCP_RELOAD_SIGNAL_FILE) {
+        restart();
+      }
+    });
+    watcher.on("error", (err) => {
+      log.warn({ err, signalsDir }, "MCP reload watcher failed");
+    });
+    watcher.unref();
+    log.info({ dir: signalsDir }, "Watching for MCP reload signals");
+  } catch (err) {
+    log.warn(
+      { err, signalsDir },
+      "Failed to watch for MCP reload signals; MCP servers stay as connected at startup",
+    );
+  }
+}
 
 async function main(): Promise<void> {
   // Only the daemon stamps SSE seqs and writes the shared reservation file.
@@ -114,7 +192,25 @@ async function main(): Promise<void> {
   // Connecting here rather than borrowing the daemon's connections is what
   // keeps this process independent of the daemon's event loop, which is the
   // reason it is a separate process at all.
-  await startConfiguredMcpServers(getConfig().mcp);
+  //
+  // Bounded by MCP_STARTUP_GRACE_MS: unreachable servers must not hold the
+  // schedules that do not use them. The connect runs on past the deadline.
+  const mcpStartup = startConfiguredMcpServers(getConfig().mcp);
+  await Promise.race([
+    mcpStartup,
+    // Unref'd so a connect that beats the deadline leaves nothing pending.
+    new Promise((resolve) => {
+      setTimeout(resolve, MCP_STARTUP_GRACE_MS).unref();
+    }),
+  ]);
+
+  // React to an MCP reload in the daemon. The server set belongs to the config
+  // and the daemon owns the watcher that notices it change; this process holds
+  // its own connections to the same servers, so without this it keeps serving
+  // whatever was configured when it started, including servers since disabled
+  // or removed. Best-effort: a signals directory that cannot be watched leaves
+  // this process on its startup connections until it restarts.
+  watchForMcpReload();
 
   // Sweep idle conversations out of the in-memory pool. The daemon starts
   // this at startup; this process hosts conversations too, so without it

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -20,6 +20,8 @@ import {
 import { getConfig } from "../config/loader.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
 import { startConversationEvictor } from "../daemon/conversation-evictor.js";
+import { stopMcpServerManager } from "../mcp/manager.js";
+import { startConfiguredMcpServers } from "../mcp/startup.js";
 import { resetDb } from "../persistence/db-connection.js";
 import { registerWorkerPluginSurface } from "../plugins/worker-plugin-surface.js";
 import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
@@ -102,6 +104,18 @@ async function main(): Promise<void> {
     );
   }
 
+  // Connect this process's own MCP servers. The tool registry is per-process
+  // and MCP tools reach it only by connecting to each server and listing what
+  // it offers, so `initializeTools()` above leaves them out: it loads core
+  // built-ins and workspace tools from disk and nothing else. Without this an
+  // execute-mode schedule fails every `mcp__*` call as "Unknown tool" while the
+  // daemon, which does connect at boot, lists the same tool as registered.
+  //
+  // Connecting here rather than borrowing the daemon's connections is what
+  // keeps this process independent of the daemon's event loop, which is the
+  // reason it is a separate process at all.
+  await startConfiguredMcpServers(getConfig().mcp);
+
   // Sweep idle conversations out of the in-memory pool. The daemon starts
   // this at startup; this process hosts conversations too, so without it
   // every scheduled run's conversation is retained for the process lifetime.
@@ -122,6 +136,13 @@ async function main(): Promise<void> {
       clearInterval(flagRefreshTimer);
     }
     disposePidGuard?.();
+    // Best-effort, deliberately not awaited: this process exits immediately on
+    // a signal by design, and the exit is what everything else here relies on.
+    // Starting the close still lets a stdio server see its stdin shut rather
+    // than only noticing when the pipe breaks.
+    void stopMcpServerManager().catch((err) => {
+      log.warn({ err }, "MCP server shutdown failed (non-fatal)");
+    });
     cleanupWorkerPidFile(pidPath);
     process.exit(0);
   };


### PR DESCRIPTION
## Prompt / plan

MCP tools show up in `assistant tools list` but every `mcp__*` call from an
execute-mode schedule fails as "Unknown tool".

Cause: MCP tools aren't loaded from disk. Something has to connect to the
server, call `listTools`, and register the results into an in-memory map, and
that map is per-process. Only the daemon ran that step
(`daemon/providers-setup.ts`). The schedule worker is its own process and calls
`initializeTools()`, which loads core built-ins and workspace tools and stops,
so scheduled turns have no `mcp__*` tools at all.

The worker already re-runs the daemon's other startup steps for itself
(platform credentials, feature flags, plugin surface, tools). This adds MCP to
that list and extracts the shared step into `mcp/startup.ts` so the two callers
can't drift. It connects rather than borrowing the daemon's connections because
staying off the daemon's event loop is the reason the worker is a separate
process; tokens are already readable from a second process, so no auth changes.

Subagents get MCP tools back as a side effect: they're in-process and the
default `builder` role has no allowlist, so they only lost them when the worker
was the host.

## Test plan

- `src/mcp/__tests__/startup.test.ts` (new): registers what a server reports,
  no-ops with no servers configured, survives a server that won't start.
- `src/schedule/__tests__/worker-mcp-tools.test.ts` (new): source guard that the
  worker connects before its first tick. Verified it fails when the call is
  removed.
- `bun run lint`, `bunx tsc --noEmit`, `bun run test`: 2383 files pass (2381 on
  `main` plus the two added here).
- Not verified against a live MCP server.

## Note on scope

`plugins/defaults/memory/worker.ts` has the same gap. Left out: its passes run
against narrow allowlists, so whether they should pay for MCP connections is a
separate call. Happy to include it if you'd rather.