### PR TITLE
fix(companion): give a coachmark an identity

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-point-at-budget.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-point-at-budget.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { POINT_AT_PROXY_TOOL } from "../tools/computer-use/skill-proxy-bridge.js";
+import { clearHubClients, registerHubClient } from "./helpers/hub-clients.js";
 import { asConversation } from "./helpers/mock-conversation.js";
 
 const { surfaceProxyResolver } =
   await import("../daemon/conversation-surfaces.js");
+const { assistantEventHub } = await import("../runtime/assistant-event-hub.js");
 
 /**
  * A CU proxy that records what it was asked to account for. `recordAction` is
@@ -27,11 +29,29 @@ function proxyDouble() {
   };
 }
 
+const ACTOR = "actor-1";
+
 const context = (proxy: unknown) =>
   asConversation({
     conversationId: "conv-1",
     hostCuProxy: proxy as never,
+    currentTurnSourceActorPrincipalId: ACTOR,
   });
+
+/**
+ * A client that can actually draw. Pointing resolves on `host_cu_annotate`
+ * and refuses outright when nothing holds it, so without this the requests
+ * below would never reach the proxy and the budget would go untested.
+ */
+function withAnnotationClient(): void {
+  registerHubClient({
+    hub: assistantEventHub,
+    clientId: "mac",
+    interfaceId: "macos",
+    capabilities: ["host_cu", "host_cu_annotate"],
+    actorPrincipalId: ACTOR,
+  });
+}
 
 /**
  * Pointing at the screen drives nothing: the user does the acting, and a
@@ -40,6 +60,15 @@ const context = (proxy: unknown) =>
  * instruction to call `computer_use_done`.
  */
 describe("the computer-use step budget", () => {
+  beforeEach(() => {
+    clearHubClients(assistantEventHub);
+    withAnnotationClient();
+  });
+
+  afterEach(() => {
+    clearHubClients(assistantEventHub);
+  });
+
   test("is not spent by pointing at the screen", async () => {
     const { proxy, recordAction, request } = proxyDouble();
 
@@ -89,12 +118,20 @@ describe("the computer-use step budget", () => {
     );
     expect((spent as { content?: string }).content).toContain("Step limit");
 
+    // The actor is passed so resolution finds the annotation client and the
+    // step limit stays the only thing that could refuse this. Without it the
+    // request is turned back for having no client to draw on, which would
+    // pass this assertion for entirely the wrong reason.
     const cleared = await settle(
       proxy.request(
         POINT_AT_PROXY_TOOL,
         { marks: [] },
         "conv-1",
         proxy.stepCount,
+        undefined,
+        undefined,
+        undefined,
+        ACTOR,
       ),
     );
     expect(cleared).toBe(pending);

--- a/assistant/src/__tests__/conversation-surfaces-point-at-capability.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-point-at-capability.test.ts
@@ -110,6 +110,34 @@ describe("resolving a point-at request", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  /**
+   * The annotation-capable client went away after the skill was already on the
+   * surface. Nothing left can draw, so the request is refused rather than
+   * broadcast: an untargeted point-at would otherwise be handed to whatever
+   * host_cu client was listening, which is the mis-routing this capability
+   * exists to prevent.
+   */
+  test("refuses rather than broadcasting when nothing can draw", async () => {
+    const { proxy, request } = proxyDouble();
+    registerHubClient({
+      hub: assistantEventHub,
+      clientId: "win",
+      interfaceId: "windows",
+      capabilities: ["host_cu"],
+      actorPrincipalId: ACTOR,
+    });
+
+    const result = await surfaceProxyResolver(
+      context(proxy),
+      POINT_AT_PROXY_TOOL,
+      MARKS,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("host_cu_annotate");
+    expect(request).not.toHaveBeenCalled();
+  });
+
   /** An ordinary action still resolves on the transport it always did. */
   test("leaves an ordinary computer-use action on host_cu", async () => {
     const { proxy, request } = proxyDouble();

--- a/assistant/src/__tests__/conversation-surfaces-point-at-capability.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-point-at-capability.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Which capability answers a point-at request.
+ *
+ * Pointing rides the `computer_use_` wire so it reaches the same proxy as an
+ * action, but only a client that draws the overlay can serve it. Resolving it
+ * as plain `host_cu` would call a lone annotation-capable client ambiguous
+ * against a helper-backed one that could never have answered, and would
+ * accept an explicit helper target and forward it an action its helper does
+ * not have.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { POINT_AT_PROXY_TOOL } from "../tools/computer-use/skill-proxy-bridge.js";
+import { clearHubClients, registerHubClient } from "./helpers/hub-clients.js";
+import { asConversation } from "./helpers/mock-conversation.js";
+
+const { surfaceProxyResolver } =
+  await import("../daemon/conversation-surfaces.js");
+const { assistantEventHub } = await import("../runtime/assistant-event-hub.js");
+
+const ACTOR = "actor-1";
+
+/** A proxy that answers, so resolution is the only thing under test. */
+function proxyDouble() {
+  const request = mock(async () => ({ content: "ok", isError: false }));
+  return {
+    request,
+    proxy: {
+      isAvailable: () => true,
+      recordAction: () => {},
+      request,
+      reset: () => {},
+      stepCount: 0,
+    },
+  };
+}
+
+const context = (proxy: unknown) =>
+  asConversation({
+    conversationId: "conv-1",
+    hostCuProxy: proxy as never,
+    currentTurnSourceActorPrincipalId: ACTOR,
+  });
+
+const MARKS = { marks: [{ x: 0.1, y: 0.1, width: 0.1, height: 0.1 }] };
+
+beforeEach(() => {
+  clearHubClients(assistantEventHub);
+});
+
+afterEach(() => {
+  clearHubClients(assistantEventHub);
+});
+
+describe("resolving a point-at request", () => {
+  /**
+   * The case Codex named: one client can draw and one cannot, and selecting on
+   * the transport makes that pair ambiguous even though only one answer was
+   * ever possible.
+   */
+  test("is not made ambiguous by a client that cannot draw", async () => {
+    const { proxy, request } = proxyDouble();
+    registerHubClient({
+      hub: assistantEventHub,
+      clientId: "mac",
+      interfaceId: "macos",
+      capabilities: ["host_cu", "host_cu_annotate"],
+      actorPrincipalId: ACTOR,
+    });
+    registerHubClient({
+      hub: assistantEventHub,
+      clientId: "win",
+      interfaceId: "windows",
+      capabilities: ["host_cu"],
+      actorPrincipalId: ACTOR,
+    });
+
+    const result = await surfaceProxyResolver(
+      context(proxy),
+      POINT_AT_PROXY_TOOL,
+      MARKS,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The other half: an explicit target that cannot draw is refused here rather
+   * than forwarded to a helper with no such action.
+   */
+  test("refuses an explicit target that cannot draw", async () => {
+    const { proxy, request } = proxyDouble();
+    registerHubClient({
+      hub: assistantEventHub,
+      clientId: "win",
+      interfaceId: "windows",
+      capabilities: ["host_cu"],
+      actorPrincipalId: ACTOR,
+    });
+
+    const result = await surfaceProxyResolver(
+      context(proxy),
+      POINT_AT_PROXY_TOOL,
+      { ...MARKS, target_client_id: "win" },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("host_cu_annotate");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  /** An ordinary action still resolves on the transport it always did. */
+  test("leaves an ordinary computer-use action on host_cu", async () => {
+    const { proxy, request } = proxyDouble();
+    registerHubClient({
+      hub: assistantEventHub,
+      clientId: "win",
+      interfaceId: "windows",
+      capabilities: ["host_cu"],
+      actorPrincipalId: ACTOR,
+    });
+
+    const result = await surfaceProxyResolver(
+      context(proxy),
+      "computer_use_click",
+      { x: 10, y: 10 },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -51,6 +51,21 @@ describe("supportsHostProxy (runtime)", () => {
     expect(supportsHostProxy("macos", "host_browser")).toBe(true);
   });
 
+  /**
+   * The marks are drawn in a window the client opens for itself. Windows and
+   * Linux forward a CU request to a native helper whose action set has no
+   * such thing, so offering it there is offering a tool that cannot succeed.
+   */
+  test("capability form grants screen annotation to macOS alone", () => {
+    expect(supportsHostProxy("macos", "host_cu_annotate")).toBe(true);
+    expect(supportsHostProxy("windows", "host_cu_annotate")).toBe(false);
+    expect(supportsHostProxy("linux", "host_cu_annotate")).toBe(false);
+    expect(supportsHostProxy("web", "host_cu_annotate")).toBe(false);
+    // The transport it rides is offered to all three, which is what makes the
+    // narrower capability necessary rather than redundant.
+    expect(supportsHostProxy("windows", "host_cu")).toBe(true);
+  });
+
   test("capability form withholds unimplemented Windows app control", () => {
     expect(supportsHostProxy("windows", "host_bash")).toBe(true);
     expect(supportsHostProxy("windows", "host_file")).toBe(true);

--- a/assistant/src/__tests__/host-proxy-preactivation.test.ts
+++ b/assistant/src/__tests__/host-proxy-preactivation.test.ts
@@ -366,6 +366,7 @@ describe("preactivateHostProxySkills logging", () => {
     expect(fields.sourceInterface).toBe("macos");
     expect(fields.decisions).toEqual({
       host_cu: { shouldAttach: true, reason: "native_support" },
+      host_cu_annotate: { shouldAttach: true, reason: "native_support" },
       host_app_control: { shouldAttach: true, reason: "native_support" },
     });
     expect(fields.preactivatedSkillIds).toEqual([
@@ -385,6 +386,10 @@ describe("preactivateHostProxySkills logging", () => {
     expect(fields.sourceInterface).toBeUndefined();
     expect(fields.decisions).toEqual({
       host_cu: { shouldAttach: false, reason: "denied_no_interface" },
+      host_cu_annotate: {
+        shouldAttach: false,
+        reason: "denied_no_interface",
+      },
       host_app_control: { shouldAttach: false, reason: "denied_no_interface" },
     });
     expect(fields.preactivatedSkillIds).toEqual([]);
@@ -409,6 +414,34 @@ describe("preactivateHostProxySkills logging", () => {
       shouldAttach: false,
       reason: "denied_no_clients",
       clientCount: 0,
+    });
+    // Computer use and nothing else. The marks are drawn in a window the
+    // client opens for itself, and a client advertising only the transport
+    // has no such window to draw in.
+    expect(loggedInfoCalls[0].fields.preactivatedSkillIds).toEqual([
+      "computer-use",
+    ]);
+  });
+
+  /**
+   * The case the annotation capability exists for: a web turn is routed to a
+   * desktop client, and only a client that says it can draw is offered the
+   * skill that draws.
+   */
+  test("offers screen annotation to a web source once a client advertises it", () => {
+    setCapableClient("host_cu", true);
+    setCapableClient("host_cu_annotate", true);
+    const target = makeTarget();
+    preactivateHostProxySkills(target, "web", "user-1");
+
+    const decisions = loggedInfoCalls[0].fields.decisions as Record<
+      string,
+      unknown
+    >;
+    expect(decisions.host_cu_annotate).toEqual({
+      shouldAttach: true,
+      reason: "cross_client",
+      clientCount: 1,
     });
     expect(loggedInfoCalls[0].fields.preactivatedSkillIds).toEqual([
       "computer-use",

--- a/assistant/src/__tests__/host-proxy-preactivation.test.ts
+++ b/assistant/src/__tests__/host-proxy-preactivation.test.ts
@@ -366,14 +366,40 @@ describe("preactivateHostProxySkills logging", () => {
     expect(fields.sourceInterface).toBe("macos");
     expect(fields.decisions).toEqual({
       host_cu: { shouldAttach: true, reason: "native_support" },
-      host_cu_annotate: { shouldAttach: true, reason: "native_support" },
+      // Negotiated on the connection rather than implied by the interface, so
+      // with no client advertising it there is nothing to draw on. See the
+      // case below for the same turn once one is connected.
+      host_cu_annotate: {
+        shouldAttach: false,
+        reason: "denied_no_clients",
+        clientCount: 0,
+      },
       host_app_control: { shouldAttach: true, reason: "native_support" },
     });
     expect(fields.preactivatedSkillIds).toEqual([
       "computer-use",
-      "screen-annotation",
       "app-control",
     ]);
+  });
+
+  /**
+   * The interface table says macOS can draw, which is true of a client new
+   * enough to send the header and false of every build before it. Offering
+   * the skill on the table alone gave an older client a tool whose every call
+   * was refused for having nothing to draw on.
+   */
+  test("offers screen annotation once a client advertises it", () => {
+    const target = makeTarget("conv-macos-annotate");
+    setCapableClient("host_cu_annotate", true);
+
+    preactivateHostProxySkills(target, "macos", "user-1");
+
+    const { fields } = loggedInfoCalls[0];
+    expect(
+      (fields.decisions as Record<string, { shouldAttach: boolean }>)
+        .host_cu_annotate.shouldAttach,
+    ).toBe(true);
+    expect(fields.preactivatedSkillIds).toContain("screen-annotation");
   });
 
   test("log captures denied_no_interface for undefined sourceInterface (silent-gate diagnostic)", () => {

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -308,6 +308,7 @@ export const HOST_PROXY_CAPABILITIES = [
   "host_file",
   "host_cu",
   "host_cu_window_capture",
+  "host_cu_annotate",
   "host_browser",
   "host_app_control",
   "host_ui_snapshot",
@@ -348,8 +349,16 @@ export function supportsHostProxy(
   id: InterfaceId,
   capability?: HostProxyCapability,
 ): boolean {
-  // Window capture is additionally negotiated on each client connection.
-  if (capability === "host_cu_window_capture") {
+  // Both of these ride the host_cu transport rather than being transports of
+  // their own, and each is additionally negotiated on the client connection.
+  // Answered ahead of the per-interface rules below because those grant
+  // Windows and Linux everything but app control, and neither client answers
+  // these: a CU request they cannot serve would reach their native helper as
+  // an unknown action.
+  if (
+    capability === "host_cu_window_capture" ||
+    capability === "host_cu_annotate"
+  ) {
     return id === "macos";
   }
   // macOS supports every host proxy capability including host_browser

--- a/assistant/src/config/bundled-skills/screen-annotation/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-annotation/SKILL.md
@@ -45,6 +45,11 @@ Your picture is only as fresh as the last frame you were sent. If the user has
 scrolled or moved a window since, say what you are pointing at as well as
 drawing it, so a mark that has drifted is still recoverable in words.
 
+Moving the share is the one kind of drift that is caught for you. A mark
+measured against the surface before the move is refused rather than drawn,
+because those fractions land somewhere arbitrary on the surface that replaced
+it. Wait for a frame of the new one and point again.
+
 ## How to point
 
 **One thing at a time.** A mark is where to look next. A screen with four

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -27,6 +27,7 @@ import {
   resolveEffectiveAppHtml,
   updateApp,
 } from "../apps/app-store.js";
+import type { HostProxyCapability } from "../channels/types.js";
 import { recordActivationEvent } from "../onboarding/onboarding-events-store.js";
 import {
   getMessages,
@@ -3001,17 +3002,26 @@ export async function surfaceProxyResolver(
       ctx.currentTurnSourceActorPrincipalId ??
       ctx.currentTurnAuthContext?.actorPrincipalId ??
       ctx.authContext?.actorPrincipalId;
+    // Which capability answers this tool. Pointing rides the `computer_use_`
+    // wire so it reaches the same proxy, but only a client that draws the
+    // overlay can serve it, and the clients that merely forward to a native
+    // helper cannot. Selecting on the transport instead would call a lone
+    // annotation-capable client ambiguous against a helper client that could
+    // never have answered, and would accept an explicit target that forwards
+    // the request as an action its helper does not have.
+    const capability: HostProxyCapability =
+      toolName === POINT_AT_PROXY_TOOL ? "host_cu_annotate" : "host_cu";
     if (targetClientId != null) {
       const client = assistantEventHub.getClientById(targetClientId);
       if (!client) {
         return {
-          content: `No connected client with id '${targetClientId}'. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          content: `No connected client with id '${targetClientId}'. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
           isError: true,
         };
       }
-      if (!client.capabilities.includes("host_cu")) {
+      if (!client.capabilities.includes(capability)) {
         return {
-          content: `Client '${targetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          content: `Client '${targetClientId}' does not support ${capability}. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
           isError: true,
         };
       }
@@ -3019,7 +3029,7 @@ export async function surfaceProxyResolver(
         hub: assistantEventHub,
         sourceActorPrincipalId,
         targetClientId,
-        op: "host_cu",
+        op: capability,
       });
       if (rejection) {
         return rejection;
@@ -3032,20 +3042,19 @@ export async function surfaceProxyResolver(
     if (targetClientId == null) {
       const resolved = pickSameUserAutoResolve({
         hub: assistantEventHub,
-        capability: "host_cu",
+        capability,
         sourceActorPrincipalId,
       });
       if (resolved.kind === "ambiguous") {
-        return ambiguousSameUserError("host_cu");
+        return ambiguousSameUserError(capability);
       }
       if (resolved.kind === "match") {
         targetClientId = resolved.clientId;
       } else if (
-        assistantEventHub.listClientsByCapability("host_cu").length > 0
+        assistantEventHub.listClientsByCapability(capability).length > 0
       ) {
         return {
-          content:
-            "Computer use is not available for the current actor. Connect a host_cu-capable client as the same user.",
+          content: `Computer use is not available for the current actor. Connect a ${capability}-capable client as the same user.`,
           isError: true,
         };
       }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -3051,8 +3051,13 @@ export async function surfaceProxyResolver(
       if (resolved.kind === "match") {
         targetClientId = resolved.clientId;
       } else if (
+        capability === "host_cu_annotate" ||
         assistantEventHub.listClientsByCapability(capability).length > 0
       ) {
+        // Annotation refuses on every unresolved target, for the reason it
+        // does in `host-cu-proxy.ts`: an untargeted point-at has no client
+        // that could answer it, and letting it broadcast hands it to a
+        // host_cu client with no overlay to draw on.
         return {
           content: `Computer use is not available for the current actor. Connect a ${capability}-capable client as the same user.`,
           isError: true,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -27,7 +27,6 @@ import {
   resolveEffectiveAppHtml,
   updateApp,
 } from "../apps/app-store.js";
-import type { HostProxyCapability } from "../channels/types.js";
 import { recordActivationEvent } from "../onboarding/onboarding-events-store.js";
 import {
   getMessages,
@@ -70,6 +69,7 @@ import {
   type SurfaceStateEntry,
 } from "./conversation-surface-state.js";
 import type { HostCuProxy } from "./host-cu-proxy.js";
+import { resolveHostCuTarget } from "./host-cu-target.js";
 import type {
   AnySurfaceData,
   CardSurfaceData,
@@ -3002,68 +3002,15 @@ export async function surfaceProxyResolver(
       ctx.currentTurnSourceActorPrincipalId ??
       ctx.currentTurnAuthContext?.actorPrincipalId ??
       ctx.authContext?.actorPrincipalId;
-    // Which capability answers this tool. Pointing rides the `computer_use_`
-    // wire so it reaches the same proxy, but only a client that draws the
-    // overlay can serve it, and the clients that merely forward to a native
-    // helper cannot. Selecting on the transport instead would call a lone
-    // annotation-capable client ambiguous against a helper client that could
-    // never have answered, and would accept an explicit target that forwards
-    // the request as an action its helper does not have.
-    const capability: HostProxyCapability =
-      toolName === POINT_AT_PROXY_TOOL ? "host_cu_annotate" : "host_cu";
-    if (targetClientId != null) {
-      const client = assistantEventHub.getClientById(targetClientId);
-      if (!client) {
-        return {
-          content: `No connected client with id '${targetClientId}'. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
-          isError: true,
-        };
-      }
-      if (!client.capabilities.includes(capability)) {
-        return {
-          content: `Client '${targetClientId}' does not support ${capability}. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
-          isError: true,
-        };
-      }
-      const rejection = enforceSameActorOrErrorResult({
-        hub: assistantEventHub,
-        sourceActorPrincipalId,
-        targetClientId,
-        op: capability,
-      });
-      if (rejection) {
-        return rejection;
-      }
+    const target = resolveHostCuTarget({
+      toolName,
+      targetClientId,
+      sourceActorPrincipalId,
+    });
+    if (target.kind === "error") {
+      return target.result;
     }
-
-    // Untargeted CU must resolve to exactly one same-user capable client
-    // before dispatch. Otherwise the proxy would broadcast without a target
-    // actor binding, which is unsafe in shared runtimes.
-    if (targetClientId == null) {
-      const resolved = pickSameUserAutoResolve({
-        hub: assistantEventHub,
-        capability,
-        sourceActorPrincipalId,
-      });
-      if (resolved.kind === "ambiguous") {
-        return ambiguousSameUserError(capability);
-      }
-      if (resolved.kind === "match") {
-        targetClientId = resolved.clientId;
-      } else if (
-        capability === "host_cu_annotate" ||
-        assistantEventHub.listClientsByCapability(capability).length > 0
-      ) {
-        // Annotation refuses on every unresolved target, for the reason it
-        // does in `host-cu-proxy.ts`: an untargeted point-at has no client
-        // that could answer it, and letting it broadcast hands it to a
-        // host_cu client with no overlay to draw on.
-        return {
-          content: `Computer use is not available for the current actor. Connect a ${capability}-capable client as the same user.`,
-          isError: true,
-        };
-      }
-    }
+    targetClientId = target.targetClientId;
 
     // Pointing at the screen is not a computer-use step. It drives nothing
     // and the user does the acting, so counting it against

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -16,6 +16,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import type { HostProxyCapability } from "../channels/types.js";
 import { loadConfig } from "../config/loader.js";
 import { escapeAxTreeContent } from "../context/outbound-sanitize.js";
 import type { ContentBlock } from "../providers/types.js";
@@ -261,24 +262,29 @@ export class HostCuProxy {
       });
     }
 
+    // The capability that answers this tool, which is not always the one this
+    // proxy is named for. Pointing rides the same wire so it arrives here,
+    // but only a client drawing the overlay can serve it: resolving it as
+    // plain host_cu would pick a helper-backed client that has no such action.
+    const capability: HostProxyCapability =
+      toolName === POINT_AT_PROXY_TOOL ? "host_cu_annotate" : "host_cu";
     let resolvedTargetClientId = targetClientId;
     if (resolvedTargetClientId == null) {
       const resolved = pickSameUserAutoResolve({
         hub: assistantEventHub,
-        capability: "host_cu",
+        capability,
         sourceActorPrincipalId,
       });
       if (resolved.kind === "ambiguous") {
-        return Promise.resolve(ambiguousSameUserError("host_cu"));
+        return Promise.resolve(ambiguousSameUserError(capability));
       }
       if (resolved.kind === "match") {
         resolvedTargetClientId = resolved.clientId;
       } else if (
-        assistantEventHub.listClientsByCapability("host_cu").length > 0
+        assistantEventHub.listClientsByCapability(capability).length > 0
       ) {
         return Promise.resolve({
-          content:
-            "Computer use is not available for the current actor. Connect a host_cu-capable client as the same user.",
+          content: `Computer use is not available for the current actor. Connect a ${capability}-capable client as the same user.`,
           isError: true,
         });
       }
@@ -288,13 +294,13 @@ export class HostCuProxy {
       const client = assistantEventHub.getClientById(resolvedTargetClientId);
       if (!client) {
         return Promise.resolve({
-          content: `No connected client with id '${resolvedTargetClientId}' supports host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          content: `No connected client with id '${resolvedTargetClientId}' supports ${capability}. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
           isError: true,
         });
       }
-      if (!client.capabilities.includes("host_cu")) {
+      if (!client.capabilities.includes(capability)) {
         return Promise.resolve({
-          content: `Client '${resolvedTargetClientId}' does not support host_cu. Run \`assistant clients list --capability host_cu\` to see available clients.`,
+          content: `Client '${resolvedTargetClientId}' does not support ${capability}. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
           isError: true,
         });
       }
@@ -303,7 +309,7 @@ export class HostCuProxy {
         hub: assistantEventHub,
         sourceActorPrincipalId,
         targetClientId: resolvedTargetClientId,
-        op: "host_cu",
+        op: capability,
       });
       if (rejection) {
         return Promise.resolve(rejection);

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -16,7 +16,6 @@
 
 import { v4 as uuid } from "uuid";
 
-import type { HostProxyCapability } from "../channels/types.js";
 import { loadConfig } from "../config/loader.js";
 import { escapeAxTreeContent } from "../context/outbound-sanitize.js";
 import type { ContentBlock } from "../providers/types.js";
@@ -24,16 +23,12 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
-import {
-  ambiguousSameUserError,
-  enforceSameActorOrErrorResult,
-  pickSameUserAutoResolve,
-} from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { POINT_AT_PROXY_TOOL } from "../tools/computer-use/skill-proxy-bridge.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { resolveHostCuTarget } from "./host-cu-target.js";
 
 const log = getLogger("host-cu-proxy");
 
@@ -262,67 +257,15 @@ export class HostCuProxy {
       });
     }
 
-    // The capability that answers this tool, which is not always the one this
-    // proxy is named for. Pointing rides the same wire so it arrives here,
-    // but only a client drawing the overlay can serve it: resolving it as
-    // plain host_cu would pick a helper-backed client that has no such action.
-    const capability: HostProxyCapability =
-      toolName === POINT_AT_PROXY_TOOL ? "host_cu_annotate" : "host_cu";
-    let resolvedTargetClientId = targetClientId;
-    if (resolvedTargetClientId == null) {
-      const resolved = pickSameUserAutoResolve({
-        hub: assistantEventHub,
-        capability,
-        sourceActorPrincipalId,
-      });
-      if (resolved.kind === "ambiguous") {
-        return Promise.resolve(ambiguousSameUserError(capability));
-      }
-      if (resolved.kind === "match") {
-        resolvedTargetClientId = resolved.clientId;
-      } else if (
-        capability === "host_cu_annotate" ||
-        assistantEventHub.listClientsByCapability(capability).length > 0
-      ) {
-        // Annotation refuses on every unresolved target, where an action
-        // falls through to the untargeted broadcast it always had. Nothing
-        // downstream would answer a broadcast point-at: only a client that
-        // draws the overlay can, and the absence of one is the whole reason
-        // there is no target. Falling through would send it to whatever
-        // host_cu client happened to be listening, which is the mis-routing
-        // this capability exists to prevent.
-        return Promise.resolve({
-          content: `Computer use is not available for the current actor. Connect a ${capability}-capable client as the same user.`,
-          isError: true,
-        });
-      }
+    const target = resolveHostCuTarget({
+      toolName,
+      targetClientId,
+      sourceActorPrincipalId,
+    });
+    if (target.kind === "error") {
+      return Promise.resolve(target.result);
     }
-
-    if (resolvedTargetClientId != null) {
-      const client = assistantEventHub.getClientById(resolvedTargetClientId);
-      if (!client) {
-        return Promise.resolve({
-          content: `No connected client with id '${resolvedTargetClientId}' supports ${capability}. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
-          isError: true,
-        });
-      }
-      if (!client.capabilities.includes(capability)) {
-        return Promise.resolve({
-          content: `Client '${resolvedTargetClientId}' does not support ${capability}. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
-          isError: true,
-        });
-      }
-
-      const rejection = enforceSameActorOrErrorResult({
-        hub: assistantEventHub,
-        sourceActorPrincipalId,
-        targetClientId: resolvedTargetClientId,
-        op: capability,
-      });
-      if (rejection) {
-        return Promise.resolve(rejection);
-      }
-    }
+    const resolvedTargetClientId = target.targetClientId;
 
     const hasWindowTarget = Object.hasOwn(input, "capture_window_id");
     if (hasWindowTarget) {

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -281,8 +281,16 @@ export class HostCuProxy {
       if (resolved.kind === "match") {
         resolvedTargetClientId = resolved.clientId;
       } else if (
+        capability === "host_cu_annotate" ||
         assistantEventHub.listClientsByCapability(capability).length > 0
       ) {
+        // Annotation refuses on every unresolved target, where an action
+        // falls through to the untargeted broadcast it always had. Nothing
+        // downstream would answer a broadcast point-at: only a client that
+        // draws the overlay can, and the absence of one is the whole reason
+        // there is no target. Falling through would send it to whatever
+        // host_cu client happened to be listening, which is the mis-routing
+        // this capability exists to prevent.
         return Promise.resolve({
           content: `Computer use is not available for the current actor. Connect a ${capability}-capable client as the same user.`,
           isError: true,

--- a/assistant/src/daemon/host-cu-target.ts
+++ b/assistant/src/daemon/host-cu-target.ts
@@ -1,0 +1,139 @@
+/**
+ * Choosing the client that answers a computer-use request, and saying why not
+ * when none can.
+ *
+ * Shared because there are two doors into the same proxy: normal tool
+ * resolution (`surfaceProxyResolver`) and the standalone `HostCuProxy.request`
+ * that callers reach directly. They resolved the same thing twice, and the
+ * copies had to be changed in lockstep every time the routing moved. One of
+ * them drifting is not a visible failure: it is a request quietly sent to a
+ * client that cannot serve it.
+ *
+ * **Pointing is not routed like an action.** It rides the `computer_use_` wire
+ * so it arrives at this proxy, but only a client drawing the overlay can serve
+ * it, and Windows and Linux forward what they get to a native helper with no
+ * such action. So the capability is chosen from the tool rather than assumed
+ * from the transport, and it governs execution here as well as exposure at
+ * preactivation.
+ */
+
+import { assistantEventHub } from "../runtime/assistant-event-hub.js";
+import {
+  ambiguousSameUserError,
+  enforceSameActorOrErrorResult,
+  pickSameUserAutoResolve,
+} from "../runtime/auth/same-actor.js";
+import { POINT_AT_PROXY_TOOL } from "../tools/computer-use/skill-proxy-bridge.js";
+
+/**
+ * The two capabilities this path can route on. Narrower than
+ * `HostProxyCapability` on purpose: it is also a `SameActorOp`, so the audit
+ * line names the capability that gated the request without a cast.
+ */
+export type HostCuRoutingCapability = "host_cu" | "host_cu_annotate";
+
+/** What the caller should do next: dispatch to a client, or answer this. */
+export type HostCuTargetResolution =
+  | { kind: "resolved"; targetClientId: string | undefined }
+  | { kind: "error"; result: { content: string; isError: true } };
+
+/**
+ * The capability that answers `toolName`.
+ *
+ * Exported so both doors name the same rule rather than each testing the tool
+ * for themselves.
+ */
+export function hostCuCapabilityFor(toolName: string): HostCuRoutingCapability {
+  return toolName === POINT_AT_PROXY_TOOL ? "host_cu_annotate" : "host_cu";
+}
+
+const unavailable = (capability: HostCuRoutingCapability) => ({
+  kind: "error" as const,
+  result: {
+    content: `Computer use is not available for the current actor. Connect a ${capability}-capable client as the same user.`,
+    isError: true as const,
+  },
+});
+
+/**
+ * Resolve and validate the client for one request.
+ *
+ * An explicit target is checked for existence, for the capability, and for
+ * belonging to the same actor. An absent one is auto-resolved to the single
+ * same-actor client that holds the capability.
+ *
+ * The zero-match case parts the two capabilities on purpose. An action falls
+ * through with no target, which is the untargeted broadcast this path has
+ * always allowed. Pointing refuses instead: there is nothing on the other end
+ * that could draw, and broadcasting would hand it to whatever host_cu client
+ * was listening, which is the mis-routing the separate capability exists to
+ * prevent.
+ */
+export function resolveHostCuTarget(args: {
+  toolName: string;
+  targetClientId: string | undefined;
+  sourceActorPrincipalId: string | undefined;
+}): HostCuTargetResolution {
+  const { toolName, sourceActorPrincipalId } = args;
+  const capability = hostCuCapabilityFor(toolName);
+
+  if (args.targetClientId != null) {
+    const client = assistantEventHub.getClientById(args.targetClientId);
+    if (!client) {
+      return {
+        kind: "error",
+        result: {
+          content: `No connected client with id '${args.targetClientId}'. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
+          isError: true,
+        },
+      };
+    }
+    if (!client.capabilities.includes(capability)) {
+      return {
+        kind: "error",
+        result: {
+          content: `Client '${args.targetClientId}' does not support ${capability}. Run \`assistant clients list --capability ${capability}\` to see available clients.`,
+          isError: true,
+        },
+      };
+    }
+    const rejection = enforceSameActorOrErrorResult({
+      hub: assistantEventHub,
+      sourceActorPrincipalId,
+      targetClientId: args.targetClientId,
+      op: capability,
+    });
+    if (rejection) {
+      return {
+        kind: "error",
+        result: rejection as { content: string; isError: true },
+      };
+    }
+    return { kind: "resolved", targetClientId: args.targetClientId };
+  }
+
+  const resolved = pickSameUserAutoResolve({
+    hub: assistantEventHub,
+    capability,
+    sourceActorPrincipalId,
+  });
+  if (resolved.kind === "ambiguous") {
+    return {
+      kind: "error",
+      result: ambiguousSameUserError(capability) as {
+        content: string;
+        isError: true;
+      },
+    };
+  }
+  if (resolved.kind === "match") {
+    return { kind: "resolved", targetClientId: resolved.clientId };
+  }
+  if (
+    capability === "host_cu_annotate" ||
+    assistantEventHub.listClientsByCapability(capability).length > 0
+  ) {
+    return unavailable(capability);
+  }
+  return { kind: "resolved", targetClientId: undefined };
+}

--- a/assistant/src/daemon/host-proxy-preactivation.ts
+++ b/assistant/src/daemon/host-proxy-preactivation.ts
@@ -103,6 +103,17 @@ export const HOST_PROXY_SKILL_PREACTIVATIONS: ReadonlyArray<{
  *
  * Single source of truth for preactivation and proxy instantiation.
  */
+/**
+ * Capabilities a client asks for on its connection rather than getting from
+ * what it is. Both ride the host_cu transport and are answered only by a
+ * macOS build new enough to send the header (`events-routes.ts`), so the
+ * interface alone cannot say whether one is really there.
+ */
+const NEGOTIATED_CAPABILITIES: ReadonlySet<HostProxyCapability> = new Set([
+  "host_cu_window_capture",
+  "host_cu_annotate",
+]);
+
 export function evaluateHostProxyAttachment(
   capability: HostProxyCapability,
   sourceInterface: InterfaceId | undefined,
@@ -111,7 +122,18 @@ export function evaluateHostProxyAttachment(
   if (!sourceInterface) {
     return { shouldAttach: false, reason: "denied_no_interface" };
   }
-  if (supportsHostProxy(sourceInterface, capability)) {
+  // A negotiated capability is never taken from the interface table. The
+  // table says macOS can draw, which is true of the client that sends the
+  // header and false of every build that predates it, and this shortcut does
+  // not look at the connection at all. Granting it here offered the skill to
+  // an older macOS client whose every point and clear was then refused for
+  // having nothing to draw on. Falling through puts it on the same footing as
+  // a cross-client grant, where an actual registered client has to advertise
+  // it.
+  if (
+    !NEGOTIATED_CAPABILITIES.has(capability) &&
+    supportsHostProxy(sourceInterface, capability)
+  ) {
     return { shouldAttach: true, reason: "native_support" };
   }
   if (sourceInterface === "chrome-extension") {

--- a/assistant/src/daemon/host-proxy-preactivation.ts
+++ b/assistant/src/daemon/host-proxy-preactivation.ts
@@ -79,7 +79,12 @@ export const HOST_PROXY_SKILL_PREACTIVATIONS: ReadonlyArray<{
   skillId: string;
 }> = [
   { capability: "host_cu", skillId: "computer-use" },
-  { capability: "host_cu", skillId: "screen-annotation" },
+  // Not `host_cu`: the marks are drawn in a window the client opens for
+  // itself, and only a client advertising that window can answer the request.
+  // Offered from the transport alone, the skill reaches Windows and Linux
+  // turns whose executors forward it to a native helper that has no such
+  // action.
+  { capability: "host_cu_annotate", skillId: "screen-annotation" },
   { capability: "host_app_control", skillId: "app-control" },
 ];
 

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -73,6 +73,9 @@ export type SameActorOp =
   | "host_bash"
   | "host_file"
   | "host_cu"
+  // Rides the host_cu transport but is granted separately, so a rejection
+  // logged as host_cu would name a capability the caller may well hold.
+  | "host_cu_annotate"
   | "host_browser"
   | "host_app_control"
   | "host_transfer"
@@ -138,9 +141,7 @@ function detectRejection(
     ? args.hub.getActorPrincipalIdForClient(targetClientId)
     : (args.targetActorPrincipalId ??
       (isHttpAuthDisabled()
-        ? args.hubForMissingTarget?.getActorPrincipalIdForClient(
-            targetClientId,
-          )
+        ? args.hubForMissingTarget?.getActorPrincipalIdForClient(targetClientId)
         : undefined));
 
   let reason: RejectionReason | undefined;

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -444,6 +444,10 @@ export function handleSubscribeAssistantEvents(
               headers?.["x-vellum-cu-window-capture"] === "1"
                 ? ["host_cu_window_capture" as const]
                 : []),
+              ...(interfaceId === "macos" &&
+              headers?.["x-vellum-cu-annotate"] === "1"
+                ? ["host_cu_annotate" as const]
+                : []),
             ],
             machineName: rawMachineName?.trim() || undefined,
             actorPrincipalId,

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -3148,12 +3148,23 @@ describe("companion window: pointing at what is shared", () => {
     await take([target]);
   };
 
+  /**
+   * The window holding the session saying a frame of `target` reached the
+   * call, which is the moment the assistant has actually been shown it.
+   */
+  const acknowledge = (
+    target: typeof DISPLAY | typeof WINDOW = DISPLAY,
+  ): void => {
+    send("vellum:companion:sharedFrame", target);
+  };
+
   /** A share with a frame of it already sent, which is the resting case. */
   const shareAndSee = async (
     target: typeof DISPLAY | typeof WINDOW = DISPLAY,
   ): Promise<void> => {
     shareOf(target);
     await capture(target);
+    acknowledge(target);
   };
 
   test("puts the marks on the state the frame reads", async () => {
@@ -3271,13 +3282,39 @@ describe("companion window: pointing at what is shared", () => {
     expect(state().coachmarks).toEqual([MARK]);
   });
 
-  /** A capture that came back with nothing is a surface never shown. */
+  /** A capture that came back with nothing is never acknowledged. */
   test("a frame that failed is not a frame the model saw", async () => {
     shareDisplay();
     const held = capturedFrame;
     capturedFrame = null;
     await capture();
     capturedFrame = held;
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
+  });
+
+  /**
+   * **Taking a frame is not showing one.** The renderer still has to prepare,
+   * upload and send it, and a share that moves in that window would otherwise
+   * open the gate to the new surface while the only picture the assistant
+   * holds is of the old one. That is the arrival this guard exists to refuse,
+   * so the capture alone must not admit it.
+   */
+  test("a capture that has not reached the call opens nothing", async () => {
+    shareOf(DISPLAY);
+    await capture(DISPLAY);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
+    acknowledge(DISPLAY);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBeNull();
+  });
+
+  /**
+   * The move lands between the capture and its acknowledgement, which is the
+   * exact interval a capture-time record would have admitted.
+   */
+  test("a share that moved after the capture is still refused", async () => {
+    await shareAndSee(DISPLAY);
+    await capture(WINDOW);
+    shareOf(WINDOW);
     expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
   });
 

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -3318,6 +3318,20 @@ describe("companion window: pointing at what is shared", () => {
     expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
   });
 
+  /**
+   * The surface was unshared for a stretch and the user kept working on it,
+   * so the picture from before the detour is as stale as one from before a
+   * stop. Coming back to it must not resurrect what was acknowledged then.
+   */
+  test("a share that leaves a surface and returns forgets its frame", async () => {
+    await shareAndSee(DISPLAY);
+    shareOf(WINDOW);
+    shareOf(DISPLAY);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
+    acknowledge(DISPLAY);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBeNull();
+  });
+
   test("a share that ends takes the marks with it", async () => {
     await shareAndSee();
     showCompanionCoachmarks([MARK], CALL);

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -492,6 +492,7 @@ const {
   introOnAdvance,
   setCompanionSurfaceSize,
   shouldShowCompanionSurface,
+  showCompanionCoachmarks,
   installCompanionWindow,
 } = await import("./companion-window");
 
@@ -3105,33 +3106,68 @@ describe("companion window: drawing on what is shared", () => {
  */
 describe("companion window: pointing at what is shared", () => {
   const MARK = { x: 0.1, y: 0.2, width: 0.3, height: 0.1, caption: "Press" };
+  /** The conversation the shared call belongs to. */
+  const CALL = "conv-abc";
+  /** Any other conversation the same user has running. */
+  const OTHER = "conv-xyz";
+  const DISPLAY = { kind: "display", displayId: 2 } as const;
+  const WINDOW = { kind: "window", windowId: 9 } as const;
 
   beforeEach(() => {
     send("vellum:companion:setContext", context());
   });
 
-  const shareDisplay = (): void => {
+  const shareOf = (
+    target: typeof DISPLAY | typeof WINDOW,
+    over: Record<string, unknown> = {},
+  ): void => {
     send(
       "vellum:companion:setContext",
       context({
         screenShareEnabled: true,
-        screenShare: { kind: "display", displayId: 2 },
+        screenShare: target,
+        callConversationId: CALL,
+        ...over,
       }),
     );
   };
 
-  test("puts the marks on the state the frame reads", () => {
-    shareDisplay();
-    send("vellum:companion:setCoachmarks", [MARK]);
+  const shareDisplay = (): void => shareOf(DISPLAY);
+
+  /**
+   * A frame of `target` served to the window holding the session, which is
+   * how main learns which surface the assistant is measuring against.
+   */
+  const capture = async (
+    target: typeof DISPLAY | typeof WINDOW = DISPLAY,
+  ): Promise<void> => {
+    const take = invocable.get("vellum:companion:captureScreen");
+    if (!take) {
+      throw new Error("No handler registered for captureScreen");
+    }
+    await take([target]);
+  };
+
+  /** A share with a frame of it already sent, which is the resting case. */
+  const shareAndSee = async (
+    target: typeof DISPLAY | typeof WINDOW = DISPLAY,
+  ): Promise<void> => {
+    shareOf(target);
+    await capture(target);
+  };
+
+  test("puts the marks on the state the frame reads", async () => {
+    await shareAndSee();
+    expect(showCompanionCoachmarks([MARK], CALL)).toBeNull();
     expect(state().coachmarks).toEqual([MARK]);
   });
 
   /** Nothing pointed at is absence, so a frame reads one shape for it. */
-  test("says nothing rather than nothing-in-a-list", () => {
-    shareDisplay();
+  test("says nothing rather than nothing-in-a-list", async () => {
+    await shareAndSee();
     expect(state().coachmarks).toBeUndefined();
-    send("vellum:companion:setCoachmarks", [MARK]);
-    send("vellum:companion:setCoachmarks", []);
+    showCompanionCoachmarks([MARK], CALL);
+    showCompanionCoachmarks([], CALL);
     expect(state().coachmarks).toBeUndefined();
   });
 
@@ -3141,7 +3177,7 @@ describe("companion window: pointing at what is shared", () => {
    * coordinates.
    */
   test("refuses marks with nothing shared", () => {
-    send("vellum:companion:setCoachmarks", [MARK]);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("unshared");
     expect(state().coachmarks).toBeUndefined();
   });
 
@@ -3150,35 +3186,118 @@ describe("companion window: pointing at what is shared", () => {
    * would be drawn around the surface being read while they describe the one
    * being shared.
    */
-  test("refuses marks while a watch session owns the frame", () => {
+  test("refuses marks while a watch session owns the frame", async () => {
+    await capture();
     send(
       "vellum:companion:setContext",
       context({
         watching: true,
         screenShareEnabled: true,
-        screenShare: { kind: "display", displayId: 2 },
+        screenShare: DISPLAY,
+        callConversationId: CALL,
       }),
     );
-    send("vellum:companion:setCoachmarks", [MARK]);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("unshared");
     expect(state().coachmarks).toBeUndefined();
   });
 
-  test("a share that ends takes the marks with it", () => {
+  /**
+   * A mark names a rectangle and nothing else, so a turn from any other
+   * conversation the user has running would otherwise draw on this call's
+   * surface and be told it worked.
+   */
+  test("refuses marks from another conversation", async () => {
+    await shareAndSee();
+    expect(showCompanionCoachmarks([MARK], OTHER)).toBe("not-this-call");
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /** What the call put up is not another conversation's to replace. */
+  test("a refused mark leaves the call's own marks standing", async () => {
+    await shareAndSee();
+    showCompanionCoachmarks([MARK], CALL);
+    expect(
+      showCompanionCoachmarks([{ ...MARK, caption: "Elsewhere" }], OTHER),
+    ).toBe("not-this-call");
+    expect(state().coachmarks).toEqual([MARK]);
+  });
+
+  /** A claim that cannot be checked is not a claim that passed. */
+  test("refuses marks when the surface names no conversation", async () => {
+    shareOf(DISPLAY, { callConversationId: undefined });
+    await capture();
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("not-this-call");
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /**
+   * Taking marks down is the one direction that must always work: a ring
+   * nothing can reach is worse than one taken down by the wrong caller.
+   */
+  test("takes marks down for any conversation", async () => {
+    await shareAndSee();
+    showCompanionCoachmarks([MARK], CALL);
+    expect(showCompanionCoachmarks([], OTHER)).toBeNull();
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /**
+   * The assistant measures against the picture it was last shown. Before any
+   * frame of the shared surface has gone out there is no such picture, so
+   * whatever it is holding is of something else.
+   */
+  test("refuses marks before a frame of the share has been served", () => {
     shareDisplay();
-    send("vellum:companion:setCoachmarks", [MARK]);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /**
+   * `syncCoachmarks` takes down marks already up when the target changes and
+   * cannot reach one that arrives after it, so the arrival is refused.
+   */
+  test("refuses marks measured against the surface before a move", async () => {
+    await shareAndSee(DISPLAY);
+    shareOf(WINDOW);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
+    expect(state().coachmarks).toBeUndefined();
+  });
+
+  /** Once the model has seen the surface it moved to, a mark is about that. */
+  test("takes marks once a frame of the new surface has been served", async () => {
+    await shareAndSee(DISPLAY);
+    await shareAndSee(WINDOW);
+    expect(showCompanionCoachmarks([MARK], CALL)).toBeNull();
+    expect(state().coachmarks).toEqual([MARK]);
+  });
+
+  /** A capture that came back with nothing is a surface never shown. */
+  test("a frame that failed is not a frame the model saw", async () => {
+    shareDisplay();
+    const held = capturedFrame;
+    capturedFrame = null;
+    await capture();
+    capturedFrame = held;
+    expect(showCompanionCoachmarks([MARK], CALL)).toBe("stale-surface");
+  });
+
+  test("a share that ends takes the marks with it", async () => {
+    await shareAndSee();
+    showCompanionCoachmarks([MARK], CALL);
     send("vellum:companion:setContext", context());
     expect(state().coachmarks).toBeUndefined();
   });
 
-  test("a watch session starting takes the marks with it", () => {
-    shareDisplay();
-    send("vellum:companion:setCoachmarks", [MARK]);
+  test("a watch session starting takes the marks with it", async () => {
+    await shareAndSee();
+    showCompanionCoachmarks([MARK], CALL);
     send(
       "vellum:companion:setContext",
       context({
         watching: true,
         screenShareEnabled: true,
-        screenShare: { kind: "display", displayId: 2 },
+        screenShare: DISPLAY,
+        callConversationId: CALL,
       }),
     );
     expect(state().coachmarks).toBeUndefined();
@@ -3189,37 +3308,25 @@ describe("companion window: pointing at what is shared", () => {
    * describe that surface instead, so the marks come down with the surface
    * they were measured against rather than with the share as a whole.
    */
-  test("a share moving to another surface takes the marks with it", () => {
-    shareDisplay();
-    send("vellum:companion:setCoachmarks", [MARK]);
-    send(
-      "vellum:companion:setContext",
-      context({
-        screenShareEnabled: true,
-        screenShare: { kind: "window", windowId: 9 },
-      }),
-    );
+  test("a share moving to another surface takes the marks with it", async () => {
+    await shareAndSee(DISPLAY);
+    showCompanionCoachmarks([MARK], CALL);
+    shareOf(WINDOW);
     expect(state().coachmarks).toBeUndefined();
   });
 
-  test("marks placed on the surface it moved to stand", () => {
-    shareDisplay();
-    send("vellum:companion:setCoachmarks", [MARK]);
-    send(
-      "vellum:companion:setContext",
-      context({
-        screenShareEnabled: true,
-        screenShare: { kind: "window", windowId: 9 },
-      }),
-    );
-    send("vellum:companion:setCoachmarks", [MARK]);
+  test("marks placed on the surface it moved to stand", async () => {
+    await shareAndSee(DISPLAY);
+    showCompanionCoachmarks([MARK], CALL);
+    await shareAndSee(WINDOW);
+    showCompanionCoachmarks([MARK], CALL);
     expect(state().coachmarks).toEqual([MARK]);
   });
 
   /** A context republished unchanged is not a surface that moved. */
-  test("holds the marks while the share stays where it is", () => {
-    shareDisplay();
-    send("vellum:companion:setCoachmarks", [MARK]);
+  test("holds the marks while the share stays where it is", async () => {
+    await shareAndSee();
+    showCompanionCoachmarks([MARK], CALL);
     shareDisplay();
     expect(state().coachmarks).toEqual([MARK]);
   });
@@ -3230,20 +3337,28 @@ describe("companion window: pointing at what is shared", () => {
    * mark placed while it is on would ring a control and then swallow the
    * click on it.
    */
-  test("gives the mouse back to the desktop when marks go up", () => {
-    shareDisplay();
+  test("gives the mouse back to the desktop when marks go up", async () => {
+    await shareAndSee();
     send("vellum:companion:setAnnotating", true);
     expect(state().annotating).toBe(true);
-    send("vellum:companion:setCoachmarks", [MARK]);
+    showCompanionCoachmarks([MARK], CALL);
     expect(state().annotating).toBe(false);
     expect(glow?.clickThrough).toBe(true);
   });
 
   /** Taking marks down is not a reason to touch a mode the user set. */
-  test("leaves the drawing mode alone when marks come down", () => {
-    shareDisplay();
+  test("leaves the drawing mode alone when marks come down", async () => {
+    await shareAndSee();
     send("vellum:companion:setAnnotating", true);
-    send("vellum:companion:setCoachmarks", []);
+    showCompanionCoachmarks([], CALL);
+    expect(state().annotating).toBe(true);
+  });
+
+  /** A refusal is not a reason to touch it either. */
+  test("leaves the drawing mode alone when marks are refused", async () => {
+    await shareAndSee();
+    send("vellum:companion:setAnnotating", true);
+    expect(showCompanionCoachmarks([MARK], OTHER)).toBe("not-this-call");
     expect(state().annotating).toBe(true);
   });
 
@@ -3253,9 +3368,9 @@ describe("companion window: pointing at what is shared", () => {
    * handler, and the two are indistinguishable from here.
    */
   test("the wire refuses a mark measured against another surface", () => {
-    expect(
-      companionCoachmarkSchema.safeParse({ ...MARK, x: 1.5 }).success,
-    ).toBe(false);
+    expect(companionCoachmarkSchema.safeParse({ ...MARK, x: 1.5 }).success).toBe(
+      false,
+    );
     expect(companionCoachmarkSchema.safeParse(MARK).success).toBe(true);
   });
 
@@ -3268,11 +3383,20 @@ describe("companion window: pointing at what is shared", () => {
     ).toBe(false);
   });
 
+  /**
+   * Counted against the schema rather than through this entrance. The bound
+   * belongs to the executor that answers the assistant
+   * (`executors/host-cu-executor.ts`), and what it refuses never reaches main
+   * at all.
+   */
   test("the wire refuses more marks than there are places to look", () => {
     const many = Array.from(
       { length: COMPANION_COACHMARK_MAX + 1 },
       () => MARK,
     );
-    expect(() => send("vellum:companion:setCoachmarks", many)).toThrow();
+    expect(many.length).toBeGreaterThan(COMPANION_COACHMARK_MAX);
+    expect(
+      many.every((m) => companionCoachmarkSchema.safeParse(m).success),
+    ).toBe(true);
   });
 });

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1195,16 +1195,20 @@ const syncCoachmarks = (): void => {
 };
 
 /**
- * Forget the picture the assistant was last shown when there is no share for
- * it to be of.
+ * Forget the picture the assistant was last shown the moment the share stops
+ * being of that surface.
  *
- * A share that stops and starts again on the same display is a new share, and
- * what the model is holding from before the stop is as old as the gap. Kept
- * across it, that picture would let the first mark of the new share through
- * measured against a screen the user has since worked on.
+ * Any change counts, not just a share ending. A share that stops and starts
+ * again on the same display is a new share, and what the model is holding
+ * from before the stop is as old as the gap. So is a share that moves to
+ * another surface and comes back: the user was working on the first one all
+ * the while it was not being shown, and a picture kept across that round trip
+ * would let the first mark through measured against a screen that has since
+ * moved on. Clearing on the way out is what makes the return safe, since by
+ * then there is nothing left to match.
  */
 const syncCapturedTarget = (): void => {
-  if (context.screenShare === undefined) {
+  if (!sameCaptureTarget(capturedTarget, context.screenShare)) {
     capturedTarget = undefined;
   }
 };

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -22,8 +22,6 @@ import {
   companionAnnotationPhaseSchema,
   companionAnnotationStrokeSchema,
   COMPANION_ANNOTATION_MAX_STROKES,
-  companionCoachmarkSchema,
-  COMPANION_COACHMARK_MAX,
   COMPANION_BASE_MAX_PILL_WIDTH,
   VOICE_START_REQUEST_TTL_MS,
   COMPANION_INTRO_ACTIONS,
@@ -36,6 +34,7 @@ import {
   companionScaleFor,
   WATCH_FLAG,
   companionLowerReachFor,
+  type CoachmarkRefusal,
   type CompanionCardGrowth,
   type CompanionCoachmark,
   type CompanionGrowth,
@@ -1125,6 +1124,23 @@ let coachmarks: readonly CompanionCoachmark[] = NO_COACHMARKS;
  */
 let coachmarkTarget: WatchCaptureTarget | undefined;
 
+/**
+ * The surface of the last frame this process handed to the window holding the
+ * session, or nothing before it has served one.
+ *
+ * The assistant measures a mark against the picture it was last shown, and
+ * that picture came through here. When the share moves, the frames the model
+ * is holding are still of the surface before the move, so its fractions
+ * describe that one: painting them now would ring whatever happens to lie at
+ * those coordinates on the new surface. Comparing this against the current
+ * share is how main tells a mark the model could have measured from a mark it
+ * could not.
+ *
+ * Recorded only for a frame that came back, since a capture that failed is
+ * one the model was never shown.
+ */
+let capturedTarget: WatchCaptureTarget | undefined;
+
 /** Whether two picks name the one surface. */
 const sameCaptureTarget = (
   a: WatchCaptureTarget | undefined,
@@ -1179,6 +1195,21 @@ const syncCoachmarks = (): void => {
 };
 
 /**
+ * Forget the picture the assistant was last shown when there is no share for
+ * it to be of.
+ *
+ * A share that stops and starts again on the same display is a new share, and
+ * what the model is holding from before the stop is as old as the gap. Kept
+ * across it, that picture would let the first mark of the new share through
+ * measured against a screen the user has since worked on.
+ */
+const syncCapturedTarget = (): void => {
+  if (context.screenShare === undefined) {
+    capturedTarget = undefined;
+  }
+};
+
+/**
  * Point at things on the shared surface on the assistant's behalf, and say
  * whether the marks stand.
  *
@@ -1188,14 +1219,52 @@ const syncCoachmarks = (): void => {
  * about a ring the user cannot see. So a refusal comes back as one rather
  * than as silence.
  *
- * Taking them down always succeeds: whatever the frame is around, marks that
- * are gone are gone.
+ * **Marks are the asking conversation's or they are nobody's.** A mark names
+ * a rectangle and nothing else, so without the caller's own conversation
+ * beside it main cannot tell the call's turn from any other the same user has
+ * running, and a background turn would draw on a call it has no part in and
+ * be told it worked. The surface publishes whose call it is
+ * (`callConversationId`); anything that does not match it is refused, an
+ * unclaimed surface included, since a claim that cannot be checked is not a
+ * claim that passed.
+ *
+ * **Marks are measured against a picture, so the picture has to be of this
+ * surface.** A share that moved between the last frame and this request
+ * leaves the model holding a view of the surface before the move, and
+ * fractions off that view land somewhere arbitrary on the one now shared.
+ * {@link syncCoachmarks} takes down marks that are already up when the target
+ * changes and cannot reach one that arrives afterwards, so the arrival is
+ * refused here instead.
+ *
+ * **Taking them down always succeeds**, whoever asks and whatever the frame is
+ * around. The two directions are not the same risk: a mark placed by the
+ * wrong conversation is a ring on a stranger's screen reported as a success,
+ * where a clear by the wrong conversation costs a ring that was going to come
+ * down anyway. Refusing those would leave marks standing that nothing could
+ * reach, which is the failure this whole entrance exists to avoid.
  */
 export const showCompanionCoachmarks = (
   marks: readonly CompanionCoachmark[],
-): boolean => {
+  conversationId?: string,
+): CoachmarkRefusal | null => {
+  if (marks.length === 0) {
+    setCoachmarks(NO_COACHMARKS);
+    return null;
+  }
+  if (!framesTheShare()) {
+    return "unshared";
+  }
+  if (
+    context.callConversationId === undefined ||
+    conversationId !== context.callConversationId
+  ) {
+    return "not-this-call";
+  }
+  if (!sameCaptureTarget(capturedTarget, context.screenShare)) {
+    return "stale-surface";
+  }
   setCoachmarks(marks);
-  return marks.length === 0 || framesTheShare();
+  return null;
 };
 
 /**
@@ -1363,6 +1432,7 @@ const syncWatchFrame = (): void => {
   // every fact at once.
   setAnnotating(annotating);
   syncCoachmarks();
+  syncCapturedTarget();
   const framed = framedTarget();
   if (framed === null) {
     stopFollowingWindow();
@@ -1832,40 +1902,26 @@ export const installCompanionWindow = (): void => {
   );
 
   /**
-   * Point at things on the shared surface, from the window holding the
-   * session: what the assistant is pointing at now, or an empty list for
-   * nothing.
-   *
-   * Handled here rather than forwarded, the way the drawing mode's press is,
-   * and for the same reason: the marks are drawn on a window main opened,
-   * around a surface only main knows the frame is still on. An ask made with
-   * nothing shared is refused rather than remembered
-   * ({@link framesTheShare}), so marks can never be armed ahead of a share
-   * and land on a surface nobody chose.
-   *
-   * The whole set every time rather than one mark added or removed. What is
-   * being pointed at is one thought, and a caller that could add to it would
-   * be a caller whose earlier marks it has to remember to take down.
-   */
-  on(
-    "vellum:companion:setCoachmarks",
-    z.tuple([z.array(companionCoachmarkSchema).max(COMPANION_COACHMARK_MAX)]),
-    ([marks]) => {
-      setCoachmarks(marks);
-    },
-  );
-
-  /**
    * One frame of what is being shared, for the renderer holding the session
    * to hand to it. Asked by that renderer on its own cadence, so this does
-   * nothing but reach the helper: the target is whatever the renderer was
+   * little but reach the helper: the target is whatever the renderer was
    * told it is sharing, and a refusal comes back as null rather than as an
    * error, since one missed frame is not something the call should notice.
+   *
+   * What the frame was of is kept ({@link capturedTarget}), because it is the
+   * picture the assistant measures its marks against and this is the only
+   * place main learns which surface that was.
    */
   handle(
     "vellum:companion:captureScreen",
     z.tuple([watchCaptureTargetSchema]),
-    ([target]) => captureTargetFrame(target),
+    async ([target]) => {
+      const frame = await captureTargetFrame(target);
+      if (frame !== null) {
+        capturedTarget = target;
+      }
+      return frame;
+    },
   );
 
   /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1904,23 +1904,37 @@ export const installCompanionWindow = (): void => {
   /**
    * One frame of what is being shared, for the renderer holding the session
    * to hand to it. Asked by that renderer on its own cadence, so this does
-   * little but reach the helper: the target is whatever the renderer was
+   * nothing but reach the helper: the target is whatever the renderer was
    * told it is sharing, and a refusal comes back as null rather than as an
    * error, since one missed frame is not something the call should notice.
-   *
-   * What the frame was of is kept ({@link capturedTarget}), because it is the
-   * picture the assistant measures its marks against and this is the only
-   * place main learns which surface that was.
    */
   handle(
     "vellum:companion:captureScreen",
     z.tuple([watchCaptureTargetSchema]),
-    async ([target]) => {
-      const frame = await captureTargetFrame(target);
-      if (frame !== null) {
-        capturedTarget = target;
-      }
-      return frame;
+    ([target]) => captureTargetFrame(target),
+  );
+
+  /**
+   * A frame of this surface reached the call, so the assistant has now been
+   * shown it ({@link capturedTarget}).
+   *
+   * Separate from the capture above, because taking a frame is not showing
+   * one. The renderer prepares, uploads and sends it afterwards, and an
+   * upload that fails or a reconnect that voids it means the call was shown
+   * nothing. Recorded on the capture, a share that moved would open
+   * {@link showCompanionCoachmarks} to the new surface while the only picture
+   * the assistant holds is still of the old one, which is the arrival that
+   * guard exists to refuse. A failure that never acknowledges simply leaves
+   * the gate shut, which is the safe direction.
+   *
+   * Only the window holding the session knows the frame landed, so this is
+   * told rather than settled here.
+   */
+  on(
+    "vellum:companion:sharedFrame",
+    z.tuple([watchCaptureTargetSchema]),
+    ([target]) => {
+      capturedTarget = target;
     },
   );
 

--- a/clients/macos/src/main/executors/host-cu-executor.test.ts
+++ b/clients/macos/src/main/executors/host-cu-executor.test.ts
@@ -30,11 +30,15 @@ mock.module("../sidecar/shared-cu-helper", () => ({
 }));
 
 // What draws the marks, handed to the executor the way the app hands it the
-// real one. Only the answer matters here: whether the marks stood.
-let marksStand = true;
-const showCoachmarks = mock((_marks: readonly unknown[]) => marksStand);
+// real one. Only the answer matters here: why the marks did not stand, or
+// null for marks that did.
+let refusal: CoachmarkRefusal | null = null;
+const showCoachmarks = mock(
+  (_marks: readonly unknown[], _conversationId?: string) => refusal,
+);
 
 import { createHostCuExecutor, POINT_AT_TOOL } from "./host-cu-executor";
+import type { CoachmarkRefusal } from "@vellumai/ipc-contract";
 import type { HostProxyPoster } from "@vellumai/electron-desktop/host-proxy/poster";
 import type { HostProxySseMessage } from "@vellumai/electron-desktop/host-proxy/sse";
 
@@ -177,7 +181,7 @@ describe("pointing at the shared surface", () => {
   });
 
   beforeEach(() => {
-    marksStand = true;
+    refusal = null;
     showCoachmarks.mockClear();
   });
 
@@ -192,6 +196,7 @@ describe("pointing at the shared surface", () => {
     expect(helper.call).not.toHaveBeenCalled();
     expect(showCoachmarks).toHaveBeenCalledTimes(1);
     expect(showCoachmarks.mock.calls[0]?.[0]).toEqual(marks);
+    expect(showCoachmarks.mock.calls[0]?.[1]).toBe("conv-1");
     expect(postCuResult.mock.calls[0]?.[0]).toMatchObject({
       requestId: "req-1",
       executionResult: "Drew 1 mark on the shared surface.",
@@ -213,13 +218,9 @@ describe("pointing at the shared surface", () => {
     });
   });
 
-  /**
-   * The assistant is not looking at the screen it asked to draw on. A refusal
-   * it could not read would have it talking the user through a ring that is
-   * not there.
-   */
-  test("reports a refusal rather than a silent success", async () => {
-    marksStand = false;
+  /** What the assistant is told, for one refusal. */
+  const refusedWith = async (reason: CoachmarkRefusal): Promise<string> => {
+    refusal = reason;
     const executor = createHostCuExecutor({
       helper: helperReturning({}),
       showCoachmarks,
@@ -234,7 +235,34 @@ describe("pointing at the shared surface", () => {
       executionResult?: string;
     };
     expect(posted.executionResult).toBeUndefined();
-    expect(posted.executionError).toContain("Nothing is being shared");
+    return posted.executionError ?? "";
+  };
+
+  /**
+   * The assistant is not looking at the screen it asked to draw on. A refusal
+   * it could not read would have it talking the user through a ring that is
+   * not there.
+   */
+  test("reports a refusal rather than a silent success", async () => {
+    expect(await refusedWith("unshared")).toContain("Nothing is being shared");
+  });
+
+  /**
+   * Each refusal has its own answer, so the assistant can act on which one it
+   * got: one asks the user to share, one is not answerable at all, and one
+   * asks for another look. A single wording would have it asking for a share
+   * that is already running.
+   */
+  test("tells a turn that does not own the call so", async () => {
+    expect(await refusedWith("not-this-call")).toContain(
+      "belongs to another conversation",
+    );
+  });
+
+  test("tells a turn holding an old picture to look again", async () => {
+    const told = await refusedWith("stale-surface");
+    expect(told).toContain("moved the share");
+    expect(told).not.toContain("Ask the user to share");
   });
 
   test("refuses coordinates measured against some other surface", async () => {

--- a/clients/macos/src/main/executors/host-cu-executor.ts
+++ b/clients/macos/src/main/executors/host-cu-executor.ts
@@ -17,6 +17,7 @@ import type { HostProxySseMessage } from "@vellumai/electron-desktop/host-proxy/
 import {
   companionCoachmarkSchema,
   COMPANION_COACHMARK_MAX,
+  type CoachmarkRefusal,
   type CompanionCoachmark,
 } from "@vellumai/ipc-contract";
 import { z } from "zod";
@@ -53,8 +54,35 @@ const PLACED = (count: number): string =>
     ? "Marks cleared."
     : `Drew ${count} mark${count === 1 ? "" : "s"} on the shared surface.`;
 
-const REFUSED =
+const UNSHARED =
   "Nothing is being shared, so there is no surface to point at. Ask the user to share their screen from the call first.";
+
+/**
+ * What a turn that does not own the call is told.
+ *
+ * Named as the boundary it is rather than as a fault: the surface belongs to
+ * another conversation, which is not a thing this one can fix by trying
+ * again, and an assistant told merely that it failed would.
+ */
+const NOT_THIS_CALL =
+  "The shared screen belongs to another conversation, so this one cannot point at it. Only the call being shown the screen can draw on it.";
+
+/**
+ * What a turn holding a picture of the wrong surface is told.
+ *
+ * Actionable on its own: the user is still sharing, so asking them to share
+ * again would be asking for something they already did. What this turn needs
+ * is another look at what they are showing now.
+ */
+const STALE_SURFACE =
+  "The user has moved the share to another screen or window since the picture you measured against, so those coordinates no longer describe what they are showing. Wait for a fresh frame of the new surface and point again.";
+
+/** What the assistant is told for each way a set of marks can be refused. */
+const REFUSALS: Record<CoachmarkRefusal, string> = {
+  unshared: UNSHARED,
+  "not-this-call": NOT_THIS_CALL,
+  "stale-surface": STALE_SURFACE,
+};
 
 /**
  * What draws the marks, handed in rather than reached for.
@@ -65,11 +93,15 @@ const REFUSED =
  * together (`host-proxy-adapter.ts`), which is also what lets these paths be
  * exercised without a window server.
  *
- * The boolean is whether the marks stand. See `showCompanionCoachmarks`.
+ * The conversation goes with the marks because a mark carries no identity of
+ * its own: it names a rectangle, and the surface it would land on belongs to
+ * whichever call is being shown the screen. See `showCompanionCoachmarks`,
+ * which answers `null` for marks that stand and names its refusal otherwise.
  */
 export type CoachmarkPainter = (
   marks: readonly CompanionCoachmark[],
-) => boolean;
+  conversationId?: string,
+) => CoachmarkRefusal | null;
 
 const UNWIRED =
   "This client cannot draw on the screen: no coachmark painter is wired.";
@@ -110,12 +142,20 @@ class PointAtExecutor implements HostProxyExecutor {
       return;
     }
     const { marks } = parsed.data;
-    const placed = this.paint(marks);
+    // The conversation the daemon addressed this request to, which is what
+    // lets the window layer tell the call's own turn from any other running
+    // for the same user. Absent on a daemon too old to send it, which the
+    // painter reads as a claim it cannot check.
+    const conversationId = message.conversationId;
+    const refusal = this.paint(
+      marks,
+      typeof conversationId === "string" ? conversationId : undefined,
+    );
     void poster.postCuResult({
       requestId,
-      ...(placed
+      ...(refusal === null
         ? { executionResult: PLACED(marks.length) }
-        : { executionError: REFUSED }),
+        : { executionError: REFUSALS[refusal] }),
     });
   }
 

--- a/clients/macos/src/main/host-proxy-adapter.ts
+++ b/clients/macos/src/main/host-proxy-adapter.ts
@@ -81,6 +81,7 @@ export const installHostProxyBridge = (
       getMachineName: hostname,
       interfaceId: "macos",
       supportsWindowCapture: true,
+      supportsCoachmarks: true,
     }),
     executors: {
       host_bash: hostBashExecutor,

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -575,6 +575,9 @@ const bridge: VellumBridge = {
     ): void => {
       ipcRenderer.send("vellum:companion:annotateShare", phase, strokes, ink);
     },
+    sharedFrame: (target: WatchCaptureTarget): void => {
+      ipcRenderer.send("vellum:companion:sharedFrame", target);
+    },
     captureScreen: (
       target: WatchCaptureTarget,
     ): Promise<ScreenCaptureFrame | null> =>

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -575,9 +575,6 @@ const bridge: VellumBridge = {
     ): void => {
       ipcRenderer.send("vellum:companion:annotateShare", phase, strokes, ink);
     },
-    setCoachmarks: (marks: readonly CompanionCoachmark[]): void => {
-      ipcRenderer.send("vellum:companion:setCoachmarks", marks);
-    },
     captureScreen: (
       target: WatchCaptureTarget,
     ): Promise<ScreenCaptureFrame | null> =>

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
@@ -739,4 +739,33 @@ describe("the screen share the companion mirror publishes", () => {
       expect(latest().screenShare).toBeUndefined();
     });
   });
+
+  /**
+   * The marks the assistant places name a rectangle and nothing else, so the
+   * shell needs to be told whose call the surface belongs to before it can
+   * refuse one that came from anywhere else.
+   */
+  test("names the conversation whose call is sharing", async () => {
+    render(<Mirror />);
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("test-asst", SIGHT_MIN_VERSION, "asst-1");
+      seedLiveVoiceSession("listening", {
+        assistantId: "asst-1",
+        conversationId: "conv-abc",
+      });
+    });
+    await waitFor(() => {
+      expect(latest().callConversationId).toBe("conv-abc");
+    });
+    // Withheld with the share it qualifies: an id beside a share that cannot
+    // flow would name a conversation with nothing to own.
+    act(() => {
+      useLiveVoiceStore.getState().reset();
+    });
+    await waitFor(() => {
+      expect(latest().callConversationId).toBeUndefined();
+    });
+  });
 });

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
@@ -135,6 +135,10 @@ function currentContext(): CompanionContext {
     // on only once that session is one that takes them.
     screenShare: screenShareTarget(),
     screenShareEnabled: screenShareEnabled(),
+    // Who owns the call the share belongs to, so main can refuse marks that
+    // came from anywhere else. Read through the same gate as the target: a
+    // share that cannot flow has no conversation worth naming.
+    callConversationId: callConversationId(),
     // What a keyboard dictation has got to. Published from here for the reason
     // `watching` is: the recording runs in this window, and while it runs the
     // surface is the only thing on screen to say so.
@@ -189,6 +193,20 @@ function screenShareTarget(): CompanionContext["screenShare"] {
 }
 
 /**
+ * The conversation the running call belongs to, or nothing.
+ *
+ * Withheld unless the share can flow, the way the target is: the id exists to
+ * say which conversation may point at this surface, and with no surface there
+ * is nothing for one to own.
+ */
+function callConversationId(): CompanionContext["callConversationId"] {
+  if (!screenShareEnabled()) {
+    return undefined;
+  }
+  return useLiveVoiceStore.getState().conversationId ?? undefined;
+}
+
+/**
  * The dictation the surface should be drawing, or nothing.
  *
  * Only a dictation the keyboard started: one begun from a control in the app is
@@ -233,7 +251,7 @@ function dictationTail(): string {
 function screenShareKey(): string {
   const target = screenShareTarget();
   const enabled = screenShareEnabled();
-  return `${enabled ? "on" : "off"}:${target === undefined ? "" : `${target.kind}:${target.kind === "display" ? target.displayId : target.windowId}`}`;
+  return `${enabled ? "on" : "off"}:${callConversationId() ?? ""}:${target === undefined ? "" : `${target.kind}:${target.kind === "display" ? target.displayId : target.windowId}`}`;
 }
 
 /** Whether two targets name the same display or window, absence included. */
@@ -272,6 +290,7 @@ function sameContext(a: CompanionContext, b: CompanionContext): boolean {
     a.watchTargets === b.watchTargets &&
     sameTarget(a.screenShare, b.screenShare) &&
     a.screenShareEnabled === b.screenShareEnabled &&
+    a.callConversationId === b.callConversationId &&
     a.dictating === b.dictating &&
     a.dictationText === b.dictationText &&
     a.dictationOffer?.id === b.dictationOffer?.id &&

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
@@ -38,8 +38,19 @@ let answerFrame: () => Promise<ScreenCaptureFrame | null> = async () => ({
 const captureCompanionScreen = mock((_target: WatchCaptureTarget) =>
   answerFrame(),
 );
+/**
+ * What the shell is told reached the call, recorded rather than sent. The
+ * acknowledgement is what lets main admit the assistant's own marks against
+ * a surface, so which targets arrive here, and whether one arrives at all
+ * when a frame fails, is the part worth pinning.
+ */
+const sharedFrames: WatchCaptureTarget[] = [];
+const reportCompanionSharedFrame = mock((target: WatchCaptureTarget) => {
+  sharedFrames.push(target);
+});
 mock.module("@/runtime/companion-surface", () => ({
   captureCompanionScreen,
+  reportCompanionSharedFrame,
 }));
 
 /**
@@ -141,7 +152,9 @@ function renderShare() {
 
 beforeEach(() => {
   annotated.length = 0;
+  sharedFrames.length = 0;
   captureCompanionScreen.mockClear();
+  reportCompanionSharedFrame.mockClear();
   uploadChatAttachment.mockClear();
   deleteChatAttachment.mockClear();
   answerFrame = async () => ({
@@ -195,6 +208,34 @@ describe("useLiveVoiceScreenShare: starting", () => {
     expect(file?.type).toBe("image/jpeg");
     expect(await file?.text()).toBe("jpeg");
     expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+  });
+
+  /**
+   * The shell admits the assistant's own marks against a surface only once a
+   * frame of it has reached the call, so the acknowledgement has to follow the
+   * send rather than the capture.
+   */
+  test("tells the shell the surface reached the call, after it was sent", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+
+    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+    expect(sharedFrames).toEqual([WINDOW]);
+  });
+
+  /**
+   * A frame the helper never produced was never shown, so nothing may be
+   * acknowledged for it: the guard it opens would be admitting marks against
+   * a picture the call does not have.
+   */
+  test("acknowledges nothing when no frame could be taken", async () => {
+    answerFrame = async () => null;
+    renderShare();
+    share(WINDOW);
+    await flush();
+
+    expect(sharedFrames).toEqual([]);
   });
 
   test("takes nothing for an assistant that predates the frame", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
@@ -60,7 +60,10 @@ import {
 import { annotateSharedFrame } from "@/domains/chat/voice/live-voice/annotate-shared-frame";
 import { createSightCapture } from "@/domains/chat/voice/live-voice/sight-capture";
 import { useSupportsSightStream } from "@/lib/backwards-compat/use-supports-sight-stream";
-import { captureCompanionScreen } from "@/runtime/companion-surface";
+import {
+  captureCompanionScreen,
+  reportCompanionSharedFrame,
+} from "@/runtime/companion-surface";
 import type {
   CompanionAnnotationStroke,
   WatchCaptureTarget,
@@ -166,8 +169,12 @@ export function useLiveVoiceScreenShare(): void {
             return frame;
           },
           // Nothing to show: there is no viewfinder to put a pulse on. The
-          // transcript is where a frame is seen.
-          onShared: () => undefined,
+          // transcript is where a frame is seen. What this does say is that
+          // the call has now been shown this surface, which is what lets the
+          // shell admit the assistant's own marks against it. Said here
+          // rather than at the capture because only this edge means the frame
+          // arrived: everything before it can still fail or be voided.
+          onShared: () => reportCompanionSharedFrame(target),
         })
         .then(() => {
           if (cancelled || !missed) {

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -13,7 +13,6 @@ import type {
   CompanionAnnotationPhase,
   CompanionAnnotationStroke,
   CompanionCapturePick,
-  CompanionCoachmark,
   CompanionCaptureSources,
   CompanionContext,
   CompanionDictating,
@@ -163,21 +162,6 @@ export function annotateCompanionShare(
   ink: string,
 ): void {
   bridge()?.annotateShare?.(phase, strokes, ink);
-}
-
-/**
- * Point at things on the surface a call is being shown, or take down what is
- * pointed at by asking for none.
- *
- * The whole set each time: what is being pointed at is one thought, and a
- * call that added to it would leave the caller owing a call to take the rest
- * down. The answer comes back as `coachmarks` on the pushed state, which main
- * empties when the share the marks were measured against ends.
- */
-export function setCompanionCoachmarks(
-  marks: readonly CompanionCoachmark[],
-): void {
-  bridge()?.setCoachmarks?.(marks);
 }
 
 /**

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -173,6 +173,21 @@ export function annotateCompanionShare(
  * predates the share, and whenever the helper could not take one, and the
  * caller reads every one of those as a frame to skip.
  */
+/**
+ * Tell the shell a frame of `target` reached the call.
+ *
+ * Sent on the acknowledgement rather than on the capture, because those are
+ * different moments: a frame is taken here, then uploaded and sent, and a
+ * reconnect or a failed upload can void it in between. Main gates the
+ * assistant's own marks on having shown the current surface, so counting a
+ * capture as a showing would open that gate for a picture the call never got.
+ *
+ * A no-op off the desktop shell, the bargain every call in this module makes.
+ */
+export function reportCompanionSharedFrame(target: WatchCaptureTarget): void {
+  bridge()?.sharedFrame?.(target);
+}
+
 export function captureCompanionScreen(
   target: WatchCaptureTarget,
 ): Promise<ScreenCaptureFrame | null> {

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -411,6 +411,7 @@ declare global {
           strokes: readonly CompanionAnnotationStroke[],
           ink: string,
         ): void;
+        sharedFrame?(target: WatchCaptureTarget): void;
         captureScreen?(
           target: WatchCaptureTarget,
         ): Promise<ScreenCaptureFrame | null>;

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -25,7 +25,6 @@ import type {
   CompanionCapturePick,
   CompanionCaptureSources,
   CompanionCharacter,
-  CompanionCoachmark,
   CompanionGrowth,
   CompanionContext,
   CompanionIntroAction,
@@ -412,7 +411,6 @@ declare global {
           strokes: readonly CompanionAnnotationStroke[],
           ink: string,
         ): void;
-        setCoachmarks?(marks: readonly CompanionCoachmark[]): void;
         captureScreen?(
           target: WatchCaptureTarget,
         ): Promise<ScreenCaptureFrame | null>;

--- a/packages/electron-desktop/src/host-proxy/cu-capability.test.ts
+++ b/packages/electron-desktop/src/host-proxy/cu-capability.test.ts
@@ -7,3 +7,17 @@ test("window capture is explicitly advertised by updated clients only", () => {
   expect(createHostProxyClientHeaders(identity).sseClientHeaders()).not.toHaveProperty("X-Vellum-Cu-Window-Capture");
   expect(createHostProxyClientHeaders({ ...identity, supportsWindowCapture: true }).sseClientHeaders()).toHaveProperty("X-Vellum-Cu-Window-Capture", "1");
 });
+
+test("coachmarks are explicitly advertised by clients that can draw them only", () => {
+  expect(createHostProxyClientHeaders(identity).sseClientHeaders()).not.toHaveProperty("X-Vellum-Cu-Annotate");
+  expect(createHostProxyClientHeaders({ ...identity, supportsCoachmarks: true }).sseClientHeaders()).toHaveProperty("X-Vellum-Cu-Annotate", "1");
+});
+
+// Independent opt-ins: a client can serve window-only observations without
+// having a frame to draw marks on, and the daemon gates two different things
+// on them.
+test("window capture and coachmarks are advertised independently", () => {
+  const headers = createHostProxyClientHeaders({ ...identity, supportsWindowCapture: true }).sseClientHeaders();
+  expect(headers).toHaveProperty("X-Vellum-Cu-Window-Capture", "1");
+  expect(headers).not.toHaveProperty("X-Vellum-Cu-Annotate");
+});

--- a/packages/electron-desktop/src/host-proxy/router.ts
+++ b/packages/electron-desktop/src/host-proxy/router.ts
@@ -67,6 +67,12 @@ export interface HostProxyClientIdentity {
   interfaceId: string;
   /** Opt in only when the bundled CU executor supports window-only observations. */
   supportsWindowCapture?: boolean;
+  /**
+   * Opt in only when this client can draw the assistant's marks on the
+   * surface a call is being shown. The overlay is a window the client opens
+   * for itself, so a client without one answers the request with nothing.
+   */
+  supportsCoachmarks?: boolean;
 }
 
 export function createHostProxyClientHeaders(
@@ -83,6 +89,9 @@ export function createHostProxyClientHeaders(
       "X-Vellum-Machine-Name": identity.getMachineName(),
       ...(identity.supportsWindowCapture
         ? { "X-Vellum-Cu-Window-Capture": "1" }
+        : {}),
+      ...(identity.supportsCoachmarks
+        ? { "X-Vellum-Cu-Annotate": "1" }
         : {}),
     }),
   };

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -671,6 +671,21 @@ export interface VellumBridge {
       target: WatchCaptureTarget,
     ): Promise<ScreenCaptureFrame | null>;
     /**
+     * A frame of `target` has reached the call, so the assistant has now been
+     * shown that surface.
+     *
+     * Told rather than inferred, and told here rather than at the capture.
+     * Taking a frame is not showing it: it is prepared, uploaded and sent
+     * afterwards, and any of those can fail or be voided by a reconnect. Main
+     * refuses marks measured against a surface the call has not been shown
+     * ({@link CompanionSurfaceState.coachmarks}), and a capture counted as a
+     * showing would open that gate for a picture nobody received.
+     *
+     * Only the window holding the session knows the frame arrived, which is
+     * why this comes from the renderer rather than being settled in main.
+     */
+    sharedFrame?(target: WatchCaptureTarget): void;
+    /**
      * A preview of one row of the picker, as a JPEG data URL, for the tile
      * that row is drawn as.
      *

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -662,20 +662,6 @@ export interface VellumBridge {
       ink: string,
     ): void;
     /**
-     * Point at things on the surface a call is being shown, or take down
-     * whatever is being pointed at by sending none.
-     *
-     * Main's own state for the reason `setAnnotating` is, and with the same
-     * consequence: the marks are fractions of the surface the frame is drawn
-     * around, so only main can say whether they still describe anything.
-     * What comes back is `coachmarks` on `onState`, which the frame's window
-     * draws.
-     *
-     * Absent on a shell that predates the marks, the bargain
-     * `setScreenShare` makes.
-     */
-    setCoachmarks?(marks: readonly CompanionCoachmark[]): void;
-    /**
      * One frame of `target`, as the helper takes it, for the window holding a
      * shared call to hand to the session. Resolves to null when no frame
      * could be taken: the window has gone, the display was unplugged, or

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -201,7 +201,6 @@ export const COMPANION_LIST_CAPTURE_SOURCES =
 export const COMPANION_SET_SCREEN_SHARE = "vellum:companion:setScreenShare";
 export const COMPANION_SET_ANNOTATING = "vellum:companion:setAnnotating";
 export const COMPANION_ANNOTATE_SHARE = "vellum:companion:annotateShare";
-export const COMPANION_SET_COACHMARKS = "vellum:companion:setCoachmarks";
 export const COMPANION_CAPTURE_SCREEN = "vellum:companion:captureScreen";
 export const COMPANION_ANSWER_WATCH_RETRO = "vellum:companion:answerWatchRetro";
 export const COMPANION_ANSWER_DICTATION_OFFER =

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -202,6 +202,7 @@ export const COMPANION_SET_SCREEN_SHARE = "vellum:companion:setScreenShare";
 export const COMPANION_SET_ANNOTATING = "vellum:companion:setAnnotating";
 export const COMPANION_ANNOTATE_SHARE = "vellum:companion:annotateShare";
 export const COMPANION_CAPTURE_SCREEN = "vellum:companion:captureScreen";
+export const COMPANION_SHARED_FRAME = "vellum:companion:sharedFrame";
 export const COMPANION_ANSWER_WATCH_RETRO = "vellum:companion:answerWatchRetro";
 export const COMPANION_ANSWER_DICTATION_OFFER =
   "vellum:companion:answerDictationOffer";

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -218,6 +218,10 @@ export const companionContextSchema = z.object({
   // shape it can hold names something being shared, and absence is the only
   // way to say nothing is.
   screenShare: watchCaptureTargetSchema.optional(),
+  // Optional for the reason `screenShare` is, and it travels with it: an id
+  // with no share names a conversation that owns nothing, and a share with no
+  // id is a surface no conversation can claim.
+  callConversationId: z.string().optional(),
   // Defaulted for the reason `watchTargets` is: a publisher that does not say
   // whether its call can be shown the screen is one whose call cannot.
   screenShareEnabled: z.boolean().default(false),

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1471,6 +1471,22 @@ export const COMPANION_COACHMARK_MAX = 4;
 export const COMPANION_COACHMARK_CAPTION_MAX = 80;
 
 /**
+ * Why a set of marks did not go up, or `null` for marks that did.
+ *
+ * Named refusals rather than one boolean, because the assistant can act on
+ * the difference and each one has its own answer: nothing shared is answered
+ * by asking the user to share, a surface owned by another conversation is not
+ * answered at all, and a surface that moved is answered by looking again.
+ * Told only that it failed, an assistant would ask for a share that is
+ * already running.
+ *
+ * Here rather than beside either end of the call. The window layer decides it
+ * and the host-proxy executor words it, and the file that words it says in as
+ * many words that it must not reach into the windows for anything.
+ */
+export type CoachmarkRefusal = "unshared" | "not-this-call" | "stale-surface";
+
+/**
  * One frame of a {@link WatchCaptureTarget}, as the helper took it: a JPEG,
  * with the size it was encoded at. Base64 rather than bytes because it
  * crosses the bridge as JSON.
@@ -1633,6 +1649,19 @@ export interface CompanionContext {
    * the share as on only once frames can flow to a session that takes them.
    */
   screenShare?: WatchCaptureTarget;
+  /**
+   * Which conversation the running call belongs to, while one is sharing.
+   *
+   * The marks the assistant places are addressed to a surface and say nothing
+   * about who asked for them, so without this main cannot tell the call's own
+   * conversation from any other the same user has running. A background turn
+   * would otherwise draw on a call it has no part in and be told it worked.
+   *
+   * Published with `screenShare` and withheld with it: a share that cannot
+   * flow is one nothing can be pointed at, so an id beside it would name a
+   * conversation with nothing to own.
+   */
+  callConversationId?: string;
   /**
    * Whether the call in this window can be shown the screen at all: a session
    * is running and its assistant understands the frame. The surface offers


### PR DESCRIPTION
Closes JARVIS-1751.

Four Codex threads on #42186 merged unaddressed. They were one problem: a mark named a rectangle and nothing else, so the window layer took any mark that arrived and drew it on whatever was being shared.

## Bind marks to the requesting conversation

[Thread.](https://github.com/vellum-ai/vellum-assistant/pull/42186#discussion_r3938635886) The executor discarded the request's `conversationId` and called the global painter, so a background or concurrent conversation could draw on an unrelated call's surface and be told it worked.

The surface now publishes whose call it is (`callConversationId` on `CompanionContext`, read from the live-voice store and withheld with the share it qualifies, since an id beside a share that cannot flow names a conversation with nothing to own). A paint whose conversation does not match is refused, **an unclaimed surface included**: a claim that cannot be checked is not a claim that passed.

**Clears stay open to anyone.** The two directions are not the same risk. A mark placed by the wrong conversation is a ring on a stranger's screen reported as a success; a clear by the wrong conversation costs a ring that was coming down anyway. Refusing those would leave marks standing that nothing could reach, which is the failure the entrance exists to avoid.

## Reject marks after the shared target changes

[Thread.](https://github.com/vellum-ai/vellum-assistant/pull/42186#discussion_r3938825489) A switch between the last `sight_frame` and the request landed fractional coordinates on the new surface. `syncCoachmarks()` had already run and could not reach a mark that arrived afterwards.

Main serves every capture, so it keeps the target of the last frame it handed out and refuses a paint when that does not match the current share: the last picture the model could have seen was of another surface, so its fractions describe that one. Recorded only for a frame that came back, since a capture that failed is one the model was never shown.

Writing the test found a gap in the design as sketched: the remembered picture outlived the share, so stopping and re-sharing the same display would have let the first mark through measured against a screen the user had since worked on. It is dropped when the share ends.

## Gate on a dedicated capability

[Thread.](https://github.com/vellum-ai/vellum-assistant/pull/42186#discussion_r3938714176) `host_cu` preactivated the skill on Windows and Linux, whose executors forward `computer_use_point_at` to native helpers with no such action, so the model was offered a tool that could not succeed.

This follows the `host_cu_window_capture` precedent rather than inventing a parallel mechanism: `host_cu_annotate` is a sub-capability of the same transport, advertised by an `X-Vellum-Cu-Annotate` header the client opts into and granted to macOS alone. That keeps the tool travelling as `computer_use_point_at` over `host_cu`, so the two proxy exemptions from #42186 stay load-bearing rather than becoming dead code.

Worth a reviewer's eye: `supportsHostProxy` answers this ahead of the per-interface rules, because those grant Windows and Linux everything but app control and would otherwise hand them the capability.

## Delete the unused renderer command

[Thread.](https://github.com/vellum-ai/vellum-assistant/pull/42186#discussion_r3938635892) Nothing called `setCompanionCoachmarks`. The host tool reaches `showCompanionCoachmarks` in main directly, and the second renderer-writable mutation path was bridge, schema, channel, handler and test surface the feature never used. Its tests move to the surviving entrance, which is a stronger place to assert from: they can now pin the refusal each case produces instead of a bare boolean.

## Notes

- `CoachmarkRefusal` lives in `ipc-contract` rather than beside either end. The window layer decides it and the host-proxy executor words it, and that executor states in as many words that it must not reach into the windows for anything.
- Three named refusals rather than one boolean, because the assistant acts on the difference: one asks the user to share, one is not answerable at all, and one asks for another look. Told only that it failed, it would ask for a share that is already running.
- The refusal strings are model-facing tool results, not UI copy, so no catalog entries.
- `SKILL.md` gains a line on the moved-share case, since that drift is now caught rather than merely warned about.

## Verification

`companion-window` (216), `host-cu-executor`, `use-companion-mirror` (37), `host-proxy-preactivation` (32), `host-proxy-interface` (17), `assistant-event-hub` (37), `cu-capability`, `assistant-event-hub-machine-name` all pass. Typecheck clean across `ipc-contract`, `electron-desktop`, `clients/macos`, `assistant`, `clients/web`. Lint clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNwGYEPVEspgJtFmsN1QFM