### PR TITLE
feat(llm): add GPT-6 Astra to the model catalog

### DIFF
--- a/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
+++ b/assistant/src/__tests__/openai-responses-prompt-cache.test.ts
@@ -412,12 +412,17 @@ describe("OpenAIResponsesProvider explicit prompt caching (GPT-5.6+)", () => {
     expect(JSON.stringify(messages)).not.toContain("prompt_cache_breakpoint");
   });
 
-  test("catalog flags exactly the GPT-5.6 direct-openai rows", () => {
+  test("catalog flags GPT-5.6 and GPT-6 Astra direct-openai rows", () => {
     const openai = PROVIDER_CATALOG.find((p) => p.id === "openai");
     const flagged = (openai?.models ?? [])
       .filter((m) => m.supportsPromptCacheBreakpoints)
       .map((m) => m.id)
       .sort();
-    expect(flagged).toEqual(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
+    expect(flagged).toEqual([
+      "gpt-5.6-luna",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-6-astra",
+    ]);
   });
 });

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -700,6 +700,36 @@ describe("OpenAIResponsesProvider", () => {
     });
   });
 
+  test('GPT-6 Astra effort: "max" is sent as reasoning.effort "max"', async () => {
+    const astraProvider = new OpenAIResponsesProvider("sk-test", "gpt-6-astra");
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await astraProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { effort: "max" } },
+    );
+
+    expect(lastStreamParams!.reasoning).toEqual({
+      effort: "max",
+      summary: "auto",
+    });
+  });
+
+  test('GPT-6 Astra effort: "none" snaps to the lowest accepted value', async () => {
+    const astraProvider = new OpenAIResponsesProvider("sk-test", "gpt-6-astra");
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await astraProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { effort: "none" } },
+    );
+
+    expect(lastStreamParams!.reasoning).toEqual({
+      effort: "low",
+      summary: "auto",
+    });
+  });
+
   test("no effort config means no reasoning in params", async () => {
     fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
 
@@ -843,6 +873,18 @@ describe("OpenAIResponsesProvider", () => {
     );
 
     expect(lastStreamParams!.text).toEqual({ verbosity: "high" });
+  });
+
+  test("verbosity is forwarded for GPT-6 Astra", async () => {
+    const astraProvider = new OpenAIResponsesProvider("sk-test", "gpt-6-astra");
+    fakeStreamEvents = [textDeltaEvent("OK"), completedEvent(10, 2)];
+
+    await astraProvider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { verbosity: "low" } },
+    );
+
+    expect(lastStreamParams!.text).toEqual({ verbosity: "low" });
   });
 
   test("verbosity is forwarded for GPT-5 fine-tune IDs", async () => {

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -121,6 +121,35 @@ describe("resolvePricing", () => {
       expect(result.estimatedCostUsd).toBeCloseTo(5 + 6.25 + 1 + 45, 10);
     });
 
+    test("bills GPT-6 Astra at published short-context rates", () => {
+      const result = resolvePricingForUsage("openai", "gpt-6-astra", {
+        directInputTokens: 50_000,
+        outputTokens: 0,
+        cacheCreationInputTokens: 50_000,
+        cacheReadInputTokens: 50_000,
+        anthropicCacheCreation: null,
+      });
+
+      expect(result.pricingStatus).toBe("priced");
+      // 0.05M x $10 direct + 0.05M x $12.5 write + 0.05M x $1 read
+      expect(result.estimatedCostUsd).toBeCloseTo(0.5 + 0.625 + 0.05, 10);
+    });
+
+    test("bills GPT-6 Astra at the long-context tier above 272k", () => {
+      const result = resolvePricingForUsage("openai", "gpt-6-astra", {
+        directInputTokens: 500_000,
+        outputTokens: 1_000_000,
+        cacheCreationInputTokens: 500_000,
+        cacheReadInputTokens: 1_000_000,
+        anthropicCacheCreation: null,
+      });
+
+      expect(result.pricingStatus).toBe("priced");
+      // Tier rates: 0.5M x $20 direct + 0.5M x $25 write + 1M x $2 read
+      // + 1M x $75 output.
+      expect(result.estimatedCostUsd).toBeCloseTo(10 + 12.5 + 2 + 75, 10);
+    });
+
     test("uses OpenAI short-context tiers through 272k prompt tokens", () => {
       const result = resolvePricingForUsage("openai", "gpt-5.4", {
         directInputTokens: 272_000,

--- a/assistant/src/providers/__tests__/connection-model-compat.test.ts
+++ b/assistant/src/providers/__tests__/connection-model-compat.test.ts
@@ -54,6 +54,7 @@ describe("isConnectionCompatibleWithModel", () => {
 
   test("oauth_subscription connection is compatible with a Codex model", () => {
     const conn = { auth: oauthAuth };
+    expect(isConnectionCompatibleWithModel(conn, "gpt-6-astra")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.6-sol")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.6-terra")).toBe(true);
     expect(isConnectionCompatibleWithModel(conn, "gpt-5.6-luna")).toBe(true);

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -403,6 +403,42 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       linkLabel: "Open OpenAI Platform",
     },
     models: [
+      // GPT-6 Astra. cacheRead is the 90% cached-read discount; cacheWrite
+      // is the 1.25x-input rate GPT-5.6+ bills for prompt tokens written to
+      // the cache (reported as `cache_write_tokens` in usage, tracked as
+      // `cacheCreationInputTokens`). Long-context (>272K input) is 2x input
+      // / 1.5x output / 2x cache-read+write for the whole request. Effort
+      // accepts low through max and rejects `none`.
+      {
+        id: "gpt-6-astra",
+        displayName: "GPT-6 Astra",
+        contextWindowTokens: 1050000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens:
+          OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
+        maxEffort: "max",
+        supportedEfforts: ["low", "medium", "high", "xhigh", "max"],
+        pricing: {
+          inputPer1mTokens: 10.0,
+          outputPer1mTokens: 50.0,
+          cacheWritePer1mTokens: 12.5,
+          cacheReadPer1mTokens: 1.0,
+          tiers: [
+            {
+              inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+              inputPer1mTokens: 20,
+              outputPer1mTokens: 75,
+              cacheWritePer1mTokens: 25,
+              cacheReadPer1mTokens: 2,
+            },
+          ],
+        },
+      },
       // GPT-5.6 family (Sol / Terra / Luna). cacheRead is the 90% cached-read
       // discount; cacheWrite is the 1.25x-input rate GPT-5.6+ bills for
       // prompt tokens written to the cache (reported as `cache_write_tokens`
@@ -1309,6 +1345,72 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       // OpenAI
+      // GPT-6 Astra. The `*-pro` slug is the same underlying model served
+      // with `reasoning.mode: pro` at identical rates. cacheWrite is the
+      // 1.25x-input rate GPT-5.6+ bills for prompt tokens written to the
+      // cache. Long-context (>272K input) is 2x input / 1.5x output / 2x
+      // cache-read+write for the whole request. Effort accepts low through
+      // max and rejects `none`.
+      {
+        id: "openai/gpt-6-astra",
+        displayName: "GPT-6 Astra",
+        contextWindowTokens: 1050000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens:
+          OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
+        maxEffort: "max",
+        supportedEfforts: ["low", "medium", "high", "xhigh", "max"],
+        pricing: {
+          inputPer1mTokens: 10.0,
+          outputPer1mTokens: 50.0,
+          cacheWritePer1mTokens: 12.5,
+          cacheReadPer1mTokens: 1.0,
+          tiers: [
+            {
+              inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+              inputPer1mTokens: 20,
+              outputPer1mTokens: 75,
+              cacheWritePer1mTokens: 25,
+              cacheReadPer1mTokens: 2,
+            },
+          ],
+        },
+      },
+      {
+        id: "openai/gpt-6-astra-pro",
+        displayName: "GPT-6 Astra Pro",
+        contextWindowTokens: 1050000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens:
+          OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        supportsPromptCacheBreakpoints: true,
+        maxEffort: "max",
+        supportedEfforts: ["low", "medium", "high", "xhigh", "max"],
+        pricing: {
+          inputPer1mTokens: 10.0,
+          outputPer1mTokens: 50.0,
+          cacheWritePer1mTokens: 12.5,
+          cacheReadPer1mTokens: 1.0,
+          tiers: [
+            {
+              inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
+              inputPer1mTokens: 20,
+              outputPer1mTokens: 75,
+              cacheWritePer1mTokens: 25,
+              cacheReadPer1mTokens: 2,
+            },
+          ],
+        },
+      },
       // GPT-5.6 family (Sol / Terra / Luna). The `*-pro` slugs are the same
       // underlying models served with `reasoning.mode: pro` at identical
       // rates. cacheWrite is the 1.25x-input rate GPT-5.6+ bills for prompt

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -191,7 +191,7 @@ const log = getLogger("chat-completions");
 /** Wire-level reasoning_effort values. The OpenAI SDK type doesn't include
  *  `"max"`, but Fireworks accepts it for DeepSeek V4; the assignment to
  *  `params.reasoning_effort` casts through this union. */
-type ReasoningEffortWire = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+export type ReasoningEffortWire = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 
 const REASONING_EFFORT_RANK: Record<ReasoningEffortWire, number> = {
   none: 0,

--- a/assistant/src/providers/openai/codex-models.ts
+++ b/assistant/src/providers/openai/codex-models.ts
@@ -9,6 +9,7 @@
  * connection" profile.
  */
 export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
+  "gpt-6-astra",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -8,7 +8,11 @@ import { extractRetryAfterMs } from "../../util/retry.js";
 import { clampProviderString } from "../content-block-size.js";
 import { fileBlockToProviderText } from "../file-block-text.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
-import { PROMPT_CACHE_BREAKPOINT_MODEL_IDS } from "../model-catalog.js";
+import {
+  modelEffortCeilings,
+  modelSupportedEfforts,
+  PROMPT_CACHE_BREAKPOINT_MODEL_IDS,
+} from "../model-catalog.js";
 import { recordProviderRequestDiagnostics } from "../request-diagnostics.js";
 import { createStreamTimeout } from "../stream-timeout.js";
 import { createToolProgressEmitter } from "../tool-progress-events.js";
@@ -26,7 +30,12 @@ import {
   formatNormalizedOpenAIAPIError,
   normalizeOpenAIAPIError,
 } from "./api-error-normalization.js";
-import { detectOpenAICompatibleContextOverflow } from "./chat-completions-provider.js";
+import {
+  clampReasoningEffort,
+  detectOpenAICompatibleContextOverflow,
+  snapReasoningEffortToSupported,
+  type ReasoningEffortWire,
+} from "./chat-completions-provider.js";
 import { serializeToolResult } from "./orphaned-tool-result.js";
 
 const log = getLogger("openai-responses");
@@ -46,21 +55,62 @@ export interface OpenAIResponsesProviderOptions {
 }
 
 /** Map our internal effort values to the Responses API reasoning.effort parameter.
- *  OpenAI caps at "xhigh", so our "max" tier collapses to "xhigh". `"none"` is
- *  passed through explicitly because OpenAI defaults `reasoning.effort` to
- *  "medium" when the field is omitted — the user's opt-out is only honored
- *  when we send it on the wire. */
-const EFFORT_TO_REASONING_EFFORT: Record<
-  string,
-  "none" | "low" | "medium" | "high" | "xhigh"
-> = {
+ *  `"max"` is emitted raw and then clamped to the model's catalog ceiling
+ *  ({@link mapResponsesReasoningEffort}); models that omit `maxEffort`
+ *  inherit OpenAI's historical `xhigh` cap. `"none"` is passed through
+ *  explicitly because OpenAI defaults `reasoning.effort` to "medium" when
+ *  the field is omitted, except on models whose `supportedEfforts` omit
+ *  `none` (those snap to the lowest accepted value). */
+const EFFORT_TO_REASONING_EFFORT: Record<string, ReasoningEffortWire> = {
   none: "none",
   low: "low",
   medium: "medium",
   high: "high",
   xhigh: "xhigh",
-  max: "xhigh",
+  max: "max",
 };
+
+const OPENAI_EFFORT_CEILINGS = modelEffortCeilings("openai");
+const OPENROUTER_EFFORT_CEILINGS = modelEffortCeilings("openrouter");
+const OPENAI_SUPPORTED_EFFORTS = modelSupportedEfforts("openai");
+const OPENROUTER_SUPPORTED_EFFORTS = modelSupportedEfforts("openrouter");
+
+function effortCeilingForModel(model: string): "high" | "xhigh" | "max" {
+  return (
+    OPENAI_EFFORT_CEILINGS.get(model) ??
+    OPENROUTER_EFFORT_CEILINGS.get(model) ??
+    "xhigh"
+  );
+}
+
+function supportedEffortsForModel(
+  model: string,
+): readonly ("low" | "medium" | "high" | "xhigh" | "max")[] | undefined {
+  return (
+    OPENAI_SUPPORTED_EFFORTS.get(model) ??
+    OPENROUTER_SUPPORTED_EFFORTS.get(model)
+  );
+}
+
+/** Translate a Vellum effort value onto the Responses wire for `model`. */
+function mapResponsesReasoningEffort(
+  effort: string,
+  model: string,
+): ReasoningEffortWire | undefined {
+  const raw = EFFORT_TO_REASONING_EFFORT[effort];
+  if (!raw) {
+    return undefined;
+  }
+  const supported = supportedEffortsForModel(model);
+  if (raw === "none") {
+    if (supported && supported.length > 0) {
+      return supported[0];
+    }
+    return "none";
+  }
+  const clamped = clampReasoningEffort(raw, effortCeilingForModel(model));
+  return supported ? snapReasoningEffortToSupported(clamped, supported) : clamped;
+}
 
 /** Values accepted by the Responses API `text.verbosity` parameter. */
 const VALID_VERBOSITIES = new Set<string>(["low", "medium", "high"]);
@@ -102,15 +152,15 @@ export function mapNeutralToolChoiceForResponses(
   }
 }
 
-/** `text.verbosity` is a GPT-5-series-only parameter. Older models on the
+/** `text.verbosity` is a GPT-5/GPT-6-series parameter. Older models on the
  *  Responses API (o-series, etc.) reject unknown wire fields with HTTP 400, so
  *  gate forwarding by model name here. The retry layer can't make this call
  *  because verbosity defaults to "medium" in the LLM schema, so every
  *  callSite-resolved request would otherwise carry it regardless of model.
  *  Also matches OpenAI fine-tune IDs of the form `ft:gpt-5.x:org::id` so users
- *  on GPT-5 fine-tunes keep explicit verbosity control. */
+ *  on GPT-5/GPT-6 fine-tunes keep explicit verbosity control. */
 function modelSupportsVerbosity(model: string): boolean {
-  return /^(ft:)?gpt-5(\b|[-.])/i.test(model);
+  return /^(ft:)?gpt-[56](\b|[-.])/i.test(model);
 }
 
 /** Loosely-typed Responses stream event to avoid `any` while the SDK types settle. */
@@ -295,7 +345,7 @@ export class OpenAIResponsesProvider implements Provider {
       }
 
       const reasoningEffort = effort
-        ? EFFORT_TO_REASONING_EFFORT[effort]
+        ? mapResponsesReasoningEffort(effort, effectiveModel)
         : undefined;
       if (reasoningEffort) {
         // Request a human-readable reasoning summary whenever the model will

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -33,8 +33,8 @@ import {
 import {
   clampReasoningEffort,
   detectOpenAICompatibleContextOverflow,
-  snapReasoningEffortToSupported,
   type ReasoningEffortWire,
+  snapReasoningEffortToSupported,
 } from "./chat-completions-provider.js";
 import { serializeToolResult } from "./orphaned-tool-result.js";
 

--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -223,7 +223,10 @@ export function inferProviderFromModel(model: string): string | undefined {
   if (model.startsWith("accounts/fireworks/models/")) {
     return "fireworks";
   }
-  if (model.startsWith("openai/gpt-5.6")) {
+  if (
+    model.startsWith("openai/gpt-5.6") ||
+    model.startsWith("openai/gpt-6-astra")
+  ) {
     // Listed by OpenRouter (#37856), the earlier catalog entry; the Vercel
     // AI Gateway does not carry these IDs.
     return "openrouter";

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -153,6 +153,15 @@ export const MODELS_BY_PROVIDER = {
   ],
   openai: [
     {
+      id: "gpt-6-astra",
+      displayName: "GPT-6 Astra",
+      contextWindowTokens: 1_050_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      longContextPricingThresholdTokens: 272_000,
+    },
+    {
       id: "gpt-5.6-sol",
       displayName: "GPT-5.6 Sol",
       contextWindowTokens: 1_050_000,
@@ -580,6 +589,25 @@ export const MODELS_BY_PROVIDER = {
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
       supportsThinking: true,
+    },
+    {
+      id: "openai/gpt-6-astra",
+      displayName: "GPT-6 Astra",
+      contextWindowTokens: 1_050_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      longContextPricingThresholdTokens: 272_000,
+    },
+    {
+      id: "openai/gpt-6-astra-pro",
+      displayName: "GPT-6 Astra Pro",
+      vendor: "openai",
+      contextWindowTokens: 1_050_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      longContextPricingThresholdTokens: 272_000,
     },
     {
       id: "openai/gpt-5.6-sol",
@@ -1323,6 +1351,7 @@ export function getManagedUpstreamForModel(
 // the "chatgpt" identity's model list resolves here like every provider's;
 // the settings domain re-exports it from codex-subscription-models.
 export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
+  "gpt-6-astra",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",

--- a/clients/web/src/domains/settings/ai/model-first-groups.test.ts
+++ b/clients/web/src/domains/settings/ai/model-first-groups.test.ts
@@ -260,13 +260,14 @@ describe("collapseSectionRows", () => {
   });
 
   test("spends the three rows on three lines, not three versions of one", () => {
-    // Every OpenAI line's newest member is a 5.6, so the section leads with
-    // those rather than walking down through 5.5 and 5.4.
+    // Astra is its own line, then each 5.6 flavor is a line of its own, so
+    // the section leads with those rather than walking down through 5.5
+    // and 5.4.
     const { shown } = collapseSectionRows(optionsFor("openai"));
     expect(shown.map((option) => option.displayName)).toEqual([
+      "GPT-6 Astra",
       "GPT-5.6 Sol",
       "GPT-5.6 Terra",
-      "GPT-5.6 Luna",
     ]);
   });
 

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -202,6 +202,14 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.thinkingLevel).toBe(false);
   });
 
+  test("openai gpt-6-astra enables effort and verbosity", () => {
+    const vis = resolveProfileParamVisibility("openai", "gpt-6-astra");
+    expect(vis.effort).toBe(true);
+    expect(vis.verbosity).toBe(true);
+    expect(vis.thinking).toBe(false);
+    expect(vis.thinkingLevel).toBe(false);
+  });
+
   test("gemini enables thinkingLevel for thinking-capable models", () => {
     const vis = resolveProfileParamVisibility("gemini", "gemini-2.5-flash");
     expect(vis.thinkingLevel).toBe(true);

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -34,11 +34,14 @@ export const VISIBILITY_NONE: ProfileParamVisibility = {
   thinkingLevel: false,
 };
 
-function isOpenAIGPT5Family(modelId: string): boolean {
+function isOpenAIGptReasoningFamily(modelId: string): boolean {
   return (
     modelId === "gpt-5" ||
+    modelId === "gpt-6" ||
     modelId.startsWith("gpt-5.") ||
-    modelId.startsWith("gpt-5-")
+    modelId.startsWith("gpt-5-") ||
+    modelId.startsWith("gpt-6.") ||
+    modelId.startsWith("gpt-6-")
   );
 }
 
@@ -168,7 +171,7 @@ function supportsEffort(
     return !modelId.includes("haiku") && supportsThinking;
   }
   if (provider === "openai") {
-    return isOpenAIGPT5Family(modelId);
+    return isOpenAIGptReasoningFamily(modelId);
   }
   if (provider === "openrouter" || provider === "vercel-ai-gateway") {
     if (isVendorPrefixedAnthropicModel(modelId)) {
@@ -240,7 +243,7 @@ export function resolveProfileParamVisibility(
     contextWindow: true,
     effort: supportsEffort(providerId, modelId, supportsThinkingResult),
     speed: providerId === "anthropic" && modelId.includes("opus"),
-    verbosity: providerId === "openai" && isOpenAIGPT5Family(modelId),
+    verbosity: providerId === "openai" && isOpenAIGptReasoningFamily(modelId),
     temperature: usesAnthropicWire,
     topP: supportsTopP(providerId, usesAnthropicWire),
     // Gateway thinking is anthropic/*-only: the OpenAI-compat path has no

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -244,6 +244,34 @@
       "defaultModel": "gpt-5.5",
       "models": [
         {
+          "id": "gpt-6-astra",
+          "displayName": "GPT-6 Astra",
+          "contextWindowTokens": 1050000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 272000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 10,
+            "outputPer1mTokens": 50,
+            "cacheWritePer1mTokens": 12.5,
+            "cacheReadPer1mTokens": 1,
+            "tiers": [
+              {
+                "inputTokenThreshold": 272000,
+                "inputPer1mTokens": 20,
+                "outputPer1mTokens": 75,
+                "cacheWritePer1mTokens": 25,
+                "cacheReadPer1mTokens": 2
+              }
+            ]
+          }
+        },
+        {
           "id": "gpt-5.6-sol",
           "displayName": "GPT-5.6 Sol",
           "contextWindowTokens": 1050000,
@@ -1180,6 +1208,62 @@
             "outputPer1mTokens": 5,
             "cacheWritePer1mTokens": 1.25,
             "cacheReadPer1mTokens": 0.1
+          }
+        },
+        {
+          "id": "openai/gpt-6-astra",
+          "displayName": "GPT-6 Astra",
+          "contextWindowTokens": 1050000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 272000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 10,
+            "outputPer1mTokens": 50,
+            "cacheWritePer1mTokens": 12.5,
+            "cacheReadPer1mTokens": 1,
+            "tiers": [
+              {
+                "inputTokenThreshold": 272000,
+                "inputPer1mTokens": 20,
+                "outputPer1mTokens": 75,
+                "cacheWritePer1mTokens": 25,
+                "cacheReadPer1mTokens": 2
+              }
+            ]
+          }
+        },
+        {
+          "id": "openai/gpt-6-astra-pro",
+          "displayName": "GPT-6 Astra Pro",
+          "contextWindowTokens": 1050000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 272000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 10,
+            "outputPer1mTokens": 50,
+            "cacheWritePer1mTokens": 12.5,
+            "cacheReadPer1mTokens": 1,
+            "tiers": [
+              {
+                "inputTokenThreshold": 272000,
+                "inputPer1mTokens": 20,
+                "outputPer1mTokens": 75,
+                "cacheWritePer1mTokens": 25,
+                "cacheReadPer1mTokens": 2
+              }
+            ]
           }
         },
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Add GPT-6 Astra (`gpt-6-astra`) as a selectable model in Vellum Assistant, with matching OpenRouter slugs, Codex allowlisting, and Responses API effort handling for `max`.

Do not change shipped default profiles. `quality-optimized` stays on `gpt-5.6-sol` because Astra list price is roughly 2x Sol.

## Summary
- List GPT-6 Astra first in the OpenAI catalog (1.05M context, 128K max output, 272K long-context threshold).
- Add OpenRouter `openai/gpt-6-astra` and `openai/gpt-6-astra-pro`.
- Allow Astra through Codex subscription routing.
- Send Responses `reasoning.effort: max` for models whose catalog ceiling includes `max`. Other GPT-5 models still clamp `max` to `xhigh`.
- Snap Astra `none` to `low` because the model rejects `none`.
- Enable verbosity controls for GPT-6 in the profile picker.
- Infer `openai/gpt-6-astra*` as OpenRouter in the CLI (Vercel AI Gateway does not list these IDs).

Companion platform PR (already merged): https://github.com/vellum-ai/vellum-assistant-platform/pull/10360. The platform rate card is the hosted-proxy allowlist.

## Test plan
- `cd assistant && bun test src/__tests__/pricing.test.ts src/__tests__/openai-responses-provider.test.ts src/__tests__/openai-responses-prompt-cache.test.ts src/providers/__tests__/connection-model-compat.test.ts src/__tests__/llm-catalog-parity.test.ts`
- `cd assistant && bun run lint -- src/providers/openai/responses-provider.ts`
- `cd clients/web && bun test src/assistant/llm-model-catalog.test.ts src/domains/settings/ai/profile-param-visibility.test.ts src/domains/settings/ai/codex-subscription-models.test.ts src/domains/settings/ai/model-first-groups.test.ts`
- `cd cli && bun test src/__tests__/provider-inference-parity.test.ts`
- `cd assistant && bun run sync:llm-catalog -- --check`

## CLI verb checklist
No new runtime routes.

## Risk
- Medium on Responses effort mapping: `max` is no longer globally collapsed to `xhigh`. Models without a catalog `maxEffort` still inherit `xhigh`, which preserves GPT-5.2 behavior.
- Defaults are unchanged, so existing quality-optimized users do not silently move onto a more expensive model.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aa66e88-42c9-4a32-8ff6-0ecf5cff7e4e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aa66e88-42c9-4a32-8ff6-0ecf5cff7e4e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

