### PR TITLE
fix(outlook): create mailbox drafts from messaging_send (LUM-3548)

### DIFF
--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -44,14 +44,17 @@ const telegramProvider = makeProvider("telegram", "Telegram");
 const outlookProvider = makeProvider("outlook", "Outlook");
 let provider: MessagingProvider = phoneProvider;
 
+let connection: OAuthConnection | undefined = undefined;
+
 mock.module("../config/bundled-skills/messaging/tools/shared.js", () => ({
   resolveProvider: () => provider,
-  getProviderConnection: () => undefined,
+  getProviderConnection: () => connection,
   ok: (content: string) => ({ content, isError: false }),
   err: (content: string) => ({ content, isError: true }),
   extractHeader: () => "",
   parseAddressList: () => [],
   extractEmail: (a: string) => a.toLowerCase(),
+  isMailboxAddress: (value: string) => value.includes("@"),
 }));
 
 // ── Sent-post record dependency mocks ──
@@ -74,6 +77,34 @@ const resolveProactiveHomeConversationMock = mock(
 const recordDeliveredChannelPostMock = mock(
   async (_post: Record<string, unknown>) => ({ messageId: "row-1" }),
 );
+
+const mockOutlookCreateDraft = mock(async () => ({
+  id: "outlook-draft-1",
+  conversationId: "conv-draft",
+  subject: "Docs",
+  webLink: "https://outlook.office.com/mail/drafts/id/outlook-draft-1",
+}));
+
+const mockOutlookCreateReplyDraft = mock(async () => ({
+  id: "outlook-reply-draft-1",
+  conversationId: "conv-reply",
+  subject: "Re: Hello",
+  webLink: "https://outlook.office.com/mail/drafts/id/outlook-reply-draft-1",
+}));
+
+mock.module("../messaging/providers/outlook/client.js", () => ({
+  createDraft: mockOutlookCreateDraft,
+  createReplyDraft: mockOutlookCreateReplyDraft,
+  toOutlookFileAttachments: (
+    attachments: Array<{ filename: string; mimeType: string; data: Buffer }>,
+  ) =>
+    attachments.map((att) => ({
+      "@odata.type": "#microsoft.graph.fileAttachment",
+      name: att.filename,
+      contentType: att.mimeType,
+      contentBytes: att.data.toString("base64"),
+    })),
+}));
 
 mock.module("../persistence/conversation-crud.js", () => ({
   setConversationProcessingStartedAt: () => {},
@@ -99,7 +130,10 @@ import { run } from "../config/bundled-skills/messaging/tools/messaging-send.js"
 describe("messaging-send tool", () => {
   beforeEach(() => {
     provider = phoneProvider;
+    connection = undefined;
     sendMessageMock.mockClear();
+    mockOutlookCreateDraft.mockClear();
+    mockOutlookCreateReplyDraft.mockClear();
     getConversationMock.mockClear();
     syncMessageToDiskMock.mockClear();
     resolveProactiveHomeConversationMock.mockClear();
@@ -195,11 +229,15 @@ describe("messaging-send tool", () => {
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
-  test("reads and forwards attachments to attachment-capable non-Gmail providers", async () => {
+  test("reads and forwards attachments onto an Outlook draft", async () => {
     const dir = mkdtempSync(join(tmpdir(), "msg-send-att-"));
     const filePath = join(dir, "report.pdf");
     writeFileSync(filePath, "pdf-bytes");
     provider = outlookProvider;
+    connection = {
+      id: "outlook-conn-1",
+      provider: "outlook",
+    } as OAuthConnection;
 
     try {
       const result = await run(
@@ -219,17 +257,26 @@ describe("messaging-send tool", () => {
       );
 
       expect(result.isError).toBe(false);
-      const options = sendMessageMock.mock.calls[0][3] as {
-        attachments?: Array<{
-          filename: string;
-          mimeType: string;
-          data: Buffer;
-        }>;
+      expect(result.content).toContain("Outlook draft created");
+      expect(result.content).toContain("Draft ID: outlook-draft-1");
+      expect(sendMessageMock).not.toHaveBeenCalled();
+      expect(mockOutlookCreateDraft).toHaveBeenCalledTimes(1);
+      const draftArg = mockOutlookCreateDraft.mock.calls[0]![1] as {
+        subject: string;
+        body: { contentType: string; content: string };
+        toRecipients?: Array<{ emailAddress: { address: string } }>;
+        attachments?: Array<{ name: string; contentType: string }>;
       };
-      expect(options.attachments).toHaveLength(1);
-      expect(options.attachments?.[0]?.filename).toBe("report.pdf");
-      expect(options.attachments?.[0]?.mimeType).toBe("application/pdf");
-      expect(options.attachments?.[0]?.data.toString()).toBe("pdf-bytes");
+      expect(draftArg.subject).toBe("Docs");
+      expect(draftArg.body).toEqual({
+        contentType: "text",
+        content: "see attached",
+      });
+      expect(draftArg.toRecipients).toEqual([
+        { emailAddress: { address: "user@example.com" } },
+      ]);
+      expect(draftArg.attachments).toHaveLength(1);
+      expect(draftArg.attachments?.[0]?.name).toBe("report.pdf");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -305,6 +352,10 @@ describe("messaging-send tool", () => {
 
   test("records nothing for a provider that is not a channel", async () => {
     provider = outlookProvider;
+    connection = {
+      id: "outlook-conn-1",
+      provider: "outlook",
+    } as OAuthConnection;
 
     await run(
       {
@@ -322,6 +373,96 @@ describe("messaging-send tool", () => {
 
     expect(resolveProactiveHomeConversationMock).not.toHaveBeenCalled();
     expect(recordDeliveredChannelPostMock).not.toHaveBeenCalled();
+  });
+
+  test("creates an Outlook draft without a To address when conversation_id is not an email", async () => {
+    provider = outlookProvider;
+    connection = {
+      id: "outlook-conn-1",
+      provider: "outlook",
+    } as OAuthConnection;
+
+    const result = await run(
+      {
+        platform: "outlook",
+        conversation_id: "drafts",
+        text: "Hey team, here is the update.",
+        subject: "Team update",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-1",
+        assistantId: "ast-alpha",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Outlook draft created");
+    expect(result.content).toContain("No recipient set");
+    expect(result.content).toContain("Open it:");
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    const draftArg = mockOutlookCreateDraft.mock.calls[0]![1] as {
+      toRecipients?: unknown;
+      subject: string;
+    };
+    expect(draftArg.toRecipients).toBeUndefined();
+    expect(draftArg.subject).toBe("Team update");
+  });
+
+  test("creates an Outlook reply draft instead of sending when in_reply_to is set", async () => {
+    provider = outlookProvider;
+    connection = {
+      id: "outlook-conn-1",
+      provider: "outlook",
+    } as OAuthConnection;
+
+    const result = await run(
+      {
+        platform: "outlook",
+        conversation_id: "user@example.com",
+        text: "Thanks, that works.",
+        in_reply_to: "AAMk-original",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-1",
+        assistantId: "ast-alpha",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(mockOutlookCreateReplyDraft).toHaveBeenCalledWith(
+      connection,
+      "AAMk-original",
+      "Thanks, that works.",
+    );
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(result.content).toContain("outlook-reply-draft-1");
+  });
+
+  test("errors when Outlook is not connected", async () => {
+    provider = outlookProvider;
+    connection = undefined;
+
+    const result = await run(
+      {
+        platform: "outlook",
+        conversation_id: "user@example.com",
+        text: "hello",
+      },
+      {
+        workingDir: "/tmp",
+        conversationId: "conv-1",
+        assistantId: "ast-alpha",
+        trustClass: "guardian" as const,
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("OAuth connection");
+    expect(mockOutlookCreateDraft).not.toHaveBeenCalled();
   });
 
   test("a record failure does not fail the send", async () => {

--- a/assistant/src/__tests__/messaging-send-tool.test.ts
+++ b/assistant/src/__tests__/messaging-send-tool.test.ts
@@ -78,19 +78,23 @@ const recordDeliveredChannelPostMock = mock(
   async (_post: Record<string, unknown>) => ({ messageId: "row-1" }),
 );
 
-const mockOutlookCreateDraft = mock(async () => ({
-  id: "outlook-draft-1",
-  conversationId: "conv-draft",
-  subject: "Docs",
-  webLink: "https://outlook.office.com/mail/drafts/id/outlook-draft-1",
-}));
+const mockOutlookCreateDraft = mock(
+  async (_conn: OAuthConnection, _draft: Record<string, unknown>) => ({
+    id: "outlook-draft-1",
+    conversationId: "conv-draft",
+    subject: "Docs",
+    webLink: "https://outlook.office.com/mail/drafts/id/outlook-draft-1",
+  }),
+);
 
-const mockOutlookCreateReplyDraft = mock(async () => ({
-  id: "outlook-reply-draft-1",
-  conversationId: "conv-reply",
-  subject: "Re: Hello",
-  webLink: "https://outlook.office.com/mail/drafts/id/outlook-reply-draft-1",
-}));
+const mockOutlookCreateReplyDraft = mock(
+  async (_conn: OAuthConnection, _messageId: string, _comment?: string) => ({
+    id: "outlook-reply-draft-1",
+    conversationId: "conv-reply",
+    subject: "Re: Hello",
+    webLink: "https://outlook.office.com/mail/drafts/id/outlook-reply-draft-1",
+  }),
+);
 
 mock.module("../messaging/providers/outlook/client.js", () => ({
   createDraft: mockOutlookCreateDraft,
@@ -261,22 +265,17 @@ describe("messaging-send tool", () => {
       expect(result.content).toContain("Draft ID: outlook-draft-1");
       expect(sendMessageMock).not.toHaveBeenCalled();
       expect(mockOutlookCreateDraft).toHaveBeenCalledTimes(1);
-      const draftArg = mockOutlookCreateDraft.mock.calls[0]![1] as {
-        subject: string;
-        body: { contentType: string; content: string };
-        toRecipients?: Array<{ emailAddress: { address: string } }>;
-        attachments?: Array<{ name: string; contentType: string }>;
-      };
-      expect(draftArg.subject).toBe("Docs");
-      expect(draftArg.body).toEqual({
-        contentType: "text",
-        content: "see attached",
-      });
-      expect(draftArg.toRecipients).toEqual([
-        { emailAddress: { address: "user@example.com" } },
-      ]);
-      expect(draftArg.attachments).toHaveLength(1);
-      expect(draftArg.attachments?.[0]?.name).toBe("report.pdf");
+      expect(mockOutlookCreateDraft).toHaveBeenCalledWith(
+        connection,
+        expect.objectContaining({
+          subject: "Docs",
+          body: { contentType: "text", content: "see attached" },
+          toRecipients: [
+            { emailAddress: { address: "user@example.com" } },
+          ],
+          attachments: [expect.objectContaining({ name: "report.pdf" })],
+        }),
+      );
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -402,12 +401,18 @@ describe("messaging-send tool", () => {
     expect(result.content).toContain("No recipient set");
     expect(result.content).toContain("Open it:");
     expect(sendMessageMock).not.toHaveBeenCalled();
-    const draftArg = mockOutlookCreateDraft.mock.calls[0]![1] as {
-      toRecipients?: unknown;
-      subject: string;
-    };
+    expect(mockOutlookCreateDraft).toHaveBeenCalledWith(
+      connection,
+      expect.objectContaining({
+        subject: "Team update",
+        body: {
+          contentType: "text",
+          content: "Hey team, here is the update.",
+        },
+      }),
+    );
+    const draftArg = mockOutlookCreateDraft.mock.calls[0][1];
     expect(draftArg.toRecipients).toBeUndefined();
-    expect(draftArg.subject).toBe("Team update");
   });
 
   test("creates an Outlook reply draft instead of sending when in_reply_to is set", async () => {

--- a/assistant/src/__tests__/messaging-shared.test.ts
+++ b/assistant/src/__tests__/messaging-shared.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { isMailboxAddress } from "../config/bundled-skills/messaging/tools/shared.js";
+
+describe("isMailboxAddress", () => {
+  test("accepts a bare email", () => {
+    expect(isMailboxAddress("user@example.com")).toBe(true);
+  });
+
+  test("accepts a display-name address", () => {
+    expect(isMailboxAddress("Alice <alice@example.org>")).toBe(true);
+  });
+
+  test("rejects placeholders used when the recipient is unknown", () => {
+    expect(isMailboxAddress("drafts")).toBe(false);
+    expect(isMailboxAddress("outlook")).toBe(false);
+    expect(isMailboxAddress("")).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/outlook-messaging-provider.test.ts
+++ b/assistant/src/__tests__/outlook-messaging-provider.test.ts
@@ -148,6 +148,15 @@ mock.module("../messaging/providers/outlook/client.js", () => ({
   getAutoReplySettings: mockGetAutoReplySettings,
   updateAutoReplySettings: mockUpdateAutoReplySettings,
   listMessagesDelta: mockListMessagesDelta,
+  toOutlookFileAttachments: (
+    attachments: Array<{ filename: string; mimeType: string; data: Buffer }>,
+  ) =>
+    attachments.map((att) => ({
+      "@odata.type": "#microsoft.graph.fileAttachment",
+      name: att.filename,
+      contentType: att.mimeType,
+      contentBytes: att.data.toString("base64"),
+    })),
 }));
 
 import { outlookMessagingProvider } from "../messaging/providers/outlook/adapter.js";

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -32,6 +32,8 @@ Reading, searching, or summarizing the user's inbox is a **messaging task** — 
 
 When a platform is connected (auth test succeeds), always use the messaging API tools for that platform. Never fall back to browser automation, shell commands (bash, curl), or any other approach for operations that messaging tools can handle. The messaging tools handle authentication internally - never try to access tokens or call APIs directly. Browser automation is only appropriate for initial credential setup (OAuth consent screens), not for day-to-day messaging operations.
 
+On Gmail and Outlook, `messaging_send` creates a real mailbox draft for review. It does not send. Recipients are optional on Outlook: if the user has not named a To address, still create the draft (use a non-email `conversation_id` such as `drafts`) and tell them only after the tool returns a draft ID. If draft creation fails or is interrupted, say so and offer the email copy in chat. Do not claim a draft exists until the tool succeeds.
+
 **Exception: Slack.** Slack messaging should use the Slack Web API directly via CLI, not messaging tools. See the **slack** skill for details.
 
 ## Connection Setup

--- a/assistant/src/config/bundled-skills/messaging/TOOLS.json
+++ b/assistant/src/config/bundled-skills/messaging/TOOLS.json
@@ -125,7 +125,7 @@
     },
     {
       "name": "messaging_send",
-      "description": "Send a message, reply to a thread, or create a draft. On Gmail, always creates a draft for review. Supports replies (via thread_id), attachments (via attachment_paths, Gmail and Outlook), and all messaging platforms.",
+      "description": "Send a message, reply to a thread, or create a draft. On Gmail and Outlook, always creates a real mailbox draft for review (recipients optional on Outlook). Supports replies (via thread_id), attachments (via attachment_paths, Gmail and Outlook), and all messaging platforms.",
       "category": "messaging",
       "risk": "high",
       "input_schema": {
@@ -141,7 +141,7 @@
           },
           "conversation_id": {
             "type": "string",
-            "description": "Conversation/channel ID. For Gmail new messages, use the recipient email address."
+            "description": "Conversation/channel ID. For Gmail or Outlook new messages, use the recipient email address. On Outlook, a non-email placeholder still creates a Drafts-folder draft with no To address."
           },
           "text": {
             "type": "string",
@@ -149,11 +149,11 @@
           },
           "subject": {
             "type": "string",
-            "description": "Email subject line (Gmail only)"
+            "description": "Email subject line (Gmail and Outlook)"
           },
           "in_reply_to": {
             "type": "string",
-            "description": "Message-ID header for replies (Gmail only)"
+            "description": "Message ID to reply to. Gmail: RFC 822 Message-ID header. Outlook: Graph message ID, creates a reply draft."
           },
           "attachment_paths": {
             "type": "array",

--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-send.ts
@@ -10,6 +10,12 @@ import {
   getThread,
 } from "../../../../messaging/providers/gmail/client.js";
 import { buildMultipartMime } from "../../../../messaging/providers/gmail/mime-builder.js";
+import {
+  createDraft as createOutlookDraft,
+  createReplyDraft as createOutlookReplyDraft,
+  toOutlookFileAttachments,
+} from "../../../../messaging/providers/outlook/client.js";
+import type { OutlookDraftMessage } from "../../../../messaging/providers/outlook/types.js";
 import { resolveProactiveHomeConversation } from "../../../../notifications/conversation-pairing.js";
 import { recordDeliveredChannelPost } from "../../../../notifications/delivered-post-record.js";
 import { getConversation } from "../../../../persistence/conversation-crud.js";
@@ -25,6 +31,7 @@ import {
   extractEmail,
   extractHeader,
   getProviderConnection,
+  isMailboxAddress,
   ok,
   parseAddressList,
   resolveProvider,
@@ -287,7 +294,66 @@ export async function run(
       );
     }
 
-    // Non-Gmail platforms
+    // Outlook: create a Graph draft instead of sending. Recipients are
+    // optional so a voice-composed email can land in Drafts before the user
+    // names a To address.
+    if (provider.id === "outlook") {
+      if (!conn) {
+        return err(
+          "Outlook requires an OAuth connection. Is the account connected?",
+        );
+      }
+
+      const attachments = attachmentPaths?.length
+        ? await readAttachments(attachmentPaths)
+        : undefined;
+      const graphAttachments = attachments?.length
+        ? toOutlookFileAttachments(attachments)
+        : undefined;
+      const toAddress = isMailboxAddress(conversationId)
+        ? extractEmail(conversationId)
+        : undefined;
+
+      if (inReplyTo) {
+        const draft = await createOutlookReplyDraft(
+          conn,
+          inReplyTo,
+          text,
+        );
+        const recipientSummary = toAddress ? `To: ${toAddress}` : undefined;
+        return ok(
+          formatOutlookDraftCreated({
+            draftId: draft.id,
+            webLink: draft.webLink,
+            recipientSummary,
+            attachmentCount: attachments?.length,
+            filenames: attachments?.map((a) => a.filename).join(", "),
+          }),
+        );
+      }
+
+      const draftBody: OutlookDraftMessage = {
+        subject: subject ?? "",
+        body: { contentType: "text", content: text },
+        ...(toAddress
+          ? { toRecipients: [{ emailAddress: { address: toAddress } }] }
+          : {}),
+        ...(graphAttachments ? { attachments: graphAttachments } : {}),
+      };
+      const draft = await createOutlookDraft(conn, draftBody);
+      const recipientSummary = toAddress ? `To: ${toAddress}` : undefined;
+      return ok(
+        formatOutlookDraftCreated({
+          draftId: draft.id,
+          webLink: draft.webLink,
+          recipientSummary,
+          attachmentCount: attachments?.length,
+          filenames: attachments?.map((a) => a.filename).join(", "),
+        }),
+      );
+    }
+
+    // Non-email platforms
     const attachments = attachmentPaths?.length
       ? await readAttachments(attachmentPaths)
       : undefined;
@@ -315,4 +381,22 @@ export async function run(
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }
+}
+
+function formatOutlookDraftCreated(opts: {
+  draftId: string;
+  webLink?: string;
+  recipientSummary?: string;
+  attachmentCount?: number;
+  filenames?: string;
+}): string {
+  const attachmentBit =
+    opts.attachmentCount && opts.filenames
+      ? ` with ${opts.attachmentCount} attachment(s): ${opts.filenames}`
+      : "";
+  const recipientBit = opts.recipientSummary
+    ? ` ${opts.recipientSummary}.`
+    : " No recipient set. Open the draft in Outlook to add one.";
+  const linkBit = opts.webLink ? ` Open it: ${opts.webLink}` : "";
+  return `Outlook draft created${attachmentBit} (Draft ID: ${opts.draftId}).${recipientBit}${linkBit} Review it in your Outlook Drafts, then tell me to send it or send it yourself from Outlook.`;
 }

--- a/assistant/src/config/bundled-skills/messaging/tools/shared.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/shared.ts
@@ -106,6 +106,12 @@ export function extractEmail(address: string): string {
     .toLowerCase();
 }
 
+/** True when `value` contains a usable mailbox (has `@`, no spaces). */
+export function isMailboxAddress(value: string): boolean {
+  const email = extractEmail(value);
+  return email.includes("@") && !email.includes(" ");
+}
+
 /**
  * Resolve the messaging provider from user input.
  * If platform is specified, look it up directly.

--- a/assistant/src/messaging/providers/outlook/adapter.ts
+++ b/assistant/src/messaging/providers/outlook/adapter.ts
@@ -19,18 +19,7 @@ import type {
   SendResult,
 } from "../../provider-types.js";
 import * as outlook from "./client.js";
-import type { OutlookMessage, OutlookSendFileAttachment } from "./types.js";
-
-function toGraphAttachments(
-  attachments: NonNullable<SendOptions["attachments"]>,
-): OutlookSendFileAttachment[] {
-  return attachments.map((att) => ({
-    "@odata.type": "#microsoft.graph.fileAttachment",
-    name: att.filename,
-    contentType: att.mimeType,
-    contentBytes: att.data.toString("base64"),
-  }));
-}
+import type { OutlookMessage } from "./types.js";
 
 function requireConnection(
   connection: OAuthConnection | undefined,
@@ -155,7 +144,7 @@ export const outlookMessagingProvider: MessagingProvider = {
   ): Promise<SendResult> {
     const conn = requireConnection(connection);
     const attachments = options?.attachments?.length
-      ? toGraphAttachments(options.attachments)
+      ? outlook.toOutlookFileAttachments(options.attachments)
       : undefined;
 
     if (options?.inReplyTo) {

--- a/assistant/src/messaging/providers/outlook/client.ts
+++ b/assistant/src/messaging/providers/outlook/client.ts
@@ -286,6 +286,18 @@ export async function markMessageRead(
   );
 }
 
+/** Map in-memory file parts to Graph fileAttachment objects. */
+export function toOutlookFileAttachments(
+  attachments: Array<{ filename: string; mimeType: string; data: Buffer }>,
+): OutlookSendFileAttachment[] {
+  return attachments.map((att) => ({
+    "@odata.type": "#microsoft.graph.fileAttachment",
+    name: att.filename,
+    contentType: att.mimeType,
+    contentBytes: att.data.toString("base64"),
+  }));
+}
+
 /** Create a draft message in the user's Drafts folder. */
 export async function createDraft(
   connection: OAuthConnection,
@@ -293,7 +305,7 @@ export async function createDraft(
 ): Promise<OutlookMessage> {
   return request<OutlookMessage>(connection, "/v1.0/me/messages", {
     method: "POST",
-    body: JSON.stringify(draft),
+    body: JSON.stringify({ ...draft, isDraft: true }),
   });
 }
 

--- a/assistant/src/messaging/providers/outlook/types.ts
+++ b/assistant/src/messaging/providers/outlook/types.ts
@@ -53,6 +53,7 @@ export interface OutlookMessage {
     flagStatus: "notFlagged" | "flagged" | "complete";
   };
   internetMessageHeaders?: OutlookInternetMessageHeader[];
+  webLink?: string;
 }
 
 /** Outlook mail folder */
@@ -98,6 +99,8 @@ export interface OutlookDraftMessage {
   toRecipients?: OutlookRecipient[];
   ccRecipients?: OutlookRecipient[];
   bccRecipients?: OutlookRecipient[];
+  isDraft?: boolean;
+  attachments?: OutlookSendFileAttachment[];
 }
 
 /** Forward message payload (Graph API's /createForward returns a draft) */

--- a/clients/docs/src/app/docs/_components/skills-reference-messaging-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-messaging-content.tsx
@@ -149,7 +149,8 @@ Each platform is connected independently via OAuth (Slack, Gmail) or bot token
             </li>
             <li>
               <strong>Sending messages:</strong> Your assistant will confirm before sending messages
-              on your behalf. If you want it to send without asking, set that preference explicitly.
+              on your behalf. Gmail and Outlook compose into a mailbox draft first so you can review
+              before anything is sent. If you want it to send without asking, set that preference explicitly.
             </li>
             <li>
               <strong>Context awareness:</strong> Your assistant remembers which channels and contacts

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -35,7 +35,7 @@
     },
     "messaging": {
       "docsSlug": "messaging",
-      "sha256": "c6f265b9d8bdef9d84b5b5cef3ca19b5cf0a1f270fd64bf4b0f94d9172d23657"
+      "sha256": "5d28d9fdc04113382c9428fcdd61eb25a9b5c12a49a474b5b851cf31ff9fd873"
     },
     "phone-calls": {
       "docsSlug": "phone-calls",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -715,7 +715,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T18:19:51.000Z"
+      "updatedAt": "2026-09-07T16:38:32.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -1165,7 +1165,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-06T03:18:24.000Z"
+      "updatedAt": "2026-09-06T10:00:02.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -38,8 +38,9 @@ All operations use CLI scripts that return JSON:
 ### Email Operations
 
 ```bash
-# Draft an email
+# Draft an email (--to is optional; omit it to create a draft with no recipient)
 bun run scripts/outlook-email.ts draft --to "user@example.com" --subject "Hello" --body "Message body"
+bun run scripts/outlook-email.ts draft --subject "Hello" --body "Message body"
 
 # Send an existing draft (REQUIRES user confirmation before execution)
 bun run scripts/outlook-email.ts send-draft --draft-id "AAMk..."
@@ -123,13 +124,15 @@ If the user has not explicitly confirmed, do not execute these operations. A gen
 
 ## Drafting vs Sending (Outlook)
 
-Outlook uses a **draft-first workflow** where appropriate:
+Outlook uses a **draft-first workflow**, matching Gmail. Compose and reply land in the user's Outlook Drafts folder. Nothing is sent until they confirm.
 
-- The messaging skill's send operation sends messages directly via the Graph API.
-- The `draft` operation creates a draft in the Outlook Drafts folder for user review before sending.
+- Prefer `messaging_send` with `platform: "outlook"`. That creates a real Outlook draft (not a local file). Recipients are optional: if the user has not named a To address, pass a non-email `conversation_id` (for example `drafts`) and still create the draft.
+- `bun run scripts/outlook-email.ts draft` does the same via Graph. `--to` is optional.
+- Do not inspect this skill's scripts before creating a draft. Call `messaging_send` or run the draft command immediately.
+- Do not tell the user a draft exists until the tool or script returns success with a `draftId`. If creation fails or is interrupted, say so and offer the email copy in chat (clipboard or an in-app notification if they ask).
 - The `forward` operation creates a forward draft, preserving attachments.
 
-When the user asks to "draft" or "compose" an email, use the draft script. When they say "send", use the messaging skill's send. If ambiguous, prefer drafting so the user can review first.
+**To actually send:** use `bun run scripts/outlook-email.ts send-draft` with the draft ID after the user has reviewed it. Only run send-draft when the user explicitly says "send it" or equivalent.
 
 ## Differences from Gmail
 

--- a/skills/outlook/scripts/outlook-email.ts
+++ b/skills/outlook/scripts/outlook-email.ts
@@ -106,10 +106,10 @@ async function draft(argv: string[]): Promise<void> {
   const args = parseArgs(argv);
 
   if (args["help"]) {
-    console.log(`Usage: outlook-email.ts draft --to <emails> --subject <text> --body <html>
+    console.log(`Usage: outlook-email.ts draft [--to <emails>] --subject <text> --body <html>
 
 Options:
-  --to          Comma-separated recipient emails (required)
+  --to          Comma-separated recipient emails (optional; omit to create a draft with no To)
   --subject     Email subject (required)
   --body        Email body as HTML (required)
   --cc          Comma-separated CC emails
@@ -119,7 +119,7 @@ Options:
     return;
   }
 
-  const to = requireArg(args, "to");
+  const to = optionalArg(args, "to");
   const subject = requireArg(args, "subject");
   const body = requireArg(args, "body");
   const cc = optionalArg(args, "cc");
@@ -127,7 +127,7 @@ Options:
   const inReplyTo = optionalArg(args, "in-reply-to");
   const account = optionalArg(args, "account");
 
-  const toRecipientsList = toRecipients(parseCsv(to));
+  const toRecipientsList = to ? toRecipients(parseCsv(to)) : undefined;
   const ccRecipientsList = cc ? toRecipients(parseCsv(cc)) : undefined;
   const bccRecipientsList = bcc ? toRecipients(parseCsv(bcc)) : undefined;
 
@@ -148,41 +148,65 @@ Options:
 
     const draftId = replyResponse.data.id;
 
-    // Patch the draft to update recipients (do NOT patch subject —
-    // the Graph API auto-generates "Re: ..." and we should preserve it)
+    // Patch recipients only when the caller supplied them. Do not patch
+    // subject: Graph auto-generates "Re: ..." and we should preserve it.
     const patchBody: Record<string, unknown> = {};
-    patchBody.toRecipients = toRecipientsList;
-    if (ccRecipientsList) patchBody.ccRecipients = ccRecipientsList;
-    if (bccRecipientsList) patchBody.bccRecipients = bccRecipientsList;
+    if (toRecipientsList) {
+      patchBody.toRecipients = toRecipientsList;
+    }
+    if (ccRecipientsList) {
+      patchBody.ccRecipients = ccRecipientsList;
+    }
+    if (bccRecipientsList) {
+      patchBody.bccRecipients = bccRecipientsList;
+    }
 
-    const patchResponse = await graphPatch<DraftMessageResponse>(
-      `/v1.0/me/messages/${encodeURIComponent(draftId)}`,
-      patchBody,
-      account,
-    );
-
-    if (!patchResponse.ok) {
-      printError(
-        `Failed to update reply draft: status ${patchResponse.status}`,
+    if (Object.keys(patchBody).length > 0) {
+      const patchResponse = await graphPatch<DraftMessageResponse>(
+        `/v1.0/me/messages/${encodeURIComponent(draftId)}`,
+        patchBody,
+        account,
       );
+
+      if (!patchResponse.ok) {
+        printError(
+          `Failed to update reply draft: status ${patchResponse.status}`,
+        );
+        return;
+      }
+
+      ok({
+        draftId,
+        subject: patchResponse.data.subject ?? subject,
+        webLink: patchResponse.data.webLink,
+        to: to ?? null,
+      });
       return;
     }
 
     ok({
       draftId,
-      subject: patchResponse.data.subject ?? subject,
-      webLink: patchResponse.data.webLink,
+      subject: replyResponse.data.subject ?? subject,
+      webLink: replyResponse.data.webLink,
+      to: to ?? null,
     });
   } else {
-    // Create a new draft message
+    // Create a new draft message. Recipients are optional: Graph accepts a
+    // Drafts-folder message with no To, so the user can add addresses in Outlook.
     const messageBody: Record<string, unknown> = {
       subject,
       body: { contentType: "HTML", content: body },
-      toRecipients: toRecipientsList,
       isDraft: true,
     };
-    if (ccRecipientsList) messageBody.ccRecipients = ccRecipientsList;
-    if (bccRecipientsList) messageBody.bccRecipients = bccRecipientsList;
+    if (toRecipientsList) {
+      messageBody.toRecipients = toRecipientsList;
+    }
+    if (ccRecipientsList) {
+      messageBody.ccRecipients = ccRecipientsList;
+    }
+    if (bccRecipientsList) {
+      messageBody.bccRecipients = bccRecipientsList;
+    }
 
     const response = await graphPost<DraftMessageResponse>(
       "/v1.0/me/messages",
@@ -199,6 +223,7 @@ Options:
       draftId: response.data.id,
       subject,
       webLink: response.data.webLink,
+      to: to ?? null,
     });
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Closes LUM-3548. Production feedback `01a071f7-2048-7764-8e96-7c9a0035e3fd`: the user asked to put a composed email in Outlook Drafts. The assistant said the draft existed, but Graph never ran. Two product gaps made that easy: Outlook `messaging_send` actually sent via `sendMail` (unlike Gmail, which drafts), and `--to` was required even though Graph accepts drafts with no recipients.

Fix: Outlook compose is draft-first, matching Gmail.

- `messaging_send` with `platform: "outlook"` creates a Graph draft (`POST /v1.0/me/messages`). It does not send.
- Recipients are optional. A non-email `conversation_id` (for example `drafts`) creates a Drafts-folder item with no To.
- `outlook-email.ts draft --to` is optional for the same Graph path.
- Skill docs tell the model to call `messaging_send` immediately, and not to claim success until a `draftId` returns. On failure or interrupt, say so and offer the copy.

Sending remains `outlook-email.ts send-draft` after the user confirms.

**Behavior change:** Outlook `messaging_send` used to send. After this, it drafts. `adapter.sendMessage` still sends if called directly.

## Test plan

Verified locally:

- `cd assistant && bun test src/__tests__/messaging-send-tool.test.ts` (Outlook draft without To, attachments on draft, reply draft, missing OAuth)
- `cd assistant && bun test src/__tests__/messaging-shared.test.ts`
- `cd assistant && bun test src/__tests__/outlook-messaging-provider.test.ts`
- `cd assistant && bun test src/__tests__/skill-docs-sync-guard.test.ts`
- `cd assistant && bun run typecheck:fast`
- `node scripts/skills/check-catalog.mjs` after regenerating `skills/catalog.json`

67 pass, 0 fail. Typecheck clean. Catalog check clean.

## Risk

Medium. Any caller that depended on Outlook `messaging_send` actually sending will now get a mailbox draft instead. That is intentional Gmail parity. Direct `sendMessage` / `send-draft` paths are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5dff7a8-7ce5-4011-b728-02e1a72cd086?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5dff7a8-7ce5-4011-b728-02e1a72cd086&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

