### PR TITLE
feat(gateway): per-assistant webhook allowlist with Velay-first URL resolution

### DIFF
--- a/assistant/src/__tests__/platform-callback-registration.test.ts
+++ b/assistant/src/__tests__/platform-callback-registration.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { RegisterWebhookRouteIpcParams } from "@vellumai/gateway-client";
+
 import { setIngressPublicBaseUrl } from "../config/env.js";
+import type { IpcRegisterWebhookRouteResult } from "../ipc/gateway-client.js";
 import { credentialKey } from "../security/credential-key.js";
 
 let mockIsPlatform = true;
@@ -10,6 +13,22 @@ let mockPlatformAssistantId = "";
 let mockSecureKeys: Record<string, string> = {};
 let mockConfig: { ingress?: { publicBaseUrl?: string; enabled?: boolean } } =
   {};
+
+const REGISTERED_ROUTE = {
+  path: "/webhooks/twilio/voice",
+  type: "twilio_voice",
+  source: null,
+  match: "exact" as const,
+  createdAt: 1,
+  lastRegisteredAt: 1,
+};
+
+let mockRegisterWebhookRouteResult: IpcRegisterWebhookRouteResult = {
+  ok: true,
+  disabled: false,
+  route: REGISTERED_ROUTE,
+};
+let ipcRegisterCalls: RegisterWebhookRouteIpcParams[] = [];
 
 // Bun shares mocked modules across test files in a combined run, so each mock
 // spreads the real module and overrides only what this file drives. Replacing
@@ -32,6 +51,15 @@ mock.module("../config/env.js", () => ({
   ...actualEnv,
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
   getPlatformAssistantId: () => mockPlatformAssistantId,
+}));
+
+const actualGatewayClient = await import("../ipc/gateway-client.js");
+mock.module("../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcRegisterWebhookRoute: async (input: RegisterWebhookRouteIpcParams) => {
+    ipcRegisterCalls.push(input);
+    return mockRegisterWebhookRouteResult;
+  },
 }));
 
 const actualSecureKeys = await import("../security/secure-keys.js");
@@ -214,9 +242,7 @@ describe("platform callback registration", () => {
 
     await expect(
       registerCallbackRoute("webhooks/telegram", "telegram"),
-    ).resolves.toBe(
-      "https://my-assistant.example.com/v1/gateway/callbacks/x/",
-    );
+    ).resolves.toBe("https://my-assistant.example.com/v1/gateway/callbacks/x/");
   });
 
   test("self-hosted registerCallbackRoute sends detected module-level callback_base_url", async () => {
@@ -388,6 +414,12 @@ describe("resolveCallbackUrl resolution order", () => {
     setIngressPublicBaseUrl(undefined);
     delete process.env.ASSISTANT_API_KEY;
     registerCalls = 0;
+    ipcRegisterCalls = [];
+    mockRegisterWebhookRouteResult = {
+      ok: true,
+      disabled: false,
+      route: REGISTERED_ROUTE,
+    };
     globalThis.fetch = mock(async () => {
       registerCalls++;
       return new Response(
@@ -416,9 +448,10 @@ describe("resolveCallbackUrl resolution order", () => {
       resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
     ).resolves.toBe(PLATFORM_URL);
     expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
-  test("velay-webhooks on: a pod with a published ingress URL uses it directly", async () => {
+  test("velay-webhooks on: a pod claims the subpath and uses the published URL", async () => {
     mockIsPlatform = true;
     mockVelayWebhooksEnabled = true;
     seedPlatformCredentials();
@@ -428,11 +461,54 @@ describe("resolveCallbackUrl resolution order", () => {
         () => "https://velay.example.com/assistant-1/webhooks/twilio/voice",
         "webhooks/twilio/voice",
         "twilio_voice",
+        { callSessionId: "conv-xyz" },
+        "+15555550142",
       ),
     ).resolves.toBe(
       "https://velay.example.com/assistant-1/webhooks/twilio/voice",
     );
     expect(registerCalls).toBe(0);
+    expect(ipcRegisterCalls).toEqual([
+      {
+        path: "/webhooks/twilio/voice",
+        type: "twilio_voice",
+        source: "+15555550142",
+      },
+    ]);
+  });
+
+  test("velay-webhooks on: a refused claim falls back to the platform", async () => {
+    mockIsPlatform = true;
+    mockVelayWebhooksEnabled = true;
+    mockRegisterWebhookRouteResult = { ok: true, disabled: true };
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://velay.example.com/assistant-1/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toHaveLength(1);
+  });
+
+  test("velay-webhooks on: an unreachable gateway falls back to the platform", async () => {
+    mockIsPlatform = true;
+    mockVelayWebhooksEnabled = true;
+    mockRegisterWebhookRouteResult = { ok: false, reason: "no_response" };
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://velay.example.com/assistant-1/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toHaveLength(1);
   });
 
   test("velay-webhooks on: a pod with no published URL still registers with the platform", async () => {
@@ -444,6 +520,7 @@ describe("resolveCallbackUrl resolution order", () => {
       resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
     ).resolves.toBe(PLATFORM_URL);
     expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("velay-webhooks on: a pod with ingress disabled falls back instead of throwing", async () => {
@@ -459,6 +536,7 @@ describe("resolveCallbackUrl resolution order", () => {
       ),
     ).resolves.toBe(PLATFORM_URL);
     expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("velay-webhooks on: self-hosted opt-out still surfaces", async () => {
@@ -473,6 +551,21 @@ describe("resolveCallbackUrl resolution order", () => {
       ),
     ).rejects.toThrow("Public ingress is disabled");
     expect(registerCalls).toBe(0);
+    expect(ipcRegisterCalls).toEqual([]);
+  });
+
+  test("velay-webhooks on: a self-hosted ingress URL is not claimed on the gateway", async () => {
+    mockVelayWebhooksEnabled = true;
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://tunnel.example.com/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe("https://tunnel.example.com/webhooks/twilio/voice");
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("a configured ingress wins over platform connectivity", async () => {
@@ -486,6 +579,7 @@ describe("resolveCallbackUrl resolution order", () => {
       ),
     ).resolves.toBe("https://tunnel.example.com/webhooks/twilio/voice");
     expect(registerCalls).toBe(0);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("a platform-connected assistant with no ingress registers with the platform", async () => {

--- a/assistant/src/__tests__/platform-callback-registration.test.ts
+++ b/assistant/src/__tests__/platform-callback-registration.test.ts
@@ -4,6 +4,7 @@ import { setIngressPublicBaseUrl } from "../config/env.js";
 import { credentialKey } from "../security/credential-key.js";
 
 let mockIsPlatform = true;
+let mockVelayWebhooksEnabled = false;
 let mockPlatformBaseUrl = "";
 let mockPlatformAssistantId = "";
 let mockSecureKeys: Record<string, string> = {};
@@ -18,6 +19,12 @@ const actualEnvRegistry = await import("../config/env-registry.js");
 mock.module("../config/env-registry.js", () => ({
   ...actualEnvRegistry,
   getIsPlatform: () => mockIsPlatform,
+}));
+
+const actualVelayGate = await import("../inbound/velay-webhooks-gate.js");
+mock.module("../inbound/velay-webhooks-gate.js", () => ({
+  ...actualVelayGate,
+  isVelayWebhooksEnabled: () => mockVelayWebhooksEnabled,
 }));
 
 const actualEnv = await import("../config/env.js");
@@ -373,6 +380,7 @@ describe("resolveCallbackUrl resolution order", () => {
 
   beforeEach(() => {
     mockIsPlatform = false;
+    mockVelayWebhooksEnabled = false;
     mockPlatformBaseUrl = "";
     mockPlatformAssistantId = "";
     mockSecureKeys = {};
@@ -408,6 +416,63 @@ describe("resolveCallbackUrl resolution order", () => {
       resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
     ).resolves.toBe(PLATFORM_URL);
     expect(registerCalls).toBe(1);
+  });
+
+  test("velay-webhooks on: a pod with a published ingress URL uses it directly", async () => {
+    mockIsPlatform = true;
+    mockVelayWebhooksEnabled = true;
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://velay.example.com/assistant-1/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe(
+      "https://velay.example.com/assistant-1/webhooks/twilio/voice",
+    );
+    expect(registerCalls).toBe(0);
+  });
+
+  test("velay-webhooks on: a pod with no published URL still registers with the platform", async () => {
+    mockIsPlatform = true;
+    mockVelayWebhooksEnabled = true;
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+  });
+
+  test("velay-webhooks on: a pod with ingress disabled falls back instead of throwing", async () => {
+    mockIsPlatform = true;
+    mockVelayWebhooksEnabled = true;
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        ingressDisabled,
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+  });
+
+  test("velay-webhooks on: self-hosted opt-out still surfaces", async () => {
+    mockVelayWebhooksEnabled = true;
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        ingressDisabled,
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).rejects.toThrow("Public ingress is disabled");
+    expect(registerCalls).toBe(0);
   });
 
   test("a configured ingress wins over platform connectivity", async () => {

--- a/assistant/src/__tests__/plugin-api-webhook-url.test.ts
+++ b/assistant/src/__tests__/plugin-api-webhook-url.test.ts
@@ -8,14 +8,29 @@
  * registration type it derives, and what it refuses.
  */
 
-import { describe, expect, spyOn, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 
-import * as loader from "../config/loader.js";
-import * as registration from "../inbound/platform-callback-registration.js";
-import { resolveWebhookUrl } from "../plugin-api/webhook-url.js";
-import { runInPluginContext } from "../plugins/plugin-execution-context.js";
+let mockIsPlatform = false;
+
+// Bun shares mocked modules across test files in a combined run, so the mock
+// spreads the real module and overrides only what this file drives.
+const actualEnvRegistry = await import("../config/env-registry.js");
+mock.module("../config/env-registry.js", () => ({
+  ...actualEnvRegistry,
+  getIsPlatform: () => mockIsPlatform,
+}));
+
+const loader = await import("../config/loader.js");
+const registration =
+  await import("../inbound/platform-callback-registration.js");
+const { resolveWebhookUrl } = await import("../plugin-api/webhook-url.js");
+const { runInPluginContext } =
+  await import("../plugins/plugin-execution-context.js");
 
 describe("resolveWebhookUrl", () => {
+  afterEach(() => {
+    mockIsPlatform = false;
+  });
   test("composes the plugin's namespaced path and delegates the tier choice", async () => {
     const spy = spyOn(registration, "resolveCallbackUrl").mockResolvedValue(
       "https://callbacks.vellum.ai/abc/webhooks/plugins/imessage/events-photon",
@@ -148,6 +163,7 @@ describe("resolveWebhookUrl", () => {
     // The Velay tunnel forwards the request path verbatim and the gateway
     // admits it only when it matches a claimed path byte for byte. A trailing
     // slash on this URL would be rejected before the gateway ever saw it.
+    mockIsPlatform = true;
     const configSpy = spyOn(loader, "getConfig").mockReturnValue({
       ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-abc" },
     } as ReturnType<typeof loader.getConfig>);
@@ -163,6 +179,28 @@ describe("resolveWebhookUrl", () => {
     const claimedPath = `/${spy.mock.calls[0]![1]}`;
     expect(claimedPath).toBe("/webhooks/plugins/imessage/events-photon");
     expect(new URL(url).pathname).toBe(`/assistant-abc${claimedPath}`);
+    spy.mockRestore();
+    configSpy.mockRestore();
+  });
+
+  test("keeps the trailing slash on a self-hosted ingress URL", async () => {
+    // Off a pod the direct URL never rides the tunnel, so the spelling stays
+    // what it always was.
+    const configSpy = spyOn(loader, "getConfig").mockReturnValue({
+      ingress: { publicBaseUrl: "https://assistant.example.test" },
+    } as ReturnType<typeof loader.getConfig>);
+    const spy = spyOn(registration, "resolveCallbackUrl").mockImplementation(
+      async (directUrl) => directUrl(),
+    );
+
+    const url = await resolveWebhookUrl({
+      plugin: "imessage",
+      path: "events-photon",
+    });
+
+    expect(url).toBe(
+      "https://assistant.example.test/webhooks/plugins/imessage/events-photon/",
+    );
     spy.mockRestore();
     configSpy.mockRestore();
   });

--- a/assistant/src/__tests__/plugin-api-webhook-url.test.ts
+++ b/assistant/src/__tests__/plugin-api-webhook-url.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, spyOn, test } from "bun:test";
 
+import * as loader from "../config/loader.js";
 import * as registration from "../inbound/platform-callback-registration.js";
 import { resolveWebhookUrl } from "../plugin-api/webhook-url.js";
 import { runInPluginContext } from "../plugins/plugin-execution-context.js";
@@ -141,6 +142,29 @@ describe("resolveWebhookUrl", () => {
       "webhooks/plugins/imessage/events-comms",
     );
     spy.mockRestore();
+  });
+
+  test("hands out an ingress URL under exactly the path it claimed", async () => {
+    // The Velay tunnel forwards the request path verbatim and the gateway
+    // admits it only when it matches a claimed path byte for byte. A trailing
+    // slash on this URL would be rejected before the gateway ever saw it.
+    const configSpy = spyOn(loader, "getConfig").mockReturnValue({
+      ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-abc" },
+    } as ReturnType<typeof loader.getConfig>);
+    const spy = spyOn(registration, "resolveCallbackUrl").mockImplementation(
+      async (directUrl) => directUrl(),
+    );
+
+    const url = await resolveWebhookUrl({
+      plugin: "imessage",
+      path: "events-photon",
+    });
+
+    const claimedPath = `/${spy.mock.calls[0]![1]}`;
+    expect(claimedPath).toBe("/webhooks/plugins/imessage/events-photon");
+    expect(new URL(url).pathname).toBe(`/assistant-abc${claimedPath}`);
+    spy.mockRestore();
+    configSpy.mockRestore();
   });
 
   test("leaves a URL carrying a query string alone", async () => {

--- a/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
@@ -95,6 +95,18 @@ mock.module("../../../ipc/gateway-client.js", () => ({
   ipcGetFeatureFlags: async () => ({}),
   ipcGetVelayStatus: async () => null,
   ipcClassifyRisk: async () => ({ risk: "low" }),
+  ipcRegisterWebhookRoute: async () => ({
+    ok: false as const,
+    reason: "no_response" as const,
+  }),
+  ipcUnregisterWebhookRoute: async () => ({
+    ok: false as const,
+    reason: "no_response" as const,
+  }),
+  ipcListWebhookRoutes: async () => ({
+    ok: false as const,
+    reason: "no_response" as const,
+  }),
 }));
 
 mock.module("../../../messaging/providers/slack/send.js", () => ({

--- a/assistant/src/config/__tests__/webhook-routing.test.ts
+++ b/assistant/src/config/__tests__/webhook-routing.test.ts
@@ -12,6 +12,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let isPlatform = false;
+let velayWebhooksEnabled = false;
 let rawConfig: Record<string, unknown> = {};
 let platformContextEnabled = false;
 
@@ -28,6 +29,12 @@ mock.module("../loader.js", () => ({
   ...actualLoader,
   loadRawConfig: () => rawConfig,
   getConfig: () => rawConfig,
+}));
+
+const actualVelayGate = await import("../../inbound/velay-webhooks-gate.js");
+mock.module("../../inbound/velay-webhooks-gate.js", () => ({
+  ...actualVelayGate,
+  isVelayWebhooksEnabled: () => velayWebhooksEnabled,
 }));
 
 const actualRegistration =
@@ -50,6 +57,7 @@ const { hasIngressConfigured, hasWebhookRoutingConfigured } =
 describe("hasWebhookRoutingConfigured resolution order", () => {
   beforeEach(() => {
     isPlatform = false;
+    velayWebhooksEnabled = false;
     rawConfig = {};
     platformContextEnabled = false;
   });
@@ -72,6 +80,40 @@ describe("hasWebhookRoutingConfigured resolution order", () => {
     // `handleWebhooksRegister` registers with the platform gateway before it
     // ever reads the ingress config on a pod, so reporting the ingress URL
     // here would name a URL no webhook is actually registered against.
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: true,
+    });
+  });
+
+  test("velay-webhooks on: a pod with a published ingress URL reports it", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+    rawConfig = { ingress: { publicBaseUrl: "https://tunnel.example.com" } };
+
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: false,
+    });
+  });
+
+  test("velay-webhooks on: a pod with no published URL still reports managed", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+
+    expect(await hasWebhookRoutingConfigured(true)).toEqual({
+      configured: true,
+      usesManagedCallbacks: true,
+    });
+  });
+
+  test("velay-webhooks on: a pod with ingress disabled falls back to managed", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+    rawConfig = { ingress: { enabled: false } };
+
+    // Matches `resolveCallbackUrl` on pods: an owner toggling ingress off
+    // must not lose webhooks entirely.
     expect(await hasWebhookRoutingConfigured(true)).toEqual({
       configured: true,
       usesManagedCallbacks: true,

--- a/assistant/src/config/webhook-routing.ts
+++ b/assistant/src/config/webhook-routing.ts
@@ -16,6 +16,7 @@ import {
 
 import { resolvePlatformCallbackRegistrationContext } from "../inbound/platform-callback-registration.js";
 import { isPublicIngressDisabled } from "../inbound/public-ingress-urls.js";
+import { isVelayWebhooksEnabled } from "../inbound/velay-webhooks-gate.js";
 import { getIsPlatform } from "./env-registry.js";
 import { getConfig, loadRawConfig } from "./loader.js";
 
@@ -67,7 +68,11 @@ function isIngressExplicitlyDisabled(): boolean {
  * reports "no ingress" while `webhooks register` hands back a working callback
  * URL hides a broken registration instead of surfacing it.
  *
- *   1. **Platform pods** (`IS_PLATFORM`) always use managed callbacks.
+ *   1. **Platform pods** (`IS_PLATFORM`) with the `velay-webhooks` flag off
+ *      always use managed callbacks. With the flag on, a configured ingress
+ *      (the Velay-published URL) wins, and managed callbacks remain the
+ *      fallback — including when ingress is explicitly disabled, matching
+ *      `resolveCallbackUrl`'s pod behavior.
  *   2. **A configured public ingress wins** for everyone else.
  *   3. **Platform-connected assistants with no ingress** fall back to managed
  *      callbacks. Connectivity is decided by credentials (platform base URL +
@@ -99,12 +104,17 @@ export async function hasWebhookRoutingConfigured(
   configured: boolean;
   usesManagedCallbacks: boolean;
 }> {
-  if (allowManagedCallbacks && getIsPlatform()) {
+  const platformManaged = allowManagedCallbacks && getIsPlatform();
+  if (platformManaged && !isVelayWebhooksEnabled()) {
     return { configured: true, usesManagedCallbacks: true };
   }
 
   if (hasIngressConfigured(options)) {
     return { configured: true, usesManagedCallbacks: false };
+  }
+
+  if (platformManaged) {
+    return { configured: true, usesManagedCallbacks: true };
   }
 
   if (!allowManagedCallbacks || isIngressExplicitlyDisabled()) {

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -21,6 +21,7 @@
 import { getPlatformAssistantId, getPlatformBaseUrl } from "../config/env.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
+import { ipcRegisterWebhookRoute } from "../ipc/gateway-client.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
@@ -179,6 +180,47 @@ function resolveSelfHostedCallbackBaseUrl(): string | undefined {
 }
 
 /**
+ * Claim a webhook subpath on the gateway so the Velay tunnel forwards it.
+ *
+ * The registry matches paths exactly, so query parameters a caller appends to
+ * the resolved URL play no part. Returns false when the gateway declines the
+ * claim or cannot be reached, leaving platform callback registration as the
+ * way to keep the webhook reachable.
+ *
+ * @param callbackPath - The path to claim, e.g. "webhooks/twilio/voice".
+ */
+export async function registerLocalWebhookRoute(
+  callbackPath: string,
+  type: string,
+  sourceIdentifier?: string,
+): Promise<boolean> {
+  const path = callbackPath.startsWith("/") ? callbackPath : `/${callbackPath}`;
+  const result = await ipcRegisterWebhookRoute({
+    path,
+    type,
+    source: sourceIdentifier,
+  });
+
+  if (!result.ok) {
+    log.warn(
+      { path, type, reason: result.reason },
+      "Gateway webhook route registration failed, falling back to the platform",
+    );
+    return false;
+  }
+  if (result.disabled) {
+    log.info(
+      { path, type },
+      "Gateway is not serving its own webhooks, falling back to the platform",
+    );
+    return false;
+  }
+
+  log.debug({ path, type }, "Gateway webhook route registered");
+  return true;
+}
+
+/**
  * Resolve a callback URL, registering with the platform when appropriate.
  *
  * Resolution order, matching `handleWebhooksRegister` in
@@ -191,7 +233,9 @@ function resolveSelfHostedCallbackBaseUrl(): string | undefined {
  *      tunnel URL into `ingress.publicBaseUrl` — and fall back to platform
  *      registration on any failure, including an explicit
  *      `ingress.enabled: false`: a pod owner toggling that flag must not
- *      lose webhooks entirely.
+ *      lose webhooks entirely. The subpath is claimed on the gateway before
+ *      the tunnel URL is handed out, and a refused claim falls back the same
+ *      way.
  *   2. **A configured public ingress wins** for everyone else, so the direct
  *      supplier is tried first and its value returned when it resolves.
  *   3. **Platform-connected assistants with no ingress** register with the
@@ -230,9 +274,10 @@ export async function resolveCallbackUrl(
 ): Promise<string> {
   const isPlatform = getIsPlatform();
   if (!isPlatform || isVelayWebhooksEnabled()) {
+    let ingressUrl: string | undefined;
     let ingressError: unknown;
     try {
-      return directUrl();
+      ingressUrl = directUrl();
     } catch (err) {
       if (err instanceof PublicIngressDisabledError && !isPlatform) {
         throw err;
@@ -240,10 +285,19 @@ export async function resolveCallbackUrl(
       ingressError = err;
     }
 
-    // No ingress configured. Fall back to the platform gateway when this
-    // assistant is connected to the platform. Platform pods always are, so
-    // they skip the context probe and register directly.
-    if (!isPlatform) {
+    if (ingressUrl !== undefined) {
+      // A pod's tunnel only forwards subpaths the gateway has claimed, so the
+      // URL is handed out only once the claim succeeds.
+      if (
+        !isPlatform ||
+        (await registerLocalWebhookRoute(callbackPath, type, sourceIdentifier))
+      ) {
+        return ingressUrl;
+      }
+    } else if (!isPlatform) {
+      // No ingress configured. Fall back to the platform gateway when this
+      // assistant is connected to the platform. Platform pods always are, so
+      // they skip the context probe and register directly.
       const context = await resolvePlatformCallbackRegistrationContext();
       if (!context.enabled) {
         throw ingressError;

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -28,6 +28,7 @@ import {
   PublicIngressDisabledError,
   tryGetPublicBaseUrl,
 } from "./public-ingress-urls.js";
+import { isVelayWebhooksEnabled } from "./velay-webhooks-gate.js";
 
 const log = getLogger("platform-callback-registration");
 
@@ -184,8 +185,13 @@ function resolveSelfHostedCallbackBaseUrl(): string | undefined {
  * `runtime/routes/webhook-routes.ts` and `hasWebhookRoutingConfigured` in
  * `config/webhook-routing.ts`:
  *
- *   1. **Platform pods** (`IS_PLATFORM`) always register with the platform
- *      gateway: they have no ingress of their own to advertise.
+ *   1. **Platform pods** (`IS_PLATFORM`) with the `velay-webhooks` flag off
+ *      always register with the platform gateway. With the flag on, they try
+ *      the direct supplier first — the gateway's Velay client publishes the
+ *      tunnel URL into `ingress.publicBaseUrl` — and fall back to platform
+ *      registration on any failure, including an explicit
+ *      `ingress.enabled: false`: a pod owner toggling that flag must not
+ *      lose webhooks entirely.
  *   2. **A configured public ingress wins** for everyone else, so the direct
  *      supplier is tried first and its value returned when it resolves.
  *   3. **Platform-connected assistants with no ingress** register with the
@@ -194,12 +200,12 @@ function resolveSelfHostedCallbackBaseUrl(): string | undefined {
  *      ID + assistant API key), not by `IS_PLATFORM`, which is only ever true
  *      on a platform pod.
  *
- * An explicit `ingress.enabled: false` is a decision not to accept inbound
- * webhooks at all, so `PublicIngressDisabledError` propagates instead of being
- * routed around. Ingress precedes the platform fallback because any logged-in
- * local assistant holds platform credentials for the LLM proxy: treating
- * credential presence as "managed" would silently reroute an explicitly
- * configured self-hosted callback through the platform.
+ * Off a pod, an explicit `ingress.enabled: false` is a decision not to accept
+ * inbound webhooks at all, so `PublicIngressDisabledError` propagates instead
+ * of being routed around. Ingress precedes the platform fallback because any
+ * logged-in local assistant holds platform credentials for the LLM proxy:
+ * treating credential presence as "managed" would silently reroute an
+ * explicitly configured self-hosted callback through the platform.
  *
  * The `directUrl` parameter is a **lazy supplier** (a function returning a
  * string) rather than an eagerly-evaluated string. This is critical because
@@ -222,22 +228,26 @@ export async function resolveCallbackUrl(
   queryParams?: Record<string, string>,
   sourceIdentifier?: string,
 ): Promise<string> {
-  if (!getIsPlatform()) {
+  const isPlatform = getIsPlatform();
+  if (!isPlatform || isVelayWebhooksEnabled()) {
     let ingressError: unknown;
     try {
       return directUrl();
     } catch (err) {
-      if (err instanceof PublicIngressDisabledError) {
+      if (err instanceof PublicIngressDisabledError && !isPlatform) {
         throw err;
       }
       ingressError = err;
     }
 
     // No ingress configured. Fall back to the platform gateway when this
-    // assistant is connected to the platform.
-    const context = await resolvePlatformCallbackRegistrationContext();
-    if (!context.enabled) {
-      throw ingressError;
+    // assistant is connected to the platform. Platform pods always are, so
+    // they skip the context probe and register directly.
+    if (!isPlatform) {
+      const context = await resolvePlatformCallbackRegistrationContext();
+      if (!context.enabled) {
+        throw ingressError;
+      }
     }
   }
 

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -25,6 +25,7 @@ import { ipcRegisterWebhookRoute } from "../ipc/gateway-client.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
+import { resolveClaimedPodWebhookUrl } from "./pod-webhook-claim.js";
 import {
   PublicIngressDisabledError,
   tryGetPublicBaseUrl,
@@ -272,36 +273,37 @@ export async function resolveCallbackUrl(
   queryParams?: Record<string, string>,
   sourceIdentifier?: string,
 ): Promise<string> {
-  const isPlatform = getIsPlatform();
-  if (!isPlatform || isVelayWebhooksEnabled()) {
+  if (getIsPlatform()) {
+    if (isVelayWebhooksEnabled()) {
+      const claimed = await resolveClaimedPodWebhookUrl(directUrl, () =>
+        registerLocalWebhookRoute(callbackPath, type, sourceIdentifier),
+      );
+      if (claimed !== undefined) {
+        return claimed;
+      }
+    }
+  } else {
     let ingressUrl: string | undefined;
     let ingressError: unknown;
     try {
       ingressUrl = directUrl();
     } catch (err) {
-      if (err instanceof PublicIngressDisabledError && !isPlatform) {
+      if (err instanceof PublicIngressDisabledError) {
         throw err;
       }
       ingressError = err;
     }
 
     if (ingressUrl !== undefined) {
-      // A pod's tunnel only forwards subpaths the gateway has claimed, so the
-      // URL is handed out only once the claim succeeds.
-      if (
-        !isPlatform ||
-        (await registerLocalWebhookRoute(callbackPath, type, sourceIdentifier))
-      ) {
-        return ingressUrl;
-      }
-    } else if (!isPlatform) {
-      // No ingress configured. Fall back to the platform gateway when this
-      // assistant is connected to the platform. Platform pods always are, so
-      // they skip the context probe and register directly.
-      const context = await resolvePlatformCallbackRegistrationContext();
-      if (!context.enabled) {
-        throw ingressError;
-      }
+      return ingressUrl;
+    }
+
+    // No ingress configured. Fall back to the platform gateway when this
+    // assistant is connected to the platform. Platform pods always are, so
+    // they skip the context probe and register directly.
+    const context = await resolvePlatformCallbackRegistrationContext();
+    if (!context.enabled) {
+      throw ingressError;
     }
   }
 

--- a/assistant/src/inbound/pod-webhook-claim.ts
+++ b/assistant/src/inbound/pod-webhook-claim.ts
@@ -1,0 +1,35 @@
+/**
+ * The platform-pod tier of webhook URL resolution, shared by the two seams that
+ * resolve callback URLs: `resolveCallbackUrl` and the `webhooks_register` route
+ * handler.
+ *
+ * A pod's Velay tunnel only forwards subpaths the gateway has claimed, so the
+ * published ingress URL is handed out only once the claim succeeds. Anything
+ * else leaves the caller to register with the platform instead.
+ */
+
+/**
+ * The published ingress URL for a webhook, or undefined when the pod should
+ * fall back to platform registration.
+ *
+ * `ingressUrl` is a lazy supplier because the builders behind it throw when no
+ * public base URL has been published yet, and on a pod that throw is not fatal:
+ * a pod owner with no tunnel yet, or one who turned ingress off, must not lose
+ * webhooks entirely.
+ *
+ * @param ingressUrl - Lazy supplier for the published ingress callback URL.
+ * @param claimRoute - Claims the subpath on the gateway; false when the gateway
+ *   refuses the claim or cannot be reached.
+ */
+export async function resolveClaimedPodWebhookUrl(
+  ingressUrl: () => string,
+  claimRoute: () => Promise<boolean>,
+): Promise<string | undefined> {
+  let url: string;
+  try {
+    url = ingressUrl();
+  } catch {
+    return undefined;
+  }
+  return (await claimRoute()) ? url : undefined;
+}

--- a/assistant/src/inbound/velay-webhooks-gate.ts
+++ b/assistant/src/inbound/velay-webhooks-gate.ts
@@ -1,0 +1,20 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+
+const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks" as const;
+
+/**
+ * Whether platform pods resolve webhook callback URLs from the
+ * Velay-published ingress URL instead of registering platform callback
+ * routes.
+ *
+ * Gates the platform-pod tier in all three webhook resolution sites
+ * (`resolveCallbackUrl`, `hasWebhookRoutingConfigured`,
+ * `handleWebhooksRegister`), which must agree tier for tier. Off means the
+ * pre-Velay behavior: platform pods always register with the platform
+ * gateway. On means ingress-first with platform registration as the
+ * fallback, so a pod whose tunnel has not published a URL yet keeps
+ * working either way.
+ */
+export function isVelayWebhooksEnabled(): boolean {
+  return isAssistantFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY);
+}

--- a/assistant/src/inbound/velay-webhooks-gate.ts
+++ b/assistant/src/inbound/velay-webhooks-gate.ts
@@ -1,6 +1,6 @@
-import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
-
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+
+const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks" as const;
 
 /**
  * Whether platform pods resolve webhook callback URLs from the

--- a/assistant/src/inbound/velay-webhooks-gate.ts
+++ b/assistant/src/inbound/velay-webhooks-gate.ts
@@ -1,6 +1,6 @@
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
-const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks" as const;
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 
 /**
  * Whether platform pods resolve webhook callback URLs from the

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -14,6 +14,11 @@ import {
   type ClassifyRiskIpcParams,
   type ClassifyRiskIpcResponse,
   ClassifyRiskIpcResponseSchema,
+  ListWebhookRoutesIpcResponseSchema,
+  type RegisterWebhookRouteIpcParams,
+  RegisterWebhookRouteIpcResponseSchema,
+  UnregisterWebhookRouteIpcResponseSchema,
+  type WebhookIngressRoute,
 } from "@vellumai/gateway-client";
 import {
   ipcCall as packageIpcCall,
@@ -143,6 +148,92 @@ export async function ipcGetVelayStatus(): Promise<VelayTunnelStatus | null> {
     connected: obj.connected,
     publicUrl: typeof obj.publicUrl === "string" ? obj.publicUrl : null,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Webhook ingress route registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a webhook-route call failed.
+ *
+ * `no_response` means nothing came back. The one-shot IPC transport answers a
+ * missing gateway and a gateway-side refusal the same way, with no result, so
+ * both land here. `invalid_response` means the gateway answered but the answer
+ * does not match the shared contract, so the two sides have drifted.
+ */
+export type WebhookRouteIpcFailureReason = "no_response" | "invalid_response";
+
+export type IpcRegisterWebhookRouteResult =
+  | { ok: true; disabled: true }
+  | { ok: true; disabled: false; route: WebhookIngressRoute }
+  | { ok: false; reason: WebhookRouteIpcFailureReason };
+
+export type IpcUnregisterWebhookRouteResult =
+  | { ok: true; removed: boolean }
+  | { ok: false; reason: WebhookRouteIpcFailureReason };
+
+export type IpcListWebhookRoutesResult =
+  | { ok: true; routes: WebhookIngressRoute[] }
+  | { ok: false; reason: WebhookRouteIpcFailureReason };
+
+function webhookRouteFailure(
+  method: string,
+  result: unknown,
+  detail: Record<string, unknown> = {},
+): { ok: false; reason: WebhookRouteIpcFailureReason } {
+  const reason: WebhookRouteIpcFailureReason =
+    result === undefined ? "no_response" : "invalid_response";
+  log.warn({ ...detail, result, reason }, `${method}: gateway call failed`);
+  return { ok: false, reason };
+}
+
+/**
+ * Claim a webhook subpath on the gateway.
+ *
+ * A `disabled` result is a normal answer, not a failure: the gateway is not
+ * serving its own webhooks and the caller should fall back to platform
+ * callback registration. A failure carries the reason it failed so a caller
+ * that also falls back can log the two apart.
+ */
+export async function ipcRegisterWebhookRoute(
+  input: RegisterWebhookRouteIpcParams,
+): Promise<IpcRegisterWebhookRouteResult> {
+  const result = await ipcCall("register_webhook_route", { ...input });
+  const parsed = RegisterWebhookRouteIpcResponseSchema.safeParse(result);
+  if (!parsed.success) {
+    return webhookRouteFailure("ipcRegisterWebhookRoute", result, {
+      path: input.path,
+    });
+  }
+  return parsed.data.disabled
+    ? { ok: true, disabled: true }
+    : { ok: true, disabled: false, route: parsed.data.route };
+}
+
+/**
+ * Drop a webhook subpath from the gateway registry. A successful call reports
+ * whether a route was actually removed.
+ */
+export async function ipcUnregisterWebhookRoute(
+  path: string,
+): Promise<IpcUnregisterWebhookRouteResult> {
+  const result = await ipcCall("unregister_webhook_route", { path });
+  const parsed = UnregisterWebhookRouteIpcResponseSchema.safeParse(result);
+  if (!parsed.success) {
+    return webhookRouteFailure("ipcUnregisterWebhookRoute", result, { path });
+  }
+  return { ok: true, removed: parsed.data.removed };
+}
+
+/** List every webhook subpath the gateway currently answers. */
+export async function ipcListWebhookRoutes(): Promise<IpcListWebhookRoutesResult> {
+  const result = await ipcCall("list_webhook_routes");
+  const parsed = ListWebhookRoutesIpcResponseSchema.safeParse(result);
+  if (!parsed.success) {
+    return webhookRouteFailure("ipcListWebhookRoutes", result);
+  }
+  return { ok: true, routes: parsed.data.routes };
 }
 
 // classify_risk is an idempotent, side-effect-free read, so a transient gateway

--- a/assistant/src/plugin-api/webhook-url.ts
+++ b/assistant/src/plugin-api/webhook-url.ts
@@ -90,12 +90,11 @@ function registrationType(plugin: string, route: string): string {
 }
 
 /**
- * Keep a trailing slash on a resolved callback URL.
+ * Keep a trailing slash on a managed callback URL.
  *
  * Django in front of managed callbacks canonicalizes onto `/`. A vendor given
  * the slashless spelling is 301'd, and clients that follow a 301 on POST
- * typically retry as GET and drop the body. The gateway serves both spellings
- * of a plugin webhook, so the slashed URL is the one to hand out.
+ * typically retry as GET and drop the body.
  *
  * Query-bearing URLs are left alone: this resolver passes no query
  * parameters, and appending there would cut into the query rather than the
@@ -142,12 +141,22 @@ export async function resolveWebhookUrl(
 
   const callbackPath = `${PLUGIN_WEBHOOK_PREFIX}/${plugin}/${path}`;
 
+  let ingressUrl: string | undefined;
   const resolved = await resolveCallbackUrl(
-    () => `${getPublicBaseUrl(getConfig())}/${callbackPath}`,
+    () => {
+      ingressUrl = `${getPublicBaseUrl(getConfig())}/${callbackPath}`;
+      return ingressUrl;
+    },
     callbackPath,
     registrationType(plugin, path),
     undefined,
     sourceIdentifier,
   );
-  return withTrailingSlash(resolved);
+
+  // An ingress URL reaches the gateway through the tunnel, which forwards the
+  // request path verbatim and admits it only when it matches a claimed path
+  // byte for byte. The claim above is made under the slashless spelling, so
+  // that is the spelling to hand out. Only a managed callback URL goes through
+  // Django, so only that one is given the trailing slash.
+  return resolved === ingressUrl ? resolved : withTrailingSlash(resolved);
 }

--- a/assistant/src/plugin-api/webhook-url.ts
+++ b/assistant/src/plugin-api/webhook-url.ts
@@ -16,6 +16,7 @@
 
 import { createHash } from "node:crypto";
 
+import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { resolveCallbackUrl } from "../inbound/platform-callback-registration.js";
 import { getPublicBaseUrl } from "../inbound/public-ingress-urls.js";
@@ -153,10 +154,14 @@ export async function resolveWebhookUrl(
     sourceIdentifier,
   );
 
-  // An ingress URL reaches the gateway through the tunnel, which forwards the
-  // request path verbatim and admits it only when it matches a claimed path
-  // byte for byte. The claim above is made under the slashless spelling, so
-  // that is the spelling to hand out. Only a managed callback URL goes through
-  // Django, so only that one is given the trailing slash.
-  return resolved === ingressUrl ? resolved : withTrailingSlash(resolved);
+  // A pod's ingress URL reaches the gateway through the tunnel, which forwards
+  // the request path verbatim and admits it only when it matches a claimed
+  // path byte for byte. The claim above is made under the slashless spelling,
+  // so that is the spelling to hand out. On a pod the supplier URL is only
+  // returned once its path is claimed, so this condition holds exactly for
+  // tunnel URLs; every other branch keeps the trailing slash.
+  if (getIsPlatform() && resolved === ingressUrl) {
+    return resolved;
+  }
+  return withTrailingSlash(resolved);
 }

--- a/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { InternalError, UnprocessableEntityError } from "../errors.js";
 
 let isPlatform = false;
+let velayWebhooksEnabled = false;
 let config: Record<string, unknown> = {};
 let platformContextEnabled = false;
 let registerCallbackRouteError: Error | undefined;
@@ -35,6 +36,12 @@ mock.module("../../../config/loader.js", () => ({
   getConfig: () => config,
 }));
 
+const actualVelayGate = await import("../../../inbound/velay-webhooks-gate.js");
+mock.module("../../../inbound/velay-webhooks-gate.js", () => ({
+  ...actualVelayGate,
+  isVelayWebhooksEnabled: () => velayWebhooksEnabled,
+}));
+
 mock.module("../../../inbound/platform-callback-registration.js", () => ({
   registerCallbackRoute: registerCallbackRouteMock,
   resolvePlatformCallbackRegistrationContext: async () => ({
@@ -59,6 +66,7 @@ const register = (body: Record<string, unknown>) =>
 describe("webhooks_register callback URL resolution", () => {
   beforeEach(() => {
     isPlatform = false;
+    velayWebhooksEnabled = false;
     config = {};
     platformContextEnabled = false;
     registerCallbackRouteError = undefined;
@@ -93,6 +101,45 @@ describe("webhooks_register callback URL resolution", () => {
       "telegram",
       undefined,
     );
+  });
+
+  test("velay-webhooks on: a pod with a published ingress URL uses it directly", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+    platformContextEnabled = true;
+    config = {
+      ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-123" },
+    };
+
+    expect(await register({ type: "telegram" })).toEqual({
+      callbackUrl: "https://velay.vellum.ai/assistant-123/webhooks/telegram",
+      type: "telegram",
+      path: "webhooks/telegram",
+      mode: "self-hosted",
+    });
+    expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+  });
+
+  test("velay-webhooks on: a pod with no published URL still registers with the platform", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+    platformContextEnabled = true;
+
+    expect(await register({ type: "telegram" })).toMatchObject({
+      callbackUrl: "https://gateway.vellum.ai/assistant-123/webhooks/telegram",
+      mode: "platform",
+    });
+  });
+
+  test("velay-webhooks on: a pod with ingress disabled falls back to the platform", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+    platformContextEnabled = true;
+    config = { ingress: { enabled: false } };
+
+    expect(await register({ type: "telegram" })).toMatchObject({
+      mode: "platform",
+    });
   });
 
   test("disconnected local assistant uses the configured publicBaseUrl", async () => {

--- a/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
@@ -13,6 +13,8 @@ let config: Record<string, unknown> = {};
 let platformContextEnabled = false;
 let registerCallbackRouteError: Error | undefined;
 
+let localWebhookRouteRegistered = true;
+
 const registerCallbackRouteMock = mock(
   async (callbackPath: string, _type: string, _source?: string) => {
     if (registerCallbackRouteError) {
@@ -20,6 +22,11 @@ const registerCallbackRouteMock = mock(
     }
     return `https://gateway.vellum.ai/assistant-123/${callbackPath}`;
   },
+);
+
+const registerLocalWebhookRouteMock = mock(
+  async (_callbackPath: string, _type: string, _source?: string) =>
+    localWebhookRouteRegistered,
 );
 
 // Spread the real modules: these are broad barrels and replacing them wholesale
@@ -44,6 +51,7 @@ mock.module("../../../inbound/velay-webhooks-gate.js", () => ({
 
 mock.module("../../../inbound/platform-callback-registration.js", () => ({
   registerCallbackRoute: registerCallbackRouteMock,
+  registerLocalWebhookRoute: registerLocalWebhookRouteMock,
   resolvePlatformCallbackRegistrationContext: async () => ({
     isPlatform,
     platformBaseUrl: "https://api.vellum.ai",
@@ -70,7 +78,9 @@ describe("webhooks_register callback URL resolution", () => {
     config = {};
     platformContextEnabled = false;
     registerCallbackRouteError = undefined;
+    localWebhookRouteRegistered = true;
     registerCallbackRouteMock.mockClear();
+    registerLocalWebhookRouteMock.mockClear();
   });
 
   test("platform pods register with the platform gateway", async () => {
@@ -83,6 +93,7 @@ describe("webhooks_register callback URL resolution", () => {
       path: "webhooks/telegram",
       mode: "platform",
     });
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   // The bug: a local assistant that IS connected to the platform used to fall
@@ -103,7 +114,7 @@ describe("webhooks_register callback URL resolution", () => {
     );
   });
 
-  test("velay-webhooks on: a pod with a published ingress URL uses it directly", async () => {
+  test("velay-webhooks on: a pod claims the subpath and uses the published URL", async () => {
     isPlatform = true;
     velayWebhooksEnabled = true;
     platformContextEnabled = true;
@@ -111,13 +122,34 @@ describe("webhooks_register callback URL resolution", () => {
       ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-123" },
     };
 
-    expect(await register({ type: "telegram" })).toEqual({
+    expect(await register({ type: "telegram", source: "@my_bot" })).toEqual({
       callbackUrl: "https://velay.vellum.ai/assistant-123/webhooks/telegram",
       type: "telegram",
       path: "webhooks/telegram",
       mode: "self-hosted",
     });
+    expect(registerLocalWebhookRouteMock).toHaveBeenCalledWith(
+      "webhooks/telegram",
+      "telegram",
+      "@my_bot",
+    );
     expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+  });
+
+  test("velay-webhooks on: a refused claim falls back to the platform", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+    platformContextEnabled = true;
+    localWebhookRouteRegistered = false;
+    config = {
+      ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-123" },
+    };
+
+    expect(await register({ type: "telegram" })).toMatchObject({
+      callbackUrl: "https://gateway.vellum.ai/assistant-123/webhooks/telegram",
+      mode: "platform",
+    });
+    expect(registerLocalWebhookRouteMock).toHaveBeenCalled();
   });
 
   test("velay-webhooks on: a pod with no published URL still registers with the platform", async () => {
@@ -129,6 +161,7 @@ describe("webhooks_register callback URL resolution", () => {
       callbackUrl: "https://gateway.vellum.ai/assistant-123/webhooks/telegram",
       mode: "platform",
     });
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   test("velay-webhooks on: a pod with ingress disabled falls back to the platform", async () => {
@@ -140,6 +173,7 @@ describe("webhooks_register callback URL resolution", () => {
     expect(await register({ type: "telegram" })).toMatchObject({
       mode: "platform",
     });
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   test("disconnected local assistant uses the configured publicBaseUrl", async () => {
@@ -152,6 +186,7 @@ describe("webhooks_register callback URL resolution", () => {
       mode: "self-hosted",
     });
     expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   test("disconnected local assistant with no ingress is still unprocessable", async () => {
@@ -171,6 +206,7 @@ describe("webhooks_register callback URL resolution", () => {
       mode: "self-hosted",
     });
     expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   // The gateway publishes the Velay tunnel URL into ingress.publicBaseUrl, so

--- a/assistant/src/runtime/routes/webhook-routes.ts
+++ b/assistant/src/runtime/routes/webhook-routes.ts
@@ -15,6 +15,7 @@ import { getIsPlatform } from "../../config/env-registry.js";
 import { getConfig } from "../../config/loader.js";
 import {
   registerCallbackRoute,
+  registerLocalWebhookRoute,
   resolvePlatformCallbackRegistrationContext,
 } from "../../inbound/platform-callback-registration.js";
 import {
@@ -115,7 +116,8 @@ async function registerWithPlatform(
  *      Velay-published `ingress.publicBaseUrl` wins and platform
  *      registration is the fallback for any failure to resolve it —
  *      including an explicit `ingress.enabled: false`, matching
- *      `resolveCallbackUrl`'s pod behavior.
+ *      `resolveCallbackUrl`'s pod behavior. The subpath is claimed on the
+ *      gateway first, and a refused claim falls back the same way.
  *   2. **A configured public ingress wins** for everyone else. That URL is
  *      either the user's own tunnel (ngrok, a custom domain) or the Velay
  *      tunnel URL the gateway publishes into `ingress.publicBaseUrl`, so a
@@ -147,17 +149,23 @@ async function handleWebhooksRegister(
 
   if (getIsPlatform()) {
     if (isVelayWebhooksEnabled()) {
+      let baseUrl: string | undefined;
       try {
-        const baseUrl = getPublicBaseUrl(getConfig());
+        baseUrl = getPublicBaseUrl(getConfig());
+      } catch {
+        // No published tunnel URL yet (or ingress toggled off), so platform
+        // registration keeps webhooks working.
+      }
+      if (
+        baseUrl !== undefined &&
+        (await registerLocalWebhookRoute(webhookPath, type, sourceIdentifier))
+      ) {
         return {
           callbackUrl: `${baseUrl}/${webhookPath}`,
           type,
           path: webhookPath,
           mode: "self-hosted",
         };
-      } catch {
-        // No published tunnel URL yet (or ingress toggled off) — platform
-        // registration keeps webhooks working.
       }
     }
     return registerWithPlatform(webhookPath, type, sourceIdentifier);

--- a/assistant/src/runtime/routes/webhook-routes.ts
+++ b/assistant/src/runtime/routes/webhook-routes.ts
@@ -21,6 +21,7 @@ import {
   getPublicBaseUrl,
   isPublicIngressDisabled,
 } from "../../inbound/public-ingress-urls.js";
+import { isVelayWebhooksEnabled } from "../../inbound/velay-webhooks-gate.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   BadRequestError,
@@ -109,8 +110,12 @@ async function registerWithPlatform(
  * Resolve a stable callback URL for a webhook type.
  *
  * Resolution order:
- *   1. **Platform pods** (`IS_PLATFORM`) always register with the platform
- *      gateway: they have no ingress of their own to advertise.
+ *   1. **Platform pods** (`IS_PLATFORM`) with the `velay-webhooks` flag off
+ *      always register with the platform gateway. With the flag on, the
+ *      Velay-published `ingress.publicBaseUrl` wins and platform
+ *      registration is the fallback for any failure to resolve it —
+ *      including an explicit `ingress.enabled: false`, matching
+ *      `resolveCallbackUrl`'s pod behavior.
  *   2. **A configured public ingress wins** for everyone else. That URL is
  *      either the user's own tunnel (ngrok, a custom domain) or the Velay
  *      tunnel URL the gateway publishes into `ingress.publicBaseUrl`, so a
@@ -141,6 +146,20 @@ async function handleWebhooksRegister(
   const sourceIdentifier = source as string | undefined;
 
   if (getIsPlatform()) {
+    if (isVelayWebhooksEnabled()) {
+      try {
+        const baseUrl = getPublicBaseUrl(getConfig());
+        return {
+          callbackUrl: `${baseUrl}/${webhookPath}`,
+          type,
+          path: webhookPath,
+          mode: "self-hosted",
+        };
+      } catch {
+        // No published tunnel URL yet (or ingress toggled off) — platform
+        // registration keeps webhooks working.
+      }
+    }
     return registerWithPlatform(webhookPath, type, sourceIdentifier);
   }
 

--- a/assistant/src/runtime/routes/webhook-routes.ts
+++ b/assistant/src/runtime/routes/webhook-routes.ts
@@ -18,6 +18,7 @@ import {
   registerLocalWebhookRoute,
   resolvePlatformCallbackRegistrationContext,
 } from "../../inbound/platform-callback-registration.js";
+import { resolveClaimedPodWebhookUrl } from "../../inbound/pod-webhook-claim.js";
 import {
   getPublicBaseUrl,
   isPublicIngressDisabled,
@@ -149,19 +150,13 @@ async function handleWebhooksRegister(
 
   if (getIsPlatform()) {
     if (isVelayWebhooksEnabled()) {
-      let baseUrl: string | undefined;
-      try {
-        baseUrl = getPublicBaseUrl(getConfig());
-      } catch {
-        // No published tunnel URL yet (or ingress toggled off), so platform
-        // registration keeps webhooks working.
-      }
-      if (
-        baseUrl !== undefined &&
-        (await registerLocalWebhookRoute(webhookPath, type, sourceIdentifier))
-      ) {
+      const callbackUrl = await resolveClaimedPodWebhookUrl(
+        () => `${getPublicBaseUrl(getConfig())}/${webhookPath}`,
+        () => registerLocalWebhookRoute(webhookPath, type, sourceIdentifier),
+      );
+      if (callbackUrl !== undefined) {
         return {
-          callbackUrl: `${baseUrl}/${webhookPath}`,
+          callbackUrl,
           type,
           path: webhookPath,
           mode: "self-hosted",

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -446,6 +446,14 @@
       "label": "Model-First Profile Create",
       "description": "Reverses the two questions the web client's New Model modal asks when creating an inference profile. Off: the modal asks for a provider first and then offers that provider's models. On: it opens on one searchable list of every catalog model the assistant can reach, deduplicated across providers, and only then asks which provider serves the chosen model. That second question is skipped when a single provider serves it, answered with radio cards when several do, and turned into an inline connect form (API key, setup, or ChatGPT sign-in) when the chosen route has no connection yet. Editing an existing profile is unchanged either way, and both flows persist the same profile shape.",
       "defaultEnabled": false
+    },
+    {
+      "id": "velay-webhooks",
+      "scope": "assistant",
+      "key": "velay-webhooks",
+      "label": "Velay Webhooks",
+      "description": "Platform pods resolve webhook callback URLs from the Velay-published ingress URL instead of registering platform callback routes. Falls back to platform callback registration while no tunnel URL is published.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -708,6 +708,34 @@ export const pluginIngressApprovals = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// Webhook ingress routes (the subpaths this assistant accepts from outside)
+// ---------------------------------------------------------------------------
+
+/**
+ * The assistant's own allowlist of inbound webhook subpaths.
+ *
+ * A row is a claim that some live integration expects traffic on that exact
+ * path, so a path nothing registered can be refused before it reaches the
+ * route table or a per-route signature check.
+ */
+export const webhookIngressRoutes = sqliteTable("webhook_ingress_routes", {
+  // Origin-relative path with its leading slash, e.g. `/webhooks/telegram`.
+  path: text("path").primaryKey(),
+  // What kind of integration owns the path, e.g. `telegram` or `plugin`.
+  type: text("type").notNull(),
+  // The specific instance within that type, e.g. a plugin name. Null when
+  // the type alone identifies the owner.
+  source: text("source"),
+  // Only exact paths are matched today. The column exists so prefix or
+  // pattern rules can be added later without a schema change.
+  match: text("match").$type<"exact">().notNull().default("exact"),
+  createdAt: integer("created_at").notNull(),
+  // Refreshed on every re-registration, so a path nothing claims any more is
+  // visible as a stale row.
+  lastRegisteredAt: integer("last_registered_at").notNull(),
+});
+
+// ---------------------------------------------------------------------------
 // Inbound dedup (a vendor's retry must not become a second turn)
 // ---------------------------------------------------------------------------
 

--- a/gateway/src/db/webhook-ingress-route-store.test.ts
+++ b/gateway/src/db/webhook-ingress-route-store.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The registry decides which webhook paths this assistant answers at all, so
+ * what it stores has to survive a byte-for-byte comparison later: nothing that
+ * a URL parser would rewrite, nothing that escapes the webhook namespace, and
+ * no second opinion about a path already claimed.
+ */
+
+import { eq } from "drizzle-orm";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+import "../__tests__/test-preload.js";
+import { getGatewayDb, initGatewayDb, resetGatewayDb } from "./connection.js";
+import { webhookIngressRoutes } from "./schema.js";
+import {
+  hasWebhookIngressRoute,
+  listWebhookIngressRoutes,
+  onWebhookIngressRoutesChanged,
+  registerWebhookIngressRoute,
+  unregisterWebhookIngressRoute,
+} from "./webhook-ingress-route-store.js";
+
+const PATH = "/webhooks/telegram";
+
+beforeAll(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+beforeEach(() => {
+  getGatewayDb().delete(webhookIngressRoutes).run();
+});
+
+describe("registerWebhookIngressRoute", () => {
+  it("round-trips a route through the database", () => {
+    registerWebhookIngressRoute({
+      path: PATH,
+      type: "telegram",
+      source: "bot-1",
+    });
+
+    expect(listWebhookIngressRoutes()).toEqual([
+      {
+        path: PATH,
+        type: "telegram",
+        source: "bot-1",
+        match: "exact",
+        createdAt: expect.any(Number),
+        lastRegisteredAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("defaults an unattributed route's source to null", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(listWebhookIngressRoutes()[0]?.source).toBeNull();
+  });
+
+  it("keeps one row per path however often it is registered", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(listWebhookIngressRoutes()).toHaveLength(1);
+  });
+
+  it("refreshes the registration time and preserves the creation time", () => {
+    const created = registerWebhookIngressRoute({
+      path: PATH,
+      type: "telegram",
+    });
+    // Age the row so the refresh is visible regardless of clock resolution.
+    getGatewayDb()
+      .update(webhookIngressRoutes)
+      .set({ lastRegisteredAt: created.lastRegisteredAt - 60_000 })
+      .where(eq(webhookIngressRoutes.path, PATH))
+      .run();
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    const [row] = listWebhookIngressRoutes();
+    expect(row?.createdAt).toBe(created.createdAt);
+    expect(row?.lastRegisteredAt).toBeGreaterThan(created.createdAt - 60_000);
+  });
+
+  it("lets a re-registration move the route's owner", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "a" });
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "b" });
+
+    expect(listWebhookIngressRoutes()[0]?.source).toBe("b");
+  });
+
+  it("accepts paths whose segments are opaque strings", () => {
+    // The registry never interprets what is after `/webhooks/`; a plugin id
+    // carrying dots or dashes is a name, not a traversal.
+    for (const path of [
+      "/webhooks/plugins/a.b/hook",
+      "/webhooks/plugins/foo..bar/hook",
+      "/webhooks/twilio/sms-inbound",
+      `/webhooks/${"x".repeat(500)}`,
+    ]) {
+      expect(() =>
+        registerWebhookIngressRoute({ path, type: "plugin" }),
+      ).not.toThrow();
+      expect(hasWebhookIngressRoute(path)).toBe(true);
+    }
+  });
+
+  it("refuses anything outside the webhook namespace", () => {
+    for (const path of [
+      "/v1/audio/stream",
+      "/hooks/telegram",
+      "webhooks/telegram",
+      "//webhooks/telegram",
+      "/webhooks",
+      "",
+      "https://evil.example/webhooks/telegram",
+    ]) {
+      expect(() =>
+        registerWebhookIngressRoute({ path, type: "telegram" }),
+      ).toThrow();
+    }
+  });
+
+  it("refuses paths that would not survive a byte-for-byte comparison", () => {
+    for (const path of [
+      "/webhooks/../admin",
+      "/webhooks/../v1/guardian/init",
+      "/webhooks/a/../../etc",
+      "/webhooks/..%2fadmin",
+      "/webhooks/%2e%2e/admin",
+      "/webhooks/telegram?token=x",
+      "/webhooks/telegram#frag",
+      "/webhooks/telegram\\..\\etc",
+      "/webhooks/foo%5c..%5cadmin",
+      "/webhooks/foo%5Cbar",
+      "/webhooks/tele gram",
+      "/webhooks/telegram\n",
+      "/webhooks/tele\tgram",
+      `/webhooks/${"x".repeat(600)}`,
+    ]) {
+      expect(() =>
+        registerWebhookIngressRoute({ path, type: "telegram" }),
+      ).toThrow();
+    }
+    expect(listWebhookIngressRoutes()).toEqual([]);
+  });
+});
+
+describe("unregisterWebhookIngressRoute", () => {
+  it("removes the route and reports that it existed", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(unregisterWebhookIngressRoute(PATH)).toBe(true);
+    expect(listWebhookIngressRoutes()).toEqual([]);
+  });
+
+  it("reports a path it never held", () => {
+    expect(unregisterWebhookIngressRoute(PATH)).toBe(false);
+  });
+});
+
+describe("hasWebhookIngressRoute", () => {
+  it("answers only for the exact path", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(hasWebhookIngressRoute(PATH)).toBe(true);
+    expect(hasWebhookIngressRoute("/webhooks/telegram/extra")).toBe(false);
+    expect(hasWebhookIngressRoute("/webhooks/teleg")).toBe(false);
+    expect(hasWebhookIngressRoute("/webhooks/twilio")).toBe(false);
+  });
+});
+
+describe("onWebhookIngressRoutesChanged", () => {
+  it("fires when the set of routes changes", () => {
+    let fired = 0;
+    const unsubscribe = onWebhookIngressRoutesChanged(() => {
+      fired += 1;
+    });
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    expect(fired).toBe(1);
+
+    unregisterWebhookIngressRoute(PATH);
+    expect(fired).toBe(2);
+
+    unsubscribe();
+  });
+
+  it("stays quiet when a re-registration changes nothing", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "a" });
+
+    let fired = 0;
+    const unsubscribe = onWebhookIngressRoutesChanged(() => {
+      fired += 1;
+    });
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "a" });
+    expect(fired).toBe(0);
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "b" });
+    expect(fired).toBe(1);
+
+    unsubscribe();
+  });
+
+  it("stays quiet when a removal finds nothing and after unsubscribing", () => {
+    let fired = 0;
+    const unsubscribe = onWebhookIngressRoutesChanged(() => {
+      fired += 1;
+    });
+
+    unregisterWebhookIngressRoute(PATH);
+    expect(fired).toBe(0);
+
+    unsubscribe();
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    expect(fired).toBe(0);
+  });
+});

--- a/gateway/src/db/webhook-ingress-route-store.ts
+++ b/gateway/src/db/webhook-ingress-route-store.ts
@@ -1,0 +1,164 @@
+/** Store for the webhook subpaths this assistant accepts from outside. */
+
+import { eq } from "drizzle-orm";
+
+import { isSafeOriginRelativePath } from "../velay/bridge-utils.js";
+import { getGatewayDb } from "./connection.js";
+import { webhookIngressRoutes } from "./schema.js";
+
+export interface WebhookIngressRoute {
+  path: string;
+  type: string;
+  source: string | null;
+  match: "exact";
+  createdAt: number;
+  lastRegisteredAt: number;
+}
+
+const WEBHOOK_PATH_PREFIX = "/webhooks/";
+const MAX_WEBHOOK_PATH_LENGTH = 512;
+
+const changeListeners = new Set<() => void>();
+
+/**
+ * Register a callback that fires after every registration or removal.
+ * Returns an unsubscribe function.
+ */
+export function onWebhookIngressRoutesChanged(cb: () => void): () => void {
+  changeListeners.add(cb);
+  return () => {
+    changeListeners.delete(cb);
+  };
+}
+
+function notifyChanged(): void {
+  for (const cb of changeListeners) {
+    cb();
+  }
+}
+
+/**
+ * Consecutive dots inside a segment are part of a name, so only a segment that
+ * is exactly `..` is traversal. The path is percent-decoded first because a
+ * consumer downstream may decode before it splits the path on slashes. A
+ * decoded backslash is refused outright because a URL parser treats it as a
+ * separator, which would turn `/webhooks/foo%5c..%5cadmin` into `/webhooks/admin`.
+ */
+function hasTraversalSegment(path: string): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(path);
+  } catch {
+    return true;
+  }
+  return decoded.includes("\\") || decoded.split("/").includes("..");
+}
+
+/**
+ * Paths are stored verbatim and compared byte for byte, so the only shapes
+ * refused are the ones that would not survive that: anything outside the
+ * webhook namespace, anything a URL parser would rewrite, and traversal.
+ */
+function isValidWebhookIngressPath(path: string): boolean {
+  return (
+    path.length <= MAX_WEBHOOK_PATH_LENGTH &&
+    path.startsWith(WEBHOOK_PATH_PREFIX) &&
+    !hasTraversalSegment(path) &&
+    !/\s/.test(path) &&
+    isSafeOriginRelativePath(path)
+  );
+}
+
+export interface RegisterWebhookIngressRouteInput {
+  /** Exact subpath, leading slash included, under `/webhooks/`. */
+  path: string;
+  type: string;
+  source?: string | null;
+}
+
+/**
+ * Claim `path` for `type`. Registering the same path again refreshes its
+ * registration time and keeps the original `createdAt`.
+ */
+export function registerWebhookIngressRoute(
+  input: RegisterWebhookIngressRouteInput,
+): WebhookIngressRoute {
+  const { path } = input;
+  if (!isValidWebhookIngressPath(path)) {
+    throw new Error(`Invalid webhook ingress path: ${path}`);
+  }
+
+  const existing = readWebhookIngressRoute(path);
+  const now = Date.now();
+  const row: WebhookIngressRoute = {
+    path,
+    type: input.type,
+    source: input.source ?? null,
+    match: "exact",
+    createdAt: existing?.createdAt ?? now,
+    lastRegisteredAt: now,
+  };
+
+  getGatewayDb()
+    .insert(webhookIngressRoutes)
+    .values(row)
+    .onConflictDoUpdate({
+      target: webhookIngressRoutes.path,
+      set: {
+        type: row.type,
+        source: row.source,
+        lastRegisteredAt: row.lastRegisteredAt,
+      },
+    })
+    .run();
+
+  // Re-registering an unchanged row leaves the advertised path set identical,
+  // so subscribers have nothing to react to.
+  if (
+    existing === undefined ||
+    existing.type !== row.type ||
+    existing.source !== row.source
+  ) {
+    notifyChanged();
+  }
+  return row;
+}
+
+/** Drop `path`. Returns true when a row was removed. */
+export function unregisterWebhookIngressRoute(path: string): boolean {
+  if (!hasWebhookIngressRoute(path)) {
+    return false;
+  }
+  getGatewayDb()
+    .delete(webhookIngressRoutes)
+    .where(eq(webhookIngressRoutes.path, path))
+    .run();
+  notifyChanged();
+  return true;
+}
+
+/** Every registered route. */
+export function listWebhookIngressRoutes(): WebhookIngressRoute[] {
+  return getGatewayDb().select().from(webhookIngressRoutes).all();
+}
+
+/** Whether `path` is registered. On the bridge's per-request path. */
+export function hasWebhookIngressRoute(path: string): boolean {
+  return (
+    getGatewayDb()
+      .select({ path: webhookIngressRoutes.path })
+      .from(webhookIngressRoutes)
+      .where(eq(webhookIngressRoutes.path, path))
+      .get() !== undefined
+  );
+}
+
+function readWebhookIngressRoute(
+  path: string,
+): WebhookIngressRoute | undefined {
+  return getGatewayDb()
+    .select()
+    .from(webhookIngressRoutes)
+    .where(eq(webhookIngressRoutes.path, path))
+    .get();
+}

--- a/gateway/src/db/webhook-ingress-route-store.ts
+++ b/gateway/src/db/webhook-ingress-route-store.ts
@@ -1,21 +1,15 @@
 /** Store for the webhook subpaths this assistant accepts from outside. */
 
+import type { WebhookIngressRoute } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import { eq } from "drizzle-orm";
 
-import { isSafeOriginRelativePath } from "../velay/bridge-utils.js";
+import {
+  isSafeOriginRelativePath,
+  WEBHOOK_PATH_PREFIX,
+} from "../velay/path-utils.js";
 import { getGatewayDb } from "./connection.js";
 import { webhookIngressRoutes } from "./schema.js";
 
-export interface WebhookIngressRoute {
-  path: string;
-  type: string;
-  source: string | null;
-  match: "exact";
-  createdAt: number;
-  lastRegisteredAt: number;
-}
-
-const WEBHOOK_PATH_PREFIX = "/webhooks/";
 const MAX_WEBHOOK_PATH_LENGTH = 512;
 
 const changeListeners = new Set<() => void>();

--- a/gateway/src/http/routes/channel-verification-session-proxy.test.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.test.ts
@@ -20,7 +20,11 @@ mock.module("../../fetch.js", () => ({
   },
 }));
 
+// Spread the actual module so untouched exports (getLegacyRootDir, …) stay
+// importable by transitive dependencies of the modules under test.
+const actualPaths = await import("../../paths.js");
 mock.module("../../paths.js", () => ({
+  ...actualPaths,
   getGatewaySecurityDir: () => "/tmp/test-gateway-sec",
   getWorkspaceDir: () => "/tmp/test-workspace",
 }));

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -215,7 +215,10 @@ import {
 import { SleepWakeDetector } from "./sleep-wake-detector.js";
 import { callTelegramApi } from "./telegram/api.js";
 import { fetchImpl } from "./fetch.js";
-import { arePlatformFeaturesEnabled } from "./feature-flag-resolver.js";
+import {
+  arePlatformFeaturesEnabled,
+  isFeatureFlagEnabled,
+} from "./feature-flag-resolver.js";
 import { isNewCommand, handleNewCommand } from "./webhook-pipeline.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 import { registerEmailCallbackRoute } from "./email/register-callback.js";
@@ -248,7 +251,9 @@ import { createWebhookRouteRoutes } from "./ipc/webhook-route-handlers.js";
 import { refreshRouteSchema } from "./ipc/route-schema-cache.js";
 import { initGatewayDb } from "./db/connection.js";
 import { cleanupExpiredInboundEvents } from "./db/inbound-dedup-store.js";
+import { onWebhookIngressRoutesChanged } from "./db/webhook-ingress-route-store.js";
 import { runPostAssistantReady } from "./post-assistant-ready.js";
+import { VELAY_WEBHOOKS_FLAG_KEY } from "./velay/allowed-paths.js";
 import {
   clearManagedPublicBaseUrl,
   createVelayTunnelClient,
@@ -408,6 +413,11 @@ async function main() {
   const velayTunnelClient = createVelayTunnelClient(config, {
     credentials: credentialCache,
     configFile: configFileCache,
+  });
+  // Velay only sees a webhook route on the next tunnel connect, so a registry
+  // write asks for one.
+  onWebhookIngressRoutesChanged(() => {
+    velayTunnelClient?.requestRulesRefresh("webhook-routes-changed");
   });
 
   // ── Integration readiness flags ──
@@ -2996,8 +3006,16 @@ async function main() {
     assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl,
   });
 
+  let velayWebhooksEnabled = isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY);
   emitFlagChanged = () => {
     ipcServer.emit("feature_flags_changed");
+    // The flag decides the shape of the advertised rules, so flipping it has
+    // to re-advertise rather than wait out the periodic tunnel refresh.
+    const enabled = isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY);
+    if (enabled !== velayWebhooksEnabled) {
+      velayWebhooksEnabled = enabled;
+      velayTunnelClient?.requestRulesRefresh("velay-webhooks-flag-changed");
+    }
   };
 
   const featureFlagWatcher = new FeatureFlagWatcher({

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -244,6 +244,7 @@ import { trustRulesRoutes } from "./ipc/trust-rules-handlers.js";
 
 import { riskClassificationRoutes } from "./ipc/risk-classification-handlers.js";
 import { createVelayRoutes } from "./ipc/velay-handlers.js";
+import { createWebhookRouteRoutes } from "./ipc/webhook-route-handlers.js";
 import { refreshRouteSchema } from "./ipc/route-schema-cache.js";
 import { initGatewayDb } from "./db/connection.js";
 import { cleanupExpiredInboundEvents } from "./db/inbound-dedup-store.js";
@@ -2978,6 +2979,7 @@ async function main() {
     }),
     ...trustRulesRoutes,
     ...createVelayRoutes(velayTunnelClient),
+    ...createWebhookRouteRoutes(),
     ...createCredentialRequestIpcRoutes(
       config,
       configFileCache,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -4,6 +4,7 @@ import { eventRefersToAnotherMessage } from "./channels/inbound-event.js";
 import { buildSlackSourceMetadata } from "./slack/source-metadata.js";
 import { randomBytes } from "node:crypto";
 
+import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import {
   TWILIO_MEDIA_STREAM_WEBHOOK_PATH,
   TWILIO_STATUS_WEBHOOK_PATH,
@@ -253,7 +254,6 @@ import { initGatewayDb } from "./db/connection.js";
 import { cleanupExpiredInboundEvents } from "./db/inbound-dedup-store.js";
 import { onWebhookIngressRoutesChanged } from "./db/webhook-ingress-route-store.js";
 import { runPostAssistantReady } from "./post-assistant-ready.js";
-import { VELAY_WEBHOOKS_FLAG_KEY } from "./velay/allowed-paths.js";
 import {
   clearManagedPublicBaseUrl,
   createVelayTunnelClient,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -4,7 +4,6 @@ import { eventRefersToAnotherMessage } from "./channels/inbound-event.js";
 import { buildSlackSourceMetadata } from "./slack/source-metadata.js";
 import { randomBytes } from "node:crypto";
 
-import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import {
   TWILIO_MEDIA_STREAM_WEBHOOK_PATH,
   TWILIO_STATUS_WEBHOOK_PATH,
@@ -3006,12 +3005,12 @@ async function main() {
     assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl,
   });
 
-  let velayWebhooksEnabled = isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY);
+  let velayWebhooksEnabled = isFeatureFlagEnabled("velay-webhooks");
   emitFlagChanged = () => {
     ipcServer.emit("feature_flags_changed");
     // The flag decides the shape of the advertised rules, so flipping it has
     // to re-advertise rather than wait out the periodic tunnel refresh.
-    const enabled = isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY);
+    const enabled = isFeatureFlagEnabled("velay-webhooks");
     if (enabled !== velayWebhooksEnabled) {
       velayWebhooksEnabled = enabled;
       velayTunnelClient?.requestRulesRefresh("velay-webhooks-flag-changed");

--- a/gateway/src/ipc/webhook-route-handlers.test.ts
+++ b/gateway/src/ipc/webhook-route-handlers.test.ts
@@ -1,0 +1,178 @@
+/**
+ * The registry is what decides whether an inbound webhook is answered, so the
+ * IPC surface has to refuse a claim while the flag is off, refuse a path the
+ * store would not store, and otherwise show back exactly what it wrote.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+
+import "../__tests__/test-preload.js";
+
+let flagEnabled = true;
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (_key: string) => flagEnabled,
+}));
+
+import {
+  ListWebhookRoutesIpcResponseSchema,
+  RegisterWebhookRouteIpcResponseSchema,
+  UnregisterWebhookRouteIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { webhookIngressRoutes } from "../db/schema.js";
+import { createWebhookRouteRoutes } from "./webhook-route-handlers.js";
+
+const PATH = "/webhooks/telegram";
+
+const routes = createWebhookRouteRoutes();
+
+function route(method: string) {
+  const found = routes.find((r) => r.method === method);
+  if (!found) throw new Error(`No route registered for ${method}`);
+  return found;
+}
+
+const register = (params: Record<string, unknown>) =>
+  route("register_webhook_route").handler(params);
+const unregister = (params: Record<string, unknown>) =>
+  route("unregister_webhook_route").handler(params);
+const list = () => route("list_webhook_routes").handler();
+
+beforeAll(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+beforeEach(() => {
+  flagEnabled = true;
+  getGatewayDb().delete(webhookIngressRoutes).run();
+});
+
+describe("register_webhook_route", () => {
+  it("rejects params the store could never key on", () => {
+    const schema = route("register_webhook_route").schema;
+
+    expect(schema?.safeParse({ path: PATH, type: "telegram" }).success).toBe(
+      true,
+    );
+    expect(schema?.safeParse({ path: "", type: "telegram" }).success).toBe(
+      false,
+    );
+    expect(schema?.safeParse({ path: PATH, type: "" }).success).toBe(false);
+    expect(schema?.safeParse({ path: PATH }).success).toBe(false);
+  });
+
+  it("refuses without writing while the flag is off", () => {
+    flagEnabled = false;
+
+    expect(register({ path: PATH, type: "telegram" })).toEqual({
+      disabled: true,
+    });
+    expect(list()).toEqual({ routes: [] });
+  });
+
+  it("returns the stored row and shows it in the listing", () => {
+    const result = register({
+      path: PATH,
+      type: "telegram",
+      source: "bot-1",
+    }) as { disabled: false; route: unknown };
+
+    expect(result).toEqual({
+      disabled: false,
+      route: {
+        path: PATH,
+        type: "telegram",
+        source: "bot-1",
+        match: "exact",
+        createdAt: expect.any(Number),
+        lastRegisteredAt: expect.any(Number),
+      },
+    });
+    expect(list()).toEqual({ routes: [result.route] });
+  });
+
+  it("stores an unattributed route with a null source", () => {
+    register({ path: PATH, type: "telegram" });
+
+    expect(list()).toEqual({
+      routes: [expect.objectContaining({ source: null })],
+    });
+  });
+
+  it("throws on a path outside the webhook namespace", () => {
+    expect(() => register({ path: "/v1/admin", type: "telegram" })).toThrow();
+    expect(() =>
+      register({ path: "/webhooks/../admin", type: "telegram" }),
+    ).toThrow();
+    expect(list()).toEqual({ routes: [] });
+  });
+});
+
+describe("shared IPC contract", () => {
+  it("answers every method in the shape the daemon parses", () => {
+    flagEnabled = false;
+    expect(
+      RegisterWebhookRouteIpcResponseSchema.safeParse(
+        register({ path: PATH, type: "telegram" }),
+      ).success,
+    ).toBe(true);
+
+    flagEnabled = true;
+    expect(
+      RegisterWebhookRouteIpcResponseSchema.safeParse(
+        register({ path: PATH, type: "telegram", source: "bot-1" }),
+      ).success,
+    ).toBe(true);
+    expect(ListWebhookRoutesIpcResponseSchema.safeParse(list()).success).toBe(
+      true,
+    );
+    expect(
+      UnregisterWebhookRouteIpcResponseSchema.safeParse(
+        unregister({ path: PATH }),
+      ).success,
+    ).toBe(true);
+  });
+});
+
+describe("unregister_webhook_route", () => {
+  it("removes a registered route and reports it", () => {
+    register({ path: PATH, type: "telegram" });
+
+    expect(unregister({ path: PATH })).toEqual({ removed: true });
+    expect(list()).toEqual({ routes: [] });
+  });
+
+  it("reports a path it never held", () => {
+    expect(unregister({ path: PATH })).toEqual({ removed: false });
+  });
+
+  it("still revokes and lists while the flag is off", () => {
+    register({ path: PATH, type: "telegram" });
+    flagEnabled = false;
+
+    expect(list()).toEqual({
+      routes: [expect.objectContaining({ path: PATH })],
+    });
+    expect(unregister({ path: PATH })).toEqual({ removed: true });
+    expect(list()).toEqual({ routes: [] });
+  });
+});

--- a/gateway/src/ipc/webhook-route-handlers.ts
+++ b/gateway/src/ipc/webhook-route-handlers.ts
@@ -1,0 +1,57 @@
+/**
+ * IPC route definitions for the webhook ingress route registry.
+ *
+ * Lets the daemon claim, drop, and inspect the exact subpaths this assistant
+ * answers from outside. Only registration is gated on `velay-webhooks`;
+ * revocation and inspection stay available so an operator can always see and
+ * remove what was claimed while the flag was on.
+ *
+ * The request and response shapes are the shared contract in
+ * `@vellumai/gateway-client`, which the daemon reads the other end of.
+ */
+
+import {
+  type ListWebhookRoutesIpcResponse,
+  RegisterWebhookRouteIpcParamsSchema,
+  type RegisterWebhookRouteIpcResponse,
+  UnregisterWebhookRouteIpcParamsSchema,
+  type UnregisterWebhookRouteIpcResponse,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import {
+  listWebhookIngressRoutes,
+  registerWebhookIngressRoute,
+  unregisterWebhookIngressRoute,
+} from "../db/webhook-ingress-route-store.js";
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
+import { ipcRoute, type IpcRoute } from "./server.js";
+
+const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
+
+export function createWebhookRouteRoutes(): IpcRoute[] {
+  return [
+    ipcRoute({
+      method: "register_webhook_route",
+      schema: RegisterWebhookRouteIpcParamsSchema,
+      handler: (params): RegisterWebhookRouteIpcResponse => {
+        if (!isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY)) {
+          return { disabled: true };
+        }
+        return { disabled: false, route: registerWebhookIngressRoute(params) };
+      },
+    }),
+    ipcRoute({
+      method: "unregister_webhook_route",
+      schema: UnregisterWebhookRouteIpcParamsSchema,
+      handler: (params): UnregisterWebhookRouteIpcResponse => ({
+        removed: unregisterWebhookIngressRoute(params.path),
+      }),
+    }),
+    {
+      method: "list_webhook_routes",
+      handler: (): ListWebhookRoutesIpcResponse => ({
+        routes: listWebhookIngressRoutes(),
+      }),
+    },
+  ];
+}

--- a/gateway/src/ipc/webhook-route-handlers.ts
+++ b/gateway/src/ipc/webhook-route-handlers.ts
@@ -16,6 +16,7 @@ import {
   type RegisterWebhookRouteIpcResponse,
   UnregisterWebhookRouteIpcParamsSchema,
   type UnregisterWebhookRouteIpcResponse,
+  VELAY_WEBHOOKS_FLAG_KEY,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import {
@@ -25,8 +26,6 @@ import {
 } from "../db/webhook-ingress-route-store.js";
 import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 import { ipcRoute, type IpcRoute } from "./server.js";
-
-const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
 
 export function createWebhookRouteRoutes(): IpcRoute[] {
   return [

--- a/gateway/src/ipc/webhook-route-handlers.ts
+++ b/gateway/src/ipc/webhook-route-handlers.ts
@@ -16,7 +16,6 @@ import {
   type RegisterWebhookRouteIpcResponse,
   UnregisterWebhookRouteIpcParamsSchema,
   type UnregisterWebhookRouteIpcResponse,
-  VELAY_WEBHOOKS_FLAG_KEY,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import {
@@ -33,7 +32,7 @@ export function createWebhookRouteRoutes(): IpcRoute[] {
       method: "register_webhook_route",
       schema: RegisterWebhookRouteIpcParamsSchema,
       handler: (params): RegisterWebhookRouteIpcResponse => {
-        if (!isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY)) {
+        if (!isFeatureFlagEnabled("velay-webhooks")) {
           return { disabled: true };
         }
         return { disabled: false, route: registerWebhookIngressRoute(params) };

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -1,14 +1,31 @@
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
-import {
+let velayWebhooksEnabled = false;
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (flag: string) =>
+    flag === "velay-webhooks" ? velayWebhooksEnabled : false,
+}));
+
+const {
   VELAY_ALLOWED_PATHS,
   VELAY_ALLOWED_PATHS_HEADER,
   VELAY_ALLOWED_PATHS_HEADER_VALUE,
-} from "./allowed-paths.js";
-import {
-  isAllowedVelayWebSocketPath,
-  VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS,
-} from "./bridge-utils.js";
+  VELAY_STATIC_ALLOWED_PATHS,
+  buildVelayAllowedPathsHeaderValue,
+} = await import("./allowed-paths.js");
+// Imported after the mock is installed, and dynamically for the same reason the
+// module above is, so the bridge reads the same flag resolver these tests drive.
+const { isAllowedVelayWebSocketPath, VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS } =
+  await import("./bridge-utils.js");
+
+function decode(headerValue: string): string[] {
+  return JSON.parse(headerValue) as string[];
+}
+
+beforeEach(() => {
+  velayWebhooksEnabled = false;
+});
 
 describe("VELAY_ALLOWED_PATHS", () => {
   it("matches the platform-side header name (must stay in sync with vellum-assistant-platform RegistrationAllowedPathsHeader)", () => {
@@ -27,7 +44,17 @@ describe("VELAY_ALLOWED_PATHS", () => {
   it("contains only RE2-portable regex patterns (no JS-specific lookaround / backreferences) that compile in JavaScript too", () => {
     // We can't run Go RE2 here, but every pattern below is plain anchored
     // prefix/exact matching that's a strict subset of both engines.
-    for (const pattern of VELAY_ALLOWED_PATHS) {
+    velayWebhooksEnabled = true;
+    const patterns = [
+      ...VELAY_ALLOWED_PATHS,
+      ...decode(
+        buildVelayAllowedPathsHeaderValue([
+          "/webhooks/plugins/example/realtime",
+          "/webhooks/plugins/ex.am+ple/(realtime)",
+        ]),
+      ),
+    ];
+    for (const pattern of patterns) {
       expect(() => new RegExp(pattern)).not.toThrow();
       // RE2-incompatible features that should never appear: lookahead,
       // lookbehind, backreferences. A simple guard is enough — the platform
@@ -156,5 +183,61 @@ describe("the registration allowlist and the bridge's WebSocket allowlist", () =
         bridge: isAllowedVelayWebSocketPath(path),
       }).toEqual({ path, registration: false, bridge: false });
     }
+  });
+});
+
+describe("buildVelayAllowedPathsHeaderValue", () => {
+  it("advertises the legacy list verbatim while the flag is off", () => {
+    expect(buildVelayAllowedPathsHeaderValue([])).toBe(
+      VELAY_ALLOWED_PATHS_HEADER_VALUE,
+    );
+    expect(buildVelayAllowedPathsHeaderValue(["/webhooks/telegram"])).toBe(
+      VELAY_ALLOWED_PATHS_HEADER_VALUE,
+    );
+  });
+
+  it("drops the webhook wildcard for the statics plus one exact rule per registered path", () => {
+    velayWebhooksEnabled = true;
+
+    const rules = decode(
+      buildVelayAllowedPathsHeaderValue([
+        "/webhooks/telegram",
+        "/webhooks/plugins/example/realtime",
+      ]),
+    );
+
+    expect(rules).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+      "^/webhooks/plugins/example/realtime$",
+    ]);
+    expect(rules).not.toContain("^/webhooks/");
+    // The Twilio subtree keeps its prefix rule because its paths carry call
+    // state the registry cannot hold.
+    expect(rules).toContain("^/webhooks/twilio/");
+  });
+
+  it("advertises only the statics when nothing is registered", () => {
+    velayWebhooksEnabled = true;
+
+    expect(decode(buildVelayAllowedPathsHeaderValue([]))).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+    ]);
+  });
+
+  it("escapes regex metacharacters so a generated rule matches only its own path", () => {
+    velayWebhooksEnabled = true;
+    const path = "/webhooks/plugins/a.b+c*d?e|f(g)h[i]j{k}^l$m\\n";
+
+    const rules = decode(buildVelayAllowedPathsHeaderValue([path]));
+    const generated = rules[rules.length - 1];
+    const compiled = new RegExp(generated);
+
+    expect(compiled.test(path)).toBe(true);
+    expect(compiled.test("/webhooks/plugins/aXbXcXdXeXfXgXhXiXjXkXlXmXn")).toBe(
+      false,
+    );
+    expect(compiled.test(`${path}/extra`)).toBe(false);
+    expect(compiled.test(`/prefix${path}`)).toBe(false);
   });
 });

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -10,24 +10,8 @@
  *
  * Each entry is a Go RE2 regex string. Patterns are anchored at the start
  * (`^/...`) and either prefix-bound (trailing `/`) or exactly anchored (`$`)
- * depending on the route shape:
- *
- *   - `^/webhooks/` — every webhook handler under `/webhooks/*` (Twilio voice,
- *     status, voice-verify, the media-stream WebSocket upgrade, Telegram,
- *     WhatsApp, email, Resend, Mailgun, OAuth callback).
- *     Provider-side signature validation is performed by the per-route
- *     handlers in the gateway runtime, not by Velay.
- *   - `^/v1/audio/` — Twilio fetches generated audio URLs directly on the
- *     public surface (see comment at `gateway/src/index.ts` audio route).
- *   - `^/v1/live-voice` — exact match for the browser live-voice WebSocket
- *     (the Twilio media-stream WebSocket rides `^/webhooks/`).
- *   - `^/v1/stt/stream` — exact match for the public STT streaming WebSocket.
- *   - `^/assistant/credentials/enter$` — the gateway-served one-time
- *     credential entry page (self-contained HTML; the single-use token rides
- *     the URL fragment, which never reaches Velay or the gateway logs).
- *   - `^/v1/credential-requests/(peek|submit)$` — the entry page's
- *     unauthenticated API calls; the single-use token travels in the POST
- *     body and is validated by the gateway handlers.
+ * depending on the route shape. Provider-side signature validation is
+ * performed by the per-route handlers in the gateway runtime, not by Velay.
  *
  *   - `^/v1/watch/stream` — exact match for the browser watch-session
  *     WebSocket, which carries a session's narration audio.
@@ -53,11 +37,30 @@
  * If you add a new public route to `gateway/src/index.ts` that must be
  * reachable through the Velay tunnel (i.e. anything an external provider
  * calls or any unauthenticated callback endpoint), add a matching pattern
- * here as well. The route-table guard test in `allowed-paths.test.ts` enforces
- * symmetry between the allowlist and the gateway's actual public surface.
+ * here as well. Webhook routes instead go in the webhook ingress registry,
+ * which {@link buildVelayAllowedPathsHeaderValue} advertises row by row. The
+ * route-table guard test in `allowed-paths.test.ts` enforces symmetry between
+ * the allowlist and the gateway's actual public surface.
  */
-export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
-  "^/webhooks/",
+
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
+
+/**
+ * Public routes outside the webhook namespace:
+ *
+ *   - `^/v1/audio/`: Twilio fetches generated audio URLs directly on the
+ *     public surface (see comment at `gateway/src/index.ts` audio route).
+ *   - `^/v1/live-voice$`: the browser live-voice WebSocket (the Twilio
+ *     media-stream WebSocket rides the Twilio webhook prefix).
+ *   - `^/v1/stt/stream$`: the public STT streaming WebSocket.
+ *   - `^/assistant/credentials/enter$`: the gateway-served one-time
+ *     credential entry page (self-contained HTML; the single-use token rides
+ *     the URL fragment, which never reaches Velay or the gateway logs).
+ *   - `^/v1/credential-requests/(peek|submit)$`: the entry page's
+ *     unauthenticated API calls; the single-use token travels in the POST
+ *     body and is validated by the gateway handlers.
+ */
+const VELAY_NON_WEBHOOK_ALLOWED_PATHS: readonly string[] = Object.freeze([
   "^/v1/audio/",
   "^/v1/live-voice$",
   "^/v1/stt/stream$",
@@ -67,16 +70,75 @@ export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
 ]);
 
 /**
+ * Twilio reaches the gateway on paths carrying call state in their segments
+ * (`/webhooks/twilio/media-stream/<callSessionId>/<token>`), which an
+ * exact-match registry row cannot express, so the whole Twilio subtree stays a
+ * prefix rule.
+ */
+const VELAY_TWILIO_WEBHOOKS_PATH = "^/webhooks/twilio/";
+
+/**
+ * Every handler under `/webhooks/*`: Twilio voice, status, voice-verify, the
+ * media-stream WebSocket upgrade, Telegram, WhatsApp, email, Resend, Mailgun,
+ * the OAuth callback, and plugin-declared webhooks.
+ */
+const VELAY_WEBHOOKS_WILDCARD_PATH = "^/webhooks/";
+
+/** The rules advertised while `velay-webhooks` is off. */
+export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
+  VELAY_WEBHOOKS_WILDCARD_PATH,
+  ...VELAY_NON_WEBHOOK_ALLOWED_PATHS,
+]);
+
+/**
+ * The rules that hold whatever the webhook ingress registry contains.
+ * {@link buildVelayAllowedPathsHeaderValue} appends one exact-match rule per
+ * registered webhook path to these.
+ */
+export const VELAY_STATIC_ALLOWED_PATHS: readonly string[] = Object.freeze([
+  VELAY_TWILIO_WEBHOOKS_PATH,
+  ...VELAY_NON_WEBHOOK_ALLOWED_PATHS,
+]);
+
+/**
  * HTTP request header set on the WebSocket upgrade to declare the tunnel's
- * path allowlist to Velay. The value is `JSON.stringify(VELAY_ALLOWED_PATHS)`.
- * Mirrors `RegistrationAllowedPathsHeader` on the platform side.
+ * path allowlist to Velay. Mirrors `RegistrationAllowedPathsHeader` on the
+ * platform side.
  */
 export const VELAY_ALLOWED_PATHS_HEADER = "X-Vellum-Velay-Allowed-Paths";
 
-/**
- * Encoded header value to attach to the registration WS upgrade. Cached at
- * module load — the allowlist is static for the lifetime of the gateway
- * process.
- */
+/** Encoded header value advertised while `velay-webhooks` is off. */
 export const VELAY_ALLOWED_PATHS_HEADER_VALUE =
   JSON.stringify(VELAY_ALLOWED_PATHS);
+
+/**
+ * Gates whether the webhook namespace is advertised as one wildcard rule or as
+ * one exact rule per registered path.
+ */
+export const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
+
+const RE2_METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
+
+/** Escape `value` so it matches only itself under both RE2 and JavaScript. */
+function escapeForRe2(value: string): string {
+  return value.replace(RE2_METACHARACTERS, "\\$&");
+}
+
+/**
+ * The header value to advertise for a tunnel serving `registeredPaths`.
+ *
+ * With `velay-webhooks` off this is the wildcard allowlist. With it on the
+ * webhook namespace narrows to exactly the registered paths, so Velay drops
+ * anything else under `/webhooks/` before it reaches the gateway.
+ */
+export function buildVelayAllowedPathsHeaderValue(
+  registeredPaths: string[],
+): string {
+  if (!isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY)) {
+    return VELAY_ALLOWED_PATHS_HEADER_VALUE;
+  }
+  return JSON.stringify([
+    ...VELAY_STATIC_ALLOWED_PATHS,
+    ...registeredPaths.map((path) => `^${escapeForRe2(path)}$`),
+  ]);
+}

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -43,8 +43,6 @@
  * the allowlist and the gateway's actual public surface.
  */
 
-import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
-
 import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 
 /**
@@ -130,7 +128,7 @@ function escapeForRe2(value: string): string {
 export function buildVelayAllowedPathsHeaderValue(
   registeredPaths: string[],
 ): string {
-  if (!isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY)) {
+  if (!isFeatureFlagEnabled("velay-webhooks")) {
     return VELAY_ALLOWED_PATHS_HEADER_VALUE;
   }
   return JSON.stringify([

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -43,6 +43,8 @@
  * the allowlist and the gateway's actual public surface.
  */
 
+import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
+
 import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 
 /**
@@ -110,12 +112,6 @@ export const VELAY_ALLOWED_PATHS_HEADER = "X-Vellum-Velay-Allowed-Paths";
 /** Encoded header value advertised while `velay-webhooks` is off. */
 export const VELAY_ALLOWED_PATHS_HEADER_VALUE =
   JSON.stringify(VELAY_ALLOWED_PATHS);
-
-/**
- * Gates whether the webhook namespace is advertised as one wildcard rule or as
- * one exact rule per registered path.
- */
-export const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
 
 const RE2_METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
 

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -2,17 +2,30 @@ import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
 import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
 
+import { hasWebhookIngressRoute } from "../db/webhook-ingress-route-store.js";
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 import type { VelayHeaders } from "./protocol.js";
 
 const MAX_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 
+const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
+const WEBHOOK_PATH_PREFIX = "/webhooks/";
+
+/**
+ * Velay admission is decided across three layers. The webhook ingress route
+ * registry is authoritative for `/webhooks/*` once the `velay-webhooks` flag is
+ * on, so an assistant that registers nothing accepts nothing. The static
+ * prefixes and exact paths below are authoritative for every other route, and
+ * they still carry `/webhooks/twilio/` so Twilio keeps working until it
+ * registers its own routes. The rules in `allowed-paths.ts` are the coarse
+ * outer filter Velay applies platform-side and never widen what this bridge
+ * admits.
+ */
 const VELAY_ALLOWED_HTTP_PATH_PREFIXES = [
   "/webhooks/twilio/",
   "/v1/audio/",
 ] as const;
-// Exact-match HTTP paths (no trailing segments). Keep in sync with the
-// registration allowlist in allowed-paths.ts — Velay enforces that list
-// platform-side, and this bridge check is the local second layer.
+/** Exact-match HTTP paths (no trailing segments). */
 const VELAY_ALLOWED_HTTP_EXACT_PATHS = [
   "/assistant/credentials/enter",
   "/v1/credential-requests/peek",
@@ -40,6 +53,13 @@ export const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
 export const VELAY_FORWARDED_HEADER = "x-velay-forwarded" as const;
 
 export function isAllowedVelayHttpPath(path: string): boolean {
+  if (
+    path.startsWith(WEBHOOK_PATH_PREFIX) &&
+    isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY) &&
+    hasWebhookIngressRoute(path)
+  ) {
+    return true;
+  }
   return (
     VELAY_ALLOWED_HTTP_PATH_PREFIXES.some((prefix) =>
       path.startsWith(prefix),
@@ -50,6 +70,7 @@ export function isAllowedVelayHttpPath(path: string): boolean {
   );
 }
 
+/** A registered webhook route admits a WebSocket upgrade on that same path. */
 export function isAllowedVelayWebSocketPath(path: string): boolean {
   return (
     isAllowedVelayHttpPath(path) ||

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -1,7 +1,6 @@
 import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
 import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
-import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { hasWebhookIngressRoute } from "../db/webhook-ingress-route-store.js";
 import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
@@ -54,7 +53,7 @@ export const VELAY_FORWARDED_HEADER = "x-velay-forwarded" as const;
 export function isAllowedVelayHttpPath(path: string): boolean {
   if (
     path.startsWith(WEBHOOK_PATH_PREFIX) &&
-    isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY) &&
+    isFeatureFlagEnabled("velay-webhooks") &&
     hasWebhookIngressRoute(path)
   ) {
     return true;

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -1,15 +1,14 @@
 import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
 import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
+import { VELAY_WEBHOOKS_FLAG_KEY } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { hasWebhookIngressRoute } from "../db/webhook-ingress-route-store.js";
 import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
+import { isSafeOriginRelativePath, WEBHOOK_PATH_PREFIX } from "./path-utils.js";
 import type { VelayHeaders } from "./protocol.js";
 
 const MAX_WEBSOCKET_CLOSE_REASON_BYTES = 123;
-
-const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
-const WEBHOOK_PATH_PREFIX = "/webhooks/";
 
 /**
  * Velay admission is decided across three layers. The webhook ingress route
@@ -78,19 +77,6 @@ export function isAllowedVelayWebSocketPath(path: string): boolean {
       path as (typeof VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS)[number],
     )
   );
-}
-
-export function isSafeOriginRelativePath(path: string): boolean {
-  if (!path.startsWith("/") || path.startsWith("//")) return false;
-  if (path.includes("\\") || path.includes("?") || path.includes("#")) {
-    return false;
-  }
-  try {
-    const parsed = new URL(path, "http://127.0.0.1");
-    return parsed.origin === "http://127.0.0.1" && parsed.pathname === path;
-  } catch {
-    return false;
-  }
 }
 
 export function formatRawQuery(rawQuery: string | undefined): string {

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -13,7 +13,6 @@ import type { GatewayConfig } from "../config.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
-import { VELAY_ALLOWED_PATHS_HEADER_VALUE } from "./allowed-paths.js";
 import {
   FakeWebSocket,
   makeFakeWebSocketConstructor,
@@ -29,12 +28,36 @@ import {
 } from "./protocol.js";
 
 let workspaceDir = "";
+let registeredWebhookPaths: string[] = [];
+let velayWebhooksEnabled = false;
 
 mock.module("../credential-reader.js", () => ({
   getWorkspaceDir: () => workspaceDir,
   readCredential: async () => undefined,
 }));
 
+mock.module("../db/webhook-ingress-route-store.js", () => ({
+  listWebhookIngressRoutes: () =>
+    registeredWebhookPaths.map((path) => ({ path })),
+  hasWebhookIngressRoute: (path: string) =>
+    registeredWebhookPaths.includes(path),
+  registerWebhookIngressRoute: () => {
+    throw new Error("not expected in these tests");
+  },
+  unregisterWebhookIngressRoute: () => false,
+  onWebhookIngressRoutesChanged: () => () => {},
+}));
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (flag: string) =>
+    flag === "velay-webhooks" ? velayWebhooksEnabled : false,
+}));
+
+const {
+  VELAY_ALLOWED_PATHS_HEADER_VALUE,
+  VELAY_STATIC_ALLOWED_PATHS,
+  buildVelayAllowedPathsHeaderValue,
+} = await import("./allowed-paths.js");
 const { VelayTunnelClient, createVelayTunnelClient, enablePublicIngress } =
   await import("./client.js");
 
@@ -212,6 +235,8 @@ async function flushPromises(): Promise<void> {
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "velay-client-"));
+  registeredWebhookPaths = [];
+  velayWebhooksEnabled = false;
 });
 
 afterEach(() => {
@@ -1469,6 +1494,192 @@ describe("proactive tunnel refresh", () => {
     callbacks[0]();
     await flushPromises();
     expect(sockets[0].closes).toEqual([]);
+    await client.stop();
+  });
+});
+
+describe("advertised path rules", () => {
+  async function registerTunnel(socket: FakeWebSocket): Promise<void> {
+    socket.readyState = WS_OPEN;
+    socket.emit("open");
+    sendFrame(socket, {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+  }
+
+  function headerValue(socket: FakeWebSocket): unknown {
+    return (socket.options as { headers: Record<string, string> } | undefined)
+      ?.headers["X-Vellum-Velay-Allowed-Paths"];
+  }
+
+  test("advertises the registered routes on connect while the flag is on", async () => {
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/telegram"];
+    const sockets: FakeWebSocket[] = [];
+    const client = makeClient({ sockets });
+
+    client.start();
+    await flushPromises();
+
+    expect(headerValue(sockets[0])).toBe(
+      buildVelayAllowedPathsHeaderValue(["/webhooks/telegram"]),
+    );
+    expect(JSON.parse(headerValue(sockets[0]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+    ]);
+    await client.stop();
+  });
+
+  test("coalesces a burst of registry changes into one reconnect", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets[0]);
+    expect(delays).toEqual([]);
+
+    client.requestRulesRefresh("first");
+    client.requestRulesRefresh("second");
+    client.requestRulesRefresh("third");
+    expect(delays).toEqual([5000]);
+
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/telegram"];
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+
+    // The reconnect carries the rules the burst asked for.
+    callbacks[1]();
+    await flushPromises();
+    expect(sockets).toHaveLength(2);
+    expect(JSON.parse(headerValue(sockets[1]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+    ]);
+    await client.stop();
+  });
+
+  test("defers a rule refresh while the tunnel is busy, then refreshes once idle", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const bridgeConnections = { count: 1 };
+    const bridgeIdle = { fire: () => {} };
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+      bridgeConnections,
+      bridgeIdle,
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets[0]);
+
+    client.requestRulesRefresh("webhook-routes-changed");
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([]);
+
+    bridgeConnections.count = 0;
+    bridgeIdle.fire();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+    await client.stop();
+  });
+
+  test("ignores a rule refresh while disconnected and advertises the rules on the next connect", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+    });
+
+    client.requestRulesRefresh("before start");
+    expect(delays).toEqual([]);
+
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/plugins/example/realtime"];
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets[0]);
+
+    expect(JSON.parse(headerValue(sockets[0]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/plugins/example/realtime$",
+    ]);
+    expect(delays).toEqual([]);
+    await client.stop();
+  });
+
+  test("refreshes the reconnected tunnel when a reconnect races the debounce", async () => {
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/telegram"];
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets[0]);
+
+    client.requestRulesRefresh("first change");
+    expect(delays).toEqual([5000]);
+
+    // The tunnel drops and reconnects before the debounce fires, so the
+    // replacement socket already advertises the first change.
+    sockets[0].readyState = WS_CLOSED;
+    sockets[0].emit("close", { code: 1006, reason: "" });
+    await flushPromises();
+    callbacks[1]();
+    await flushPromises();
+    expect(sockets).toHaveLength(2);
+    await registerTunnel(sockets[1]);
+
+    // A second change lands after the replacement connected, so only a
+    // refresh of that socket can advertise it.
+    registeredWebhookPaths = ["/webhooks/telegram", "/webhooks/stripe"];
+    client.requestRulesRefresh("second change");
+
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[1].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+
+    callbacks[callbacks.length - 1]();
+    await flushPromises();
+    expect(sockets).toHaveLength(3);
+    expect(JSON.parse(headerValue(sockets[2]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+      "^/webhooks/stripe$",
+    ]);
     await client.stop();
   });
 });

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -30,6 +30,7 @@ import {
 let workspaceDir = "";
 let registeredWebhookPaths: string[] = [];
 let velayWebhooksEnabled = false;
+let webhookRouteReadError: Error | undefined;
 
 mock.module("../credential-reader.js", () => ({
   getWorkspaceDir: () => workspaceDir,
@@ -37,8 +38,12 @@ mock.module("../credential-reader.js", () => ({
 }));
 
 mock.module("../db/webhook-ingress-route-store.js", () => ({
-  listWebhookIngressRoutes: () =>
-    registeredWebhookPaths.map((path) => ({ path })),
+  listWebhookIngressRoutes: () => {
+    if (webhookRouteReadError) {
+      throw webhookRouteReadError;
+    }
+    return registeredWebhookPaths.map((path) => ({ path }));
+  },
   hasWebhookIngressRoute: (path: string) =>
     registeredWebhookPaths.includes(path),
   registerWebhookIngressRoute: () => {
@@ -237,6 +242,7 @@ beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "velay-client-"));
   registeredWebhookPaths = [];
   velayWebhooksEnabled = false;
+  webhookRouteReadError = undefined;
 });
 
 afterEach(() => {
@@ -1531,6 +1537,20 @@ describe("advertised path rules", () => {
       ...VELAY_STATIC_ALLOWED_PATHS,
       "^/webhooks/telegram$",
     ]);
+    await client.stop();
+  });
+
+  test("still connects with statics-only rules when the registry read fails", async () => {
+    velayWebhooksEnabled = true;
+    webhookRouteReadError = new Error("database disk image is malformed");
+    const sockets: FakeWebSocket[] = [];
+    const client = makeClient({ sockets });
+
+    client.start();
+    await flushPromises();
+
+    expect(sockets.length).toBe(1);
+    expect(headerValue(sockets[0])).toBe(buildVelayAllowedPathsHeaderValue([]));
     await client.stop();
   });
 

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -9,9 +9,10 @@ import { credentialKey } from "../credential-key.js";
 import { mutateConfigFile } from "../config-file-utils.js";
 import { getLogger } from "../logger.js";
 import { ExponentialBackoff } from "../util/exponential-backoff.js";
+import { listWebhookIngressRoutes } from "../db/webhook-ingress-route-store.js";
 import {
   VELAY_ALLOWED_PATHS_HEADER,
-  VELAY_ALLOWED_PATHS_HEADER_VALUE,
+  buildVelayAllowedPathsHeaderValue,
 } from "./allowed-paths.js";
 import { bridgeVelayHttpRequest } from "./http-bridge.js";
 import { closeWebSocket } from "./bridge-utils.js";
@@ -40,6 +41,9 @@ const HEARTBEAT_READ_TIMEOUT_MS = 60_000;
 // ever chopping an established call.
 const TUNNEL_REFRESH_AFTER_MS = 3_300_000;
 const TUNNEL_REFRESH_BUSY_RETRY_MS = 30_000;
+// A lifecycle that registers several webhook routes in a row should cost one
+// reconnect, not one per route, so rule refreshes coalesce over this window.
+const RULES_REFRESH_DEBOUNCE_MS = 5_000;
 
 export type WebSocketConstructorWithOptions = {
   new (
@@ -102,6 +106,7 @@ export class VelayTunnelClient {
   private heartbeatTimer: unknown = null;
   private readTimeoutTimer: unknown = null;
   private refreshTimer: unknown = null;
+  private rulesRefreshTimer: unknown = null;
   // Set when the refresh deadline passed while the tunnel was busy: the
   // refresh then fires as soon as the tunnel drains (last bridged
   // connection or in-flight HTTP request completes) instead of waiting for
@@ -190,6 +195,34 @@ export class VelayTunnelClient {
     this.connectForCredentialRefresh(reason);
   }
 
+  /**
+   * Reconnect so Velay sees the current path rules. Only a live tunnel needs
+   * this: the next connect reads the registry itself, so a client that is
+   * stopped or disconnected already picks the change up. Deferred while the
+   * tunnel is busy, the same way the load-balancer refresh is. The socket to
+   * refresh is resolved when the debounce fires rather than captured when it
+   * is armed, so a reconnect during the debounce window still advertises the
+   * rules that landed after it connected.
+   */
+  requestRulesRefresh(reason: string): void {
+    if (!this.running || !this.ws || this.rulesRefreshTimer) {
+      return;
+    }
+    this.rulesRefreshTimer = this.timerApi.setTimeout(() => {
+      this.rulesRefreshTimer = null;
+      const ws = this.ws;
+      if (!this.running || !ws) {
+        return;
+      }
+      if (this.isTunnelBusy()) {
+        this.refreshDue = true;
+        return;
+      }
+      log.info({ reason }, "Reconnecting Velay tunnel to advertise new rules");
+      this.performTunnelRefresh(ws);
+    }, RULES_REFRESH_DEBOUNCE_MS);
+  }
+
   start(): void {
     if (this.running) return;
     this.running = true;
@@ -218,6 +251,10 @@ export class VelayTunnelClient {
     }
     this.clearHeartbeat();
     this.clearTunnelRefresh();
+    if (this.rulesRefreshTimer) {
+      this.timerApi.clearTimeout(this.rulesRefreshTimer);
+      this.rulesRefreshTimer = null;
+    }
     const ws = this.ws;
     this.ws = null;
     this.webSocketBridge.closeAll();
@@ -302,9 +339,13 @@ export class VelayTunnelClient {
         headers: {
           Authorization: `Api-Key ${apiKey}`,
           // Declares the path allowlist Velay enforces for inbound proxied
-          // traffic on this tunnel. See ./allowed-paths.ts for the route
-          // inventory and the platform-side enforcement (ATL-402).
-          [VELAY_ALLOWED_PATHS_HEADER]: VELAY_ALLOWED_PATHS_HEADER_VALUE,
+          // traffic on this tunnel. Read per attempt so a reconnect picks up
+          // webhook routes registered since the last one. See
+          // ./allowed-paths.ts for the route inventory and the platform-side
+          // enforcement (ATL-402).
+          [VELAY_ALLOWED_PATHS_HEADER]: buildVelayAllowedPathsHeaderValue(
+            listWebhookIngressRoutes().map((route) => route.path),
+          ),
         },
       });
       ws.binaryType = "arraybuffer";

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -269,6 +269,23 @@ export class VelayTunnelClient {
     await this.connect();
   }
 
+  /**
+   * A registry read failure must never block the tunnel: fall back to an
+   * empty path list, which the header builder turns into legacy or
+   * statics-only rules.
+   */
+  private readRegisteredWebhookPaths(): string[] {
+    try {
+      return listWebhookIngressRoutes().map((route) => route.path);
+    } catch (err) {
+      log.error(
+        { err },
+        "Failed to read webhook ingress routes for tunnel rules",
+      );
+      return [];
+    }
+  }
+
   private async connect(): Promise<void> {
     if (!this.running || this.connecting) return;
     this.connecting = true;
@@ -344,7 +361,7 @@ export class VelayTunnelClient {
           // ./allowed-paths.ts for the route inventory and the platform-side
           // enforcement (ATL-402).
           [VELAY_ALLOWED_PATHS_HEADER]: buildVelayAllowedPathsHeaderValue(
-            listWebhookIngressRoutes().map((route) => route.path),
+            this.readRegisteredWebhookPaths(),
           ),
         },
       });

--- a/gateway/src/velay/http-bridge.test.ts
+++ b/gateway/src/velay/http-bridge.test.ts
@@ -16,12 +16,26 @@ mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
 }));
 
+let velayWebhooksFlagEnabled = false;
+let registeredWebhookPaths = new Set<string>();
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (key: string) =>
+    key === "velay-webhooks" ? velayWebhooksFlagEnabled : false,
+}));
+
+mock.module("../db/webhook-ingress-route-store.js", () => ({
+  hasWebhookIngressRoute: (path: string) => registeredWebhookPaths.has(path),
+}));
+
 const { bridgeVelayHttpRequest } = await import("./http-bridge.js");
 
 const TWILIO_EXAMPLE_PATH = "/webhooks/twilio/example";
 
 afterEach(() => {
   fetchMock = mock(async () => new Response());
+  velayWebhooksFlagEnabled = false;
+  registeredWebhookPaths = new Set();
 });
 
 function makeFrame(
@@ -291,5 +305,87 @@ describe("Velay HTTP bridge", () => {
 
     expect(captured).toHaveLength(1);
     expect(captured[0].get("x-velay-forwarded")).toBe("1");
+  });
+});
+
+describe("Velay HTTP bridge webhook ingress registry", () => {
+  const STATIC_PATHS = [
+    TWILIO_EXAMPLE_PATH,
+    "/v1/audio/550e8400-e29b-41d4-a716-446655440000",
+    "/assistant/credentials/enter",
+    "/v1/credential-requests/peek",
+    "/v1/credential-requests/submit",
+  ];
+
+  test("flag off: a registered webhook path is still rejected", async () => {
+    registeredWebhookPaths = new Set(["/webhooks/telegram"]);
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch");
+    });
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ path: "/webhooks/telegram" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status_code).toBe(502);
+  });
+
+  test("flag on: a registered webhook path is forwarded and its response relayed", async () => {
+    velayWebhooksFlagEnabled = true;
+    registeredWebhookPaths = new Set(["/webhooks/telegram"]);
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push((input as Request).url);
+      return new Response("handled", { status: 202 });
+    });
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ path: "/webhooks/telegram" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(captured).toEqual(["http://127.0.0.1:7830/webhooks/telegram"]);
+    expect(response.status_code).toBe(202);
+    expect(decodeBase64(response.body_base64)).toBe("handled");
+  });
+
+  test("flag on: an unregistered webhook path is rejected without contacting the loopback listener", async () => {
+    velayWebhooksFlagEnabled = true;
+    registeredWebhookPaths = new Set(["/webhooks/telegram"]);
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch");
+    });
+
+    for (const path of [
+      "/webhooks/slack",
+      "/webhooks/telegram/extra",
+      "/webhooks/telegramX",
+    ]) {
+      const response = await bridgeVelayHttpRequest(
+        makeFrame({ path }),
+        "http://127.0.0.1:7830",
+      );
+      expect(response.status_code).toBe(502);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("static allowlist paths are forwarded regardless of the flag", async () => {
+    for (const flagEnabled of [false, true]) {
+      velayWebhooksFlagEnabled = flagEnabled;
+      registeredWebhookPaths = new Set();
+
+      for (const path of STATIC_PATHS) {
+        fetchMock = mock(async () => new Response("ok", { status: 200 }));
+        const response = await bridgeVelayHttpRequest(
+          makeFrame({ path }),
+          "http://127.0.0.1:7830",
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(response.status_code).toBe(200);
+      }
+    }
   });
 });

--- a/gateway/src/velay/path-utils.ts
+++ b/gateway/src/velay/path-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Path shapes shared by the Velay bridge and the webhook ingress route store.
+ *
+ * This module holds no imports of its own so the two sides can agree on what a
+ * webhook path looks like without depending on each other.
+ */
+
+/** Every path the webhook ingress registry can claim sits under this prefix. */
+export const WEBHOOK_PATH_PREFIX = "/webhooks/";
+
+export function isSafeOriginRelativePath(path: string): boolean {
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (path.includes("\\") || path.includes("?") || path.includes("#")) {
+    return false;
+  }
+  try {
+    const parsed = new URL(path, "http://127.0.0.1");
+    return parsed.origin === "http://127.0.0.1" && parsed.pathname === path;
+  } catch {
+    return false;
+  }
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -446,6 +446,14 @@
       "label": "Model-First Profile Create",
       "description": "Reverses the two questions the web client's New Model modal asks when creating an inference profile. Off: the modal asks for a provider first and then offers that provider's models. On: it opens on one searchable list of every catalog model the assistant can reach, deduplicated across providers, and only then asks which provider serves the chosen model. That second question is skipped when a single provider serves it, answered with radio cards when several do, and turned into an inline connect form (API key, setup, or ChatGPT sign-in) when the chosen route has no connection yet. Editing an existing profile is unchanged either way, and both flows persist the same profile shape.",
       "defaultEnabled": false
+    },
+    {
+      "id": "velay-webhooks",
+      "scope": "assistant",
+      "key": "velay-webhooks",
+      "label": "Velay Webhooks",
+      "description": "Platform pods resolve webhook callback URLs from the Velay-published ingress URL instead of registering platform callback routes. Falls back to platform callback registration while no tunnel URL is published.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -399,6 +399,71 @@ export const ContactsIdentitySnapshotIpcResponseSchema = z.object({
 
 export type ContactsIdentitySnapshotIpcResponse = z.infer<
   typeof ContactsIdentitySnapshotIpcResponseSchema
+
+// ── webhook ingress routes ───────────────────────────────────────────────────
+// The gateway owns the registry of subpaths this assistant answers from
+// outside; the daemon claims, drops, and inspects them over IPC. Both sides
+// read these schemas so a change to the stored row has to travel through the
+// contract.
+
+export const WebhookIngressRouteSchema = z.object({
+  path: z.string(),
+  type: z.string(),
+  source: z.string().nullable(),
+  match: z.literal("exact"),
+  createdAt: z.number(),
+  lastRegisteredAt: z.number(),
+});
+
+export type WebhookIngressRoute = z.infer<typeof WebhookIngressRouteSchema>;
+
+export const RegisterWebhookRouteIpcParamsSchema = z.object({
+  /** Exact subpath, leading slash included, under `/webhooks/`. */
+  path: z.string().min(1),
+  type: z.string().min(1),
+  source: z.string().nullish(),
+});
+
+export type RegisterWebhookRouteIpcParams = z.infer<
+  typeof RegisterWebhookRouteIpcParamsSchema
+>;
+
+/**
+ * A refusal is a normal result rather than an error: the daemon reads
+ * `disabled` as "this assistant is not serving its own webhooks" and falls
+ * back to the platform's callback routes.
+ */
+export const RegisterWebhookRouteIpcResponseSchema = z.union([
+  z.object({ disabled: z.literal(true) }),
+  z.object({ disabled: z.literal(false), route: WebhookIngressRouteSchema }),
+]);
+
+export type RegisterWebhookRouteIpcResponse = z.infer<
+  typeof RegisterWebhookRouteIpcResponseSchema
+>;
+
+export const UnregisterWebhookRouteIpcParamsSchema = z.object({
+  path: z.string().min(1),
+});
+
+export type UnregisterWebhookRouteIpcParams = z.infer<
+  typeof UnregisterWebhookRouteIpcParamsSchema
+>;
+
+export const UnregisterWebhookRouteIpcResponseSchema = z.object({
+  removed: z.boolean(),
+});
+
+export type UnregisterWebhookRouteIpcResponse = z.infer<
+  typeof UnregisterWebhookRouteIpcResponseSchema
+>;
+
+export const ListWebhookRoutesIpcResponseSchema = z.object({
+  routes: z.array(WebhookIngressRouteSchema),
+});
+
+export type ListWebhookRoutesIpcResponse = z.infer<
+  typeof ListWebhookRoutesIpcResponseSchema
 >;
 
 // ── classify_risk ────────────────────────────────────────────────────────────

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -399,6 +399,7 @@ export const ContactsIdentitySnapshotIpcResponseSchema = z.object({
 
 export type ContactsIdentitySnapshotIpcResponse = z.infer<
   typeof ContactsIdentitySnapshotIpcResponseSchema
+>;
 
 // ── webhook ingress routes ───────────────────────────────────────────────────
 // The gateway owns the registry of subpaths this assistant answers from

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -413,8 +413,6 @@ export type ContactsIdentitySnapshotIpcResponse = z.infer<
  * and the daemon reads it to decide whether to claim at all, so both sides have
  * to name the same key.
  */
-export const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
-
 export const WebhookIngressRouteSchema = z.object({
   path: z.string(),
   type: z.string(),

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -407,6 +407,14 @@ export type ContactsIdentitySnapshotIpcResponse = z.infer<
 // read these schemas so a change to the stored row has to travel through the
 // contract.
 
+/**
+ * Feature flag gating the whole webhook ingress registry. The gateway reads it
+ * to decide whether to accept a claim and how to advertise its allowed paths,
+ * and the daemon reads it to decide whether to claim at all, so both sides have
+ * to name the same key.
+ */
+export const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
+
 export const WebhookIngressRouteSchema = z.object({
   path: z.string(),
   type: z.string(),


### PR DESCRIPTION
## Summary
- Behind the `velay-webhooks` flag (default off), platform pods mint webhook callback URLs on the Velay tunnel instead of registering Django callback routes. Each URL's exact path is claimed in a gateway-owned allowlist before it's handed out; Django remains the fallback when there's no tunnel URL, the claim fails, or the flag is off.
- The allowlist is enforced at the Velay edge (per-path rules sent on tunnel connect, refreshed when the registry or flag changes) and re-checked by the tunnel bridge per request. Unregistered `/webhooks/*` paths are refused. Twilio's static entries are unchanged.
- Flag off is behavior-identical to main.

**Rollback:** turning the flag off for an assistant that ran with it on leaves any tunnel URLs it already handed to vendors unreachable until re-registered; new URLs immediately fall back to Django.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ug73ozz1CtdmDKoPf5ytEM