### PR TITLE
fix(companion): thin the resting pill's lit rim to 2px

### DIFF
--- a/clients/web/src/components/companion-idle-pill.stories.tsx
+++ b/clients/web/src/components/companion-idle-pill.stories.tsx
@@ -435,8 +435,8 @@ const HOLLOW = {
   // Thick enough to be a band rather than a hairline, which is what holds the
   // shape together once there is no fill inside it. Backed off from 3.5, where
   // the band starts reading as a frame around the creature rather than as the
-  // creature's own outline.
-  rimWidth: 2.5,
+  // creature's own outline, and again to 2.
+  rimWidth: 2,
   accentHex: "#5EEAD4",
   content: "creature",
 } satisfies IdlePillProps;

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1875,7 +1875,7 @@ describe("the pill the surface rests in", () => {
 
     const shadow = restingPillOf(container).style.boxShadow;
     expect(shadow).toContain("#ff8800");
-    expect(shadow).toContain("inset 0 0 0 2.5px");
+    expect(shadow).toContain("inset 0 0 0 2px");
   });
 
   /**
@@ -1928,7 +1928,7 @@ describe("the pill the surface rests in", () => {
     const pill = restingPillOf(container);
     expect(pill.style.width).toBe("64px");
     expect(pill.style.height).toBe("14px");
-    expect(pill.style.boxShadow).toContain("inset 0 0 0 2.5px");
+    expect(pill.style.boxShadow).toContain("inset 0 0 0 2px");
   });
 
   /**

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -271,7 +271,7 @@ const RESTING_PILL = {
    */
   closing: AVATAR_IMAGE,
   /** The lit line's thickness, at every size and every setting. */
-  rim: 2.5,
+  rim: 2,
   /** How far that line throws light, as the nearer of its two blooms. */
   bloom: 4,
 };


### PR DESCRIPTION
The hollow resting pill is found by its edge rather than by its fill, so the rim's thickness is the whole of how the shape reads. At 2.5 the band was starting to sit as a frame *around* the creature; 2 keeps it the creature's own outline without losing the line at a glance.

### What moved

| | before | after |
|---|---|---|
| `RESTING_PILL.rim` — what the surface draws | `2.5` | `2` |
| `HOLLOW.rimWidth` — the idle-pill bench's record of the same setting | `2.5` | `2` |

Both statements of the number move together. `HOLLOW` is documented as "the setting the exercise landed on", so a bench that no longer matches what ships is a bench nobody can trust.

The bloom is untouched. `RESTING_PILL.bloom` was already at its 1x baseline, which is the same value the bench's `glow` multiplier already sat at, so there was nothing to move.

### Tests

Two assertions pinned the old thickness and now pin the new one:

- `companion-surface.test.tsx:1878` — lights the edge in the assistant's colour
- `companion-surface.test.tsx:1931` — draws the marker and the rim at one size on every setting

`companion-surface.test.tsx` 136 pass / 0 fail, `companion-peek.test.tsx` 17 pass / 0 fail.

### Reviewer notes

- **Expect a conflict with `alex/jarvis-1749-companion-pill-draws-in`.** That branch rewrites this same region of `companion-surface.tsx` (+82/-54) and carries `rim: 2.5` through unchanged. The conflict is one numeric literal, but whichever lands second needs to keep `2`.
- This is a look change, so the test diff is the weakest part of the evidence. Worth an eye on the four backdrops in **Components → CompanionSurface → Idle pill lab** before approving, particularly `busy` and `photo`, where a thinner line has the least contrast to work with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Em2tagYLNJsmzy4ScPLp5