### PR TITLE
fix(live-voice): ask for the microphone inside the gesture (JARVIS-1757)

### DIFF
--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -459,14 +459,21 @@ the destination stream. Automatic reconnects must reuse the already-started
 player and MediaStream element: creating a replacement from a backoff timer
 loses the original user activation and can make `play()` fail.
 
+Ask for the microphone from that same gesture. WebKit refuses a `getUserMedia`
+made after an await has spent the activation, with `NotAllowedError` and no
+prompt, and the readiness preflight is such an await. `prewarm()` reserves the
+microphone synchronously from the click and the session adopts the pending
+stream at connect time (`reserveLiveVoiceMicrophone` in `pcm-capture.ts`).
+
 **Re-render the track once the microphone is live.** WebKit binds a MediaStream
 renderer to whichever capture unit is active when the renderer starts, and the
 echo reference belongs to that unit. Starting the element in the entry gesture
-is therefore necessary but not sufficient: at that moment `getUserMedia` has not
-run, so the renderer can come up bound to a plain output unit and never acquire
-a reference. `LiveVoiceAudioPlayer.restartOutputRoute()` pauses and replays the
-element, and the session calls it once capture reports running. The queue is
-silent at that point, so the restart is inaudible.
+is therefore necessary but not sufficient: at that moment the `getUserMedia`
+reserved in the same gesture has not resolved, so the renderer can come up bound
+to a plain output unit and never acquire a reference.
+`LiveVoiceAudioPlayer.restartOutputRoute()` pauses and replays the element, and
+the session calls it once capture reports running. The queue is silent at that
+point, so the restart is inaudible.
 
 It also **rebuilds a route that has already fallen back**, which is what the
 gesture-less entry points depend on. A session started from Siri, the Action

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -2993,6 +2993,32 @@ describe("ChatComposer — live-voice integration", () => {
     expect(useLiveVoiceStore.getState().error).toBeNull();
   });
 
+  test("unmounting during the readiness preflight releases the microphone reserved from the click", async () => {
+    // GIVEN a preflight that has not answered yet
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    let settlePreflight: () => void = () => {};
+    preflightSpy.mockImplementationOnce(
+      () =>
+        new Promise<LiveVoicePreflightVerdict | null>((resolve) => {
+          settlePreflight = () => resolve({ status: "ready" });
+        }),
+    );
+    const { getByLabelText, unmount } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+    expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
+
+    // WHEN the composer unmounts before the verdict arrives
+    unmount();
+    await act(async () => {
+      settlePreflight();
+    });
+
+    // THEN the microphone reserved from the click goes back, and no session
+    // starts for the page the user left
+    expect(liveCancelPrewarmSpy).toHaveBeenCalledTimes(1);
+    expect(liveStarterSpy).not.toHaveBeenCalled();
+  });
+
   test("unmounting mid-reclaim releases the microphone reserved from the click", async () => {
     // GIVEN a reclaim whose out-of-band end has not settled yet
     useTurnStore.setState(INITIAL_TURN_STATE);

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -2993,6 +2993,44 @@ describe("ChatComposer — live-voice integration", () => {
     expect(useLiveVoiceStore.getState().error).toBeNull();
   });
 
+  test("unmounting mid-reclaim releases the microphone reserved from the click", async () => {
+    // GIVEN a reclaim whose out-of-band end has not settled yet
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    seedLiveVoiceSession("listening");
+    sessionEndSpy.mockClear();
+    preflightSpy.mockClear();
+    let settleEnd: (ended: boolean) => void = () => {};
+    sessionEndSpy.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          settleEnd = resolve;
+        }),
+    );
+    useLiveVoiceStore
+      .getState()
+      .fail("Voice is already active in the Mac app.", {
+        kind: "reclaim",
+        holderConversationId: "conversation-elsewhere",
+      });
+    const { getByText, unmount } = renderVoiceComposer();
+
+    // WHEN the user takes the slot, then leaves before the end settles
+    await act(async () => {
+      fireEvent.click(getByText("End it and start here"));
+    });
+    expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
+    unmount();
+    await act(async () => {
+      settleEnd(true);
+    });
+
+    // THEN the microphone reserved from the click goes back, and nothing
+    // starts: the layout-owned controller outlives this composer, so an
+    // unreleased reservation would sit open behind no session.
+    expect(liveCancelPrewarmSpy).toHaveBeenCalledTimes(1);
+    expect(preflightSpy).not.toHaveBeenCalled();
+  });
+
   test("a busy failure in this conversation offers no destination", () => {
     // GIVEN the blocking session is in the conversation already on screen
     useTurnStore.setState(INITIAL_TURN_STATE);

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -638,6 +638,13 @@ export function ChatComposer({
       liveVoiceReclaimRef.current = null;
     }
     if (reclaim.signal.aborted) {
+      // Aborted by the composer unmounting (the ref is cleared) or by a newer
+      // reclaim (the ref holds it). The newer one prewarmed against the same
+      // reservation and starts with it; the unmount left nobody to, so the
+      // microphone goes back rather than staying open behind no session.
+      if (liveVoiceReclaimRef.current === null) {
+        useLiveVoiceStore.getState().starter?.cancelPrewarm();
+      }
       return;
     }
     dismissLiveVoiceFailure();

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -530,9 +530,11 @@ export function ChatComposer({
     if (!assistantId || liveVoicePreflightPendingRef.current) {
       return;
     }
-    // WebKit's media-element playback permission is transient. Reserve and
-    // prewarm the controller-owned player synchronously from this gesture,
-    // before the readiness request yields to the event loop.
+    // WebKit's media-element playback permission is transient, and so is its
+    // willingness to show the microphone prompt: a `getUserMedia` made after
+    // the readiness await below is refused without ever asking. Reserve both
+    // synchronously from this gesture, before the request yields to the
+    // event loop.
     const starter = useLiveVoiceStore.getState().starter;
     starter?.prewarm();
     // Gate the open on the daemon's readiness verdict BEFORE starting, so the

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -509,6 +509,10 @@ export function ChatComposer({
   // race to start). A ref, not state — this must gate synchronously and never
   // trigger a re-render.
   const liveVoicePreflightPendingRef = useRef(false);
+  // Whether this composer is still mounted, read on the far side of the
+  // preflight await. The unmount cleanup below has already released what the
+  // click reserved, so an attempt that outlives its composer just stops.
+  const liveVoiceMountedRef = useRef(true);
   // Latest chat identity, re-read after the preflight await. The awaiting
   // callback holds the assistant/conversation captured when it was created, so
   // a user who switches chats (or leaves) mid-flight would otherwise resume and
@@ -548,6 +552,9 @@ export function ChatComposer({
       readiness = await voiceReadiness(assistantId);
     } finally {
       liveVoicePreflightPendingRef.current = false;
+    }
+    if (!liveVoiceMountedRef.current) {
+      return;
     }
     // The user may have moved to another chat while the POST was in flight.
     // Drop the result entirely rather than opening a room bound to the chat
@@ -607,8 +614,18 @@ export function ChatComposer({
   const liveVoiceReclaimRef = useRef<AbortController | null>(null);
   useEffect(
     () => () => {
+      liveVoiceMountedRef.current = false;
+      const reclaimPending = liveVoiceReclaimRef.current !== null;
       liveVoiceReclaimRef.current?.abort();
       liveVoiceReclaimRef.current = null;
+      // A start or reclaim still in flight reserved the microphone from its
+      // click, and nothing will now adopt it: the layout-owned controller
+      // outlives this composer, so left alone the tracks would stay open
+      // behind no session. Released here, before any successor composer can
+      // reserve one of its own, so the cancel cannot take a newer reservation.
+      if (liveVoicePreflightPendingRef.current || reclaimPending) {
+        useLiveVoiceStore.getState().starter?.cancelPrewarm();
+      }
     },
     [],
   );
@@ -638,13 +655,8 @@ export function ChatComposer({
       liveVoiceReclaimRef.current = null;
     }
     if (reclaim.signal.aborted) {
-      // Aborted by the composer unmounting (the ref is cleared) or by a newer
-      // reclaim (the ref holds it). The newer one prewarmed against the same
-      // reservation and starts with it; the unmount left nobody to, so the
-      // microphone goes back rather than staying open behind no session.
-      if (liveVoiceReclaimRef.current === null) {
-        useLiveVoiceStore.getState().starter?.cancelPrewarm();
-      }
+      // Aborted by a newer reclaim, which starts with the same reservation, or
+      // by the composer unmounting, whose cleanup already released it.
       return;
     }
     dismissLiveVoiceFailure();

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -147,6 +147,11 @@ export class FakeCapture {
    * since the controller starts the capture at connect time).
    */
   deferStart = false;
+  /**
+   * The reservation the controller handed to the latest `start()`, so tests
+   * can assert a microphone asked for in the gesture reached the capture.
+   */
+  reservedMicrophone: Promise<MediaStream> | null = null;
   private startResolvers: Array<(result: LiveVoiceCaptureResult) => void> = [];
 
   constructor(options: LiveVoiceAudioCaptureOptions) {
@@ -154,8 +159,11 @@ export class FakeCapture {
     this.onAmplitude = options.onAmplitude;
   }
 
-  async start(): Promise<LiveVoiceCaptureResult> {
+  async start(
+    reserved?: Promise<MediaStream>,
+  ): Promise<LiveVoiceCaptureResult> {
     this.startCount++;
+    this.reservedMicrophone = reserved ?? null;
     if (this.deferStart) {
       return new Promise((resolve) => this.startResolvers.push(resolve));
     }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -260,16 +260,23 @@ export interface LiveVoiceEntryOrigin {
 
 /**
  * Mount-scoped entry points for starting live voice. The composer prewarms
- * playback synchronously from the user's gesture, before its async readiness
- * preflight, then either starts with that player or cancels the reservation.
+ * synchronously from the user's gesture, before its async readiness
+ * preflight, then either starts with what was reserved or cancels the
+ * reservation.
  */
 export interface LiveVoiceSessionStarter {
-  /** Unlock playback while the initiating user gesture is still active. */
+  /**
+   * Unlock playback and ask for the microphone while the initiating user
+   * gesture is still active. The microphone in particular cannot wait:
+   * WebKit refuses a `getUserMedia` made after the gesture has been spent,
+   * and never shows the prompt.
+   */
   prewarm(): void;
-  /** Release playback reserved by a preflight that will not start a session. */
+  /** Release what a preflight reserved when it will not start a session. */
   cancelPrewarm(): void;
   /**
-   * Start a session, consuming the prewarmed player when one exists.
+   * Start a session, consuming the prewarmed player and microphone when they
+   * exist.
    *
    * `seedText` takes a first turn on the session's behalf once the microphone
    * is live, so the assistant speaks without waiting for the user. It becomes

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
@@ -4,6 +4,8 @@ import {
   isSupported,
   LIVE_VOICE_AUDIO_FORMAT,
   LiveVoiceAudioCapture,
+  releaseReservedMicrophone,
+  reserveLiveVoiceMicrophone,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
 
 // ---------------------------------------------------------------------------
@@ -246,6 +248,76 @@ describe("permission handling", () => {
     if (!result.ok) {
       expect(result.error).toBe("no-device");
     }
+  });
+});
+
+describe("microphone reservation", () => {
+  test("start adopts a reserved stream instead of asking the browser again", async () => {
+    let getUserMediaCalls = 0;
+    const stream = new FakeMediaStream();
+    getUserMediaImpl = () => {
+      getUserMediaCalls += 1;
+      return Promise.resolve(stream);
+    };
+
+    // Asked for inside the gesture.
+    const reserved = reserveLiveVoiceMicrophone();
+    expect(getUserMediaCalls).toBe(1);
+
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+    const result = await capture.start(reserved);
+
+    expect(result.ok).toBe(true);
+    expect(getUserMediaCalls).toBe(1);
+    // The adopted stream is the one the graph was built on, and stop()
+    // releases it like any stream the capture opened itself.
+    await capture.stop();
+    expect(stream.tracks.every((t) => t.stopped)).toBe(true);
+  });
+
+  test("a refused reservation surfaces at start as permission-denied", async () => {
+    getUserMediaImpl = () =>
+      Promise.reject(new DOMException("denied", "NotAllowedError"));
+    const reserved = reserveLiveVoiceMicrophone();
+    // The holder's no-op handler, as the controller attaches while it waits.
+    reserved.catch(() => {});
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+
+    const result = await capture.start(reserved);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("permission-denied");
+    }
+    expect(FakeAudioContext.lastInstance).toBeNull();
+  });
+
+  test("releasing a reservation stops its tracks once the stream arrives", async () => {
+    const stream = new FakeMediaStream();
+    let resolveGum: (s: FakeMediaStream) => void = () => {};
+    getUserMediaImpl = () =>
+      new Promise<FakeMediaStream>((resolve) => {
+        resolveGum = resolve;
+      });
+
+    const reserved = reserveLiveVoiceMicrophone();
+    // Released while the prompt is still up (a preflight said not-ready).
+    releaseReservedMicrophone(reserved);
+    expect(stream.tracks.every((t) => t.stopped)).toBe(false);
+
+    resolveGum(stream);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stream.tracks.every((t) => t.stopped)).toBe(true);
+  });
+
+  test("releasing a refused reservation absorbs the rejection", async () => {
+    getUserMediaImpl = () =>
+      Promise.reject(new DOMException("denied", "NotAllowedError"));
+
+    releaseReservedMicrophone(reserveLiveVoiceMicrophone());
+    // Bun fails the test on an unhandled rejection reaching the event loop.
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -19,6 +19,15 @@
  * first-run card complies by rendering locked (no ✕ / backdrop / Escape, a
  * single "Start talking" that leads straight here) on iOS — see
  * `chat-composer.tsx`'s `handleLiveVoiceStart` and `VoiceFirstRunCard`.
+ *
+ * The `getUserMedia` call has to happen inside the user's gesture. WebKit
+ * refuses one made after the gesture has been spent, with `NotAllowedError`
+ * and without ever showing the prompt, and an `await` on anything else (a
+ * readiness round trip, a token mint) is enough to spend it. A caller that
+ * has such an await between the gesture and `start()` reserves the
+ * microphone first with {@link reserveLiveVoiceMicrophone}, synchronously
+ * from the gesture, and hands the pending stream to `start()`, which adopts
+ * it instead of asking again.
  */
 
 // Import the worklet as a Vite-bundled, *transpiled* classic script asset and
@@ -101,6 +110,33 @@ export function isSupported(): boolean {
   );
 }
 
+/**
+ * Ask for the microphone now, from inside a user gesture, so the browser's
+ * permission prompt belongs to that gesture. The pending stream goes to
+ * {@link LiveVoiceAudioCapture.start} once the caller is ready to build the
+ * graph; a caller that will not start after all stops the tracks with
+ * {@link releaseReservedMicrophone}.
+ *
+ * The promise is left unhandled on purpose. A refusal must reach `start()`
+ * as the rejection it is, so it classifies as `permission-denied` there
+ * rather than being swallowed at reservation time; callers that hold it
+ * without starting attach their own no-op rejection handler.
+ */
+export function reserveLiveVoiceMicrophone(): Promise<MediaStream> {
+  return getVoiceInputMediaStream();
+}
+
+/**
+ * Stop the tracks of a reservation that no session will adopt. Settles the
+ * pending prompt either way: a stream that arrives after the caller moved on
+ * is released on arrival, and a refusal is absorbed.
+ */
+export function releaseReservedMicrophone(
+  reserved: Promise<MediaStream>,
+): void {
+  void reserved.then(stopTracks, () => {});
+}
+
 function classifyError(cause: unknown): LiveVoiceCaptureError {
   if (cause instanceof DOMException) {
     switch (cause.name) {
@@ -154,15 +190,32 @@ export class LiveVoiceAudioCapture {
    * Requests mic access, builds the audio graph, and begins emitting chunks.
    * Permission/device failures are returned as a typed result — they never
    * throw. Calling `start()` while already running is a no-op success.
+   *
+   * With `reserved` (from {@link reserveLiveVoiceMicrophone}) the capture
+   * adopts that stream instead of asking the browser again. The reservation
+   * is owned from here on, whatever happens: a start that is cancelled or
+   * fails stops its tracks like any stream it opened itself, and a capture
+   * that cannot use it (already running, disposed, unsupported) releases it.
    */
-  async start(): Promise<LiveVoiceCaptureResult> {
+  async start(
+    reserved?: Promise<MediaStream>,
+  ): Promise<LiveVoiceCaptureResult> {
     if (this.disposed) {
+      if (reserved) {
+        releaseReservedMicrophone(reserved);
+      }
       return { ok: false, error: "unsupported" };
     }
     if (this.context) {
+      if (reserved) {
+        releaseReservedMicrophone(reserved);
+      }
       return { ok: true };
     }
     if (!isSupported()) {
+      if (reserved) {
+        releaseReservedMicrophone(reserved);
+      }
       return { ok: false, error: "unsupported" };
     }
 
@@ -174,7 +227,7 @@ export class LiveVoiceAudioCapture {
 
     let stream: MediaStream;
     try {
-      stream = await getVoiceInputMediaStream();
+      stream = await (reserved ?? getVoiceInputMediaStream());
     } catch (cause) {
       return { ok: false, error: classifyError(cause), cause };
     }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -179,11 +179,10 @@ export function useLiveVoiceSessionController(
   // `observeAudioState: false` — the controller consumes nothing reactive
   // beyond the low-frequency `state`/`error` fields, so high-frequency
   // amplitude/transcript updates must not re-render the mounting layout.
-  const { start, sendText, prewarmPlayback, cancelPrewarmedPlayback } =
-    useLiveVoice({
-      ...options,
-      observeAudioState: false,
-    });
+  const { start, sendText, prewarm, cancelPrewarm } = useLiveVoice({
+    ...options,
+    observeAudioState: false,
+  });
 
   // A parked start-voice request is drained here, and the drain lands on the
   // conversation it mints for the session (see `start-voice-request.ts`). Held
@@ -197,8 +196,8 @@ export function useLiveVoiceSessionController(
 
   useEffect(() => {
     useLiveVoiceStore.getState().setStarter({
-      prewarm: prewarmPlayback,
-      cancelPrewarm: cancelPrewarmedPlayback,
+      prewarm,
+      cancelPrewarm,
       start: (assistantId, conversationId, options) =>
         // Hands-free (server-side turn detection) is the only mode the voice
         // button starts — it keeps one socket open across turns so the
@@ -223,7 +222,7 @@ export function useLiveVoiceSessionController(
     return () => {
       useLiveVoiceStore.getState().setStarter(null);
     };
-  }, [start, sendText, prewarmPlayback, cancelPrewarmedPlayback]);
+  }, [start, sendText, prewarm, cancelPrewarm]);
 
   // The drain's second trigger, and the only one a parked request has once the
   // starter is registered: the effect above runs on the starter's identity, not

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -2243,7 +2243,7 @@ describe("failure", () => {
 
     expect(h.view.result.current.state).toBe("failed");
     expect(h.view.result.current.error).toBe(
-      "Microphone access is blocked. Allow it for this site and try again.",
+      "Microphone access is blocked. Allow it in your browser or system settings and try again.",
     );
     expect(h.client.closed).toBe(true);
     // No audio frame was ever sent on the failed session.
@@ -2363,7 +2363,7 @@ describe("concurrent mic acquisition", () => {
     });
     expect(h.view.result.current.state).toBe("failed");
     expect(h.view.result.current.error).toBe(
-      "Microphone access is blocked. Allow it for this site and try again.",
+      "Microphone access is blocked. Allow it in your browser or system settings and try again.",
     );
     expect(h.client.closed).toBe(true);
     expect(h.client.sentAudio).toHaveLength(0);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -73,6 +73,7 @@ function renderController(
     reconnectBackoffMs?: number[];
     heldPlaybackTimeoutMs?: number;
     endAfterSeedReplyQuietMs?: number;
+    reserveMicrophone?: () => Promise<MediaStream>;
     /**
      * Configure each FakeCapture at creation — before the controller calls
      * `capture.start()`, which happens synchronously at connect time (so
@@ -158,12 +159,22 @@ afterEach(() => {
   useLiveVoiceStore.getState().reset();
 });
 
-describe("playback prewarm", () => {
+/** A stand-in for the stream `getUserMedia` resolves, with stoppable tracks. */
+function fakeMicrophone() {
+  const track = { stopped: false, stop: () => {} };
+  track.stop = () => {
+    track.stopped = true;
+  };
+  const stream = { getTracks: () => [track] } as unknown as MediaStream;
+  return { stream, track };
+}
+
+describe("prewarm", () => {
   test("reserves playback before start and reuses it for the session", async () => {
     const h = renderController();
 
     act(() => {
-      h.view.result.current.prewarmPlayback();
+      h.view.result.current.prewarm();
     });
 
     expect(h.getPlayerCreateCount()).toBe(1);
@@ -181,11 +192,99 @@ describe("playback prewarm", () => {
   test("canceling a prewarm releases the reserved player", () => {
     const h = renderController();
     act(() => {
-      h.view.result.current.prewarmPlayback();
-      h.view.result.current.cancelPrewarmedPlayback();
+      h.view.result.current.prewarm();
+      h.view.result.current.cancelPrewarm();
     });
 
     expect(h.player.disposeCount).toBe(1);
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("asks for the microphone from the gesture, once, and the session's capture adopts it", async () => {
+    // WebKit refuses a `getUserMedia` made after the composer's readiness
+    // await has spent the gesture, so the reservation has to be made by
+    // `prewarm()` and reach the capture unchanged.
+    const reserved = Promise.resolve(fakeMicrophone().stream);
+    let reserveCount = 0;
+    const h = renderController({
+      reserveMicrophone: () => {
+        reserveCount += 1;
+        return reserved;
+      },
+    });
+
+    act(() => {
+      h.view.result.current.prewarm();
+      // A second prewarm inside the same gesture (the reclaim path prewarms,
+      // then the composer's start prewarms again) must not ask twice.
+      h.view.result.current.prewarm();
+    });
+    expect(reserveCount).toBe(1);
+
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    expect(h.getCapture().reservedMicrophone).toBe(reserved);
+    expect(reserveCount).toBe(1);
+  });
+
+  test("a start with no reservation leaves the capture to ask for itself", async () => {
+    const h = renderController({
+      reserveMicrophone: () => Promise.resolve(fakeMicrophone().stream),
+    });
+
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1");
+    });
+
+    expect(h.getCapture().reservedMicrophone).toBeNull();
+  });
+
+  test("canceling a prewarm stops the reserved microphone's tracks", async () => {
+    const mic = fakeMicrophone();
+    const h = renderController({
+      reserveMicrophone: () => Promise.resolve(mic.stream),
+    });
+
+    act(() => {
+      h.view.result.current.prewarm();
+      h.view.result.current.cancelPrewarm();
+    });
+    await flushMicrotasks();
+
+    expect(mic.track.stopped).toBe(true);
+    expect(h.view.result.current.state).toBe("idle");
+  });
+
+  test("unmounting releases a reserved microphone nobody adopted", async () => {
+    const mic = fakeMicrophone();
+    const h = renderController({
+      reserveMicrophone: () => Promise.resolve(mic.stream),
+    });
+
+    act(() => {
+      h.view.result.current.prewarm();
+    });
+    h.view.unmount();
+    await flushMicrotasks();
+
+    expect(mic.track.stopped).toBe(true);
+  });
+
+  test("a refused reservation does not surface as an unhandled rejection", async () => {
+    const h = renderController({
+      reserveMicrophone: () =>
+        Promise.reject(new DOMException("denied", "NotAllowedError")),
+    });
+
+    act(() => {
+      h.view.result.current.prewarm();
+      h.view.result.current.cancelPrewarm();
+    });
+    // Bun fails the test on an unhandled rejection reaching the event loop.
+    await flushMicrotasks();
+
     expect(h.view.result.current.state).toBe("idle");
   });
 });
@@ -2129,7 +2228,8 @@ describe("failure", () => {
       await h.view.result.current.start("assistant-1");
     });
     // The denial resolved pre-`ready`; the failure surfaces when `ready`
-    // processes the capture result (same user-facing error as before).
+    // processes the capture result, and says it was a denial rather than a
+    // missing device, so a "no prompt" report can be told apart.
     expect(h.view.result.current.state).toBe("connecting");
     await act(async () => {
       h.client.emit("ready", {
@@ -2143,7 +2243,7 @@ describe("failure", () => {
 
     expect(h.view.result.current.state).toBe("failed");
     expect(h.view.result.current.error).toBe(
-      "Microphone capture could not start.",
+      "Microphone access is blocked. Allow it for this site and try again.",
     );
     expect(h.client.closed).toBe(true);
     // No audio frame was ever sent on the failed session.
@@ -2263,7 +2363,7 @@ describe("concurrent mic acquisition", () => {
     });
     expect(h.view.result.current.state).toBe("failed");
     expect(h.view.result.current.error).toBe(
-      "Microphone capture could not start.",
+      "Microphone access is blocked. Allow it for this site and try again.",
     );
     expect(h.client.closed).toBe(true);
     expect(h.client.sentAudio).toHaveLength(0);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -52,10 +52,13 @@
  * `idle`/`failed`.
  *
  * ## Mic forwarding
- * The mic is *acquired* at connect time — `capture.start()` (getUserMedia +
- * worklet load) is kicked off inside the mic-button gesture, concurrently with
- * the token mint / WS connect / server `ready` chain, so permission and device
- * spin-up overlap the network handshake instead of serializing after it. The
+ * The mic is *asked for* inside the mic-button gesture: `prewarm()` reserves
+ * it (getUserMedia) synchronously from the click, before the composer's
+ * readiness preflight, because WebKit refuses a `getUserMedia` made after
+ * the gesture has been spent and never shows the prompt. `capture.start()`
+ * then adopts the reservation at connect time (or asks itself, for a start
+ * with no reservation, such as a reconnect) and loads the worklet
+ * concurrently with the token mint / WS connect / server `ready` chain. The
  * `ready` handler awaits that acquisition before flipping forwarding on, so no
  * audio is ever sent pre-`ready`. Once running, the capture graph stays open
  * for the entire active session so amplitude keeps flowing for barge-in even
@@ -88,8 +91,11 @@ import {
   type LiveVoiceClientError,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
 import {
+  isSupported as isCaptureSupported,
   LiveVoiceAudioCapture,
   LIVE_VOICE_AUDIO_FORMAT,
+  releaseReservedMicrophone,
+  reserveLiveVoiceMicrophone,
   type LiveVoiceCaptureResult,
 } from "@/domains/chat/voice/live-voice/pcm-capture";
 import {
@@ -177,10 +183,14 @@ export interface UseLiveVoiceResult {
   inputAmplitude: number;
   /** Failure message when `state === "failed"`, else `null`. */
   error: string | null;
-  /** Unlock assistant playback synchronously from the initiating user gesture. */
-  prewarmPlayback: () => void;
-  /** Release playback reserved by a readiness check that will not start. */
-  cancelPrewarmedPlayback: () => void;
+  /**
+   * Reserve what the session needs from the initiating user gesture, before
+   * any await spends it: unlock assistant playback, and ask for the
+   * microphone so the browser's prompt belongs to the gesture.
+   */
+  prewarm: () => void;
+  /** Release what `prewarm` reserved for a start that will not happen. */
+  cancelPrewarm: () => void;
   /** Start a session for `assistantId`, optionally attaching a conversation. */
   start: (
     assistantId: string,
@@ -257,6 +267,11 @@ export interface UseLiveVoiceOptions {
   ) => LiveVoiceAudioCapture;
   createPlayer?: () => LiveVoiceAudioPlayer;
   /**
+   * How `prewarm()` asks for the microphone. Defaults to the real
+   * `getUserMedia` reservation; tests hand back a fake stream.
+   */
+  reserveMicrophone?: () => Promise<MediaStream>;
+  /**
    * When `false`, this hook instance does not subscribe to the high-frequency
    * audio/transcript store fields — `inputAmplitude` (updated on every mic
    * amplitude sample), `partialTranscript`, `finalTranscript`, and
@@ -322,6 +337,13 @@ interface SessionContext {
    * `forwardingAudio` on, so no audio is ever sent pre-`ready`.
    */
   capturePromise: Promise<LiveVoiceCaptureResult>;
+  /**
+   * The microphone `prewarm()` asked for inside the user's gesture, for
+   * {@link beginCaptureStartup} to hand to the capture. Null for a start
+   * with no reservation (a reconnect, or a caller with no gesture to spend),
+   * where the capture asks for itself.
+   */
+  reservedMicrophone: Promise<MediaStream> | null;
   /** Whether the mic capture graph is running (open for the whole session). */
   captureRunning: boolean;
   /**
@@ -479,6 +501,11 @@ export function useLiveVoice(
   // backoff. Keeping its MediaStream element alive preserves the user
   // activation that started iOS voice-processing playback.
   const standbyPlayerRef = useRef<LiveVoiceAudioPlayer | null>(null);
+  // The microphone `prewarm()` asked for inside the user's gesture, held
+  // until the session adopts it or `cancelPrewarm()` lets it go. Pending
+  // rather than resolved: the browser's prompt is up while the composer's
+  // readiness preflight runs, and the session adopts whatever it settles to.
+  const standbyMicrophoneRef = useRef<Promise<MediaStream> | null>(null);
   // The player currently rendering audio, so the assistant-mute control can
   // reach its gain stage mid-session. `standbyPlayerRef` cannot serve: it is
   // deliberately emptied the moment a session adopts the player.
@@ -534,10 +561,19 @@ export function useLiveVoice(
     }
   }, []);
 
+  const releaseStandbyMicrophone = useCallback(() => {
+    const reserved = standbyMicrophoneRef.current;
+    standbyMicrophoneRef.current = null;
+    if (reserved) {
+      releaseReservedMicrophone(reserved);
+    }
+  }, []);
+
   const cancelPendingConnection = useCallback(() => {
     clearReconnectTimer();
     disposeStandbyPlayer();
-  }, [clearReconnectTimer, disposeStandbyPlayer]);
+    releaseStandbyMicrophone();
+  }, [clearReconnectTimer, disposeStandbyPlayer, releaseStandbyMicrophone]);
 
   /**
    * Tear down the active session's primitives, clear the ref, and reset the
@@ -735,25 +771,40 @@ export function useLiveVoice(
     [],
   );
 
-  const prewarmPlayback = useCallback(() => {
+  const prewarm = useCallback(() => {
     if (
       sessionRef.current ||
-      standbyPlayerRef.current ||
       isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)
     ) {
       return;
     }
-    const player = createPlayer();
-    standbyPlayerRef.current = player;
-    player.prewarm();
+    if (!standbyPlayerRef.current) {
+      const player = createPlayer();
+      standbyPlayerRef.current = player;
+      player.prewarm();
+    }
+    // The microphone has to be asked for here, inside the gesture: WebKit
+    // refuses a `getUserMedia` made after an await has spent it, and never
+    // shows the prompt. A refusal is kept as the rejection it is, for the
+    // session's capture to classify; the handler here only keeps a refusal
+    // nobody adopted from surfacing as an unhandled rejection.
+    if (!standbyMicrophoneRef.current) {
+      const reserve = optionsRef.current.reserveMicrophone;
+      if (reserve || isCaptureSupported()) {
+        const reserved = reserve ? reserve() : reserveLiveVoiceMicrophone();
+        reserved.catch(() => {});
+        standbyMicrophoneRef.current = reserved;
+      }
+    }
   }, [createPlayer]);
 
-  const cancelPrewarmedPlayback = useCallback(() => {
+  const cancelPrewarm = useCallback(() => {
     if (reconnectTimerRef.current !== null) {
       return;
     }
     disposeStandbyPlayer();
-  }, [disposeStandbyPlayer]);
+    releaseStandbyMicrophone();
+  }, [disposeStandbyPlayer, releaseStandbyMicrophone]);
 
   // The connect flow, shared by the user-facing `start()` and the hands-free
   // reconnect path. `start()` owns the "already active" guard and resets the
@@ -766,6 +817,12 @@ export function useLiveVoice(
       conversationId: string | undefined,
       startOptions: LiveVoiceStartOptions,
     ) => {
+      // The microphone reserved from the gesture, taken before anything
+      // below can release it (a teardown of a stale session drops standby
+      // reservations). A reconnect finds none and the capture asks for
+      // itself; by then the permission is on record and no gesture is needed.
+      const reservedMicrophone = standbyMicrophoneRef.current;
+      standbyMicrophoneRef.current = null;
       if (sessionRef.current) {
         teardown();
       }
@@ -860,6 +917,7 @@ export function useLiveVoice(
         client,
         capture: undefined as unknown as LiveVoiceAudioCapture,
         capturePromise: undefined as unknown as Promise<LiveVoiceCaptureResult>,
+        reservedMicrophone,
         player,
         unsubscribes: [],
         generation: 0,
@@ -1623,8 +1681,8 @@ export function useLiveVoice(
     assistantTranscript,
     inputAmplitude,
     error,
-    prewarmPlayback,
-    cancelPrewarmedPlayback,
+    prewarm,
+    cancelPrewarm,
     start,
     stop,
     sendText,
@@ -1678,16 +1736,22 @@ function disposeSessionPrimitives(
  */
 function beginCaptureStartup(session: SessionContext): void {
   const generation = session.generation;
-  session.capturePromise = session.capture.start().then((result) => {
-    if (result.ok) {
-      if (session.generation !== generation) {
-        void session.capture.stop();
-      } else {
-        useLiveVoiceStore.getState().setMicrophoneActive(true);
+  const reserved = session.reservedMicrophone;
+  // The capture owns the reservation from here: it stops the tracks on a
+  // cancelled or failed start, as it would for a stream it opened itself.
+  session.reservedMicrophone = null;
+  session.capturePromise = session.capture
+    .start(reserved ?? undefined)
+    .then((result) => {
+      if (result.ok) {
+        if (session.generation !== generation) {
+          void session.capture.stop();
+        } else {
+          useLiveVoiceStore.getState().setMicrophoneActive(true);
+        }
       }
-    }
-    return result;
-  });
+      return result;
+    });
 }
 
 /**
@@ -1707,7 +1771,16 @@ async function finishCaptureStartup(
     return;
   }
   if (!result.ok) {
-    finishWithError(session, teardown, "Microphone capture could not start.");
+    // Named in the log so a report of "no prompt, can't talk" can be told
+    // apart from a missing device; the copy says which of the two it was.
+    console.warn(`live-voice: microphone capture failed: ${result.error}`);
+    finishWithError(
+      session,
+      teardown,
+      result.error === "permission-denied"
+        ? fixedT("chat")("liveVoiceStatus.microphoneDenied")
+        : "Microphone capture could not start.",
+    );
     return;
   }
   session.captureRunning = true;

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -905,6 +905,7 @@
     "connecting": "Connecting…",
     "ending": "Ending…",
     "listening": "Listening…",
+    "microphoneDenied": "Microphone access is blocked. Allow it for this site and try again.",
     "muted": "Muted",
     "reconnecting": "Reconnecting…",
     "speaking": "Speaking…",

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -905,7 +905,7 @@
     "connecting": "Connecting…",
     "ending": "Ending…",
     "listening": "Listening…",
-    "microphoneDenied": "Microphone access is blocked. Allow it for this site and try again.",
+    "microphoneDenied": "Microphone access is blocked. Allow it in your browser or system settings and try again.",
     "muted": "Muted",
     "reconnecting": "Reconnecting…",
     "speaking": "Speaking…",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -861,6 +861,7 @@
     "connecting": "Conectando…",
     "ending": "Finalizando…",
     "listening": "Escuchando…",
+    "microphoneDenied": "El acceso al micrófono está bloqueado. Permítelo para este sitio e inténtalo de nuevo.",
     "muted": "Silenciado",
     "reconnecting": "Reconectando…",
     "speaking": "Hablando…",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -861,7 +861,7 @@
     "connecting": "Conectando…",
     "ending": "Finalizando…",
     "listening": "Escuchando…",
-    "microphoneDenied": "El acceso al micrófono está bloqueado. Permítelo para este sitio e inténtalo de nuevo.",
+    "microphoneDenied": "El acceso al micrófono está bloqueado. Permítelo en la configuración del navegador o del sistema e inténtalo de nuevo.",
     "muted": "Silenciado",
     "reconnecting": "Reconectando…",
     "speaking": "Hablando…",


### PR DESCRIPTION
Fixes JARVIS-1757

## What

Web users who started a voice conversation landed in the voice room without ever seeing the browser's microphone prompt, then got "Microphone capture could not start." (LogRocket: first-run card → "Start talking" → room opens → no prompt → can't talk.)

## Why

`startLiveVoiceSession` awaits the daemon readiness preflight before `starter.start()`, and `start()` is where `getUserMedia` ran. That await spends the user gesture. WebKit (Safari, iOS) refuses a `getUserMedia` made outside user activation with `NotAllowedError` and never shows the prompt. Chrome has no such rule, which is why it never reproduced locally.

The player prewarm was moved in front of the await when the preflight was introduced (#38463, July); the mic acquisition was not. The header comment in `use-live-voice.ts` still described capture as "kicked off inside the mic-button gesture".

## How

- `prewarm()` now reserves the microphone synchronously from the click (`reserveLiveVoiceMicrophone` in `pcm-capture.ts`), next to the player it already prewarmed. Every gesture-driven entry already goes through `starter.prewarm()` before its await, so the composer's start, the first-run card, and the reclaim path all pick this up.
- `LiveVoiceAudioCapture.start(reserved?)` adopts the pending stream instead of asking again, and owns it from there (cancelled/failed starts stop its tracks; a capture that cannot use it releases it).
- `cancelPrewarm()`, `stop()`, and unmount release a reservation nobody adopted. The reservation is taken at the top of `connectSession`, before the stale-session teardown that would otherwise drop it.
- A reconnect has no reservation and the capture asks for itself, which needs no gesture once the permission is on record.
- A `permission-denied` capture result now fails the session with copy that says the mic is blocked (new `chat:liveVoiceStatus.microphoneDenied`, en + es) and logs the failure kind, so the next report of this shape is diagnosable.
- `prewarmPlayback` / `cancelPrewarmedPlayback` renamed to `prewarm` / `cancelPrewarm` on the hook, since they no longer only cover playback. Store-level starter names were already these.
- `docs/CAPACITOR.md` § echo cancellation updated: the mic is asked for in the same gesture as the media element.

## Behaviour note

A user whose readiness preflight comes back `not-ready` now sees the mic prompt and then the "Configure voice" notice, where before they saw only the notice. The prompt is legitimately needed for the feature and can't be deferred on WebKit, so this is the trade.

## Tests

- `pcm-capture.test.ts`: reservation adopted without a second `getUserMedia`; refused reservation surfaces as `permission-denied`; release stops tracks on arrival; release absorbs a refusal.
- `use-live-voice.test.ts`: prewarm reserves once and the capture receives it; a start with no reservation leaves the capture to ask; cancel/unmount stop the reserved tracks; a refused reservation is not an unhandled rejection; denial copy updated in the two existing denial tests.
- Ran: both suites, session-controller, start-voice-request, chat-composer, i18n catalog parity, `bun run typecheck`, eslint on changed files.

Not verified on a real Safari yet; the fix is by construction (call `getUserMedia` before the first await), and I'd appreciate a Safari check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPNbCre5LZyasbFUXm5aqy
