### PR TITLE
fix(providers): salvage XML tool calls from OpenAI-compatible text

### DIFF
--- a/assistant/src/providers/__tests__/xml-tool-call-salvage.test.ts
+++ b/assistant/src/providers/__tests__/xml-tool-call-salvage.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  salvageXmlToolCalls,
+  splitXmlToolCallHoldback,
+} from "../xml-tool-call-salvage.js";
+
+const OFFERED = new Set(["bash", "file_read", "ui_show"]);
+
+describe("salvageXmlToolCalls", () => {
+  test("converts a DeepSeek-style bash invoke into a structured call", () => {
+    const text = `Let me actually run the check.
+
+<invoke name="bash">
+<parameter name="command">cd /workspace/example && git status</parameter>
+<parameter name="activity">Checking live repo state</parameter>
+<parameter name="timeout_seconds">60</parameter>
+</invoke>`;
+
+    const salvaged = salvageXmlToolCalls(text, OFFERED);
+    expect(salvaged).not.toBeNull();
+    expect(salvaged!.text).toBe("Let me actually run the check.");
+    expect(salvaged!.calls).toEqual([
+      {
+        name: "bash",
+        input: {
+          command: "cd /workspace/example && git status",
+          activity: "Checking live repo state",
+          timeout_seconds: 60,
+        },
+      },
+    ]);
+  });
+
+  test("salvages multiple invokes and strips an empty function_calls wrapper", () => {
+    const text = `<function_calls>
+<invoke name="file_read">
+<parameter name="path">/workspace/README.md</parameter>
+</invoke>
+<invoke name="bash">
+<parameter name="command">ls</parameter>
+</invoke>
+</function_calls>`;
+
+    const salvaged = salvageXmlToolCalls(text, OFFERED);
+    expect(salvaged!.text).toBe("");
+    expect(salvaged!.calls.map((call) => call.name)).toEqual([
+      "file_read",
+      "bash",
+    ]);
+  });
+
+  test("leaves unknown tool names as text", () => {
+    const text = `<invoke name="not_a_real_tool">
+<parameter name="command">rm -rf /</parameter>
+</invoke>`;
+
+    expect(salvageXmlToolCalls(text, OFFERED)).toBeNull();
+  });
+
+  test("salvages offered tools and leaves unknown invokes in the leftover text", () => {
+    const text = `<invoke name="bash">
+<parameter name="command">pwd</parameter>
+</invoke>
+<invoke name="not_a_real_tool">
+<parameter name="command">nope</parameter>
+</invoke>`;
+
+    const salvaged = salvageXmlToolCalls(text, OFFERED);
+    expect(salvaged!.calls).toEqual([
+      { name: "bash", input: { command: "pwd" } },
+    ]);
+    expect(salvaged!.text).toContain('name="not_a_real_tool"');
+    expect(salvaged!.text).not.toContain('name="bash"');
+  });
+
+  test("does not salvage a truncated invoke", () => {
+    const text = `<invoke name="bash">
+<parameter name="command">git status</parameter>
+<parameter name="activity">Checking`;
+
+    expect(salvageXmlToolCalls(text, OFFERED)).toBeNull();
+  });
+
+  test("matches offered tool names case-insensitively", () => {
+    const salvaged = salvageXmlToolCalls(
+      `<invoke name="Bash"><parameter name="command">echo hi</parameter></invoke>`,
+      OFFERED,
+    );
+    expect(salvaged!.calls[0]?.name).toBe("bash");
+  });
+
+  test("returns null when no tools were offered", () => {
+    const text = `<invoke name="bash"><parameter name="command">ls</parameter></invoke>`;
+    expect(salvageXmlToolCalls(text, new Set())).toBeNull();
+  });
+
+  test("decodes XML entities in parameter values", () => {
+    const salvaged = salvageXmlToolCalls(
+      `<invoke name="bash"><parameter name="command">echo &quot;a &amp; b&quot;</parameter></invoke>`,
+      OFFERED,
+    );
+    expect(salvaged!.calls[0]?.input.command).toBe('echo "a & b"');
+  });
+});
+
+describe("splitXmlToolCallHoldback", () => {
+  test("holds a complete invoke opener and the rest of the buffer", () => {
+    expect(splitXmlToolCallHoldback("Sure.\n<invoke name=\"bash\">")).toEqual({
+      visible: "Sure.\n",
+      held: `<invoke name="bash">`,
+    });
+  });
+
+  test("holds a partial opener split across chunks", () => {
+    expect(splitXmlToolCallHoldback("Okay.<inv")).toEqual({
+      visible: "Okay.",
+      held: "<inv",
+    });
+  });
+
+  test("passes through text with no opener", () => {
+    expect(splitXmlToolCallHoldback("Hello there.")).toEqual({
+      visible: "Hello there.",
+      held: "",
+    });
+  });
+});

--- a/assistant/src/providers/__tests__/xml-tool-call-salvage.test.ts
+++ b/assistant/src/providers/__tests__/xml-tool-call-salvage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   salvageXmlToolCalls,
+  shouldSalvageXmlToolCalls,
   splitXmlToolCallHoldback,
 } from "../xml-tool-call-salvage.js";
 
@@ -101,6 +102,49 @@ describe("salvageXmlToolCalls", () => {
       OFFERED,
     );
     expect(salvaged!.calls[0]?.input.command).toBe('echo "a & b"');
+  });
+
+  test("leaves invokes inside markdown fences as text", () => {
+    const text = `Example:
+
+\`\`\`xml
+<invoke name="bash">
+<parameter name="command">ls</parameter>
+</invoke>
+\`\`\``;
+
+    expect(salvageXmlToolCalls(text, OFFERED)).toBeNull();
+  });
+
+  test("salvages an unfenced invoke next to a fenced example", () => {
+    const text = `<invoke name="bash"><parameter name="command">pwd</parameter></invoke>
+
+\`\`\`
+<invoke name="file_read"><parameter name="path">/workspace/README.md</parameter></invoke>
+\`\`\``;
+
+    const salvaged = salvageXmlToolCalls(text, OFFERED);
+    expect(salvaged!.calls).toEqual([{ name: "bash", input: { command: "pwd" } }]);
+    expect(salvaged!.text).toContain('name="file_read"');
+  });
+});
+
+describe("shouldSalvageXmlToolCalls", () => {
+  test("is true for DeepSeek model ids", () => {
+    expect(
+      shouldSalvageXmlToolCalls(
+        "accounts/fireworks/models/deepseek-v4-flash-0731",
+      ),
+    ).toBe(true);
+    expect(shouldSalvageXmlToolCalls("deepseek/deepseek-v4-flash")).toBe(true);
+  });
+
+  test("is false for other models", () => {
+    expect(shouldSalvageXmlToolCalls("gpt-5.6")).toBe(false);
+    expect(shouldSalvageXmlToolCalls("accounts/fireworks/models/minimax-m3")).toBe(
+      false,
+    );
+    expect(shouldSalvageXmlToolCalls(undefined)).toBe(false);
   });
 });
 

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-xml-salvage.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-xml-salvage.test.ts
@@ -51,15 +51,12 @@ function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
 function stubProvider(
   chunks: MockChunk[],
   options?: OpenAIChatCompletionsProviderOptions,
+  model = "test-model",
 ): {
   provider: OpenAIChatCompletionsProvider;
   events: Array<{ type: string; text?: string }>;
 } {
-  const provider = new OpenAIChatCompletionsProvider(
-    "test-key",
-    "test-model",
-    options,
-  );
+  const provider = new OpenAIChatCompletionsProvider("test-key", model, options);
   (provider as unknown as { client: unknown }).client = {
     chat: {
       completions: {
@@ -94,6 +91,7 @@ describe("OpenAIChatCompletionsProvider XML tool-call salvage", () => {
         `<parameter name="timeout_seconds">60</parameter>\n`,
         "</invoke>",
       ]),
+      { salvageXmlToolCalls: true },
     );
 
     const response = await provider.sendMessage(
@@ -138,7 +136,7 @@ describe("OpenAIChatCompletionsProvider XML tool-call salvage", () => {
   test("salvages invoke XML when parseThinkTags is enabled", async () => {
     const { provider } = stubProvider(
       contentChunks([`Okay.\n${INVOKE_XML}`]),
-      { parseThinkTags: true },
+      { parseThinkTags: true, salvageXmlToolCalls: true },
     );
 
     const response = await provider.sendMessage(
@@ -154,7 +152,8 @@ describe("OpenAIChatCompletionsProvider XML tool-call salvage", () => {
   });
 
   test("leaves XML as text when native tool_calls are already present", async () => {
-    const { provider } = stubProvider([
+    const { provider } = stubProvider(
+      [
       { choices: [{ delta: { content: `${INVOKE_XML}\n` } }] },
       {
         choices: [
@@ -178,7 +177,9 @@ describe("OpenAIChatCompletionsProvider XML tool-call salvage", () => {
         choices: [{ delta: {}, finish_reason: "tool_calls" }],
         usage: { prompt_tokens: 1, completion_tokens: 2 },
       },
-    ]);
+      ],
+      { salvageXmlToolCalls: true },
+    );
 
     const response = await provider.sendMessage(
       [{ role: "user", content: [{ type: "text", text: "hi" }] }],
@@ -220,7 +221,9 @@ describe("OpenAIChatCompletionsProvider XML tool-call salvage", () => {
   });
 
   test("leaves XML as text when tool_choice is none", async () => {
-    const { provider } = stubProvider(contentChunks([INVOKE_XML]));
+    const { provider } = stubProvider(contentChunks([INVOKE_XML]), {
+      salvageXmlToolCalls: true,
+    });
 
     const response = await provider.sendMessage(
       [{ role: "user", content: [{ type: "text", text: "hi" }] }],
@@ -228,6 +231,55 @@ describe("OpenAIChatCompletionsProvider XML tool-call salvage", () => {
         tools: [BASH_TOOL],
         config: { tool_choice: { type: "none" } },
       },
+    );
+
+    expect(response.content.some((b) => b.type === "tool_use")).toBe(false);
+    const textBlock = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(textBlock?.text).toContain("<invoke");
+  });
+
+  test("leaves XML as text on non-DeepSeek models unless salvage is opted in", async () => {
+    const { provider } = stubProvider(contentChunks([INVOKE_XML]));
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { tools: [BASH_TOOL] },
+    );
+
+    expect(response.content.some((b) => b.type === "tool_use")).toBe(false);
+    const textBlock = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(textBlock?.text).toContain("<invoke");
+  });
+
+  test("salvages by default when the model id is DeepSeek", async () => {
+    const { provider } = stubProvider(
+      contentChunks([INVOKE_XML]),
+      undefined,
+      "accounts/fireworks/models/deepseek-v4-flash-0731",
+    );
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { tools: [BASH_TOOL] },
+    );
+
+    expect(response.content.some((b) => b.type === "tool_use")).toBe(true);
+  });
+
+  test("does not salvage DeepSeek when salvageXmlToolCalls is false", async () => {
+    const { provider } = stubProvider(
+      contentChunks([INVOKE_XML]),
+      { salvageXmlToolCalls: false },
+      "accounts/fireworks/models/deepseek-v4-flash-0731",
+    );
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { tools: [BASH_TOOL] },
     );
 
     expect(response.content.some((b) => b.type === "tool_use")).toBe(false);

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-xml-salvage.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-xml-salvage.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  OpenAIChatCompletionsProvider,
+  type OpenAIChatCompletionsProviderOptions,
+} from "../chat-completions-provider.js";
+
+type MockChunkDelta = {
+  content?: string | null;
+  tool_calls?: Array<{
+    index: number;
+    id?: string;
+    function?: { name?: string; arguments?: string };
+  }>;
+};
+
+type MockChunk = {
+  choices: Array<{ delta: MockChunkDelta; finish_reason?: string | null }>;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+const BASH_TOOL = {
+  name: "bash",
+  description: "Run a shell command",
+  input_schema: {
+    type: "object",
+    properties: {
+      command: { type: "string" },
+      activity: { type: "string" },
+      timeout_seconds: { type: "number" },
+    },
+  },
+};
+
+const INVOKE_XML = `<invoke name="bash">
+<parameter name="command">cd /workspace/example && git status</parameter>
+<parameter name="activity">Checking live repo state</parameter>
+<parameter name="timeout_seconds">60</parameter>
+</invoke>`;
+
+function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) {
+        yield c;
+      }
+    },
+  };
+}
+
+function stubProvider(
+  chunks: MockChunk[],
+  options?: OpenAIChatCompletionsProviderOptions,
+): {
+  provider: OpenAIChatCompletionsProvider;
+  events: Array<{ type: string; text?: string }>;
+} {
+  const provider = new OpenAIChatCompletionsProvider(
+    "test-key",
+    "test-model",
+    options,
+  );
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async () => makeStream(chunks),
+      },
+    },
+  };
+  return { provider, events: [] };
+}
+
+function contentChunks(parts: string[], finishReason = "stop"): MockChunk[] {
+  return [
+    ...parts.map((content) => ({
+      choices: [{ delta: { content } }],
+    })),
+    {
+      choices: [{ delta: {}, finish_reason: finishReason }],
+      usage: { prompt_tokens: 1, completion_tokens: 2 },
+    },
+  ];
+}
+
+describe("OpenAIChatCompletionsProvider XML tool-call salvage", () => {
+  test("converts streamed invoke XML into a tool_use block and holds it back from text_delta", async () => {
+    const { provider, events } = stubProvider(
+      contentChunks([
+        "Let me actually run the check.\n\n",
+        "<inv",
+        `oke name="bash">\n`,
+        `<parameter name="command">cd /workspace/example && git status</parameter>\n`,
+        `<parameter name="activity">Checking live repo state</parameter>\n`,
+        `<parameter name="timeout_seconds">60</parameter>\n`,
+        "</invoke>",
+      ]),
+    );
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "check the repo" }] }],
+      {
+        tools: [BASH_TOOL],
+        onEvent: (e) => {
+          events.push(e as { type: string; text?: string });
+        },
+      },
+    );
+
+    const textDeltas = events
+      .filter((e) => e.type === "text_delta")
+      .map((e) => e.text ?? "")
+      .join("");
+    expect(textDeltas).toBe("Let me actually run the check.\n\n");
+    expect(textDeltas).not.toContain("<invoke");
+    expect(textDeltas).not.toContain("<inv");
+
+    const textBlock = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(textBlock?.text).toBe("Let me actually run the check.");
+
+    const toolUse = response.content.filter((b) => b.type === "tool_use");
+    expect(toolUse).toEqual([
+      {
+        type: "tool_use",
+        id: expect.stringMatching(/^call_/),
+        name: "bash",
+        input: {
+          command: "cd /workspace/example && git status",
+          activity: "Checking live repo state",
+          timeout_seconds: 60,
+        },
+      },
+    ]);
+    expect(response.stopReason).toBe("tool_calls");
+  });
+
+  test("salvages invoke XML when parseThinkTags is enabled", async () => {
+    const { provider } = stubProvider(
+      contentChunks([`Okay.\n${INVOKE_XML}`]),
+      { parseThinkTags: true },
+    );
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { tools: [BASH_TOOL] },
+    );
+
+    expect(response.content.some((b) => b.type === "tool_use")).toBe(true);
+    const textBlock = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(textBlock?.text).toBe("Okay.");
+  });
+
+  test("leaves XML as text when native tool_calls are already present", async () => {
+    const { provider } = stubProvider([
+      { choices: [{ delta: { content: `${INVOKE_XML}\n` } }] },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_native",
+                  function: {
+                    name: "bash",
+                    arguments: '{"command":"pwd"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: "tool_calls" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { tools: [BASH_TOOL] },
+    );
+
+    const toolUse = response.content.filter((b) => b.type === "tool_use");
+    expect(toolUse).toHaveLength(1);
+    expect(toolUse[0]).toMatchObject({
+      id: "call_native",
+      name: "bash",
+      input: { command: "pwd" },
+    });
+    const textBlock = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(textBlock?.text).toContain("<invoke");
+  });
+
+  test("leaves XML as text when no tools were offered", async () => {
+    const { provider, events } = stubProvider(contentChunks([INVOKE_XML]));
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      {
+        onEvent: (e) => {
+          events.push(e as { type: string; text?: string });
+        },
+      },
+    );
+
+    expect(response.content.some((b) => b.type === "tool_use")).toBe(false);
+    expect(
+      events
+        .filter((e) => e.type === "text_delta")
+        .map((e) => e.text ?? "")
+        .join(""),
+    ).toContain("<invoke");
+  });
+
+  test("leaves XML as text when tool_choice is none", async () => {
+    const { provider } = stubProvider(contentChunks([INVOKE_XML]));
+
+    const response = await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      {
+        tools: [BASH_TOOL],
+        config: { tool_choice: { type: "none" } },
+      },
+    );
+
+    expect(response.content.some((b) => b.type === "tool_use")).toBe(false);
+    const textBlock = response.content.find((b) => b.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(textBlock?.text).toContain("<invoke");
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -36,7 +36,11 @@ import {
   isUnparseableToolArgs,
   wrapUnparseableToolArgs,
 } from "../unparseable-tool-args.js";
-import { salvageXmlToolCalls, splitXmlToolCallHoldback } from "../xml-tool-call-salvage.js";
+import {
+  salvageXmlToolCalls,
+  shouldSalvageXmlToolCalls,
+  splitXmlToolCallHoldback,
+} from "../xml-tool-call-salvage.js";
 import {
   captureRawErrorBodyFetch,
   formatNormalizedOpenAIAPIError,
@@ -180,6 +184,12 @@ export interface OpenAIChatCompletionsProviderOptions {
    *  with minimax-m3 on Fireworks). Off by default; scalars/arrays unaffected.
    *  See {@link coerceObjectParamsToJsonString}. */
   coerceObjectArgsToJsonString?: boolean;
+  /**
+   * Convert complete `<invoke>` XML in assistant text into `tool_use` blocks.
+   * Defaults to on for DeepSeek model ids and off otherwise. Set explicitly to
+   * override the model-id default.
+   */
+  salvageXmlToolCalls?: boolean;
   /** Drop `tool_choice` when thinking/reasoning is on the wire. Strict
    *  OpenAI-compatible reasoning upstreams (DeepSeek thinking mode) reject any
    *  explicit `tool_choice` with `Thinking mode does not support this
@@ -697,6 +707,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
   private assistantReasoningField:
     "reasoning" | "reasoning_content" | undefined;
   private coerceObjectArgsToJsonString: boolean;
+  private salvageXmlToolCalls: boolean;
   private omitToolChoiceWhenReasoning: boolean;
 
   constructor(
@@ -725,6 +736,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
     this.assistantReasoningField = options.assistantReasoningField;
     this.coerceObjectArgsToJsonString =
       options.coerceObjectArgsToJsonString ?? false;
+    this.salvageXmlToolCalls =
+      options.salvageXmlToolCalls ?? shouldSalvageXmlToolCalls(model);
     this.omitToolChoiceWhenReasoning =
       options.omitToolChoiceWhenReasoning ?? false;
   }
@@ -850,7 +863,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
         // receive them; the generic openai-compatible adapter drops every
         // explicit value in thinking mode via `omitToolChoiceWhenReasoning`.
         const toolChoice = mapNeutralToolChoice(configObj?.tool_choice);
-        xmlToolCallSalvageEnabled = toolChoice !== "none";
+        xmlToolCallSalvageEnabled =
+          this.salvageXmlToolCalls && toolChoice !== "none";
         if (toolChoice !== undefined) {
           const thinkingOn = isThinkingEnabledOnWire(params);
           const skipAutoDefault = thinkingOn && toolChoice === "auto";
@@ -1172,10 +1186,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
         flushPendingContent(true);
       }
 
-      // Some OpenAI-compatible models (DeepSeek V4 Flash on Budget) emit
-      // Anthropic-style `<invoke>` XML as assistant text instead of native
-      // `tool_calls`. Convert complete offered-tool invokes into tool_use
-      // blocks so the agent loop can execute them. Native tool_calls win.
+      // DeepSeek (and any caller that sets salvageXmlToolCalls) may emit
+      // `<invoke>` XML as assistant text instead of native `tool_calls`.
+      // Convert complete offered-tool invokes into tool_use blocks so the
+      // agent loop can execute them. Native tool_calls win.
       if (xmlToolCallSalvageEnabled && toolCallMap.size === 0) {
         const salvaged = salvageXmlToolCalls(
           contentText + xmlHeld,

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import OpenAI from "openai";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../prompts/cache-boundary.js";
@@ -34,6 +36,7 @@ import {
   isUnparseableToolArgs,
   wrapUnparseableToolArgs,
 } from "../unparseable-tool-args.js";
+import { salvageXmlToolCalls, splitXmlToolCallHoldback } from "../xml-tool-call-salvage.js";
 import {
   captureRawErrorBodyFetch,
   formatNormalizedOpenAIAPIError,
@@ -812,6 +815,9 @@ export class OpenAIChatCompletionsProvider implements Provider {
         ) as OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"];
       }
 
+      const offeredToolNames = new Set((tools ?? []).map((t) => t.name));
+      let xmlToolCallSalvageEnabled = false;
+
       if (tools && tools.length > 0) {
         params.tools = tools.map((t) => {
           let parameters = t.input_schema as OpenAI.FunctionParameters;
@@ -844,6 +850,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         // receive them; the generic openai-compatible adapter drops every
         // explicit value in thinking mode via `omitToolChoiceWhenReasoning`.
         const toolChoice = mapNeutralToolChoice(configObj?.tool_choice);
+        xmlToolCallSalvageEnabled = toolChoice !== "none";
         if (toolChoice !== undefined) {
           const thinkingOn = isThinkingEnabledOnWire(params);
           const skipAutoDefault = thinkingOn && toolChoice === "auto";
@@ -862,6 +869,33 @@ export class OpenAIChatCompletionsProvider implements Provider {
       let reasoningText = "";
       let insideThinkBlock = false;
       let pendingContent = "";
+      let xmlHeld = "";
+
+      const emitVisibleText = (delta: string): void => {
+        if (!delta) {
+          return;
+        }
+        if (!xmlToolCallSalvageEnabled) {
+          contentText += delta;
+          onEvent?.({ type: "text_delta", text: delta });
+          return;
+        }
+        const split = splitXmlToolCallHoldback(xmlHeld + delta);
+        xmlHeld = split.held;
+        if (split.visible) {
+          contentText += split.visible;
+          onEvent?.({ type: "text_delta", text: split.visible });
+        }
+      };
+
+      const flushHeldXmlAsText = (): void => {
+        if (!xmlHeld) {
+          return;
+        }
+        contentText += xmlHeld;
+        onEvent?.({ type: "text_delta", text: xmlHeld });
+        xmlHeld = "";
+      };
 
       const flushPendingContent = (final: boolean): void => {
         while (pendingContent.length > 0) {
@@ -896,8 +930,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
             if (openIdx >= 0) {
               const text = pendingContent.substring(0, openIdx);
               if (text) {
-                contentText += text;
-                onEvent?.({ type: "text_delta", text });
+                emitVisibleText(text);
               }
               insideThinkBlock = true;
               pendingContent = pendingContent.substring(
@@ -909,9 +942,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 : partialTagSuffix(pendingContent, "<think>");
               const safeLen = pendingContent.length - partial;
               if (safeLen > 0) {
-                const t = pendingContent.substring(0, safeLen);
-                contentText += t;
-                onEvent?.({ type: "text_delta", text: t });
+                emitVisibleText(pendingContent.substring(0, safeLen));
               }
               pendingContent =
                 partial > 0 ? pendingContent.substring(safeLen) : "";
@@ -1020,8 +1051,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
                 pendingContent += choice.delta.content;
                 flushPendingContent(false);
               } else {
-                contentText += choice.delta.content;
-                onEvent?.({ type: "text_delta", text: choice.delta.content });
+                emitVisibleText(choice.delta.content);
               }
             }
 
@@ -1140,6 +1170,42 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       if (this.parseThinkTags && pendingContent) {
         flushPendingContent(true);
+      }
+
+      // Some OpenAI-compatible models (DeepSeek V4 Flash on Budget) emit
+      // Anthropic-style `<invoke>` XML as assistant text instead of native
+      // `tool_calls`. Convert complete offered-tool invokes into tool_use
+      // blocks so the agent loop can execute them. Native tool_calls win.
+      if (xmlToolCallSalvageEnabled && toolCallMap.size === 0) {
+        const salvaged = salvageXmlToolCalls(
+          contentText + xmlHeld,
+          offeredToolNames,
+        );
+        if (salvaged) {
+          contentText = salvaged.text;
+          xmlHeld = "";
+          log.info(
+            {
+              salvagedToolCount: salvaged.calls.length,
+              salvagedToolNames: salvaged.calls.map((call) => call.name),
+            },
+            "Converted XML-formatted assistant text into native tool calls",
+          );
+          for (const [index, call] of salvaged.calls.entries()) {
+            toolCallMap.set(index, {
+              id: `call_${randomUUID()}`,
+              name: call.name,
+              args: JSON.stringify(call.input),
+            });
+          }
+          if (finishReason === "stop" || finishReason === "unknown") {
+            finishReason = "tool_calls";
+          }
+        } else {
+          flushHeldXmlAsText();
+        }
+      } else {
+        flushHeldXmlAsText();
       }
 
       // Build content blocks

--- a/assistant/src/providers/xml-tool-call-salvage.ts
+++ b/assistant/src/providers/xml-tool-call-salvage.ts
@@ -2,10 +2,10 @@
  * Salvage Anthropic-style XML tool calls that some OpenAI-compatible models
  * emit as assistant text instead of native `tool_calls`.
  *
- * Observed on DeepSeek V4 Flash (the managed Budget profile): the request
- * carries OpenAI-format tools, but the model finishes with `stop` and a
- * `<invoke name="bash">` block in `content`. Without this conversion those
- * calls never execute.
+ * Off by default. DeepSeek model ids enable it because those models are
+ * trained to emit DSML `invoke` markup and OpenAI-compatible hosts sometimes
+ * leave a prefix-stripped variant in `content`. Invokes inside markdown
+ * fences stay as text.
  */
 
 import { indexOfTag, partialTagSuffix } from "../util/think-tag-stream.js";
@@ -35,6 +35,13 @@ const PARAMETER_CLOSE = "</parameter>";
 const EMPTY_WRAPPER_RE =
   /<(?:function_calls|minimax:tool_call)>\s*<\/(?:function_calls|minimax:tool_call)>/gi;
 
+/** True when the model id is a DeepSeek variant that leaks XML tool calls. */
+export function shouldSalvageXmlToolCalls(
+  model: string | null | undefined,
+): boolean {
+  return typeof model === "string" && /deepseek/i.test(model);
+}
+
 export function salvageXmlToolCalls(
   text: string,
   offeredToolNames: ReadonlySet<string>,
@@ -63,7 +70,7 @@ export function salvageXmlToolCalls(
     const canonicalName = rawName
       ? resolveOfferedName(rawName, offeredToolNames)
       : null;
-    if (canonicalName) {
+    if (canonicalName && !isInsideMarkdownFence(text, openMatch.index)) {
       spans.push({
         start: openMatch.index,
         end: closeIdx + INVOKE_CLOSE.length,
@@ -188,4 +195,18 @@ function decodeXmlEntities(value: string): string {
     .replace(/&quot;/g, '"')
     .replace(/&apos;/g, "'")
     .replace(/&amp;/g, "&");
+}
+
+function isInsideMarkdownFence(text: string, index: number): boolean {
+  let inside = false;
+  let searchFrom = 0;
+  while (searchFrom < index) {
+    const next = text.indexOf("```", searchFrom);
+    if (next < 0 || next >= index) {
+      break;
+    }
+    inside = !inside;
+    searchFrom = next + 3;
+  }
+  return inside;
 }

--- a/assistant/src/providers/xml-tool-call-salvage.ts
+++ b/assistant/src/providers/xml-tool-call-salvage.ts
@@ -1,0 +1,191 @@
+/**
+ * Salvage Anthropic-style XML tool calls that some OpenAI-compatible models
+ * emit as assistant text instead of native `tool_calls`.
+ *
+ * Observed on DeepSeek V4 Flash (the managed Budget profile): the request
+ * carries OpenAI-format tools, but the model finishes with `stop` and a
+ * `<invoke name="bash">` block in `content`. Without this conversion those
+ * calls never execute.
+ */
+
+import { indexOfTag, partialTagSuffix } from "../util/think-tag-stream.js";
+
+/** Openers a streaming scanner holds back so XML tool calls are not shown as text. */
+export const XML_TOOL_CALL_OPEN_TAGS = [
+  "<invoke",
+  "<function_calls",
+  "<minimax:tool_call",
+] as const;
+
+export interface SalvagedXmlToolCall {
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface XmlToolCallSalvage {
+  /** Assistant text with salvaged invoke blocks removed. */
+  text: string;
+  calls: SalvagedXmlToolCall[];
+}
+
+const INVOKE_CLOSE = "</invoke>";
+const NAME_ATTR_RE = /\bname\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i;
+const PARAMETER_CLOSE = "</parameter>";
+
+const EMPTY_WRAPPER_RE =
+  /<(?:function_calls|minimax:tool_call)>\s*<\/(?:function_calls|minimax:tool_call)>/gi;
+
+export function salvageXmlToolCalls(
+  text: string,
+  offeredToolNames: ReadonlySet<string>,
+): XmlToolCallSalvage | null {
+  if (!text || offeredToolNames.size === 0) {
+    return null;
+  }
+
+  const spans: Array<{
+    start: number;
+    end: number;
+    call: SalvagedXmlToolCall;
+  }> = [];
+
+  const invokeOpenRe = /<invoke\b[^>]*>/gi;
+  let openMatch: RegExpExecArray | null = invokeOpenRe.exec(text);
+  while (openMatch) {
+    const openTag = openMatch[0];
+    const rawName = parseNameAttr(openTag);
+    const bodyStart = openMatch.index + openTag.length;
+    const closeIdx = text.indexOf(INVOKE_CLOSE, bodyStart);
+    if (closeIdx < 0) {
+      break;
+    }
+
+    const canonicalName = rawName
+      ? resolveOfferedName(rawName, offeredToolNames)
+      : null;
+    if (canonicalName) {
+      spans.push({
+        start: openMatch.index,
+        end: closeIdx + INVOKE_CLOSE.length,
+        call: {
+          name: canonicalName,
+          input: parseParameters(text.slice(bodyStart, closeIdx)),
+        },
+      });
+    }
+
+    invokeOpenRe.lastIndex = closeIdx + INVOKE_CLOSE.length;
+    openMatch = invokeOpenRe.exec(text);
+  }
+
+  if (spans.length === 0) {
+    return null;
+  }
+
+  let leftover = "";
+  let cursor = 0;
+  for (const span of spans) {
+    leftover += text.slice(cursor, span.start);
+    cursor = span.end;
+  }
+  leftover += text.slice(cursor);
+  leftover = leftover.replace(EMPTY_WRAPPER_RE, "").trim();
+
+  return {
+    text: leftover,
+    calls: spans.map((span) => span.call),
+  };
+}
+
+/**
+ * Split streamed text so a complete or in-progress XML tool-call opener is
+ * held back rather than shown as user-visible content.
+ */
+export function splitXmlToolCallHoldback(buffer: string): {
+  visible: string;
+  held: string;
+} {
+  if (!buffer) {
+    return { visible: "", held: "" };
+  }
+  const hit = indexOfTag(buffer, XML_TOOL_CALL_OPEN_TAGS, false);
+  if (hit) {
+    return {
+      visible: buffer.slice(0, hit.index),
+      held: buffer.slice(hit.index),
+    };
+  }
+  const partial = partialTagSuffix(buffer, XML_TOOL_CALL_OPEN_TAGS, false);
+  if (partial > 0) {
+    return {
+      visible: buffer.slice(0, buffer.length - partial),
+      held: buffer.slice(buffer.length - partial),
+    };
+  }
+  return { visible: buffer, held: "" };
+}
+
+function parseNameAttr(tag: string): string | null {
+  const match = NAME_ATTR_RE.exec(tag);
+  if (!match) {
+    return null;
+  }
+  const name = match[1] ?? match[2] ?? match[3];
+  return name && name.length > 0 ? name : null;
+}
+
+function resolveOfferedName(
+  name: string,
+  offeredToolNames: ReadonlySet<string>,
+): string | null {
+  if (offeredToolNames.has(name)) {
+    return name;
+  }
+  const lower = name.toLowerCase();
+  for (const offered of offeredToolNames) {
+    if (offered.toLowerCase() === lower) {
+      return offered;
+    }
+  }
+  return null;
+}
+
+function parseParameters(body: string): Record<string, unknown> {
+  const input: Record<string, unknown> = {};
+  const parameterOpenRe = /<parameter\b[^>]*>/gi;
+  let paramMatch: RegExpExecArray | null = parameterOpenRe.exec(body);
+  while (paramMatch) {
+    const openTag = paramMatch[0];
+    const paramName = parseNameAttr(openTag);
+    const valueStart = paramMatch.index + openTag.length;
+    const closeIdx = body.indexOf(PARAMETER_CLOSE, valueStart);
+    if (closeIdx < 0) {
+      break;
+    }
+    if (paramName) {
+      input[paramName] = parseParamValue(
+        decodeXmlEntities(body.slice(valueStart, closeIdx)),
+      );
+    }
+    parameterOpenRe.lastIndex = closeIdx + PARAMETER_CLOSE.length;
+    paramMatch = parameterOpenRe.exec(body);
+  }
+  return input;
+}
+
+function parseParamValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Two user feedback reports showed the assistant printing `<invoke name="bash">...</invoke>` instead of running tools. Both were on the managed Budget profile (`cost-optimized` → DeepSeek V4 Flash on Fireworks). The request sent OpenAI-format tools, but the model finished with `stop` and Anthropic-style XML in `content`, so the agent loop never executed anything.

This is a model capability gap (XML-as-text instead of native `tool_calls`) that is solvable in the harness, the same class of workaround as MiniMax `coerceObjectArgsToJsonString`. Salvage is opt-in and currently enabled only for DeepSeek model ids, because quoted `<invoke>` examples in code fences on other models should stay as text.

## Summary

- Parse complete `<invoke name="...">` blocks whose names match the offered tool set and convert them into `tool_use` content blocks.
- Hold XML openers back from `text_delta` so the invoke markup is not streamed as chat text.
- Enable salvage only when `salvageXmlToolCalls` is true, or by default when the model id matches `/deepseek/i`. Pass `salvageXmlToolCalls: false` to disable even on DeepSeek.
- Leave invokes inside markdown fences as text.
- Do not salvage when native `tool_calls` are already present, when no tools were offered, or when `tool_choice` is `none`.
- Truncated invokes and unknown tool names stay as text.

## Test plan

- `cd assistant && bun test src/providers/__tests__/xml-tool-call-salvage.test.ts src/providers/openai/__tests__/chat-completions-provider-xml-salvage.test.ts`
- `cd assistant && bun run typecheck:fast`

## Risk

On DeepSeek, salvage executes unfenced XML that looks like a real offered-tool call. If Budget writes an invoke block as an example outside a fence, that tool would run. Native `tool_calls` still win when the model emits both. Other models are unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dff24db-2490-4e60-a111-0c98203a8551?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dff24db-2490-4e60-a111-0c98203a8551&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

