### PR TITLE
fix(voice): restore automatic gain control on live-voice capture (JARVIS-1758)

### DIFF
--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1215,6 +1215,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private receivedAudio = false;
   private detectedSpeech = false;
   private dispatchedTurn = false;
+  // Loudest server-VAD chunk the session saw, on the gate's own scale. Logged
+  // with a silent session's end so `no_speech` can be told apart: a peak
+  // under the gate is a user who talked and was not heard, a peak near the
+  // floor is a user who said nothing.
+  private peakChunkAmplitude = 0;
   // The client declared a text input affordance on the start frame, so it can
   // take a turn without the microphone. Governs one thing only: whether a
   // missing speech-to-text leg is fatal to startup (see start()).
@@ -1883,6 +1888,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ),
       outcome: failed ? "failed" : "completed",
     });
+    if (silenceReason !== null) {
+      // The levels behind a silent session, on the gate's scale, since the
+      // end event carries only the classification. A peak below `speechGate`
+      // on a `no_speech` session is a microphone the gate could not hear.
+      log.info(
+        {
+          sessionId: this.context.sessionId,
+          reason,
+          silenceReason,
+          peakChunkAmplitude: Math.round(this.peakChunkAmplitude),
+          noiseFloor:
+            this.roomNoiseFloor.floor === null
+              ? null
+              : Math.round(this.roomNoiseFloor.floor),
+          speechGate: Math.round(this.effectiveBaseThreshold()),
+        },
+        "Live-voice session ended without a turn",
+      );
+    }
 
     const shouldEmitSessionEndMetrics = this.state !== "failed";
     this.state = "closed";
@@ -2384,6 +2408,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    */
   private classifyVadEnergy(chunk: Buffer): VadClassifiedChunk[] {
     const meanAmplitude = pcm16MeanAmplitude(chunk);
+    if (meanAmplitude > this.peakChunkAmplitude) {
+      this.peakChunkAmplitude = meanAmplitude;
+    }
     const chunkMs = pcm16DurationMs(
       chunk.byteLength,
       this.context.startFrame.audio.sampleRate,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1215,10 +1215,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private receivedAudio = false;
   private detectedSpeech = false;
   private dispatchedTurn = false;
-  // Loudest server-VAD chunk the session saw, on the gate's own scale. Logged
-  // with a silent session's end so `no_speech` can be told apart: a peak
-  // under the gate is a user who talked and was not heard, a peak near the
-  // floor is a user who said nothing.
+  // Loudest server-VAD chunk not attributed to assistant playback, on the
+  // gate's own scale. Logged with a silent session's end so `no_speech` can
+  // be told apart: a peak under the gate is a user who talked and was not
+  // heard, a peak near the floor is a user who said nothing.
   private peakChunkAmplitude = 0;
   // The client declared a text input affordance on the start frame, so it can
   // take a turn without the microphone. Governs one thing only: whether a
@@ -2318,6 +2318,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (energyClassification === "echo") {
       return;
     }
+    // Measured past the echo gate, so a greeting heard through the speaker
+    // cannot stand in for the user on a silent close.
+    const meanAmplitude = pcm16MeanAmplitude(chunk);
+    if (meanAmplitude > this.peakChunkAmplitude) {
+      this.peakChunkAmplitude = meanAmplitude;
+    }
 
     // Idle mic: hold silent chunks in the bounded pre-roll instead of
     // collecting or streaming them; flushed on speech onset so the
@@ -2408,9 +2414,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    */
   private classifyVadEnergy(chunk: Buffer): VadClassifiedChunk[] {
     const meanAmplitude = pcm16MeanAmplitude(chunk);
-    if (meanAmplitude > this.peakChunkAmplitude) {
-      this.peakChunkAmplitude = meanAmplitude;
-    }
     const chunkMs = pcm16DurationMs(
       chunk.byteLength,
       this.context.startFrame.audio.sampleRate,

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
@@ -81,19 +81,13 @@ class FakeAudioContext {
 
 let getUserMediaImpl: () => Promise<FakeMediaStream> = () =>
   Promise.resolve(new FakeMediaStream());
-// Constraints handed to the last getUserMedia call, so tests can assert what
-// the capture actually asked the browser for.
-let lastGetUserMediaConstraints: MediaStreamConstraints | null = null;
 
 function installAudioGlobals(): void {
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
     value: {
       mediaDevices: {
-        getUserMedia: (constraints?: MediaStreamConstraints) => {
-          lastGetUserMediaConstraints = constraints ?? null;
-          return getUserMediaImpl();
-        },
+        getUserMedia: () => getUserMediaImpl(),
       },
     },
   });
@@ -115,7 +109,6 @@ function installAudioGlobals(): void {
 beforeEach(() => {
   lastWorklet = null;
   FakeAudioContext.lastInstance = null;
-  lastGetUserMediaConstraints = null;
   getUserMediaImpl = () => Promise.resolve(new FakeMediaStream());
   installAudioGlobals();
 });
@@ -223,37 +216,6 @@ describe("isSupported", () => {
       value: { mediaDevices: {} },
     });
     expect(isSupported()).toBe(false);
-  });
-});
-
-describe("gain control", () => {
-  test("requests auto gain by default (half-duplex consumers)", async () => {
-    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
-
-    await capture.start();
-
-    expect(lastGetUserMediaConstraints).not.toBeNull();
-    const audio = lastGetUserMediaConstraints?.audio as MediaTrackConstraints;
-    expect(audio.autoGainControl).toBe(true);
-    await capture.shutdown();
-  });
-
-  test("drops auto gain when asked, keeping echo cancellation on", async () => {
-    const capture = new LiveVoiceAudioCapture({
-      onChunk: () => {},
-      autoGainControl: false,
-    });
-
-    await capture.start();
-
-    const audio = lastGetUserMediaConstraints?.audio as MediaTrackConstraints;
-    // A moving input gain in front of the daemon's fixed absolute barge-in
-    // threshold is what lets room noise cancel a reply (JARVIS-1694). Echo
-    // cancellation is unrelated and must survive the opt-out.
-    expect(audio.autoGainControl).toBe(false);
-    expect(audio.echoCancellation).toBe(true);
-    expect(audio.noiseSuppression).toBe(true);
-    await capture.shutdown();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -79,18 +79,6 @@ export interface LiveVoiceAudioCaptureOptions {
   onChunk: (buf: ArrayBuffer) => void;
   /** Receives the smoothed RMS amplitude in [0, 1] for UI / barge-in. */
   onAmplitude?: (amplitude: number) => void;
-  /**
-   * Request automatic gain control on the mic track. Defaults to `true`.
-   *
-   * Half-duplex consumers of this pipeline (streaming dictation, the watch
-   * session) want the default: nothing is playing back, so normalizing a quiet
-   * talker only helps the transcriber. Full-duplex live voice passes `false`,
-   * because a moving input gain sits between the room and the fixed absolute
-   * threshold its barge-in gate compares against. The reasoning lives on
-   * `VoiceInputConstraintOptions.autoGainControl` in
-   * `@/utils/voice-input-device`.
-   */
-  autoGainControl?: boolean;
 }
 
 /**
@@ -141,7 +129,6 @@ function classifyError(cause: unknown): LiveVoiceCaptureError {
 export class LiveVoiceAudioCapture {
   private readonly onChunk: (buf: ArrayBuffer) => void;
   private readonly onAmplitude?: (amplitude: number) => void;
-  private readonly autoGainControl: boolean;
 
   private stream: MediaStream | null = null;
   private context: AudioContext | null = null;
@@ -161,7 +148,6 @@ export class LiveVoiceAudioCapture {
   constructor(options: LiveVoiceAudioCaptureOptions) {
     this.onChunk = options.onChunk;
     this.onAmplitude = options.onAmplitude;
-    this.autoGainControl = options.autoGainControl ?? true;
   }
 
   /**
@@ -188,9 +174,7 @@ export class LiveVoiceAudioCapture {
 
     let stream: MediaStream;
     try {
-      stream = await getVoiceInputMediaStream({
-        autoGainControl: this.autoGainControl,
-      });
+      stream = await getVoiceInputMediaStream();
     } catch (cause) {
       return { ok: false, error: classifyError(cause), cause };
     }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -890,14 +890,6 @@ export function useLiveVoice(
         onChunk: (buf) => handleChunk(session, buf),
         onAmplitude: (amplitude) =>
           handleAmplitude(session, amplitude, teardown),
-        // Full-duplex capture runs without AGC. Barge-in is decided on the
-        // daemon by comparing mean absolute amplitude against a threshold on
-        // the absolute 16-bit scale, and AGC is a moving gain in front of that
-        // fixed number: it lifts a quiet room's noise floor toward the level
-        // speech reaches in a loud one, so ordinary room noise clears the gate
-        // and cancels the reply. Every other consumer of this capture pipeline
-        // is half-duplex and keeps the default (JARVIS-1694).
-        autoGainControl: false,
       });
       session.capture = capture;
       sessionRef.current = session;

--- a/clients/web/src/utils/voice-input-device.test.ts
+++ b/clients/web/src/utils/voice-input-device.test.ts
@@ -31,22 +31,4 @@ describe("voiceInputAudioConstraints", () => {
       deviceId: { exact: "mic-42" },
     });
   });
-
-  test("drops auto gain on request, keeping the rest of the processing", () => {
-    expect(voiceInputAudioConstraints({ autoGainControl: false })).toEqual({
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: false,
-    });
-  });
-
-  test("still honors the pinned device with auto gain off", () => {
-    localStorage.setItem(LS_VOICE_INPUT_DEVICE, "mic-42");
-    expect(voiceInputAudioConstraints({ autoGainControl: false })).toEqual({
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: false,
-      deviceId: { exact: "mic-42" },
-    });
-  });
 });

--- a/clients/web/src/utils/voice-input-device.ts
+++ b/clients/web/src/utils/voice-input-device.ts
@@ -6,25 +6,6 @@ import { getLocalSetting } from "@/utils/local-settings";
  */
 export const LS_VOICE_INPUT_DEVICE = "vellum:voice:inputDeviceId";
 
-/** Per-call overrides for the shared voice capture constraints. */
-export interface VoiceInputConstraintOptions {
-  /**
-   * Request automatic gain control. Defaults to `true`, which is right for
-   * every half-duplex consumer (dictation, the amplitude meter, watch): the
-   * mic is the only sound in the room and normalizing a quiet talker up to a
-   * usable level makes the transcriber's job easier.
-   *
-   * Full-duplex live voice passes `false`. Its barge-in gate compares mean
-   * absolute amplitude against a threshold on the absolute 16-bit scale
-   * (`assistant/src/stt/speech-energy.ts`), and AGC is a moving gain between
-   * the room and that fixed number: in a quiet room it lifts the noise floor
-   * toward the same absolute level that speech reaches in a loud one, so the
-   * gate's real sensitivity becomes a property of the room rather than of the
-   * sound. See JARVIS-1694.
-   */
-  autoGainControl?: boolean;
-}
-
 export function getPreferredInputDeviceId(): string {
   return getLocalSetting(LS_VOICE_INPUT_DEVICE, "");
 }
@@ -33,18 +14,15 @@ export function getPreferredInputDeviceId(): string {
  * Audio constraints for voice capture, honoring the microphone chosen on the
  * Voice settings page. Uses `exact` so Chromium 130+ actually selects the
  * device (ideal constraints are silently ignored since that version).
- * Always requests echo cancellation and noise suppression so the mic stays
- * usable while TTS is playing (full-duplex capture); auto gain is on by
- * default and opt-out per {@link VoiceInputConstraintOptions.autoGainControl}.
+ * Always requests echo cancellation, noise suppression, and auto gain so the
+ * mic stays usable while TTS is playing (full-duplex capture).
  */
-export function voiceInputAudioConstraints(
-  options: VoiceInputConstraintOptions = {},
-): MediaTrackConstraints {
+export function voiceInputAudioConstraints(): MediaTrackConstraints {
   const deviceId = getPreferredInputDeviceId();
   return {
     echoCancellation: true,
     noiseSuppression: true,
-    autoGainControl: options.autoGainControl ?? true,
+    autoGainControl: true,
     ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
   };
 }
@@ -54,10 +32,8 @@ export function voiceInputAudioConstraints(
  * system default if the saved device is unavailable (unplugged, revoked, etc.)
  * rather than failing with an `OverconstrainedError`.
  */
-export async function getVoiceInputMediaStream(
-  options: VoiceInputConstraintOptions = {},
-): Promise<MediaStream> {
-  const constraints = voiceInputAudioConstraints(options);
+export async function getVoiceInputMediaStream(): Promise<MediaStream> {
+  const constraints = voiceInputAudioConstraints();
   try {
     return await navigator.mediaDevices.getUserMedia({ audio: constraints });
   } catch (err) {


### PR DESCRIPTION
Fixes JARVIS-1758

## What

~25% of live-voice sessions on /admin/voice end with no turn, and nearly every one of them closes as `silent_no_speech`: audio arrived for the whole session and the daemon's energy gate never classified a chunk as speech. Users describe it as the assistant having a hard time hearing them. Every platform: Windows desktop, Mac desktop, Edge, Chrome.

## Why

Hands-free sessions send nothing to speech-to-text until a chunk's mean absolute amplitude clears 800 on the 16-bit scale, raised to 3× the room's measured floor (`live-voice-session.ts` `classifyVadEnergy` → `MediaTurnDetector.onMediaChunk`). That gate was tuned against audio the browser had already normalised with AGC. #41788 (2026-08-31) dropped `autoGainControl` from live-voice capture so the gate would stop reading an AGC-lifted noise floor as speech, and nothing replaced the gain.

Measured on a MacBook Pro microphone with the macOS input slider raised to ~55%, talking loudly and continuously for 6 s: median chunk **634**, p90 1194, room floor 281 → gate 843, **33% of speech chunks clear it**. At the default input level, none did.

The dashboard's silent share is flat across Aug 31 (23.7% → 25.1%), so this didn't *cause* the silent population, but it widened it and is the reason it's now being felt by people on good hardware.

## A/B on the same microphone

MacBook Pro built-in mic, same room, same volume, 10 s of continuous speech each, measured on the app's own capture path (getUserMedia → 16 kHz → 50 ms mean-abs chunks):

| | AGC on (this PR) | AGC off (main) |
|---|---|---|
| median chunk | 505 | 150 |
| p90 | 1627 | 446 |
| max | 4820 | 789 |
| chunks over the 800 gate | 35% | 0% |

With AGC off the loudest chunk in ten seconds of talking never reaches the gate, so the daemon streams nothing to STT and the session closes `silent_no_speech`.

## How

- Reverts the capture half of #41788: `autoGainControl: true` again for live-voice capture. The `VoiceInputConstraintOptions.autoGainControl` opt-out goes with it, since nothing sets it any more.
- The room-floor adaptation that landed beside it (#41790) stays, and is now what keeps a lifted noise floor from reading as speech.
- The daemon logs the levels behind every silent close (`peakChunkAmplitude`, `noiseFloor`, `speechGate`, `silenceReason`), so the next `no_speech` report can be read as "a microphone the gate could not hear" vs "a user who said nothing" from pod logs. The end-telemetry event is unchanged; a proper field on it needs a platform serializer PR first and is a follow-up.

## Follow-up

Let the gate track the measured room floor *downward* instead of being pinned at ≥800, so it works without AGC at all. Separate ticket.

## Tests

- `pcm-capture.test.ts`, `voice-input-device.test.ts`, `use-live-voice.test.ts` (revert restores their pre-#41788 shape).
- Daemon: `live-voice-vad.test.ts`, `live-voice-session-telemetry.test.ts` (113 pass).
- `bun run typecheck` in both `assistant/` and `clients/web/`, eslint on changed files, pre-commit hooks green.

Ships to web on deploy; Mac/Windows desktop pick up the client half with the next app release, and the daemon half with the assistant deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPNbCre5LZyasbFUXm5aqy

