### PR TITLE
fix(ces): keep vault bearer out of child shells and loopback-gate CES HTTP

### DIFF
--- a/assistant/AGENTS.md
+++ b/assistant/AGENTS.md
@@ -16,7 +16,7 @@ When you introduce a new env var that the assistant process needs to read at run
 
 **Default to including it.** If the var doesn't contain secrets (e.g. a URL, a feature flag, a path, a mode string), add it. Only omit it if it carries credential material (tokens, passwords, private keys) — those must stay isolated to CES.
 
-`CES_LOCAL_SOCKET` is intentionally included despite the socket exposing credential RPCs — assistant subprocesses are expected to reach CES. Credential protection is rules-based access control inside CES, not socket-path secrecy (see root `AGENTS.md`).
+`CES_LOCAL_SOCKET` is intentionally included despite the socket exposing credential RPCs: assistant subprocesses are expected to reach CES. Credential protection is rules-based access control inside CES, not socket-path secrecy (see root `AGENTS.md`). Do not forward `CES_SERVICE_TOKEN` or `CES_CREDENTIAL_URL`: the HTTP bearer is a vault secret and must stay in the assistant process.
 
 ## Daemon startup philosophy
 

--- a/assistant/src/tools/terminal/__tests__/safe-env.test.ts
+++ b/assistant/src/tools/terminal/__tests__/safe-env.test.ts
@@ -50,6 +50,23 @@ describe("safe-env Qdrant forwarding", () => {
   });
 });
 
+describe("safe-env CES vault isolation", () => {
+  test("strips the CES HTTP bearer and credential URL from child shells", () => {
+    expect(SAFE_ENV_VARS).not.toContain("CES_SERVICE_TOKEN");
+    expect(SAFE_ENV_VARS).not.toContain("CES_CREDENTIAL_URL");
+    expect(SAFE_ENV_VARS).toContain("CES_LOCAL_SOCKET");
+
+    const env = buildSanitizedEnv("linux", {
+      CES_SERVICE_TOKEN: "vault-bearer",
+      CES_CREDENTIAL_URL: "http://127.0.0.1:8090",
+      CES_LOCAL_SOCKET: "/tmp/ces.sock",
+    });
+    expect(env.CES_SERVICE_TOKEN).toBeUndefined();
+    expect(env.CES_CREDENTIAL_URL).toBeUndefined();
+    expect(env.CES_LOCAL_SOCKET).toBe("/tmp/ces.sock");
+  });
+});
+
 describe("safe-env Windows forwarding", () => {
   test("forwards runtime paths only to Windows children", () => {
     const keys = [

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -54,8 +54,10 @@ export const SAFE_ENV_VARS = [
   "VELLUM_MARKETING_URL",
   "VELLUM_MIGRATION_EXPORT_ALLOWED_HOSTS",
   "VELLUM_MIGRATION_IMPORT_ALLOWED_HOSTS",
-  "CES_CREDENTIAL_URL",
   "CES_MANAGED_MODE",
+  // Socket path only. The CES HTTP bearer (`CES_SERVICE_TOKEN`) and
+  // `CES_CREDENTIAL_URL` stay in the assistant process: child shells must
+  // not inherit a vault token they can printenv or log.
   "CES_LOCAL_SOCKET",
   // Per-instance port of the assistant-managed Qdrant sidecar, so skill and
   // bash-tool subprocesses that use the vector helpers (e.g. embed/search over
@@ -67,7 +69,6 @@ export const SAFE_ENV_VARS = [
   "IS_PLATFORM",
   "VELLUM_CLOUD",
   "VELLUM_SANDBOX_RUNTIME",
-  "CES_SERVICE_TOKEN",
   "VELLUM_PROFILER_RUN_ID",
   "VELLUM_PROFILER_MODE",
   "VELLUM_PROFILER_MAX_BYTES",

--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -163,7 +163,10 @@ describe("health probes", () => {
     expect(src).toMatch(/\/readyz/);
     // Health server uses Bun.serve on a dedicated port, not the socket
     expect(src).toMatch(/startHealthServer\(\s*healthPort/);
-    expect(src).toMatch(/hostname:\s*"127\.0\.0\.1"/);
+    // Kubelet httpGet targets the pod IP, so the probe listener must not
+    // bind loopback-only. Credential routes are gated with isLoopbackAddress.
+    expect(src).not.toMatch(/hostname:\s*"127\.0\.0\.1"/);
+    expect(src).toMatch(/isLoopbackAddress\(/);
   });
 
   test("getHealthPort defaults to 8090", () => {

--- a/credential-executor/src/__tests__/transport.test.ts
+++ b/credential-executor/src/__tests__/transport.test.ts
@@ -163,6 +163,7 @@ describe("health probes", () => {
     expect(src).toMatch(/\/readyz/);
     // Health server uses Bun.serve on a dedicated port, not the socket
     expect(src).toMatch(/startHealthServer\(\s*healthPort/);
+    expect(src).toMatch(/hostname:\s*"127\.0\.0\.1"/);
   });
 
   test("getHealthPort defaults to 8090", () => {

--- a/credential-executor/src/http/loopback-address.test.ts
+++ b/credential-executor/src/http/loopback-address.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isCesHttpProbePath,
+  isLoopbackAddress,
+} from "./loopback-address.js";
+
+describe("isLoopbackAddress", () => {
+  test("accepts IPv4 loopback", () => {
+    expect(isLoopbackAddress("127.0.0.1")).toBe(true);
+    expect(isLoopbackAddress("127.0.0.2")).toBe(true);
+  });
+
+  test("accepts IPv6 loopback and IPv4-mapped loopback", () => {
+    expect(isLoopbackAddress("::1")).toBe(true);
+    expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true);
+  });
+
+  test("rejects non-loopback addresses", () => {
+    expect(isLoopbackAddress("10.0.0.1")).toBe(false);
+    expect(isLoopbackAddress("192.168.1.10")).toBe(false);
+    expect(isLoopbackAddress("8.8.8.8")).toBe(false);
+    expect(isLoopbackAddress("::ffff:10.0.0.1")).toBe(false);
+    expect(isLoopbackAddress("2001:db8::1")).toBe(false);
+  });
+});
+
+describe("isCesHttpProbePath", () => {
+  test("matches kubelet probe paths only", () => {
+    expect(isCesHttpProbePath("/healthz")).toBe(true);
+    expect(isCesHttpProbePath("/readyz")).toBe(true);
+    expect(isCesHttpProbePath("/v1/credentials")).toBe(false);
+    expect(isCesHttpProbePath("/v1/logs/export")).toBe(false);
+  });
+});

--- a/credential-executor/src/http/loopback-address.ts
+++ b/credential-executor/src/http/loopback-address.ts
@@ -1,0 +1,25 @@
+/**
+ * Strict loopback check for CES HTTP peers: 127.0.0.0/8 and ::1.
+ * IPv4-mapped IPv6 (`::ffff:127.0.0.1`) is treated as IPv4.
+ */
+export function isLoopbackAddress(addr: string): boolean {
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const normalized = v4Mapped ? v4Mapped[1] : addr;
+
+  if (normalized.includes(".")) {
+    const parts = normalized.split(".").map(Number);
+    if (
+      parts.length !== 4 ||
+      parts.some((p) => Number.isNaN(p) || p < 0 || p > 255)
+    ) {
+      return false;
+    }
+    return parts[0] === 127;
+  }
+
+  return normalized.toLowerCase() === "::1";
+}
+
+export function isCesHttpProbePath(pathname: string): boolean {
+  return pathname === "/healthz" || pathname === "/readyz";
+}

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -247,6 +247,7 @@ function startHealthServer(
   credentialDeps: CredentialRouteDeps | null,
 ): ReturnType<typeof Bun.serve> {
   const server = Bun.serve({
+    hostname: "127.0.0.1",
     port,
     async fetch(req) {
       const url = new URL(req.url);

--- a/credential-executor/src/main.ts
+++ b/credential-executor/src/main.ts
@@ -51,6 +51,7 @@ import {
   type CredentialRouteDeps,
 } from "./http/credential-routes.js";
 import { handleLogExportRoute } from "./http/log-export-routes.js";
+import { isLoopbackAddress } from "./http/loopback-address.js";
 import { handleMetadataRoute } from "./http/metadata-routes.js";
 import { CES_MIGRATIONS } from "./migrations/registry.js";
 import { runCesMigrations } from "./migrations/runner.js";
@@ -246,10 +247,12 @@ function startHealthServer(
   signal: AbortSignal,
   credentialDeps: CredentialRouteDeps | null,
 ): ReturnType<typeof Bun.serve> {
+  // Listen on every interface so kubelet httpGet probes can hit the pod IP.
+  // Credential CRUD, metadata, and log export stay loopback-only: assistant
+  // and gateway in this pod call http://localhost:<CES_HEALTH_PORT>.
   const server = Bun.serve({
-    hostname: "127.0.0.1",
     port,
-    async fetch(req) {
+    async fetch(req, httpServer) {
       const url = new URL(req.url);
       if (url.pathname === "/healthz") {
         return new Response(JSON.stringify({ status: "ok" }), {
@@ -257,7 +260,7 @@ function startHealthServer(
         });
       }
       if (url.pathname === "/readyz") {
-        // Always return 200 — pod readiness must not depend on whether the
+        // Always return 200: pod readiness must not depend on whether the
         // assistant has connected.  When the CES feature flag is off the
         // assistant never connects, and a 503 here would block pod
         // scheduling during dark-launch.  The sidecar can't do useful work
@@ -274,6 +277,11 @@ function startHealthServer(
             headers: { "Content-Type": "application/json" },
           },
         );
+      }
+
+      const peer = httpServer.requestIP(req)?.address;
+      if (!peer || !isLoopbackAddress(peer)) {
+        return new Response("Not Found", { status: 404 });
       }
 
       // Credential CRUD routes (only if service token is configured)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Triage of an external security report. Findings 3 and 4: the CES vault bearer is forwarded into every child shell, and the CES HTTP server binds all interfaces with plaintext credential CRUD behind that static token.

## Summary
- Remove `CES_SERVICE_TOKEN` and `CES_CREDENTIAL_URL` from the child-env allowlist used by bash and skill sandboxes. Keep `CES_LOCAL_SOCKET` (documented: subprocesses may speak CES RPC; socket auth is intentionally absent).
- CES HTTP still listens on every interface so kubelet `httpGet` probes can hit the pod IP (`/healthz`, `/readyz`). Credential CRUD, metadata, and log export require a loopback peer. Assistant and gateway in the same pod call `http://localhost:<CES_HEALTH_PORT>`.

Finding 2 (unauthenticated CES Unix socket) is not changed here. Root `AGENTS.md` documents that as the single-owner pod trust model.

## Test plan
- `cd assistant && bun test src/tools/terminal/__tests__/safe-env.test.ts`
- `cd credential-executor && bun test src/http/loopback-address.test.ts src/__tests__/transport.test.ts`

## Risk
- Skills or bash commands that called CES over HTTP with the inherited bearer will stop working. Credential refs are resolved in the parent process; no in-repo skill scripts were found using `CES_SERVICE_TOKEN`.
- Binding the whole listener to `127.0.0.1` would break kubelet probes. The loopback gate on non-probe paths keeps credential CRUD off the pod IP without that outage.

## CLI verb checklist
No new routes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c8ab155-d408-4ab9-a856-7bef28a22be2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c8ab155-d408-4ab9-a856-7bef28a22be2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

