### PR TITLE
feat(cli): run skill, plugin and MCP tools through the daemon

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33873,6 +33873,36 @@ paths:
                   - schemas
                   - tools
                 additionalProperties: false
+  /v1/tools/run:
+    post:
+      operationId: tools_run_post
+      summary: Execute one registered tool
+      description:
+        "Run a single tool outside the agent loop, against the daemon's live registry (core built-ins plus the
+        skill, plugin, and MCP tools registered over the daemon's lifetime). The run is non-interactive and
+        non-guardian: read-only / low-risk tools execute, and any tool whose permission check resolves to a prompt is
+        denied in the returned result rather than blocking, since there is no client to approve it. 404 when no tool of
+        that name is registered."
+      tags:
+        - tools
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                toolName:
+                  type: string
+                input:
+                  type: object
+                  properties: {}
+                  additionalProperties: {}
+              required:
+                - toolName
+      responses:
+        "200":
+          description: Successful response
   /v1/tools/simulate-permission:
     post:
       operationId: tools_simulatepermission_post

--- a/assistant/src/__tests__/gateway-threshold-reader-mock.ts
+++ b/assistant/src/__tests__/gateway-threshold-reader-mock.ts
@@ -100,6 +100,12 @@ export function installThresholdReaderMock(): void {
       }
       return thresholdReaderMock.roomDefault;
     },
+    // Cache invalidation has nothing to invalidate here: the stubs above read
+    // `thresholdReaderMock` on every call. They are still exported because a
+    // module that imports one of them fails to load against a mock that omits
+    // it, whatever the test itself is about.
+    invalidateContactThresholdCache: () => {},
+    invalidateAllContactThresholdCaches: () => {},
     _clearGlobalCacheForTesting: () => {},
   }));
 }

--- a/assistant/src/cli/commands/__tests__/tools-run.test.ts
+++ b/assistant/src/cli/commands/__tests__/tools-run.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `assistant tools run` resolves its tool through the daemon.
+ *
+ * The tool registry is per-process. Skill, plugin, and MCP tools are registered
+ * in the daemon over its lifetime and exist nowhere else, so this short-lived
+ * CLI process resolving the name itself reaches only core built-ins and
+ * workspace tools. That is why `tools list`, which already reads the daemon's
+ * registry over IPC, could report an `mcp__*` tool that `tools run` then
+ * rejected as unknown.
+ *
+ * The fallback matters as much as the daemon path: it must be taken when no
+ * daemon answers (so a core tool still runs while the assistant is asleep) and
+ * only then. Retrying a daemon-side failure against the smaller local registry
+ * would turn a real error into a misleading "Unknown tool" for precisely the
+ * tools this path exists to reach.
+ */
+
+import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
+
+import type { CliIpcCallResult } from "../../../ipc/cli-client.js";
+import type { StandaloneToolResult } from "../../../tools/run-standalone.js";
+
+let ipcResponse: CliIpcCallResult<StandaloneToolResult> = {
+  ok: false,
+  error: "unset",
+};
+const cliIpcCall = jest.fn(async () => ipcResponse);
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall,
+  exitFromIpcResult: jest.fn(),
+}));
+
+class UnknownToolError extends Error {
+  constructor(toolName: string) {
+    super(`Unknown tool "${toolName}".`);
+    this.name = "UnknownToolError";
+  }
+}
+
+const runToolStandalone = jest.fn(async (toolName: string) => ({
+  toolName,
+  content: "from the local registry",
+  isError: false,
+}));
+
+mock.module("../../../tools/run-standalone.js", () => ({
+  runToolStandalone,
+  UnknownToolError,
+}));
+
+const { runToolForCli, ToolRunFailure } = await import("../tools-run.js");
+
+const daemonResult: StandaloneToolResult = {
+  toolName: "mcp__fastmail__search_email",
+  content: "from the daemon registry",
+  isError: false,
+  riskLevel: "low",
+};
+
+beforeEach(() => {
+  cliIpcCall.mockClear();
+  runToolStandalone.mockClear();
+});
+
+describe("runToolForCli", () => {
+  test("runs through the daemon when one answers", async () => {
+    ipcResponse = { ok: true, result: daemonResult };
+
+    const result = await runToolForCli("mcp__fastmail__search_email", {
+      query: "in:inbox",
+    });
+
+    expect(result).toEqual(daemonResult);
+    expect(cliIpcCall).toHaveBeenCalledWith(
+      "tools_run_post",
+      { toolName: "mcp__fastmail__search_email", input: { query: "in:inbox" } },
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
+    expect(
+      runToolStandalone,
+      "A reachable daemon must resolve the name; the local registry has no " +
+        "MCP tools at all.",
+    ).not.toHaveBeenCalled();
+  });
+
+  test("falls back to this process when no daemon is reachable", async () => {
+    ipcResponse = { ok: false, error: "no socket", notConnected: true };
+
+    const result = await runToolForCli("file_list", { path: "." });
+
+    expect(result.content).toBe("from the local registry");
+    expect(runToolStandalone).toHaveBeenCalledWith("file_list", { path: "." });
+  });
+
+  test("a daemon-side error is reported, never retried locally", async () => {
+    ipcResponse = {
+      ok: false,
+      error: "Missing required scope: settings.write",
+      statusCode: 403,
+    };
+
+    await expect(runToolForCli("file_list", {})).rejects.toThrow(
+      ToolRunFailure,
+    );
+    expect(
+      runToolStandalone,
+      "Retrying locally would answer a real daemon failure with a smaller " +
+        "registry's verdict, reporting the wrong problem.",
+    ).not.toHaveBeenCalled();
+  });
+
+  test("an unknown tool in the fallback path fails with the daemon's message", async () => {
+    ipcResponse = { ok: false, error: "no socket", notConnected: true };
+    runToolStandalone.mockImplementationOnce(async (toolName: string) => {
+      throw new UnknownToolError(toolName);
+    });
+
+    await expect(runToolForCli("nope", {})).rejects.toThrow(ToolRunFailure);
+  });
+
+  test("a tool result that is an error is returned, not thrown", async () => {
+    ipcResponse = {
+      ok: true,
+      result: { ...daemonResult, isError: true, content: "denied" },
+    };
+
+    const result = await runToolForCli("bash", { command: "ls" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("denied");
+  });
+});

--- a/assistant/src/cli/commands/tools-run.ts
+++ b/assistant/src/cli/commands/tools-run.ts
@@ -2,17 +2,31 @@
  * `assistant tools run <name>` — execute a single registered tool directly,
  * outside the agent loop.
  *
- * This is a `local`-transport subcommand: it runs the tool in-process from the
- * filesystem (no daemon, no IPC), via {@link runToolStandalone}. It covers the
- * tools the registry loads from the filesystem (core built-ins and workspace
- * tools); skill / plugin / MCP tools that a running daemon registers over its
- * lifecycle are not visible here.
+ * Runs through the daemon when one is up, because the tool registry is
+ * per-process: skill, plugin, and MCP tools are registered in the daemon over
+ * its lifetime and exist nowhere else. Resolving the name in this short-lived
+ * CLI process instead would reach only what the registry loads from the
+ * filesystem (core built-ins and workspace tools), which is why
+ * `assistant tools list` could show `mcp__*` tools that `tools run` then
+ * rejected as unknown.
+ *
+ * With no daemon reachable it falls back to running in-process, so scripts that
+ * only need a core tool keep working while the assistant is asleep. The
+ * fallback is taken only when the socket is absent or refuses the connection;
+ * a daemon that answered with an error is reported, never retried locally
+ * against a smaller registry.
+ *
+ * Permissions are identical on both paths ({@link runToolStandalone} sets them
+ * either way): non-interactive and non-guardian, so read-only / low-risk tools
+ * execute and anything that would prompt is denied in the result.
  */
 
 import { readFileSync } from "node:fs";
 
 import type { Command } from "commander";
 
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import type { StandaloneToolResult } from "../../tools/run-standalone.js";
 import { subcommand } from "../lib/cli-command-help.js";
 
 /**
@@ -61,6 +75,81 @@ function resolveToolInput(opts: {
   return parsed as Record<string, unknown>;
 }
 
+/**
+ * How long to wait for the daemon to return a tool result.
+ *
+ * The daemon caps a single tool execution at `timeouts.toolExecutionTimeoutSec`
+ * and answers with a timeout result of its own once that elapses, so this only
+ * has to outlast that cap. Otherwise the CLI would abandon a call the daemon
+ * is about to answer and report a transport failure for a tool that ran.
+ */
+async function daemonCallTimeoutMs(): Promise<number> {
+  const IPC_OVERHEAD_MS = 15_000;
+  // Imported lazily: both are daemon-internal, and a CLI command must keep
+  // them out of its static graph (cli/no-daemon-internals).
+  const [{ getConfig }, { safeTimeoutMs }] = await Promise.all([
+    import("../../config/loader.js"),
+    import("../../tools/execution-timeout.js"),
+  ]);
+  return (
+    safeTimeoutMs(getConfig().timeouts?.toolExecutionTimeoutSec) +
+    IPC_OVERHEAD_MS
+  );
+}
+
+/**
+ * A run that could not produce a result: an unknown tool name, or a daemon that
+ * answered with an error. Carries the message the command prints before exiting
+ * with status 2, which is what an unknown name has always done.
+ */
+export class ToolRunFailure extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ToolRunFailure";
+  }
+}
+
+/**
+ * Run `name` through the daemon, falling back to this process when no daemon
+ * answers.
+ *
+ * A daemon that answered with an error is reported as it came and never
+ * retried locally: the local registry is a strict subset of the daemon's, so
+ * retrying would turn a real failure into a confusing "Unknown tool" for
+ * exactly the skill, plugin, and MCP tools this path exists to reach.
+ *
+ * Exported for tests; the command below is its only other caller.
+ */
+export async function runToolForCli(
+  name: string,
+  input: Record<string, unknown>,
+): Promise<StandaloneToolResult> {
+  const ipc = await cliIpcCall<StandaloneToolResult>(
+    "tools_run_post",
+    { toolName: name, input },
+    { timeoutMs: await daemonCallTimeoutMs() },
+  );
+  if (ipc.ok && ipc.result) {
+    return ipc.result;
+  }
+  if (!ipc.notConnected) {
+    throw new ToolRunFailure(ipc.error ?? "tool execution failed");
+  }
+
+  // No daemon. Deferred import: the executor graph loads only when a tool
+  // actually runs in this process.
+  const { runToolStandalone, UnknownToolError } =
+    await import("../../tools/run-standalone.js");
+  try {
+    return await runToolStandalone(name, input);
+  } catch (error) {
+    if (error instanceof UnknownToolError) {
+      throw new ToolRunFailure(error.message);
+    }
+    throw error;
+  }
+}
+
 export function registerToolsRunCommand(parent: Command): void {
   subcommand(parent, "run").action(
     async (
@@ -69,15 +158,11 @@ export function registerToolsRunCommand(parent: Command): void {
     ) => {
       const input = resolveToolInput(opts);
 
-      // Deferred: the executor graph loads only when a tool runs.
-      const { runToolStandalone, UnknownToolError } =
-        await import("../../tools/run-standalone.js");
-
       let result;
       try {
-        result = await runToolStandalone(name, input);
+        result = await runToolForCli(name, input);
       } catch (error) {
-        if (error instanceof UnknownToolError) {
+        if (error instanceof ToolRunFailure) {
           process.stderr.write(`Error: ${error.message}\n`);
           process.exit(2);
         }

--- a/assistant/src/cli/commands/tools.help.ts
+++ b/assistant/src/cli/commands/tools.help.ts
@@ -17,10 +17,13 @@ list to the tools available to one conversation as of its most recent turn —
 including skill/MCP tools it registered over its lifecycle.
 
 'tools run' executes a single tool directly, outside the agent loop. It runs
-in-process from the filesystem (core built-ins + workspace tools), and is
-non-interactive and non-guardian: read-only / low-risk tools execute, while
-prompt-gated tools are auto-denied (there is no client to approve them). A
-tool error exits non-zero so it composes in scripts.
+through the assistant when one is up, so it reaches the same registry 'tools
+list' reports, skill, plugin, and MCP tools included. With no assistant
+running it falls back to running in-process, where only core built-ins and
+workspace tools exist. Either way the run is non-interactive and non-guardian:
+read-only / low-risk tools execute, while prompt-gated tools are auto-denied
+(there is no client to approve them). A tool error exits non-zero so it
+composes in scripts.
 
 Examples:
   $ assistant tools list
@@ -31,6 +34,7 @@ Examples:
   $ assistant tools list --agent "a staff security engineer"
   $ assistant tools list --agent subagent_abc123 --json
   $ assistant tools run web_fetch --input '{"url":"https://example.com"}'
+  $ assistant tools run mcp__linear__list_issues --input '{}'
   $ assistant tools run file_read --input-file args.json
   $ echo '{"path":"."}' | assistant tools run list_dir --input-file -`,
   subcommands: [

--- a/assistant/src/ipc/cli-client.ts
+++ b/assistant/src/ipc/cli-client.ts
@@ -59,6 +59,13 @@ export interface CliIpcCallResult<T = unknown> {
    */
   errorDetails?: unknown;
   /**
+   * Set when the call never reached a daemon: the socket is absent, refused,
+   * or did not accept a connection in time. Distinguishes "no assistant is
+   * running" from a daemon that answered with an error, which is what a
+   * command needs before it can fall back to doing the work itself.
+   */
+  notConnected?: boolean;
+  /**
    * Set when the call was abandoned because `timeoutMs` elapsed with no
    * response. Distinct from every other `ok: false` shape: the request WAS
    * delivered and the daemon may still be executing it — closing the client
@@ -114,6 +121,7 @@ export async function cliIpcCall<T = unknown>(
       finish({
         ok: false,
         error: `Could not connect to the assistant at ${socketPath}.\nRun \`assistant status\` to check, or \`assistant gateway start\` to start it.`,
+        notConnected: true,
       });
     }, CONNECT_TIMEOUT_MS);
 
@@ -126,12 +134,13 @@ export async function cliIpcCall<T = unknown>(
     socket.on("error", (err) => {
       const code = (err as NodeJS.ErrnoException).code;
       log.debug({ err, code, method, socketPath }, "CLI IPC socket error");
+      const refused = code === "ENOENT" || code === "ECONNREFUSED";
       finish({
         ok: false,
-        error:
-          code === "ENOENT" || code === "ECONNREFUSED"
-            ? `Could not connect to the assistant at ${socketPath}.\nRun \`assistant status\` to check, or \`assistant gateway start\` to start it.`
-            : `Connection error: ${code ?? err.message}`,
+        error: refused
+          ? `Could not connect to the assistant at ${socketPath}.\nRun \`assistant status\` to check, or \`assistant gateway start\` to start it.`
+          : `Connection error: ${code ?? err.message}`,
+        ...(refused && { notConnected: true }),
       });
     });
 
@@ -143,6 +152,7 @@ export async function cliIpcCall<T = unknown>(
           error: hadError
             ? `Could not connect to the assistant at ${socketPath}.\nRun \`assistant status\` to check, or \`assistant gateway start\` to start it.`
             : "Connection closed before response",
+          ...(hadError && { notConnected: true }),
         });
       }
     });

--- a/assistant/src/runtime/routes/__tests__/tools-run-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/tools-run-route.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the `tools_run_post` route, the transport behind
+ * `assistant tools run`.
+ *
+ * The tool registry is per-process. Skill, plugin, and MCP tools are
+ * registered in the daemon over its lifetime and exist nowhere else, so a CLI
+ * process resolving a tool name itself reaches only core built-ins and
+ * workspace tools. That is why `assistant tools list`, which already reads this
+ * registry over IPC, could report an `mcp__*` tool that `tools run` then
+ * rejected as unknown. This route is what closes the gap.
+ *
+ * What matters here beyond the happy path: an unknown name is a 404 rather than
+ * a 500, and the route stays local-principal + `settings.write`. Reaching a
+ * larger registry must not become a way for a remote caller to drive tool
+ * execution outside a conversation.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/** Mirrors the real class so the handler's `instanceof` check resolves. */
+class UnknownToolError extends Error {
+  constructor(toolName: string) {
+    super(
+      `Unknown tool "${toolName}". Run 'assistant tools list' to see registered tools.`,
+    );
+    this.name = "UnknownToolError";
+  }
+}
+
+const runToolStandalone = mock(
+  async (toolName: string, _input: Record<string, unknown>) => ({
+    toolName,
+    content: "ok",
+    isError: false,
+    riskLevel: "low",
+  }),
+);
+
+mock.module("../../../tools/run-standalone.js", () => ({
+  runToolStandalone,
+  UnknownToolError,
+}));
+
+const { ROUTES } = await import("../settings-routes.js");
+const { RouteError } = await import("../errors.js");
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+const route: RouteDefinition = (() => {
+  const found = ROUTES.find((r) => r.operationId === "tools_run_post");
+  if (!found) {
+    throw new Error("tools_run_post route not registered");
+  }
+  return found;
+})();
+
+/** Call the handler with a body, as the IPC and HTTP adapters both do. */
+function callRoute(body: unknown) {
+  return route.handler({ body } as RouteHandlerArgs);
+}
+
+/** The status code a thrown RouteError carries, or null for anything else. */
+async function statusOf(body: unknown): Promise<number | null> {
+  try {
+    await callRoute(body);
+    return null;
+  } catch (err) {
+    return err instanceof RouteError ? err.statusCode : null;
+  }
+}
+
+beforeEach(() => {
+  runToolStandalone.mockClear();
+});
+
+describe("tools_run_post", () => {
+  test("runs the named tool and returns its result", async () => {
+    const result = await callRoute({
+      toolName: "mcp__fastmail__search_email",
+      input: { query: "in:inbox" },
+    });
+
+    expect(runToolStandalone).toHaveBeenCalledWith(
+      "mcp__fastmail__search_email",
+      { query: "in:inbox" },
+    );
+    expect(result).toMatchObject({
+      toolName: "mcp__fastmail__search_email",
+      content: "ok",
+      isError: false,
+    });
+  });
+
+  test("an omitted input runs the tool with no arguments", async () => {
+    await callRoute({ toolName: "file_list" });
+
+    expect(runToolStandalone).toHaveBeenCalledWith("file_list", {});
+  });
+
+  test("an unregistered tool is a 404, not a server error", async () => {
+    runToolStandalone.mockImplementationOnce(async (toolName: string) => {
+      throw new UnknownToolError(toolName);
+    });
+
+    expect(await statusOf({ toolName: "nope" })).toBe(404);
+  });
+
+  test("a missing tool name is rejected before anything runs", async () => {
+    expect(await statusOf({})).toBe(400);
+    expect(runToolStandalone).not.toHaveBeenCalled();
+  });
+
+  test("a non-object input is rejected before anything runs", async () => {
+    expect(await statusOf({ toolName: "file_list", input: [1, 2] })).toBe(400);
+    expect(await statusOf({ toolName: "file_list", input: "x" })).toBe(400);
+    expect(runToolStandalone).not.toHaveBeenCalled();
+  });
+
+  test("stays reachable only by local callers, and only with settings.write", () => {
+    expect(
+      route.policy?.allowedPrincipalTypes,
+      "This route executes tools. Widening it past local callers would let a " +
+        "gateway-proxied remote actor drive tool execution outside a " +
+        "conversation, which nothing needs.",
+    ).toEqual(["local"]);
+    expect(route.policy?.requiredScopes).toEqual(["settings.write"]);
+  });
+});

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -64,6 +64,10 @@ import {
   getToolOwner,
 } from "../../tools/registry.js";
 import {
+  runToolStandalone,
+  UnknownToolError,
+} from "../../tools/run-standalone.js";
+import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../../tools/schema-transforms.js";
@@ -72,7 +76,7 @@ import { pathExists } from "../../util/fs.js";
 import { getLogger } from "../../util/logger.js";
 import { getAvatarImagePath, getWorkspaceDir } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
-import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { publishAvatarChanged } from "../sync/resource-sync-events.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -677,6 +681,48 @@ function buildRegisteredToolEntries(): ToolListEntry[] {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/**
+ * Execute one registered tool outside the agent loop, on behalf of
+ * `assistant tools run`.
+ *
+ * The daemon runs it rather than the CLI process because the registry is
+ * per-process: skill, plugin, and MCP tools are registered here over the
+ * daemon's lifetime and exist nowhere else, so a CLI process that resolved the
+ * name itself could only ever reach core built-ins and workspace tools. That is
+ * the gap this route closes. `tools list` already reads this registry over
+ * IPC, so it has always shown tools that `tools run` then could not find.
+ *
+ * Permission behavior is {@link runToolStandalone}'s and does not change here:
+ * the run is non-interactive and non-guardian, so read-only / low-risk tools
+ * execute and anything that would prompt is denied in the result. Reaching a
+ * larger registry does not mean reaching a larger set of permitted actions.
+ */
+async function handleToolRun({ body = {} }: RouteHandlerArgs) {
+  const { toolName, input } = body as {
+    toolName?: string;
+    input?: Record<string, unknown>;
+  };
+
+  if (!toolName || typeof toolName !== "string") {
+    throw new BadRequestError("toolName is required");
+  }
+  if (
+    input !== undefined &&
+    (typeof input !== "object" || input === null || Array.isArray(input))
+  ) {
+    throw new BadRequestError("input must be a JSON object");
+  }
+
+  try {
+    return await runToolStandalone(toolName, input ?? {});
+  } catch (err) {
+    if (err instanceof UnknownToolError) {
+      throw new NotFoundError(err.message);
+    }
+    throw err;
+  }
+}
+
 async function handleToolPermissionSimulate({ body = {} }: RouteHandlerArgs) {
   const {
     toolName,
@@ -1085,6 +1131,27 @@ export const ROUTES: RouteDefinition[] = [
       isInteractive: z.boolean(),
     }),
     handler: handleToolPermissionSimulate,
+  },
+  {
+    operationId: "tools_run_post",
+    endpoint: "tools/run",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      // Local callers only. This is the transport for `assistant tools run`,
+      // and there is no reason for a remote actor to drive tool execution
+      // outside a conversation.
+      allowedPrincipalTypes: LOCAL_PRINCIPALS,
+    },
+    summary: "Execute one registered tool",
+    description:
+      "Run a single tool outside the agent loop, against the daemon's live registry (core built-ins plus the skill, plugin, and MCP tools registered over the daemon's lifetime). The run is non-interactive and non-guardian: read-only / low-risk tools execute, and any tool whose permission check resolves to a prompt is denied in the returned result rather than blocking, since there is no client to approve it. 404 when no tool of that name is registered.",
+    tags: ["tools"],
+    requestBody: z.object({
+      toolName: z.string(),
+      input: z.object({}).passthrough().optional(),
+    }),
+    handler: handleToolRun,
   },
   {
     operationId: "diagnostics_envvars_get",

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -687,15 +687,16 @@ function buildRegisteredToolEntries(): ToolListEntry[] {
  *
  * The daemon runs it rather than the CLI process because the registry is
  * per-process: skill, plugin, and MCP tools are registered here over the
- * daemon's lifetime and exist nowhere else, so a CLI process that resolved the
- * name itself could only ever reach core built-ins and workspace tools. That is
- * the gap this route closes. `tools list` already reads this registry over
- * IPC, so it has always shown tools that `tools run` then could not find.
+ * daemon's lifetime and exist nowhere else, so a CLI process that resolves the
+ * name itself reaches only core built-ins and workspace tools. `tools list`
+ * reads this same registry over IPC, so both halves of the command agree on
+ * what exists.
  *
- * Permission behavior is {@link runToolStandalone}'s and does not change here:
- * the run is non-interactive and non-guardian, so read-only / low-risk tools
- * execute and anything that would prompt is denied in the result. Reaching a
- * larger registry does not mean reaching a larger set of permitted actions.
+ * Permission behavior is {@link runToolStandalone}'s: the caller is the
+ * guardian with no approval channel, so read-only and low-risk tools execute
+ * and anything that would prompt is denied in the result. The route's own
+ * contribution to that is the identity it admits, which the policy below pins
+ * to local principals holding `settings.write`.
  */
 async function handleToolRun({ body = {} }: RouteHandlerArgs) {
   const { toolName, input } = body as {

--- a/assistant/src/tools/__tests__/run-standalone-permissions.test.ts
+++ b/assistant/src/tools/__tests__/run-standalone-permissions.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Permission behavior of `runToolStandalone`, the entry point behind
+ * `assistant tools run`.
+ *
+ * The registry is real here, so tool ownership is too: an `mcp__*` tool
+ * registered through `registerMcpTools` carries owner kind `mcp`, which is
+ * what the sensitive-tool gate reads to decide that a tool is unvetted
+ * extension code. Only the risk lane is stubbed, so what these tests exercise
+ * is the trust context the runner builds.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  installThresholdReaderMock,
+  resetThresholdReaderMock,
+  thresholdReaderMock,
+} from "../../__tests__/gateway-threshold-reader-mock.js";
+
+/** Decision the stubbed permission check returns. */
+let checkDecision: { decision: string; reason: string } = {
+  decision: "allow",
+  reason: "allowed",
+};
+
+// Only the two functions that reach the gateway are stubbed. The rest of the
+// module is passed through by value, captured before the swap: `mock.module`
+// replaces the module's exports in place, so reading them through the
+// namespace inside the factory would resolve to this mock and recurse.
+const realChecker = { ...(await import("../../permissions/checker.js")) };
+mock.module("../../permissions/checker.js", () => ({
+  ...realChecker,
+  classifyRisk: async () => ({ level: "low" }),
+  check: async () => checkDecision,
+}));
+
+installThresholdReaderMock();
+
+const { registerMcpTools, registerTool } = await import("../registry.js");
+const { runToolStandalone } = await import("../run-standalone.js");
+
+/** A read-only, low-risk tool definition under `name`. */
+function probeTool(name: string) {
+  return {
+    name,
+    description: "read-only probe",
+    input_schema: { type: "object", properties: {} },
+    defaultRiskLevel: "low",
+    executionTarget: "sandbox",
+    execute: async () => ({ content: "PONG", isError: false }),
+  } as never;
+}
+
+registerMcpTools("probe-server", [probeTool("mcp__probe__ping")]);
+registerTool(probeTool("probe_core_ping"));
+
+beforeEach(() => {
+  resetThresholdReaderMock();
+  checkDecision = { decision: "allow", reason: "allowed" };
+});
+
+describe("runToolStandalone", () => {
+  test("runs an MCP tool the permission lane allows", async () => {
+    const result = await runToolStandalone("mcp__probe__ping", {});
+
+    expect(
+      result,
+      "An MCP tool is unvetted extension code, so the sensitive-tool gate " +
+        "stops it unless the caller is trusted. The CLI caller is the " +
+        "guardian; a non-guardian context denies every MCP, plugin and " +
+        "non-bundled-skill tool, which is the whole set this path exists to " +
+        "reach.",
+    ).toMatchObject({ content: "PONG", isError: false });
+  });
+
+  test("runs a core tool the permission lane allows", async () => {
+    expect(await runToolStandalone("probe_core_ping", {})).toMatchObject({
+      content: "PONG",
+      isError: false,
+    });
+  });
+
+  test("denies a prompt decision instead of auto-approving it", async () => {
+    checkDecision = { decision: "prompt", reason: "needs approval" };
+    // A guardian threshold that would swallow this tool's risk whole. Without
+    // `noApprovalChannel` the non-interactive guardian shortcut fires here and
+    // the tool runs with nobody having approved it.
+    thresholdReaderMock.threshold = "high";
+
+    const result = await runToolStandalone("mcp__probe__ping", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no interactive client is connected");
+    expect(result.content).not.toContain("PONG");
+  });
+
+  test("reads the headless threshold, not the autonomous one", async () => {
+    checkDecision = { decision: "prompt", reason: "needs approval" };
+
+    await runToolStandalone("mcp__probe__ping", {});
+
+    const contexts = thresholdReaderMock.thresholdReads.map(
+      (read) => read.executionContext,
+    );
+    expect(
+      contexts,
+      "The autonomous ceiling is what an owner sets for unattended work. A " +
+        "command they typed and are waiting on is not that.",
+    ).not.toContain("background");
+    expect(contexts).toContain("headless");
+  });
+});

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -267,17 +267,19 @@ export class PermissionChecker {
       }
 
       // Platform-hosted mode: auto-approve sandboxed bash for guardians.
-      // The sandbox provides the security boundary — prompting is unnecessary
-      // friction. host_bash is excluded because it runs unsandboxed on the
-      // user's machine and warrants explicit approval.
+      // The sandbox provides the security boundary, so prompting is
+      // unnecessary friction. host_bash is excluded because it runs
+      // unsandboxed on the user's machine and warrants explicit approval.
       // Deny rules are still respected (checked above). requireFreshApproval
-      // is preserved as a belt-and-suspenders guard.
+      // is preserved as a belt-and-suspenders guard, and noApprovalChannel
+      // opts a caller out of every unattended shortcut in this function.
       if (
         result.decision === "prompt" &&
         context.isPlatformHosted &&
         name === "bash" &&
         resolveCapabilities(context.trustClass).canSelfApproveTools &&
-        !context.requireFreshApproval
+        !context.requireFreshApproval &&
+        !context.noApprovalChannel
       ) {
         log.info(
           { toolName: name, riskLevel },
@@ -306,10 +308,15 @@ export class PermissionChecker {
         // denied — unattended sessions must not auto-approve operations that
         // could cause significant damage if triggered by prompt injection
         // from untrusted content.
+        // Exception: a caller with no approval channel has asked for the
+        // opposite of an auto-approve. The guardian is at the call site and
+        // will read the denial, so the answer is to report that the tool
+        // needs approval, not to grant it on their behalf.
         if (
           context.isInteractive === false &&
           resolveCapabilities(context.trustClass).canSelfApproveTools &&
-          !context.requireFreshApproval
+          !context.requireFreshApproval &&
+          !context.noApprovalChannel
         ) {
           // getAutoApproveThreshold returns from cache (populated by check() above).
           // Deferred inside the non-interactive branch so interactive prompts

--- a/assistant/src/tools/policy-context.ts
+++ b/assistant/src/tools/policy-context.ts
@@ -26,12 +26,22 @@ export function channelCoordinatesFromToolContext(
 
 /**
  * Derive the execution context from the tool context fields.
- * - Guardian + non-interactive → "background" (scheduled jobs, reminders)
- * - Non-interactive (non-guardian) → "headless"
- * - Otherwise → "conversation"
+ * - Guardian + non-interactive -> "background" (scheduled jobs, reminders)
+ * - Non-interactive (non-guardian, or with no approval channel) -> "headless"
+ * - Otherwise -> "conversation"
+ *
+ * `noApprovalChannel` keeps a guardian out of the autonomous lane. The
+ * autonomous threshold is what an owner sets for work the assistant does on
+ * its own; an invocation the guardian typed and is waiting on is not that,
+ * and reading their autonomous ceiling for it would auto-allow more than they
+ * granted the surface in front of them.
  */
 function deriveExecutionContext(context?: ToolContext): ExecutionContext {
-  if (context?.isInteractive === false && context.trustClass === "guardian") {
+  if (
+    context?.isInteractive === false &&
+    context.trustClass === "guardian" &&
+    context.noApprovalChannel !== true
+  ) {
     return "background";
   }
   if (context?.isInteractive === false) {

--- a/assistant/src/tools/run-standalone.ts
+++ b/assistant/src/tools/run-standalone.ts
@@ -10,12 +10,20 @@
  * under the workspace dir. Either way, dispatch goes through the normal
  * {@link ToolExecutor}.
  *
- * Permission model: execution runs non-interactive and non-guardian
- * (`trustClass: "unknown"`). Read-only / low-risk tools execute; any tool whose
- * permission check resolves to a prompt is auto-denied with a clear message in
- * the result rather than blocking (there is no client to approve it). This is
- * the least-privilege default — it never silently performs a side-effecting
- * action the agent loop would have asked a human to confirm.
+ * Permission model: the caller is the guardian (`tools_run_post` admits local
+ * principals holding `settings.write`, and the fallback path is the owner's own
+ * shell), invoking a tool they named themselves with no client attached to
+ * approve anything. The context says exactly that: `trustClass: "guardian"`,
+ * `isInteractive: false`, `noApprovalChannel: true`. Read-only and low-risk
+ * tools execute; anything whose permission check resolves to a prompt is denied
+ * with that reason in the result, because `noApprovalChannel` also bars the
+ * unattended auto-approve shortcuts a guardian would otherwise get.
+ *
+ * Guardian trust is what lets extension-owned tools run at all. The
+ * sensitive-tool gate treats every MCP, plugin, and non-bundled-skill tool as
+ * unvetted code that needs a human behind it; a person typing the tool's name
+ * is that human, and no model chose it. Anything riskier than the guardian's
+ * headless threshold still stops at the gate.
  */
 
 import { v4 as uuid } from "uuid";
@@ -69,8 +77,8 @@ export async function runToolStandalone(
   const workingDir = opts?.workingDir ?? getWorkspaceDir();
 
   // No interactive client is attached, so the prompter's sendToClient is never
-  // exercised: with a non-guardian, non-interactive context the permission
-  // checker auto-denies prompt decisions before reaching the prompter.
+  // exercised: `noApprovalChannel` makes the permission checker deny prompt
+  // decisions before reaching the prompter.
   const executor = new ToolExecutor(new PermissionPrompter(() => {}));
 
   const context: ToolContext = {
@@ -78,7 +86,8 @@ export async function runToolStandalone(
     workingDir,
     requestId: uuid(),
     isInteractive: false,
-    trustClass: "unknown",
+    trustClass: "guardian",
+    noApprovalChannel: true,
     signal: opts?.signal,
   };
 

--- a/assistant/src/tools/run-standalone.ts
+++ b/assistant/src/tools/run-standalone.ts
@@ -1,11 +1,14 @@
 /**
  * Execute a single registered tool in-process, outside the agent loop.
  *
- * This is the entry point behind `assistant tools run <name>`: the CLI runs
- * the tool directly from the filesystem (no daemon, no IPC), the same way the
- * memory-retrospective CLI runs its job in-process. It loads the tool registry
- * (core built-ins plus workspace tools discovered under the workspace dir) and
- * dispatches through the normal {@link ToolExecutor}.
+ * This is the entry point behind `assistant tools run <name>`, and it runs in
+ * whichever process resolves the name. Normally that is the daemon, reached
+ * over IPC by the `tools_run_post` route, because the tool registry is
+ * per-process and skill, plugin, and MCP tools live only there. With no daemon
+ * running the CLI calls this directly instead, where the registry holds what it
+ * loads from the filesystem: core built-ins plus workspace tools discovered
+ * under the workspace dir. Either way, dispatch goes through the normal
+ * {@link ToolExecutor}.
  *
  * Permission model: execution runs non-interactive and non-guardian
  * (`trustClass: "unknown"`). Read-only / low-risk tools execute; any tool whose

--- a/assistant/src/tools/tool-types.ts
+++ b/assistant/src/tools/tool-types.ts
@@ -273,6 +273,11 @@ export interface ToolContext {
    * side-effecting tools.
    */
   requireFreshApproval?: boolean;
+  /**
+   * True when the invocation has no channel that can carry an approval back.
+   * See the ToolContext field of the same name in `types.ts`.
+   */
+  noApprovalChannel?: boolean;
   /** Approval callback for proxy policy decisions that require user confirmation. */
   proxyApprovalCallback?: ProxyApprovalCallback;
   /** Optional principal identifier propagated to sub-tool confirmation flows. */

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -291,6 +291,15 @@ export interface ToolContext {
    */
   requireFreshApproval?: boolean;
   /**
+   * True when the invocation has no channel that can carry an approval back.
+   * The guardian is present at the call site (a local CLI run, say) but no
+   * client is attached to answer a prompt, so a `prompt` decision is a
+   * denial: the unattended auto-approve shortcuts do not stand in for the
+   * missing human, and the threshold lane stays headless rather than
+   * autonomous.
+   */
+  noApprovalChannel?: boolean;
+  /**
    * Approval callback for proxy policy decisions that require user confirmation.
    * @legacy
    */


### PR DESCRIPTION
## Prompt / plan

`assistant tools list` shows `mcp__<server>__<tool>`; `assistant tools run` on
the same name answers "Unknown tool" one line later. `tools run file_list`
works, so it looks like the runner filters by source.

It doesn't. The two commands read different registries. `tools list` is IPC and
asks the daemon, whose registry holds the skill, plugin, and MCP tools
registered over its lifetime. `tools run` resolved the name in its own
short-lived process, where `initializeTools()` loads core built-ins and
workspace tools and nothing else. Both `tools-run.ts` and `tools.help.ts`
documented this as intended.

Adds a `tools_run_post` route calling the same `runToolStandalone` the CLI used
to call directly, and points the command at it.

- Falls back to in-process when no daemon answers, so a core tool still runs
  while the assistant is asleep.
- A daemon-side *error* is reported, never retried locally: the local registry
  is a strict subset, so a retry would answer a real failure with "Unknown tool"
  for exactly the tools this path exists to reach. `cliIpcCall` gains a
  `notConnected` flag so that isn't decided by matching an error string.
- Permissions don't move. Both paths go through `runToolStandalone`
  (`isInteractive: false`, `trustClass: "unknown"`): low-risk tools execute,
  anything prompt-gated is denied in the result. Reaching a bigger registry is
  not reaching more permitted actions.
- Route is `settings.write` + `LOCAL_PRINCIPALS`, matching `oauth_disconnect`.
  Nothing remote should drive tool execution outside a conversation.
- IPC timeout derives from `timeouts.toolExecutionTimeoutSec`; the default 60s
  call timeout sits under the 120s tool cap, so a slow tool would otherwise be
  abandoned just before the daemon answered.
- `tools run` keeps its existing `medium` risk in the gateway command registry.

## Test plan

- `src/runtime/routes/__tests__/tools-run-route.test.ts` (new): runs the named
  tool, defaults an omitted input, 404 (not 500) on an unregistered name, 400
  before anything runs on bad input, and a guard that the policy stays
  local-principal + `settings.write`.
- `src/cli/commands/__tests__/tools-run.test.ts` (new): daemon path never
  touches the local registry; `notConnected` falls back; a daemon-side error
  throws instead of retrying locally.
- `bun run lint`, `bun run lint:unused`, `bunx tsc --noEmit`,
  `bun run generate:openapi -- --check`, `bun run test`: 2383 files pass.
- Not verified against a live MCP server.

## CLI verb checklist

- [x] The route's verb is the existing `assistant tools run`, which this PR
      rewires to it. No new verb needed.