### PR TITLE
fix(skills): block install-time RCE and tar-size DoS

### DIFF
--- a/assistant/src/__tests__/skills-install-extract.test.ts
+++ b/assistant/src/__tests__/skills-install-extract.test.ts
@@ -5,8 +5,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   extractTarToDir,
-  SkillArchiveError,
   SKILL_DEPENDENCY_INSTALL_ARGS,
+  SkillArchiveError,
   writeSkillFilesToDir,
 } from "../skills/catalog-install.js";
 import { makeTar } from "./helpers/tar-fixtures.js";

--- a/assistant/src/__tests__/skills-install-extract.test.ts
+++ b/assistant/src/__tests__/skills-install-extract.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   extractTarToDir,
+  SkillArchiveError,
+  SKILL_DEPENDENCY_INSTALL_ARGS,
   writeSkillFilesToDir,
 } from "../skills/catalog-install.js";
 import { makeTar } from "./helpers/tar-fixtures.js";
@@ -80,6 +82,30 @@ describe("extractTarToDir", () => {
 
     expect(foundSkillMd).toBe(true);
     expect(readFileSync(join(tempDir, "SKILL.md"), "utf-8")).toBe("# demo\n");
+  });
+
+  test("rejects a negative octal size field instead of spinning", () => {
+    const header = Buffer.alloc(512, 0);
+    Buffer.from("SKILL.md\0", "ascii").copy(header, 0);
+    header[156] = "0".charCodeAt(0);
+    // Signed octal in the size field parses to -512 with parseInt(..., 8),
+    // which would cancel the 512-byte header advance and loop forever.
+    Buffer.from("-0000001000\0", "ascii").copy(header, 124);
+    const tar = Buffer.concat([header, Buffer.alloc(1024, 0)]);
+
+    expect(() => extractTarToDir(tar, tempDir)).toThrow(SkillArchiveError);
+    expect(() => extractTarToDir(tar, tempDir)).toThrow(
+      "malformed tar size field",
+    );
+  });
+
+  test("dependency install argv suppresses lifecycle scripts", () => {
+    expect(SKILL_DEPENDENCY_INSTALL_ARGS).toEqual([
+      "install",
+      "--omit=dev",
+      "--ignore-scripts",
+      "--no-save",
+    ]);
   });
 });
 

--- a/assistant/src/__tests__/skills-install-staging.test.ts
+++ b/assistant/src/__tests__/skills-install-staging.test.ts
@@ -103,6 +103,14 @@ describe("staged skill installs", () => {
       ),
     ).rejects.toThrow("dependency install failed");
 
+    expect(mockSpawn).toHaveBeenCalled();
+    expect(mockSpawn.mock.calls[0]?.[1]).toEqual([
+      "install",
+      "--omit=dev",
+      "--ignore-scripts",
+      "--no-save",
+    ]);
+
     expect(
       existsSync(join(workspaceDir, "skills", "demo-skill", "SKILL.md")),
     ).toBe(false);

--- a/assistant/src/__tests__/skills-install-staging.test.ts
+++ b/assistant/src/__tests__/skills-install-staging.test.ts
@@ -13,7 +13,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Emits `error` on the returned child so the dependency install's spawn
 // promise rejects with the injected failure.
-const mockSpawn = mock(() => {
+const spawnArgv: string[][] = [];
+const mockSpawn = mock((_cmd: string, args: string[] = []) => {
+  spawnArgv.push(args);
   const child = {
     on(event: string, cb: (arg: unknown) => void) {
       if (event === "error") {
@@ -30,7 +32,10 @@ mock.module("node:child_process", () => ({
 }));
 
 import { loadSkillCatalog } from "../config/skills.js";
-import { installSkillLocally } from "../skills/catalog-install.js";
+import {
+  installSkillLocally,
+  SKILL_DEPENDENCY_INSTALL_ARGS,
+} from "../skills/catalog-install.js";
 import { installExternalSkill } from "../skills/skillssh-registry.js";
 import { makeTar } from "./helpers/tar-fixtures.js";
 
@@ -61,6 +66,7 @@ beforeEach(() => {
   process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
   mkdirSync(join(workspaceDir, "skills"), { recursive: true });
   mockSpawn.mockClear();
+  spawnArgv.length = 0;
 });
 
 afterEach(() => {
@@ -104,12 +110,7 @@ describe("staged skill installs", () => {
     ).rejects.toThrow("dependency install failed");
 
     expect(mockSpawn).toHaveBeenCalled();
-    expect(mockSpawn.mock.calls[0]?.[1]).toEqual([
-      "install",
-      "--omit=dev",
-      "--ignore-scripts",
-      "--no-save",
-    ]);
+    expect(spawnArgv[0]).toEqual([...SKILL_DEPENDENCY_INSTALL_ARGS]);
 
     expect(
       existsSync(join(workspaceDir, "skills", "demo-skill", "SKILL.md")),

--- a/assistant/src/archive/ustar-size.test.ts
+++ b/assistant/src/archive/ustar-size.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { MALFORMED_USTAR_SIZE, parseUstarSizeField } from "./ustar-size.js";
+
+function headerWithSize(field: string): Uint8Array {
+  const header = new Uint8Array(512);
+  const bytes = Buffer.from(field, "utf-8");
+  header.set(bytes.subarray(0, 12), 124);
+  return header;
+}
+
+describe("parseUstarSizeField", () => {
+  test("reads a NUL-terminated octal size", () => {
+    expect(parseUstarSizeField(headerWithSize("00000001000\0"))).toBe(512);
+  });
+
+  test("treats an empty field as zero", () => {
+    expect(parseUstarSizeField(headerWithSize("\0".repeat(12)))).toBe(0);
+  });
+
+  test("rejects a negative octal size", () => {
+    expect(() => parseUstarSizeField(headerWithSize("-0000001000\0"))).toThrow(
+      MALFORMED_USTAR_SIZE,
+    );
+  });
+
+  test("rejects a truncated header", () => {
+    expect(() => parseUstarSizeField(new Uint8Array(100))).toThrow(
+      MALFORMED_USTAR_SIZE,
+    );
+  });
+});

--- a/assistant/src/archive/ustar-size.ts
+++ b/assistant/src/archive/ustar-size.ts
@@ -1,0 +1,23 @@
+export const MALFORMED_USTAR_SIZE = "malformed tar size field";
+
+/**
+ * Parse the ustar `size` field (bytes 124-135, octal, NUL or space
+ * terminated). Rejects non-finite and negative values so a crafted header
+ * cannot walk the archive cursor backwards.
+ */
+export function parseUstarSizeField(header: Uint8Array): number {
+  if (header.length < 136) {
+    throw new Error(MALFORMED_USTAR_SIZE);
+  }
+  const raw = header.subarray(124, 136);
+  let end = 0;
+  while (end < raw.length && raw[end] !== 0) {
+    end++;
+  }
+  const sizeStr = new TextDecoder().decode(raw.subarray(0, end)).trim();
+  const size = sizeStr ? Number.parseInt(sizeStr, 8) : 0;
+  if (!Number.isFinite(size) || size < 0) {
+    throw new Error(MALFORMED_USTAR_SIZE);
+  }
+  return size;
+}

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -29,6 +29,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
+import { MALFORMED_USTAR_SIZE, parseUstarSizeField } from "../../archive/ustar-size.js";
 import { getPlatformBaseUrl } from "../../config/env.js";
 import { getExistingDeviceId } from "../../util/device-id.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";
@@ -593,18 +594,12 @@ function readHeaderName(header: Buffer): string {
   return prefix ? `${prefix}/${name}` : name;
 }
 
-/** Parse the octal `size` field (bytes 124–136). */
 function parseTarSize(pluginName: string, header: Buffer): number {
-  const raw = header
-    .subarray(124, 136)
-    .toString("utf-8")
-    .replace(/\0/g, "")
-    .trim();
-  const size = raw ? Number.parseInt(raw, 8) : 0;
-  if (!Number.isFinite(size) || size < 0) {
-    throw new PluginArchiveError(pluginName, "malformed tar size field");
+  try {
+    return parseUstarSizeField(header);
+  } catch {
+    throw new PluginArchiveError(pluginName, MALFORMED_USTAR_SIZE);
   }
-  return size;
 }
 
 /** Decode a NUL-terminated field to a UTF-8 string. */

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -29,7 +29,10 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
-import { MALFORMED_USTAR_SIZE, parseUstarSizeField } from "../../archive/ustar-size.js";
+import {
+  MALFORMED_USTAR_SIZE,
+  parseUstarSizeField,
+} from "../../archive/ustar-size.js";
 import { getPlatformBaseUrl } from "../../config/env.js";
 import { getExistingDeviceId } from "../../util/device-id.js";
 import { getWorkspacePluginsDir } from "../../util/platform.js";

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -265,7 +265,10 @@ function parseTar(buffer: Uint8Array): TarEntry[] {
 
     // File size in octal (bytes 124-135)
     const sizeStr = decodeNullTerminated(header, 124, 12);
-    const size = parseInt(sizeStr, 8) || 0;
+    const size = sizeStr ? Number.parseInt(sizeStr, 8) : 0;
+    if (!Number.isFinite(size) || size < 0) {
+      throw new Error("malformed tar size field");
+    }
 
     // Calculate data blocks
     const dataBlocks = Math.ceil(size / BLOCK_SIZE);

--- a/assistant/src/runtime/migrations/vbundle-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-validator.ts
@@ -19,6 +19,8 @@ import { gunzipSync } from "node:zlib";
 
 import { z } from "zod";
 
+import { parseUstarSizeField } from "../../archive/ustar-size.js";
+
 // ---------------------------------------------------------------------------
 // Manifest schema (v1)
 // ---------------------------------------------------------------------------
@@ -263,12 +265,7 @@ function parseTar(buffer: Uint8Array): TarEntry[] {
     // File type (byte 156)
     const typeFlag = String.fromCharCode(header[156]);
 
-    // File size in octal (bytes 124-135)
-    const sizeStr = decodeNullTerminated(header, 124, 12);
-    const size = sizeStr ? Number.parseInt(sizeStr, 8) : 0;
-    if (!Number.isFinite(size) || size < 0) {
-      throw new Error("malformed tar size field");
-    }
+    const size = parseUstarSizeField(header);
 
     // Calculate data blocks
     const dataBlocks = Math.ceil(size / BLOCK_SIZE);

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -29,6 +29,41 @@ import {
 
 const log = getLogger("catalog-install");
 
+/**
+ * `bun install` argv for a skill's declared dependencies. Lifecycle scripts
+ * are suppressed: skill archives (catalog tarballs, skills.sh, ClawHub) are
+ * unsigned, so a `preinstall`/`postinstall` hook would be arbitrary code
+ * execution at install time. Mirrors plugin install in
+ * `cli/lib/install-plugin-dependencies.ts`.
+ */
+export const SKILL_DEPENDENCY_INSTALL_ARGS: readonly string[] = Object.freeze([
+  "install",
+  "--omit=dev",
+  "--ignore-scripts",
+  "--no-save",
+]);
+
+export class SkillArchiveError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SkillArchiveError";
+  }
+}
+
+/** Parse the ustar `size` field (bytes 124-136, octal). */
+function parseTarSize(header: Buffer): number {
+  const raw = header
+    .subarray(124, 136)
+    .toString("utf-8")
+    .replace(/\0/g, "")
+    .trim();
+  const size = raw ? Number.parseInt(raw, 8) : 0;
+  if (!Number.isFinite(size) || size < 0) {
+    throw new SkillArchiveError("malformed tar size field");
+  }
+  return size;
+}
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface CatalogSkill {
@@ -302,11 +337,13 @@ export function extractTarToDir(tarBuffer: Buffer, destDir: string): boolean {
     // File type (byte 156): '5' = directory, '0' or '\0' = regular file
     const typeFlag = header[156];
 
-    // File size (bytes 124-135, octal)
-    const sizeStr = header.subarray(124, 136).toString("utf-8").trim();
-    const size = parseInt(sizeStr, 8) || 0;
+    const size = parseTarSize(header);
 
     offset += 512; // past header
+    const paddedSize = Math.ceil(size / 512) * 512;
+    if (offset + paddedSize > tarBuffer.length) {
+      throw new SkillArchiveError("tar entry size exceeds archive length");
+    }
 
     // Skip directories and empty names
     if (name && typeFlag !== 53 /* '5' */) {
@@ -325,7 +362,7 @@ export function extractTarToDir(tarBuffer: Buffer, destDir: string): boolean {
     }
 
     // Skip to next header (data padded to 512 bytes)
-    offset += Math.ceil(size / 512) * 512;
+    offset += paddedSize;
   }
   return foundSkillMd;
 }
@@ -419,7 +456,7 @@ export async function installSkillDependenciesIfPresent(
   const env = { ...process.env };
   addToPathEnv(env, [join(homedir(), ".bun", "bin")]);
   await new Promise<void>((resolve, reject) => {
-    const child = spawn("bun", ["install"], {
+    const child = spawn("bun", [...SKILL_DEPENDENCY_INSTALL_ARGS], {
       cwd: skillDir,
       stdio: "inherit",
       env,

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -14,6 +14,7 @@ import { homedir } from "node:os";
 import { dirname, join, posix, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
+import { MALFORMED_USTAR_SIZE, parseUstarSizeField } from "../archive/ustar-size.js";
 import { getPlatformBaseUrl } from "../config/env.js";
 import { loadSkillCatalog } from "../config/skills.js";
 import { isBunVirtualPath } from "../util/bundled-asset.js";
@@ -50,18 +51,12 @@ export class SkillArchiveError extends Error {
   }
 }
 
-/** Parse the ustar `size` field (bytes 124-136, octal). */
 function parseTarSize(header: Buffer): number {
-  const raw = header
-    .subarray(124, 136)
-    .toString("utf-8")
-    .replace(/\0/g, "")
-    .trim();
-  const size = raw ? Number.parseInt(raw, 8) : 0;
-  if (!Number.isFinite(size) || size < 0) {
-    throw new SkillArchiveError("malformed tar size field");
+  try {
+    return parseUstarSizeField(header);
+  } catch {
+    throw new SkillArchiveError(MALFORMED_USTAR_SIZE);
   }
-  return size;
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -14,7 +14,10 @@ import { homedir } from "node:os";
 import { dirname, join, posix, resolve, sep } from "node:path";
 import { gunzipSync } from "node:zlib";
 
-import { MALFORMED_USTAR_SIZE, parseUstarSizeField } from "../archive/ustar-size.js";
+import {
+  MALFORMED_USTAR_SIZE,
+  parseUstarSizeField,
+} from "../archive/ustar-size.js";
 import { getPlatformBaseUrl } from "../config/env.js";
 import { loadSkillCatalog } from "../config/skills.js";
 import { isBunVirtualPath } from "../util/bundled-asset.js";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Triage of an external security report. Findings 1 and 7: unsigned skill archives run `bun install` with lifecycle scripts (install-time RCE), and the ustar size parser accepts signed octal which can livelock the extractor.

## Summary
- Skill dependency install now uses `--ignore-scripts --omit=dev --no-save`, matching the existing plugin installer.
- Skill tar extraction rejects non-finite or negative size fields and oversize entries instead of spinning.
- Catalog install, vbundle validation, and plugin tarball extract share one `parseUstarSizeField` helper so the size guard cannot drift.

Out of scope for this PR: ClawHub TOFU hash mismatch still warns and continues (fail-closed would block legitimate skill updates without a signing scheme). `npx clawhub` itself remains a trusted installer.

## Test plan
- `cd assistant && bun test src/archive/ustar-size.test.ts src/__tests__/skills-install-extract.test.ts src/__tests__/skills-install-staging.test.ts`
- `cd assistant && bun test src/cli/lib/__tests__/install-from-platform.test.ts`
- `cd assistant && bun test src/runtime/migrations/__tests__/vbundle-tar-stream.test.ts src/runtime/migrations/__tests__/vbundle-symlink-tar.test.ts`

## Risk
- Skills whose runtime deps require `postinstall` (native addons) will no longer build those addons at install time. Plugins already accepted this tradeoff.
- No migration. No feature flag.

## CLI verb checklist
No new routes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c8ab155-d408-4ab9-a856-7bef28a22be2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c8ab155-d408-4ab9-a856-7bef28a22be2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

