### PR TITLE
fix(providers): send prompt_cache_key on ChatGPT subscription Responses path

### DIFF
--- a/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
+++ b/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
@@ -1,9 +1,10 @@
 /**
  * Prompt caching on the OpenAI Responses transport: request-wide
- * `prompt_cache_key` emission for every direct-API model (routing affinity for
- * implicit-mode models, opt-in explicit mode for breakpoint-capable ones),
- * explicit `prompt_cache_options` and block-level `prompt_cache_breakpoint`
- * anchor placement for GPT-5.6+ (turn-start / previous-turn / advancing tail,
+ * `prompt_cache_key` emission for every Responses model (routing affinity for
+ * implicit-mode models, including the Codex subscription endpoint; opt-in
+ * explicit mode for breakpoint-capable direct-API models), explicit
+ * `prompt_cache_options` and block-level `prompt_cache_breakpoint` anchor
+ * placement for GPT-5.6+ (turn-start / previous-turn / advancing tail,
  * mirroring the Anthropic client), the `disableCache`
  * explicit-mode-with-zero-markers opt-out, and the unflagged-model and Codex
  * regression guards.
@@ -389,17 +390,50 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
     expect(breakpointedItemIndexes()).toEqual([0]);
   });
 
-  test("codex subscription endpoint gets no cache params", async () => {
+  test("codex subscription endpoint sends prompt_cache_key but no explicit-mode params", async () => {
     const provider = makeProvider("gpt-5.6-sol", true);
     await provider.sendMessage([userMsg("hi")], {
       config: { promptCacheKey: "conv-1" },
     });
 
+    // Codex uses implicit prefix caching. The key is a supported routing
+    // field (same as the official Codex client); prompt_cache_options,
+    // breakpoints, and prompt_cache_retention are not.
+    expect(lastStreamParams?.prompt_cache_key).toBe("conv-1");
     expect(lastStreamParams?.prompt_cache_options).toBeUndefined();
-    expect(lastStreamParams?.prompt_cache_key).toBeUndefined();
+    expect(lastStreamParams?.prompt_cache_retention).toBeUndefined();
     expect(JSON.stringify(lastStreamParams?.input)).not.toContain(
       "prompt_cache_breakpoint",
     );
+  });
+
+  test("codex subscription endpoint keeps prompt_cache_key stable across append-only turns", async () => {
+    const provider = makeProvider("gpt-5.6-sol", true);
+    await provider.sendMessage([userMsg("hi")], {
+      config: { promptCacheKey: "conv-1" },
+    });
+    expect(lastStreamParams?.prompt_cache_key).toBe("conv-1");
+
+    await provider.sendMessage(
+      [userMsg("hi"), assistantMsg("ok"), userMsg("again")],
+      { config: { promptCacheKey: "conv-1" } },
+    );
+
+    expect(lastStreamParams?.prompt_cache_key).toBe("conv-1");
+    expect(lastStreamParams?.prompt_cache_options).toBeUndefined();
+    expect(lastStreamParams?.prompt_cache_retention).toBeUndefined();
+    expect(JSON.stringify(lastStreamParams?.input)).not.toContain(
+      "prompt_cache_breakpoint",
+    );
+  });
+
+  test("codex subscription endpoint omits prompt_cache_key when absent", async () => {
+    const provider = makeProvider("gpt-5.6-sol", true);
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(lastStreamParams?.prompt_cache_key).toBeUndefined();
+    expect(lastStreamParams?.prompt_cache_options).toBeUndefined();
+    expect(lastStreamParams?.prompt_cache_retention).toBeUndefined();
   });
 
   test("never mutates the caller's messages", async () => {

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -38,7 +38,7 @@ export interface OpenAIResponsesProviderOptions {
   streamTimeoutMs?: number;
   useNativeWebSearch?: boolean;
   /** When true, target the Codex subscription endpoint and strip fields it
-   *  rejects (`max_output_tokens`). */
+   *  rejects (`max_output_tokens`, `prompt_cache_options`, breakpoints). */
   codexSubscription?: boolean;
   /** Static HTTP headers sent with every request (e.g. OpenRouter app
    *  attribution). Merged under any per-request attribution headers. */
@@ -259,13 +259,13 @@ export class OpenAIResponsesProvider implements Provider {
 
       // A per-conversation prompt-cache key gives OpenAI's cache router a
       // stable affinity key so a conversation's requests land on the same
-      // cache shard. Every model on the direct API receives it — both
+      // cache shard. Every Responses model receives it, including the Codex
+      // subscription endpoint: the key is a supported routing field there
+      // (the official Codex client defaults it from thread identity). Both
       // breakpoint-capable models (which additionally opt into explicit mode
-      // below) and implicit-mode models, which carry no explicit breakpoints
-      // yet still gain prefix-cache routing affinity from a stable key. The
-      // Codex subscription endpoint rejects extra params, so it is skipped
-      // there.
-      if (!this.codexSubscription && promptCacheKey) {
+      // below) and implicit-mode models, which carry no explicit breakpoints,
+      // still gain prefix-cache routing affinity from a stable key.
+      if (promptCacheKey) {
         params.prompt_cache_key = promptCacheKey;
       }
 
@@ -279,7 +279,9 @@ export class OpenAIResponsesProvider implements Provider {
       // breakpoints neither uses the cache nor incurs cache-write charges,
       // which is exactly the opt-out `disableCache` wants (omitting the param
       // would re-enable implicit mode). The Codex subscription endpoint
-      // rejects extra params, so these params are skipped entirely there.
+      // rejects `prompt_cache_options` and block-level breakpoints, so those
+      // stay off there. Codex runs in implicit prefix-cache mode and relies
+      // on `prompt_cache_key` above for routing affinity.
       if (
         !this.codexSubscription &&
         PROMPT_CACHE_BREAKPOINT_MODEL_IDS.has(effectiveModel)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

User report of recurring prompt-cache collapses on Vellum 0.11.9 ChatGPT-subscription Responses traffic: warm to ~2-4% cached to warm again within seconds, on byte-identical tools/instructions and append-only history. Hypothesis: `OpenAIResponsesProvider` omitted `prompt_cache_key` whenever `codexSubscription` was true, so requests had no stable cache-shard affinity.

Investigation confirmed that:

- `RetryProvider` already copies `selectionSeed` (conversation id) into `promptCacheKey` for `openai`.
- The Responses transport then dropped that key on the Codex subscription path, bundled with `prompt_cache_options` / breakpoints under a blanket "rejects extra params" skip from the explicit-cache rollout (`#37859`, later kept in `#39021`).
- Vellum never sends `prompt_cache_retention`. Known-rejected fields on this endpoint are `max_output_tokens`, `prompt_cache_options`, and block-level breakpoints.
- The official Codex client and other ChatGPT-backed adapters send `prompt_cache_key` (often defaulted from thread identity) while omitting `prompt_cache_retention`.

This PR sends the existing per-conversation key on the subscription path and keeps stripping the fields the endpoint actually rejects. `session_id` / `x-client-request-id` headers are left for a separate evaluation.

## Test plan

- [x] `cd assistant && bun test src/__tests__/openai-responses-prompt-cache.test.ts`
- [x] `cd assistant && bun test src/__tests__/retry-prompt-cache-key.test.ts src/__tests__/openai-responses-provider.test.ts --grep "codexSubscription"`
- Live `cached_tokens` before/after comparison still needs a ChatGPT subscription credential; unit tests cover wire emission only.

## Risk

If the Codex backend were to reject `prompt_cache_key` (contrary to the official client and the reporter's Hermes captures), subscription requests would 400. Residual miss rate from TTL/eviction is unchanged: a stable key provides routing affinity, not a hit guarantee.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8410d5bf-ce9b-40d9-b739-eadcf3855069?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8410d5bf-ce9b-40d9-b739-eadcf3855069&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

