### PR TITLE
feat(memory): add custom OpenAI-compatible embedding endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5102,7 +5102,7 @@ paths:
     put:
       operationId: config_embeddings_put
       summary: Set embedding config
-      description: Change the embedding provider and optionally model.
+      description: Change the embedding provider, model, and optional custom endpoint.
       tags:
         - config
       requestBody:
@@ -5116,6 +5116,14 @@ paths:
                   type: string
                 model:
                   type: string
+                baseUrl:
+                  type: string
+                dimensions:
+                  anyOf:
+                    - type: integer
+                      exclusiveMinimum: 0
+                      maximum: 9007199254740991
+                    - type: "null"
               required:
                 - provider
       responses:
@@ -20081,6 +20089,7 @@ paths:
                               - openai
                               - gemini
                               - ollama
+                              - custom
                           - type: "null"
                       model:
                         anyOf:

--- a/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
+++ b/assistant/src/__tests__/mcp-config-secret-boundary.test.ts
@@ -82,6 +82,8 @@ mock.module("../persistence/embeddings/embedding-backend.js", () => ({
     vectors: [],
   }),
   geminiCacheExtras: () => [],
+  customCacheExtras: () => [],
+  durableEmbeddingCacheExtras: () => [],
   generateSparseEmbedding: () => ({ indices: [], values: [] }),
   getMemoryBackendStatus: async () => ({
     enabled: false,

--- a/assistant/src/__tests__/memory-config-file-parity.test.ts
+++ b/assistant/src/__tests__/memory-config-file-parity.test.ts
@@ -101,6 +101,24 @@ describe("memory config file parity", () => {
     expect(memory.embeddings.provider).toBe("openai");
   });
 
+  test("custom embedding endpoint knobs are visible and identical", () => {
+    writeConfig({
+      memory: {
+        embeddings: {
+          provider: "custom",
+          baseUrl: "http://127.0.0.1:4000/v1",
+          customModel: "text-embedding-3-small",
+          customDimensions: 1024,
+        },
+      },
+    });
+    const memory = expectParity();
+    expect(memory.embeddings.provider).toBe("custom");
+    expect(memory.embeddings.baseUrl).toBe("http://127.0.0.1:4000/v1");
+    expect(memory.embeddings.customModel).toBe("text-embedding-3-small");
+    expect(memory.embeddings.customDimensions).toBe(1024);
+  });
+
   test("cross-field invariant: segmentation overlap >= target falls back like the loader", () => {
     writeConfig({
       memory: {

--- a/assistant/src/cli/commands/config.help.ts
+++ b/assistant/src/cli/commands/config.help.ts
@@ -51,7 +51,9 @@ API Keys (agent shells refuse inline keys unless --generated is passed).
 
 Examples:
   $ assistant config set llm.defaultProvider.provider anthropic
-  $ assistant config set calls.enabled true`,
+  $ assistant config set calls.enabled true
+  $ assistant config set memory.embeddings.provider custom
+  $ assistant config set memory.embeddings.baseUrl https://gateway.example.com/v1`,
     },
     {
       name: "get",

--- a/assistant/src/cli/commands/memory/worker.ts
+++ b/assistant/src/cli/commands/memory/worker.ts
@@ -35,7 +35,7 @@ interface StopResponse {
 interface EmbeddingStatus {
   enabled: boolean;
   degraded: boolean;
-  provider: "local" | "openai" | "gemini" | "ollama" | null;
+  provider: "local" | "openai" | "gemini" | "ollama" | "custom" | null;
   model: string | null;
   reason: string | null;
 }

--- a/assistant/src/config/schemas/memory-storage.test.ts
+++ b/assistant/src/config/schemas/memory-storage.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  MemoryEmbeddingsConfigSchema,
+  VALID_MEMORY_EMBEDDING_PROVIDERS,
+} from "./memory-storage.js";
+
+describe("MemoryEmbeddingsConfigSchema", () => {
+  test("includes custom in the provider enum", () => {
+    expect(VALID_MEMORY_EMBEDDING_PROVIDERS).toContain("custom");
+  });
+
+  test("accepts a custom OpenAI-compatible endpoint", () => {
+    const parsed = MemoryEmbeddingsConfigSchema.parse({
+      provider: "custom",
+      baseUrl: "https://gateway.example.com/v1",
+      customModel: "text-embedding-3-small",
+      customDimensions: 1536,
+    });
+    expect(parsed.provider).toBe("custom");
+    expect(parsed.baseUrl).toBe("https://gateway.example.com/v1");
+    expect(parsed.customModel).toBe("text-embedding-3-small");
+    expect(parsed.customDimensions).toBe(1536);
+  });
+
+  test("defaults customModel when it is omitted", () => {
+    const parsed = MemoryEmbeddingsConfigSchema.parse({
+      provider: "custom",
+      baseUrl: "http://127.0.0.1:4000/v1",
+    });
+    expect(parsed.customModel).toBe("text-embedding-3-small");
+  });
+
+  test("rejects an unknown provider", () => {
+    expect(() =>
+      MemoryEmbeddingsConfigSchema.parse({ provider: "portkey" }),
+    ).toThrow(/must be one of/);
+  });
+});

--- a/assistant/src/config/schemas/memory-storage.ts
+++ b/assistant/src/config/schemas/memory-storage.ts
@@ -6,6 +6,7 @@ export const VALID_MEMORY_EMBEDDING_PROVIDERS = [
   "openai",
   "gemini",
   "ollama",
+  "custom",
 ] as const;
 
 const VALID_QDRANT_QUANTIZATION = ["scalar", "none"] as const;
@@ -67,6 +68,26 @@ export const MemoryEmbeddingsConfigSchema = z
       .string({ error: "memory.embeddings.ollamaModel must be a string" })
       .default("nomic-embed-text")
       .describe("Model name for the Ollama embedding provider"),
+    customModel: z
+      .string({ error: "memory.embeddings.customModel must be a string" })
+      .default("text-embedding-3-small")
+      .describe(
+        "Model name for a custom OpenAI-compatible embeddings endpoint",
+      ),
+    baseUrl: z
+      .string({ error: "memory.embeddings.baseUrl must be a string" })
+      .optional()
+      .describe(
+        "Base URL of a custom OpenAI-compatible embeddings endpoint, including the /v1 prefix (for example https://gateway.example.com/v1). Required when provider is 'custom'.",
+      ),
+    customDimensions: z
+      .number({ error: "memory.embeddings.customDimensions must be a number" })
+      .int("memory.embeddings.customDimensions must be an integer")
+      .positive("memory.embeddings.customDimensions must be a positive integer")
+      .optional()
+      .describe(
+        "Output dimensionality requested from a custom embeddings endpoint when the model supports it",
+      ),
   })
   .describe("Embedding generation configuration for semantic memory search");
 

--- a/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
+++ b/assistant/src/daemon/__tests__/embedding-reconcile.test.ts
@@ -97,6 +97,9 @@ function makeDeps(opts: {
     recreateCollectionsAtDim: mock(async () => {}),
     ensureCollections: mock(async () => {}),
     enqueueReembed: mock(() => {}),
+    customEmbeddingSpaceIdentity: mock(() => null),
+    readCustomEmbeddingSpace: mock(() => null),
+    writeCustomEmbeddingSpace: mock(() => {}),
   };
 }
 
@@ -289,6 +292,77 @@ describe("reconcileEmbeddingIdentity", () => {
     expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
   });
 
+  test("noop records a first-seen custom endpoint without re-embedding", async () => {
+    const deps = makeDeps({
+      decision: { kind: "noop" },
+      committedDim: 1536,
+      probeDim: 1536,
+    });
+    deps.customEmbeddingSpaceIdentity = mock(
+      () => "custom\0text-embedding-3-small\0url=http://127.0.0.1:4000/v1",
+    );
+
+    const outcome = await reconcileEmbeddingIdentity(
+      fakeConfig("custom"),
+      deps,
+    );
+
+    expect(outcome).toEqual({ action: "noop", dim: 1536 });
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
+    expect(deps.writeCustomEmbeddingSpace).toHaveBeenCalledWith(
+      "custom\0text-embedding-3-small\0url=http://127.0.0.1:4000/v1",
+    );
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
+  });
+
+  test("noop reembeds when the custom endpoint changes at the same dimension", async () => {
+    const deps = makeDeps({
+      decision: { kind: "noop" },
+      committedDim: 1536,
+      probeDim: 1536,
+    });
+    deps.customEmbeddingSpaceIdentity = mock(
+      () => "custom\0text-embedding-3-small\0url=http://127.0.0.1:4001/v1",
+    );
+    deps.readCustomEmbeddingSpace = mock(
+      () => "custom\0text-embedding-3-small\0url=http://127.0.0.1:4000/v1",
+    );
+
+    const outcome = await reconcileEmbeddingIdentity(
+      fakeConfig("custom"),
+      deps,
+    );
+
+    expect(outcome).toEqual({ action: "reembed-space", dim: 1536 });
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(1);
+    expect(deps.writeCustomEmbeddingSpace).toHaveBeenCalledWith(
+      "custom\0text-embedding-3-small\0url=http://127.0.0.1:4001/v1",
+    );
+    expect(deps.recreateCollectionsAtDim).toHaveBeenCalledTimes(0);
+    expect(deps.persistVectorSize).toHaveBeenCalledTimes(0);
+  });
+
+  test("noop does not reembed when the custom endpoint is unchanged", async () => {
+    const identity =
+      "custom\0text-embedding-3-small\0url=http://127.0.0.1:4000/v1";
+    const deps = makeDeps({
+      decision: { kind: "noop" },
+      committedDim: 1536,
+      probeDim: 1536,
+    });
+    deps.customEmbeddingSpaceIdentity = mock(() => identity);
+    deps.readCustomEmbeddingSpace = mock(() => identity);
+
+    const outcome = await reconcileEmbeddingIdentity(
+      fakeConfig("custom"),
+      deps,
+    );
+
+    expect(outcome).toEqual({ action: "noop", dim: 1536 });
+    expect(deps.enqueueReembed).toHaveBeenCalledTimes(0);
+    expect(deps.writeCustomEmbeddingSpace).toHaveBeenCalledTimes(0);
+  });
+
   test("passes committed + probe dims and configured provider into the decision", async () => {
     const deps = makeDeps({
       decision: { kind: "noop" },
@@ -409,6 +483,9 @@ function driveBranch(
     })),
     readConceptPageCollectionDim: mock(async () => committedDim),
     decideEmbeddingReconcile: mock(() => decision),
+    customEmbeddingSpaceIdentity: mock(() => null),
+    readCustomEmbeddingSpace: mock(() => null),
+    writeCustomEmbeddingSpace: mock(() => {}),
   };
 }
 

--- a/assistant/src/daemon/__tests__/lifecycle-embedding-reconcile.test.ts
+++ b/assistant/src/daemon/__tests__/lifecycle-embedding-reconcile.test.ts
@@ -56,6 +56,9 @@ function throwingDeps(): ReconcileDeps {
     }),
     ensureCollections: mock(async () => {}),
     enqueueReembed: mock(() => {}),
+    customEmbeddingSpaceIdentity: mock(() => null),
+    readCustomEmbeddingSpace: mock(() => null),
+    writeCustomEmbeddingSpace: mock(() => {}),
   };
 }
 

--- a/assistant/src/daemon/embedding-reconcile.ts
+++ b/assistant/src/daemon/embedding-reconcile.ts
@@ -26,6 +26,15 @@ import {
 } from "../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../config/types.js";
 import {
+  deleteMemoryCheckpoint,
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../persistence/checkpoints.js";
+import {
+  CUSTOM_EMBEDDING_SPACE_CHECKPOINT,
+  customEmbeddingSpaceIdentity,
+} from "../persistence/embeddings/embedding-backend.js";
+import {
   probeBackendDimension,
   readConceptPageCollectionDim,
 } from "../persistence/embeddings/embedding-identity.js";
@@ -50,6 +59,7 @@ export type ReconcileOutcome =
   | { action: "noop"; dim: number | null }
   | { action: "commit-fresh"; dim: number }
   | { action: "migrate"; fromDim: number; toDim: number }
+  | { action: "reembed-space"; dim: number }
   | { action: "defer-degraded"; reason: string };
 
 /**
@@ -72,6 +82,12 @@ export interface ReconcileDeps {
   ensureCollections: (dim: number) => Promise<void>;
   /** Enqueue the reembed jobs that repopulate the (re)created collections. */
   enqueueReembed: () => void;
+  /** Identity of the configured custom embeddings endpoint, or null. */
+  customEmbeddingSpaceIdentity: (config: AssistantConfig) => string | null;
+  /** Last custom embedding space recorded for the populated collections. */
+  readCustomEmbeddingSpace: () => string | null;
+  /** Persist (or clear) the custom embedding space identity. */
+  writeCustomEmbeddingSpace: (identity: string | null) => void;
 }
 
 /**
@@ -201,7 +217,36 @@ export function defaultDeps(config: AssistantConfig): ReconcileDeps {
       }
     },
     enqueueReembed: () => defaultEnqueueReembed(config),
+    customEmbeddingSpaceIdentity,
+    readCustomEmbeddingSpace: () =>
+      getMemoryCheckpoint(CUSTOM_EMBEDDING_SPACE_CHECKPOINT),
+    writeCustomEmbeddingSpace: (identity) => {
+      if (identity == null) {
+        deleteMemoryCheckpoint(CUSTOM_EMBEDDING_SPACE_CHECKPOINT);
+      } else {
+        setMemoryCheckpoint(CUSTOM_EMBEDDING_SPACE_CHECKPOINT, identity);
+      }
+    },
   };
+}
+
+function syncCustomEmbeddingSpace(
+  config: AssistantConfig,
+  deps: ReconcileDeps,
+  opts: { reembedOnChange: boolean },
+): "unchanged" | "recorded" | "reembed" {
+  const current = deps.customEmbeddingSpaceIdentity(config);
+  const stored = deps.readCustomEmbeddingSpace();
+  if (current === stored) {
+    return "unchanged";
+  }
+  if (opts.reembedOnChange && current != null && stored != null) {
+    deps.enqueueReembed();
+    deps.writeCustomEmbeddingSpace(current);
+    return "reembed";
+  }
+  deps.writeCustomEmbeddingSpace(current);
+  return "recorded";
 }
 
 /**
@@ -211,12 +256,18 @@ export function defaultDeps(config: AssistantConfig): ReconcileDeps {
  *  - `noop` — committed dimension already matches (or auto-mode declines to
  *    thrash); no writes, no destructive calls. Also returned immediately when
  *    `memory.enabled === false`, before any probe/read/persist/enqueue.
+ *    When the custom embeddings endpoint identity changed at the same
+ *    dimension, this becomes `reembed-space` instead: enqueue a reembed
+ *    without recreating collections.
  *  - `commit-fresh` — fresh install adopts the reachable backend's dimension:
  *    commit the dim, ensure the collections EXIST at it (create-if-absent, never
  *    destroy), and enqueue a reembed.
  *  - `migrate` — deliberate provider intent with a confirmed probe: commit the
  *    new dim, then destroy + recreate the collections (the only destructive
  *    path) and enqueue a reembed.
+ *  - `reembed-space`: committed dimension already matches, but the custom
+ *    embeddings endpoint (base URL / model / requested dimensions) changed.
+ *    Enqueue a reembed so query and document vectors stay in one space.
  *  - `defer-degraded` — backend unreachable, OR the committed dimension could
  *    not be read (Qdrant unreachable / existing collection unreadable): no
  *    write, no destructive call; warn and leave the collections untouched.
@@ -284,14 +335,25 @@ export async function reconcileEmbeddingIdentity(
   });
 
   switch (action.kind) {
-    case "noop":
+    case "noop": {
+      const spaceOutcome = syncCustomEmbeddingSpace(config, deps, {
+        reembedOnChange: true,
+      });
+      if (spaceOutcome === "reembed" && committedDim != null) {
+        log.info(
+          "Custom embedding endpoint changed at the committed dimension; enqueued reembed",
+        );
+        return { action: "reembed-space", dim: committedDim };
+      }
       return { action: "noop", dim: committedDim };
+    }
 
     case "commit-fresh": {
       deps.setInMemoryVectorSize(action.dim);
       deps.persistVectorSize(action.dim);
       await deps.ensureCollections(action.dim);
       deps.enqueueReembed();
+      syncCustomEmbeddingSpace(config, deps, { reembedOnChange: false });
       log.info(
         { dim: action.dim },
         "Committed fresh embedding dimension and ensured collections",
@@ -324,6 +386,7 @@ export async function reconcileEmbeddingIdentity(
         throw err;
       }
       deps.enqueueReembed();
+      syncCustomEmbeddingSpace(config, deps, { reembedOnChange: false });
       log.warn(
         { fromDim: action.fromDim, toDim: action.toDim },
         "Migrated embedding dimension: recreated collections and enqueued reembed",

--- a/assistant/src/daemon/handlers/config-embeddings.ts
+++ b/assistant/src/daemon/handlers/config-embeddings.ts
@@ -50,6 +50,12 @@ const EMBEDDING_PROVIDER_CATALOG = [
     defaultModel: "nomic-embed-text",
     requiresKey: false,
   },
+  {
+    id: "custom",
+    displayName: "Custom (OpenAI-compatible)",
+    defaultModel: "text-embedding-3-small",
+    requiresKey: false,
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -61,6 +67,7 @@ const PROVIDER_MODEL_FIELD: Record<string, string> = {
   openai: "openaiModel",
   gemini: "geminiModel",
   ollama: "ollamaModel",
+  custom: "customModel",
 };
 
 // ---------------------------------------------------------------------------
@@ -70,6 +77,8 @@ const PROVIDER_MODEL_FIELD: Record<string, string> = {
 export async function getEmbeddingConfigInfo(): Promise<{
   provider: string;
   model: string | null;
+  baseUrl: string | null;
+  dimensions: number | null;
   activeProvider: string | null;
   activeModel: string | null;
   availableProviders: typeof EMBEDDING_PROVIDER_CATALOG;
@@ -88,6 +97,8 @@ export async function getEmbeddingConfigInfo(): Promise<{
   return {
     provider: embeddingConfig.provider,
     model: typeof model === "string" ? model : null,
+    baseUrl: embeddingConfig.baseUrl ?? null,
+    dimensions: embeddingConfig.customDimensions ?? null,
     activeProvider: backendStatus.provider,
     activeModel: backendStatus.model,
     availableProviders: EMBEDDING_PROVIDER_CATALOG,
@@ -107,6 +118,10 @@ export async function setEmbeddingConfig(
   provider: string,
   model: string | undefined,
   ctx: ModelSetContext,
+  extras?: {
+    baseUrl?: string;
+    dimensions?: number | null;
+  },
 ): Promise<ReturnType<typeof getEmbeddingConfigInfo>> {
   const validProviders = new Set<string>(VALID_MEMORY_EMBEDDING_PROVIDERS);
   if (!validProviders.has(provider)) {
@@ -127,6 +142,22 @@ export async function setEmbeddingConfig(
       } else {
         setMemoryEmbeddingField(raw, fieldName, model);
       }
+    }
+  }
+
+  if (extras?.baseUrl !== undefined) {
+    if (extras.baseUrl === "") {
+      deleteMemoryEmbeddingField(raw, "baseUrl");
+    } else {
+      setMemoryEmbeddingField(raw, "baseUrl", extras.baseUrl);
+    }
+  }
+
+  if (extras?.dimensions !== undefined) {
+    if (extras.dimensions === null) {
+      deleteMemoryEmbeddingField(raw, "customDimensions");
+    } else {
+      setMemoryEmbeddingField(raw, "customDimensions", extras.dimensions);
     }
   }
 

--- a/assistant/src/persistence/embeddings/embedding-backend.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AssistantConfig } from "../../config/types.js";
 import {
   clearEmbeddingBackendCache,
+  customEmbeddingSpaceIdentity,
   embedWithBackend,
   isEmbeddingDimensionAvailable,
   resetLocalEmbeddingFailureState,
@@ -494,5 +495,31 @@ describe("custom OpenAI-compatible embedding backend selection", () => {
 
     expect(await resolveBackendDimension(first)).toBe(1536);
     expect(await resolveBackendDimension(second)).toBe(1024);
+  });
+
+  test("customEmbeddingSpaceIdentity includes model, url, and dimensions", () => {
+    expect(
+      customEmbeddingSpaceIdentity(
+        customConfig({
+          baseUrl: "http://127.0.0.1:4000/v1/",
+          customModel: "embed-mistral",
+          customDimensions: 1024,
+        }),
+      ),
+    ).toBe("custom\0embed-mistral\0url=http://127.0.0.1:4000/v1\0dim=1024");
+  });
+
+  test("customEmbeddingSpaceIdentity is null when the provider is not custom", () => {
+    expect(
+      customEmbeddingSpaceIdentity({
+        memory: {
+          embeddings: {
+            provider: "openai",
+            openaiModel: "text-embedding-3-small",
+            baseUrl: "http://127.0.0.1:4000/v1",
+          },
+        },
+      } as unknown as AssistantConfig),
+    ).toBeNull();
   });
 });

--- a/assistant/src/persistence/embeddings/embedding-backend.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.test.ts
@@ -6,12 +6,14 @@ import {
   embedWithBackend,
   isEmbeddingDimensionAvailable,
   resetLocalEmbeddingFailureState,
+  resolveBackendDimension,
   selectEmbeddingBackend,
 } from "./embedding-backend.js";
 import {
   _resetEmbeddingBillingBreaker,
   recordBillingBlock,
 } from "./embedding-billing-breaker.js";
+import { OpenAIEmbeddingBackend } from "./embedding-openai.js";
 
 const getProviderKeyAsyncMock = mock(
   async (_provider: string): Promise<string | undefined> => undefined,
@@ -359,5 +361,138 @@ describe("managed-proxy Gemini fallback to direct key", () => {
     const [directUrl] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(directUrl).toContain("generativelanguage.googleapis.com");
     expect(directUrl).toContain("key=direct-key");
+  });
+});
+
+function customConfig(overrides: {
+  baseUrl?: string;
+  customModel?: string;
+  customDimensions?: number;
+}): AssistantConfig {
+  return {
+    memory: {
+      embeddings: {
+        provider: "custom",
+        customModel: overrides.customModel ?? "text-embedding-3-small",
+        baseUrl: overrides.baseUrl,
+        customDimensions: overrides.customDimensions,
+      },
+    },
+  } as unknown as AssistantConfig;
+}
+
+describe("custom OpenAI-compatible embedding backend selection", () => {
+  afterEach(() => {
+    clearEmbeddingBackendCache();
+    getProviderKeyAsyncMock.mockReset();
+    getProviderKeyAsyncMock.mockImplementation(async () => undefined);
+  });
+
+  test("selects a custom backend with a trimmed baseUrl", async () => {
+    getProviderKeyAsyncMock.mockImplementation(async (provider) =>
+      provider === "custom" ? "gw-key" : undefined,
+    );
+    const { backend, reason } = await selectEmbeddingBackend(
+      customConfig({
+        baseUrl: "http://127.0.0.1:4000/v1/",
+        customModel: "embed-mistral",
+        customDimensions: 1024,
+      }),
+    );
+    expect(reason).toBeNull();
+    expect(backend).toBeInstanceOf(OpenAIEmbeddingBackend);
+    expect(backend?.provider).toBe("custom");
+    expect(backend?.model).toBe("embed-mistral");
+    expect((backend as OpenAIEmbeddingBackend).baseURL).toBe(
+      "http://127.0.0.1:4000/v1",
+    );
+    expect((backend as OpenAIEmbeddingBackend).dimensions).toBe(1024);
+  });
+
+  test("selects a custom backend without an API key", async () => {
+    const { backend, reason } = await selectEmbeddingBackend(
+      customConfig({ baseUrl: "http://127.0.0.1:1234/v1" }),
+    );
+    expect(reason).toBeNull();
+    expect(backend?.provider).toBe("custom");
+  });
+
+  test("is not configured when baseUrl is missing", async () => {
+    const { backend, reason } = await selectEmbeddingBackend(customConfig({}));
+    expect(backend).toBeNull();
+    expect(reason).toMatch(/baseUrl/);
+  });
+
+  test("is not configured when baseUrl is not http(s)", async () => {
+    const { backend, reason } = await selectEmbeddingBackend(
+      customConfig({ baseUrl: "not-a-url" }),
+    );
+    expect(backend).toBeNull();
+    expect(reason).toMatch(/baseUrl/);
+  });
+
+  test("is not selected by auto even when baseUrl is set", async () => {
+    const { backend } = await selectEmbeddingBackend({
+      memory: {
+        embeddings: {
+          provider: "auto",
+          localModel: "BAAI/bge-small-en-v1.5",
+          baseUrl: "http://127.0.0.1:4000/v1",
+          customModel: "embed-mistral",
+        },
+      },
+    } as unknown as AssistantConfig);
+    expect(backend?.provider).toBe("local");
+  });
+
+  test("caches custom backends by baseUrl", async () => {
+    const first = await selectEmbeddingBackend(
+      customConfig({ baseUrl: "http://127.0.0.1:4000/v1" }),
+    );
+    const second = await selectEmbeddingBackend(
+      customConfig({ baseUrl: "http://127.0.0.1:4001/v1" }),
+    );
+    const firstAgain = await selectEmbeddingBackend(
+      customConfig({ baseUrl: "http://127.0.0.1:4000/v1" }),
+    );
+    expect(first.backend).not.toBe(second.backend);
+    expect(firstAgain.backend).toBe(first.backend);
+  });
+
+  test("caches custom backends by requested dimensions", async () => {
+    const first = await selectEmbeddingBackend(
+      customConfig({
+        baseUrl: "http://127.0.0.1:4000/v1",
+        customDimensions: 1024,
+      }),
+    );
+    const second = await selectEmbeddingBackend(
+      customConfig({
+        baseUrl: "http://127.0.0.1:4000/v1",
+        customDimensions: 1536,
+      }),
+    );
+    expect(first.backend).not.toBe(second.backend);
+  });
+
+  test("dimension probes for custom backends are keyed by baseUrl", async () => {
+    const { backend: first } = await selectEmbeddingBackend(
+      customConfig({ baseUrl: "http://127.0.0.1:4000/v1" }),
+    );
+    const { backend: second } = await selectEmbeddingBackend(
+      customConfig({ baseUrl: "http://127.0.0.1:4001/v1" }),
+    );
+    if (!first || !second) {
+      throw new Error("expected custom backends");
+    }
+    (first as { embed: typeof first.embed }).embed = mock(async () => [
+      new Array(1536).fill(0),
+    ]) as unknown as typeof first.embed;
+    (second as { embed: typeof second.embed }).embed = mock(async () => [
+      new Array(1024).fill(0),
+    ]) as unknown as typeof second.embed;
+
+    expect(await resolveBackendDimension(first)).toBe(1536);
+    expect(await resolveBackendDimension(second)).toBe(1024);
   });
 });

--- a/assistant/src/persistence/embeddings/embedding-backend.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.ts
@@ -17,7 +17,10 @@ import {
 } from "./embedding-billing-breaker.js";
 import { GeminiEmbeddingBackend } from "./embedding-gemini.js";
 import { OllamaEmbeddingBackend } from "./embedding-ollama.js";
-import { OpenAIEmbeddingBackend } from "./embedding-openai.js";
+import {
+  OpenAIEmbeddingBackend,
+  resolveOpenAICompatibleBaseUrl,
+} from "./embedding-openai.js";
 import { EmbeddingRuntimeManager } from "./embedding-runtime-manager.js";
 import {
   EMBEDDING_DIMENSION_PROBE_TEXT,
@@ -428,6 +431,25 @@ export function geminiCacheExtras(config: AssistantConfig): string[] {
   return extras;
 }
 
+/**
+ * Cache-key fragments for a custom OpenAI-compatible embeddings endpoint.
+ * Base URL and requested output dimensionality both change the vectors a
+ * given model returns, so they belong in the in-memory backend identity.
+ */
+export function customCacheExtras(config: AssistantConfig): string[] {
+  const extras: string[] = [];
+  const baseUrl = resolveOpenAICompatibleBaseUrl(
+    config.memory.embeddings.baseUrl,
+  );
+  if (baseUrl) {
+    extras.push(`url=${baseUrl}`);
+  }
+  if (config.memory.embeddings.customDimensions != null) {
+    extras.push(`dim=${config.memory.embeddings.customDimensions}`);
+  }
+  return extras;
+}
+
 /** Build (or reuse) the direct-API Gemini backend for the given key. */
 function getDirectGeminiBackend(
   config: AssistantConfig,
@@ -446,6 +468,29 @@ function getDirectGeminiBackend(
         },
       ),
     geminiCacheExtras(config),
+  );
+}
+
+/** Build (or reuse) a custom OpenAI-compatible embeddings backend. */
+function getCustomEmbeddingBackend(
+  config: AssistantConfig,
+  baseUrl: string,
+  apiKey: string | undefined,
+): EmbeddingBackend {
+  return getCachedOrCreate(
+    "custom",
+    config.memory.embeddings.customModel,
+    () =>
+      new OpenAIEmbeddingBackend(
+        apiKey ?? "",
+        config.memory.embeddings.customModel,
+        {
+          provider: "custom",
+          baseURL: baseUrl,
+          dimensions: config.memory.embeddings.customDimensions,
+        },
+      ),
+    customCacheExtras(config),
   );
 }
 
@@ -514,6 +559,23 @@ export async function selectEmbeddingBackend(
             apiKey: ollamaKey,
           }),
       ),
+      reason: null,
+    };
+  }
+  if (requested === "custom") {
+    const baseUrl = resolveOpenAICompatibleBaseUrl(
+      config.memory.embeddings.baseUrl,
+    );
+    if (!baseUrl) {
+      return {
+        backend: null,
+        reason:
+          'Embedding backend "custom" requires memory.embeddings.baseUrl to be an http(s) URL',
+      };
+    }
+    const customKey = (await getProviderKeyAsync("custom")) ?? undefined;
+    return {
+      backend: getCustomEmbeddingBackend(config, baseUrl, customKey),
       reason: null,
     };
   }
@@ -620,6 +682,9 @@ export async function selectEmbeddingBackend(
           reason: null,
         };
       }
+      case "custom":
+        // Custom is explicit-only and is handled before the auto chain.
+        continue;
     }
   }
 
@@ -666,13 +731,29 @@ export async function getMemoryBackendStatus(config: AssistantConfig): Promise<{
 }
 
 /**
- * Memoized output dimension per "provider:model". A backend's vector dimension
- * is fixed for the life of a (provider, model) pair, so a single probe answers
- * every subsequent {@link isEmbeddingDimensionAvailable} call without another
- * backend round-trip. Cleared alongside the backend cache so a credential
- * change or explicit reset re-probes the (possibly different) backend.
+ * Memoized output dimension per backend identity. A backend's vector
+ * dimension is fixed for the life of that identity (provider, model, and for
+ * custom OpenAI-compatible endpoints the base URL and requested dimensions),
+ * so a single probe answers every subsequent
+ * {@link isEmbeddingDimensionAvailable} call without another backend
+ * round-trip. Cleared alongside the backend cache so a credential change or
+ * explicit reset re-probes the (possibly different) backend.
  */
 const backendDimCache = new Map<string, number>();
+
+function backendDimCacheKey(backend: EmbeddingBackend): string {
+  if (backend instanceof OpenAIEmbeddingBackend) {
+    const extras: string[] = [];
+    if (backend.baseURL) {
+      extras.push(`url=${backend.baseURL}`);
+    }
+    if (backend.dimensions != null) {
+      extras.push(`dim=${backend.dimensions}`);
+    }
+    return cacheKey(backend.provider, backend.model, extras);
+  }
+  return `${backend.provider}:${backend.model}`;
+}
 
 /**
  * Whether the currently-reachable embedding backend can produce vectors of the
@@ -692,7 +773,7 @@ const backendDimCache = new Map<string, number>();
  *
  * The selected backend's output dimension is not statically known from
  * provider/model alone, so it is measured with a fixed-string probe and
- * memoized per (provider, model) — steady-state calls resolve from
+ * memoized per backend identity — steady-state calls resolve from
  * {@link backendDimCache} without a backend round-trip.
  */
 export async function isEmbeddingDimensionAvailable(
@@ -713,7 +794,7 @@ export async function isEmbeddingDimensionAvailable(
   // assembler, so this preflight can never be more pessimistic than the real
   // embed path. Dense recall stays available if ANY backend in the chain
   // produces the committed dimension. `resolveBackendDimension` memoizes per
-  // provider:model, so each backend is probed at most once.
+  // backend identity, so each backend is probed at most once.
   const expected = config.memory.qdrant.vectorSize;
   for (const candidate of await assembleEmbeddingBackends(config, backend)) {
     if ((await resolveBackendDimension(candidate)) === expected) {
@@ -736,7 +817,7 @@ export async function isEmbeddingDimensionAvailable(
 export async function resolveBackendDimension(
   backend: EmbeddingBackend,
 ): Promise<number | null> {
-  const key = `${backend.provider}:${backend.model}`;
+  const key = backendDimCacheKey(backend);
   const cached = backendDimCache.get(key);
   if (cached != null) {
     return cached;
@@ -849,7 +930,11 @@ export async function embedWithBackend(
 
   // ── Compute provider-specific vector cache extras ───────────────
   const vectorExtras =
-    primaryProvider === "gemini" ? geminiCacheExtras(config) : undefined;
+    primaryProvider === "gemini"
+      ? geminiCacheExtras(config)
+      : primaryProvider === "custom"
+        ? customCacheExtras(config)
+        : undefined;
 
   // ── In-memory cache check (primary provider only) ──────────────
   const cached: (number[] | null)[] = inputs.map((input) => {
@@ -918,7 +1003,11 @@ export async function embedWithBackend(
 
       // Populate cache with freshly embedded vectors
       const backendExtras =
-        backend.provider === "gemini" ? geminiCacheExtras(config) : undefined;
+        backend.provider === "gemini"
+          ? geminiCacheExtras(config)
+          : backend.provider === "custom"
+            ? customCacheExtras(config)
+            : undefined;
       for (let i = 0; i < inputsToEmbed.length; i++) {
         putInVectorCache(
           backend.provider,
@@ -1060,6 +1149,9 @@ async function selectFallbackBackends(
         }
         break;
       }
+      case "custom":
+      case "local":
+        break;
     }
   }
   return backends;

--- a/assistant/src/persistence/embeddings/embedding-backend.ts
+++ b/assistant/src/persistence/embeddings/embedding-backend.ts
@@ -434,7 +434,8 @@ export function geminiCacheExtras(config: AssistantConfig): string[] {
 /**
  * Cache-key fragments for a custom OpenAI-compatible embeddings endpoint.
  * Base URL and requested output dimensionality both change the vectors a
- * given model returns, so they belong in the in-memory backend identity.
+ * given model returns, so they belong in backend, in-memory, and durable
+ * cache identity.
  */
 export function customCacheExtras(config: AssistantConfig): string[] {
   const extras: string[] = [];
@@ -448,6 +449,50 @@ export function customCacheExtras(config: AssistantConfig): string[] {
     extras.push(`dim=${config.memory.embeddings.customDimensions}`);
   }
   return extras;
+}
+
+/**
+ * Provider extras that belong in durable `memory_embeddings` identity.
+ * Gemini task type / dimensions and custom endpoint URL / dimensions both
+ * change the vector for identical text, so cache readers must fold them in.
+ */
+export function durableEmbeddingCacheExtras(
+  config: AssistantConfig,
+  provider: string | null,
+): string[] {
+  if (provider === "gemini") {
+    return geminiCacheExtras(config);
+  }
+  if (provider === "custom") {
+    return customCacheExtras(config);
+  }
+  return [];
+}
+
+/**
+ * Checkpoint key for the custom embedding space last used to populate
+ * Qdrant. Compared at reconcile time so a same-dimension endpoint change
+ * still enqueues a reembed instead of mixing vector spaces.
+ */
+export const CUSTOM_EMBEDDING_SPACE_CHECKPOINT =
+  "memory:custom_embedding_space";
+
+/**
+ * Stable identity of the configured custom embeddings endpoint. Null when
+ * the provider is not `custom`. Includes model, normalized base URL, and
+ * requested dimensions.
+ */
+export function customEmbeddingSpaceIdentity(
+  config: AssistantConfig,
+): string | null {
+  if (config.memory.embeddings.provider !== "custom") {
+    return null;
+  }
+  return [
+    "custom",
+    config.memory.embeddings.customModel,
+    ...customCacheExtras(config),
+  ].join("\0");
 }
 
 /** Build (or reuse) the direct-API Gemini backend for the given key. */

--- a/assistant/src/persistence/embeddings/embedding-openai.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-openai.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const createMock = mock(async (_body: unknown, _opts?: unknown) => ({
+  data: [{ embedding: [0.1, 0.2, 0.3] }],
+}));
+
+let lastCtorArgs: { apiKey?: string; baseURL?: string } | undefined;
+
+mock.module("openai", () => ({
+  default: class OpenAI {
+    embeddings = { create: createMock };
+    constructor(opts: { apiKey: string; baseURL?: string }) {
+      lastCtorArgs = opts;
+    }
+  },
+}));
+
+import {
+  OpenAIEmbeddingBackend,
+  resolveOpenAICompatibleBaseUrl,
+} from "./embedding-openai.js";
+
+describe("resolveOpenAICompatibleBaseUrl", () => {
+  test("trims and strips a trailing slash", () => {
+    expect(
+      resolveOpenAICompatibleBaseUrl(" https://gateway.example.com/v1/ "),
+    ).toBe("https://gateway.example.com/v1");
+  });
+
+  test("accepts http localhost URLs", () => {
+    expect(resolveOpenAICompatibleBaseUrl("http://127.0.0.1:4000/v1")).toBe(
+      "http://127.0.0.1:4000/v1",
+    );
+  });
+
+  test("rejects empty, non-http, and invalid values", () => {
+    expect(resolveOpenAICompatibleBaseUrl(undefined)).toBeNull();
+    expect(resolveOpenAICompatibleBaseUrl("")).toBeNull();
+    expect(resolveOpenAICompatibleBaseUrl("   ")).toBeNull();
+    expect(resolveOpenAICompatibleBaseUrl("not-a-url")).toBeNull();
+    expect(resolveOpenAICompatibleBaseUrl("ftp://gateway.example.com/v1")).toBe(
+      null,
+    );
+  });
+});
+
+describe("OpenAIEmbeddingBackend", () => {
+  beforeEach(() => {
+    createMock.mockClear();
+    lastCtorArgs = undefined;
+  });
+
+  afterEach(() => {
+    createMock.mockClear();
+  });
+
+  test("constructs the official OpenAI client without a baseURL", () => {
+    const backend = new OpenAIEmbeddingBackend(
+      "sk-test",
+      "text-embedding-3-small",
+    );
+    expect(backend.provider).toBe("openai");
+    expect(lastCtorArgs).toEqual({ apiKey: "sk-test" });
+  });
+
+  test("routes custom embeddings through the supplied baseURL", async () => {
+    const backend = new OpenAIEmbeddingBackend("gw-key", "embed-mistral", {
+      provider: "custom",
+      baseURL: "http://127.0.0.1:4000/v1",
+      dimensions: 1024,
+    });
+    expect(backend.provider).toBe("custom");
+    expect(backend.baseURL).toBe("http://127.0.0.1:4000/v1");
+    expect(lastCtorArgs).toEqual({
+      apiKey: "gw-key",
+      baseURL: "http://127.0.0.1:4000/v1",
+    });
+
+    const vectors = await backend.embed(["hello"]);
+    expect(vectors).toEqual([[0.1, 0.2, 0.3]]);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    const [body] = createMock.mock.calls[0] as [
+      {
+        model: string;
+        input: string[];
+        encoding_format: string;
+        dimensions?: number;
+      },
+    ];
+    expect(body.model).toBe("embed-mistral");
+    expect(body.input).toEqual(["hello"]);
+    expect(body.encoding_format).toBe("float");
+    expect(body.dimensions).toBe(1024);
+  });
+
+  test("uses a placeholder API key when the custom endpoint is keyless", () => {
+    new OpenAIEmbeddingBackend("", "text-embedding-3-small", {
+      provider: "custom",
+      baseURL: "http://127.0.0.1:1234/v1",
+    });
+    expect(lastCtorArgs?.apiKey).toBe("not-needed");
+  });
+
+  test("omits dimensions when they are not configured", async () => {
+    const backend = new OpenAIEmbeddingBackend(
+      "sk-test",
+      "text-embedding-3-small",
+    );
+    await backend.embed(["hello"]);
+    const [body] = createMock.mock.calls[0] as [{ dimensions?: number }];
+    expect(body.dimensions).toBeUndefined();
+  });
+});

--- a/assistant/src/persistence/embeddings/embedding-openai.ts
+++ b/assistant/src/persistence/embeddings/embedding-openai.ts
@@ -3,18 +3,40 @@ import OpenAI from "openai";
 import {
   type EmbeddingBackend,
   type EmbeddingInput,
+  type EmbeddingProviderName,
   type EmbeddingRequestOptions,
   normalizeEmbeddingInput,
 } from "./embedding-types.js";
 
+export type OpenAICompatibleEmbeddingProvider = Extract<
+  EmbeddingProviderName,
+  "openai" | "custom"
+>;
+
+export interface OpenAIEmbeddingOptions {
+  baseURL?: string;
+  dimensions?: number;
+  provider?: OpenAICompatibleEmbeddingProvider;
+}
+
+const PLACEHOLDER_API_KEY = "not-needed";
+
 export class OpenAIEmbeddingBackend implements EmbeddingBackend {
-  readonly provider = "openai" as const;
+  readonly provider: OpenAICompatibleEmbeddingProvider;
   readonly model: string;
+  readonly baseURL?: string;
+  readonly dimensions?: number;
   private readonly client: OpenAI;
 
-  constructor(apiKey: string, model: string) {
+  constructor(apiKey: string, model: string, options?: OpenAIEmbeddingOptions) {
     this.model = model;
-    this.client = new OpenAI({ apiKey });
+    this.provider = options?.provider ?? "openai";
+    this.baseURL = options?.baseURL;
+    this.dimensions = options?.dimensions;
+    this.client = new OpenAI({
+      apiKey: apiKey || PLACEHOLDER_API_KEY,
+      ...(options?.baseURL ? { baseURL: options.baseURL } : {}),
+    });
   }
 
   async embed(
@@ -28,7 +50,9 @@ export class OpenAIEmbeddingBackend implements EmbeddingBackend {
     const texts = inputs.map((i) => {
       const n = normalizeEmbeddingInput(i);
       if (n.type !== "text") {
-        throw new Error("OpenAI embedding backend only supports text inputs");
+        throw new Error(
+          `${this.provider === "custom" ? "Custom" : "OpenAI"} embedding backend only supports text inputs`,
+        );
       }
       return n.text;
     });
@@ -38,6 +62,7 @@ export class OpenAIEmbeddingBackend implements EmbeddingBackend {
         model: this.model,
         input: texts,
         encoding_format: "float",
+        ...(this.dimensions != null ? { dimensions: this.dimensions } : {}),
       },
       {
         signal: options?.signal,
@@ -45,4 +70,30 @@ export class OpenAIEmbeddingBackend implements EmbeddingBackend {
     );
     return response.data.map((item) => item.embedding);
   }
+}
+
+/**
+ * Trim and strip a trailing slash from a user-supplied OpenAI-compatible
+ * embeddings base URL. Returns null when the value is empty, not http(s),
+ * or not a valid absolute URL.
+ */
+export function resolveOpenAICompatibleBaseUrl(
+  value: string | undefined,
+): string | null {
+  if (value == null) {
+    return null;
+  }
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  return trimmed;
 }

--- a/assistant/src/persistence/embeddings/embedding-types.test.ts
+++ b/assistant/src/persistence/embeddings/embedding-types.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  embeddingContentHashWithExtras,
   embeddingInputContentHash,
   type MultimodalEmbeddingInput,
   normalizeEmbeddingInput,
@@ -112,5 +113,28 @@ describe("embeddingInputContentHash", () => {
   test("returns a hex string", () => {
     const hash = embeddingInputContentHash("test");
     expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("embeddingContentHashWithExtras", () => {
+  test("matches the bare content hash when extras are empty", () => {
+    expect(embeddingContentHashWithExtras("hello")).toBe(
+      embeddingInputContentHash("hello"),
+    );
+    expect(embeddingContentHashWithExtras("hello", [])).toBe(
+      embeddingInputContentHash("hello"),
+    );
+  });
+
+  test("changes when extras change for identical text", () => {
+    const text = "hello";
+    const a = embeddingContentHashWithExtras(text, [
+      "url=http://127.0.0.1:4000/v1",
+    ]);
+    const b = embeddingContentHashWithExtras(text, [
+      "url=http://127.0.0.1:4001/v1",
+    ]);
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(embeddingInputContentHash(text));
   });
 });

--- a/assistant/src/persistence/embeddings/embedding-types.ts
+++ b/assistant/src/persistence/embeddings/embedding-types.ts
@@ -75,7 +75,12 @@ export function embeddingInputContentHash(input: EmbeddingInput): string {
 // circular imports between the factory and provider implementations)
 // ---------------------------------------------------------------------------
 
-export type EmbeddingProviderName = "local" | "openai" | "gemini" | "ollama";
+export type EmbeddingProviderName =
+  | "local"
+  | "openai"
+  | "gemini"
+  | "ollama"
+  | "custom";
 
 export interface EmbeddingRequestOptions {
   signal?: AbortSignal;

--- a/assistant/src/persistence/embeddings/embedding-types.ts
+++ b/assistant/src/persistence/embeddings/embedding-types.ts
@@ -70,6 +70,25 @@ export function embeddingInputContentHash(input: EmbeddingInput): string {
   return hash.digest("hex");
 }
 
+/**
+ * Durable cache identity for an embedding input. Folds provider extras
+ * (Gemini task type / dimensions, custom endpoint URL / dimensions) into the
+ * bare content hash so a change that alters the vector for identical text is
+ * a cache miss. With no extras this is the bare {@link embeddingInputContentHash}.
+ */
+export function embeddingContentHashWithExtras(
+  input: EmbeddingInput,
+  extras: string[] = [],
+): string {
+  const base = embeddingInputContentHash(input);
+  if (extras.length === 0) {
+    return base;
+  }
+  return createHash("sha256")
+    .update(`${base}\0${extras.join("\0")}`)
+    .digest("hex");
+}
+
 // ---------------------------------------------------------------------------
 // Backend interface types (extracted from embedding-backend.ts to break
 // circular imports between the factory and provider implementations)

--- a/assistant/src/persistence/job-utils.ts
+++ b/assistant/src/persistence/job-utils.ts
@@ -7,13 +7,14 @@ import { BackendUnavailableError } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import { getMemoryDb } from "./db-connection.js";
 import {
+  durableEmbeddingCacheExtras,
   embedWithBackend,
   generateSparseEmbedding,
   getMemoryBackendStatus,
 } from "./embeddings/embedding-backend.js";
 import type { EmbeddingInput } from "./embeddings/embedding-types.js";
 import {
-  embeddingInputContentHash,
+  embeddingContentHashWithExtras,
   normalizeEmbeddingInput,
 } from "./embeddings/embedding-types.js";
 import { withQdrantBreaker } from "./embeddings/qdrant-circuit-breaker.js";
@@ -186,7 +187,10 @@ export async function embedAndUpsert(
     );
   }
 
-  const contentHash = embeddingInputContentHash(input);
+  const contentHash = embeddingContentHashWithExtras(
+    input,
+    durableEmbeddingCacheExtras(config, status.provider),
+  );
   let provider = status.provider;
   let model = status.model!;
   let vector: number[];

--- a/assistant/src/plugins/defaults/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -67,6 +67,7 @@ mock.module(
       indices: [text.length % 100],
       values: [1],
     }),
+    durableEmbeddingCacheExtras: () => [],
     // Other exports from the real module — stubbed so adjacent imports
     // (e.g. via transitive `db.ts` → `indexer.ts`) don't crash on missing
     // names when the mock replaces the module wholesale.

--- a/assistant/src/plugins/defaults/memory/jobs/embed-concept-page.ts
+++ b/assistant/src/plugins/defaults/memory/jobs/embed-concept-page.ts
@@ -23,10 +23,11 @@ import { and, eq } from "drizzle-orm";
 import type { AssistantConfig } from "../../../../config/types.js";
 import { getDb } from "../../../../persistence/db-connection.js";
 import {
+  durableEmbeddingCacheExtras,
   generateSparseEmbedding,
   getMemoryBackendStatus,
 } from "../../../../persistence/embeddings/embedding-backend.js";
-import { embeddingInputContentHash } from "../../../../persistence/embeddings/embedding-types.js";
+import { embeddingContentHashWithExtras } from "../../../../persistence/embeddings/embedding-types.js";
 import { withQdrantBreaker } from "../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import {
   asString,
@@ -131,7 +132,11 @@ export async function embedConceptPageJob(
   // and (optional) summary share the same provider/model — but each gets
   // its own cache row keyed by a distinct targetId so summary edits don't
   // invalidate the body cache and vice versa.
-  const bodyContentHash = embeddingInputContentHash({ type: "text", text });
+  const extras = durableEmbeddingCacheExtras(config, cacheProvider);
+  const bodyContentHash = embeddingContentHashWithExtras(
+    { type: "text", text },
+    extras,
+  );
   const bodyCache = mem
     ? readEmbeddingCache(mem, slug, cacheProvider, cacheModel, expectedDim)
     : null;
@@ -145,7 +150,10 @@ export async function embedConceptPageJob(
   const hasSummary = summaryText.length > 0;
   const summaryCacheId = `${slug}#summary`;
   const summaryContentHash = hasSummary
-    ? embeddingInputContentHash({ type: "text", text: summaryText })
+    ? embeddingContentHashWithExtras(
+        { type: "text", text: summaryText },
+        extras,
+      )
     : undefined;
   const summaryCache =
     hasSummary && mem

--- a/assistant/src/plugins/defaults/memory/src/__tests__/memory-worker-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/__tests__/memory-worker-routes.test.ts
@@ -176,6 +176,26 @@ describe("memory_worker_status", () => {
     ).toBe(true);
   });
 
+  test("accepts custom as a documented embedding provider on the wire", async () => {
+    backendStatus = {
+      enabled: true,
+      degraded: false,
+      provider: "custom",
+      model: "text-embedding-3-small",
+      reason: null,
+    };
+
+    const res = await handler("memory_worker_status")();
+
+    expect(res).toMatchObject({
+      embedding: { provider: "custom" },
+    });
+    expect(
+      embeddingStatusSchema.safeParse((res as { embedding: unknown }).embedding)
+        .success,
+    ).toBe(true);
+  });
+
   test("surfaces a degraded embedding backend with a reason when none is configured", async () => {
     backendStatus = {
       enabled: true,

--- a/assistant/src/plugins/defaults/memory/src/memory-worker-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-worker-routes.ts
@@ -32,7 +32,9 @@ const log = getLogger("memory-worker-routes");
 export const embeddingStatusSchema = z.object({
   enabled: z.boolean(),
   degraded: z.boolean(),
-  provider: z.enum(["local", "openai", "gemini", "ollama"]).nullable(),
+  provider: z
+    .enum(["local", "openai", "gemini", "ollama", "custom"])
+    .nullable(),
   model: z.string().nullable(),
   reason: z.string().nullable(),
 });

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/reembed-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/reembed-job.test.ts
@@ -54,6 +54,7 @@ mock.module(
       reason: null,
     }),
     selectedBackendSupportsMultimodal: async () => false,
+    durableEmbeddingCacheExtras: () => [],
   }),
 );
 

--- a/assistant/src/plugins/defaults/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/plugins/defaults/memory/v2/__tests__/backfill-jobs.test.ts
@@ -131,6 +131,7 @@ mock.module(
       reason: null,
     }),
     selectedBackendSupportsMultimodal: async () => false,
+    durableEmbeddingCacheExtras: () => [],
   }),
 );
 

--- a/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
+++ b/assistant/src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts
@@ -33,6 +33,8 @@ const embedState = {
   // the section cache treats it as a miss.
   geminiTaskType: undefined as string | undefined,
   geminiDimensions: undefined as number | undefined,
+  customBaseUrl: undefined as string | undefined,
+  customDimensions: undefined as number | undefined,
 };
 mock.module(
   "../../../../../persistence/embeddings/embedding-backend.js",
@@ -63,6 +65,42 @@ mock.module(
         extras.push(`dim=${embedState.geminiDimensions}`);
       }
       return extras;
+    },
+    customCacheExtras: () => {
+      const extras: string[] = [];
+      if (embedState.customBaseUrl) {
+        extras.push(`url=${embedState.customBaseUrl}`);
+      }
+      if (embedState.customDimensions != null) {
+        extras.push(`dim=${embedState.customDimensions}`);
+      }
+      return extras;
+    },
+    durableEmbeddingCacheExtras: (
+      _config: unknown,
+      provider: string | null,
+    ) => {
+      if (provider === "gemini") {
+        const extras: string[] = [];
+        if (embedState.geminiTaskType) {
+          extras.push(`task=${embedState.geminiTaskType}`);
+        }
+        if (embedState.geminiDimensions != null) {
+          extras.push(`dim=${embedState.geminiDimensions}`);
+        }
+        return extras;
+      }
+      if (provider === "custom") {
+        const extras: string[] = [];
+        if (embedState.customBaseUrl) {
+          extras.push(`url=${embedState.customBaseUrl}`);
+        }
+        if (embedState.customDimensions != null) {
+          extras.push(`dim=${embedState.customDimensions}`);
+        }
+        return extras;
+      }
+      return [];
     },
   }),
 );
@@ -320,6 +358,8 @@ function resetState(): void {
   embedState.embedModel = "test-model";
   embedState.geminiTaskType = undefined;
   embedState.geminiDimensions = undefined;
+  embedState.customBaseUrl = undefined;
+  embedState.customDimensions = undefined;
   cacheState.store.clear();
   cacheState.reads.length = 0;
   checkpointState.deletes.length = 0;
@@ -764,6 +804,48 @@ describe("memory v3 section-dense-store — embedding cache", () => {
 
     // Folding the extras into the hash must not break ordinary hits: with the
     // task type unchanged the second pass reuses the cached vector.
+    expect(embedState.calls).toHaveLength(1);
+    expect(state.upsertCalls).toHaveLength(2);
+  });
+
+  test("a custom endpoint change re-embeds unchanged text (cache miss)", async () => {
+    state.collectionExists = true;
+    embedState.statusProvider = "custom";
+    embedState.statusModel = "text-embedding-3-small";
+    embedState.embedProvider = "custom";
+    embedState.embedModel = "text-embedding-3-small";
+    embedState.customBaseUrl = "http://127.0.0.1:4000/v1";
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "alice lead text"),
+    ]);
+    expect(embedState.calls).toHaveLength(1);
+
+    embedState.customBaseUrl = "http://127.0.0.1:4001/v1";
+
+    await upsertSections(CONFIG, [
+      section("people/alice", 0, "alice lead text"),
+    ]);
+
+    expect(embedState.calls).toEqual([
+      ["alice lead text"],
+      ["alice lead text"],
+    ]);
+  });
+
+  test("an unchanged custom endpoint still serves from cache", async () => {
+    state.collectionExists = true;
+    embedState.statusProvider = "custom";
+    embedState.statusModel = "text-embedding-3-small";
+    embedState.embedProvider = "custom";
+    embedState.embedModel = "text-embedding-3-small";
+    embedState.customBaseUrl = "http://127.0.0.1:4000/v1";
+
+    const sections = [section("people/alice", 0, "alice lead text")];
+
+    await upsertSections(CONFIG, sections);
+    await upsertSections(CONFIG, sections);
+
     expect(embedState.calls).toHaveLength(1);
     expect(state.upsertCalls).toHaveLength(2);
   });

--- a/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
+++ b/assistant/src/plugins/defaults/memory/v3/section-dense-store.ts
@@ -19,8 +19,6 @@
 // shared Qdrant client; the read side (`dense.ts`) reuses that client to query
 // this collection.
 
-import { createHash } from "node:crypto";
-
 import { QdrantClient as QdrantRestClient } from "@qdrant/js-client-rest";
 import { v5 as uuidv5 } from "uuid";
 
@@ -31,14 +29,14 @@ import {
   setMemoryCheckpoint,
 } from "../../../../persistence/checkpoints.js";
 import {
-  geminiCacheExtras,
+  durableEmbeddingCacheExtras,
   getMemoryBackendStatus,
 } from "../../../../persistence/embeddings/embedding-backend.js";
 import {
   readEmbeddingCache,
   writeEmbeddingCache,
 } from "../../../../persistence/embeddings/embedding-cache.js";
-import { embeddingInputContentHash } from "../../../../persistence/embeddings/embedding-types.js";
+import { embeddingContentHashWithExtras } from "../../../../persistence/embeddings/embedding-types.js";
 import { embedWithBackend, resolveQdrantUrl } from "../embeddings.js";
 import { getLogger } from "../logging.js";
 import { memoryDbOrNull } from "../memory-db.js";
@@ -515,24 +513,6 @@ function sectionCacheId(article: string, ordinal: number): string {
 }
 
 /**
- * Content hash a section's cached vector is keyed by. Folds the provider's
- * embedding-option extras (Gemini task type / output dimensions) into the base
- * text hash, so changing an option that alters the vector for identical text is
- * a cache miss that re-embeds. With no extras the bare text hash is returned
- * unchanged, keeping existing rows valid for non-Gemini and default-Gemini
- * configs.
- */
-function sectionContentHash(text: string, extras: string[]): string {
-  const base = embeddingInputContentHash({ type: "text", text });
-  if (extras.length === 0) {
-    return base;
-  }
-  return createHash("sha256")
-    .update(`${base}\0${extras.join("\0")}`)
-    .digest("hex");
-}
-
-/**
  * Embed each section's `text` and upsert one point per section, keyed by a
  * deterministic `(article, ordinal)`-derived ID. Stable IDs mean re-upserting
  * the same sections overwrites in place rather than accumulating duplicates,
@@ -641,11 +621,13 @@ async function embedSectionsCached(
   const status = await getMemoryBackendStatus(config);
   const mem = memoryDbOrNull("embedSectionsCached");
 
-  // Only Gemini's options change the vector for identical text, so fold the
-  // extras into the cache identity only when Gemini is the resolved provider;
-  // other backends keep the bare text hash. See {@link sectionContentHash}.
-  const extras = status.provider === "gemini" ? geminiCacheExtras(config) : [];
-  const hashes = sections.map((s) => sectionContentHash(s.text, extras));
+  // Fold provider extras that change the vector for identical text (Gemini
+  // task type / dimensions, custom endpoint URL / dimensions) into the
+  // durable cache identity. Other backends keep the bare text hash.
+  const extras = durableEmbeddingCacheExtras(config, status.provider);
+  const hashes = sections.map((s) =>
+    embeddingContentHashWithExtras({ type: "text", text: s.text }, extras),
+  );
 
   const result: Array<number[] | undefined> = new Array(sections.length);
   const missIndices: number[] = [];

--- a/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
+++ b/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
@@ -47,4 +47,8 @@ describe("API_KEY_PROVIDERS", () => {
     expect(API_KEY_PROVIDERS).toContain("tavily");
     expect(API_KEY_PROVIDERS).toContain("firecrawl");
   });
+
+  test("includes custom for OpenAI-compatible memory embeddings", () => {
+    expect(API_KEY_PROVIDERS).toContain("custom");
+  });
 });

--- a/assistant/src/providers/provider-secret-catalog.ts
+++ b/assistant/src/providers/provider-secret-catalog.ts
@@ -2,7 +2,7 @@
  * Canonical source for API-key-addressable providers.
  *
  * This module composes the full set of providers that store API keys in
- * secure storage (the `api_key` secret type) from four sources:
+ * secure storage (the `api_key` secret type) from five sources:
  *
  * 1. **LLM providers** -- derived from `PROVIDER_CATALOG`
  *    (`model-catalog.ts`). Adding a provider to the catalog automatically
@@ -15,6 +15,8 @@
  * 4. **TTS catalog providers** -- dynamically derived from the canonical
  *    TTS provider catalog by selecting entries whose secret requirements
  *    use the bare-name (non-credential) storage convention.
+ * 5. **Embedding-only providers** -- currently `custom`, the
+ *    OpenAI-compatible memory embeddings endpoint.
  *
  * Consumers that need the set of valid API-key provider names should
  * import {@link API_KEY_PROVIDERS} from this module rather than
@@ -116,6 +118,13 @@ function catalogApiKeyNames(): string[] {
     );
 }
 
+/**
+ * Embedding-only API-key names. `custom` is the OpenAI-compatible memory
+ * embeddings provider and is not an LLM catalog entry, so it is declared
+ * here rather than in `PROVIDER_CATALOG`.
+ */
+const EMBEDDING_API_KEY_PROVIDERS: readonly string[] = ["custom"];
+
 // ---------------------------------------------------------------------------
 // Unified export
 // ---------------------------------------------------------------------------
@@ -148,6 +157,7 @@ export const API_KEY_PROVIDERS: readonly string[] = (() => {
     ...LLM_AND_SEARCH_API_KEY_PROVIDERS,
     ...sttApiKeyProviderNames(),
     ...catalogApiKeyNames(),
+    ...EMBEDDING_API_KEY_PROVIDERS,
   ]) {
     if (!seen.has(name)) {
       seen.add(name);

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -6,7 +6,7 @@
  * GET    /v1/model                      — current model info
  * PUT    /v1/model/image-gen            — set image-gen model
  * GET    /v1/config/embeddings          — current embedding config
- * PUT    /v1/config/embeddings          — set embedding provider/model
+ * PUT    /v1/config/embeddings          - set embedding provider/model/baseUrl
  * GET    /v1/config                     — full raw workspace config
  * PATCH  /v1/config                     — deep-merge partial config
  * PUT    /v1/config/llm/profiles/:name  — replace an inference profile
@@ -97,6 +97,7 @@ import {
 } from "../../persistence/conversation-types.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { clearEmbeddingBackendCache } from "../../persistence/embeddings/embedding-backend.js";
+import { resolveOpenAICompatibleBaseUrl } from "../../persistence/embeddings/embedding-openai.js";
 import { getLlmRequestLogSource } from "../../persistence/llm-request-log-source.js";
 import { type LogRow } from "../../persistence/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../plugins/defaults/memory/memory-recall-log-store.js";
@@ -457,9 +458,11 @@ async function handleSetEmbeddingConfig({ body }: RouteHandlerArgs) {
   if (!body || typeof body !== "object") {
     throw new BadRequestError("Request body is required");
   }
-  const { provider, model } = body as {
+  const { provider, model, baseUrl, dimensions } = body as {
     provider?: string;
     model?: string;
+    baseUrl?: string;
+    dimensions?: number | null;
   };
   if (!provider || typeof provider !== "string") {
     throw new BadRequestError("Missing required field: provider");
@@ -472,8 +475,32 @@ async function handleSetEmbeddingConfig({ body }: RouteHandlerArgs) {
   if (model !== undefined && typeof model !== "string") {
     throw new BadRequestError("Field 'model' must be a string");
   }
+  if (baseUrl !== undefined && typeof baseUrl !== "string") {
+    throw new BadRequestError("Field 'baseUrl' must be a string");
+  }
+  if (
+    typeof baseUrl === "string" &&
+    baseUrl !== "" &&
+    !resolveOpenAICompatibleBaseUrl(baseUrl)
+  ) {
+    throw new BadRequestError("Field 'baseUrl' must be an http(s) URL");
+  }
+  if (
+    dimensions !== undefined &&
+    dimensions !== null &&
+    (typeof dimensions !== "number" ||
+      !Number.isInteger(dimensions) ||
+      dimensions <= 0)
+  ) {
+    throw new BadRequestError(
+      "Field 'dimensions' must be a positive integer or null",
+    );
+  }
   try {
-    return await setEmbeddingConfig(provider, model, getModelSetContext());
+    return await setEmbeddingConfig(provider, model, getModelSetContext(), {
+      baseUrl,
+      dimensions,
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     throw new InternalError(`Failed to set embedding config: ${message}`);
@@ -2344,11 +2371,14 @@ export const ROUTES: RouteDefinition[] = [
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     summary: "Set embedding config",
-    description: "Change the embedding provider and optionally model.",
+    description:
+      "Change the embedding provider, model, and optional custom endpoint.",
     tags: ["config"],
     requestBody: z.object({
       provider: z.string(),
       model: z.string().optional(),
+      baseUrl: z.string().optional(),
+      dimensions: z.number().int().positive().nullable().optional(),
     }),
     handler: handleSetEmbeddingConfig,
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Implements [vellum-ai/vellum-assistant#42193](https://github.com/vellum-ai/vellum-assistant/issues/42193) / **EPD-2919**: memory embeddings can target a user-supplied OpenAI-compatible `/v1/embeddings` endpoint (Portkey, LiteLLM, and similar BYOK gateways).

`memory.embeddings.provider` stays a closed enum. This adds an explicit `custom` provider rather than silently overriding the official OpenAI backend with `baseUrl`, and `custom` is not part of the `auto` fallback chain.

## Summary
- New provider: `custom`, with `memory.embeddings.baseUrl` (http(s), including `/v1`), `customModel`, and optional `customDimensions`.
- `OpenAIEmbeddingBackend` accepts an optional `baseURL` and requested dimensions. Keyless local gateways use a placeholder API key.
- `GET`/`PUT /v1/config/embeddings` expose `baseUrl` and `dimensions`. Invalid non-empty URLs are rejected as 400.
- Optional API key via `assistant keys set custom`.
- Durable identity: custom base URL and requested dimensions are folded into `memory_embeddings` content hashes. A same-dimension endpoint change records the new space in `memory:custom_embedding_space` and enqueues a reembed so query and document vectors do not mix.

Usage:
```bash
assistant config set memory.embeddings.provider custom
assistant config set memory.embeddings.baseUrl https://gateway.example.com/v1
assistant config set memory.embeddings.customModel text-embedding-3-small
assistant config set memory.embeddings.customDimensions 1024
assistant keys set custom <api-key>   # optional for keyless local gateways
```

Dimension mismatches still go through the existing Qdrant reconcile / reembed path.

Closes #42193
Closes EPD-2919

## Test plan
- `cd assistant && bun test ./src/persistence/embeddings/embedding-backend.test.ts ./src/persistence/embeddings/embedding-openai.test.ts ./src/persistence/embeddings/embedding-types.test.ts ./src/daemon/__tests__/embedding-reconcile.test.ts ./src/plugins/defaults/memory/v3/__tests__/section-dense-store.test.ts ./src/plugins/defaults/memory/jobs/__tests__/embed-concept-page.test.ts ./src/plugins/defaults/memory/substrate/__tests__/reembed-job.test.ts ./src/plugins/defaults/memory/v2/__tests__/backfill-jobs.test.ts`
- Isolated: `./src/__tests__/embedding-managed-proxy-selection.test.ts`
- `cd assistant && bun run typecheck:fast`
- No UI in this change; config is CLI / API only.

## CLI verb checklist
- No new route. `PUT /v1/config/embeddings` gained optional `baseUrl` and `dimensions`; existing `assistant config set` covers persistence, and `assistant keys set custom` covers the optional key.

## Risk
- Medium. User-controlled embedding URLs are intentional (the owner's assistant POSTs to their gateway). `custom` is a new `api_key` provider name, so it appears in `assistant keys` help. Official OpenAI embeddings are unchanged: `openai` still talks to `api.openai.com` unless the user opts into `custom`.
- No schema migration: additive config fields with schema defaults, plus a `memory_checkpoints` identity key. Switching to `custom` with a different vector size uses the existing embedding reconcile. Switching custom endpoints at the same size now reembeds.
- No feature flag and no companion platform PR. Native clients ignore unknown GET fields.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd13c256-2d56-42e4-ad80-0ce30b3465ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd13c256-2d56-42e4-ad80-0ce30b3465ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

