### PR TITLE
fix(assistant): classify OpenCode 401 ModelError as model-not-found

### DIFF
--- a/assistant/src/__tests__/conversation-error.test.ts
+++ b/assistant/src/__tests__/conversation-error.test.ts
@@ -816,6 +816,44 @@ describe("classifyConversationError", () => {
       );
     });
 
+    it("classifies an OpenCode 401 ModelError as model-not-found, not an invalid key", () => {
+      providerRoutingSources.opencode = "user-key";
+      const err = new ProviderError(
+        "OpenCode API error (401): Model muse-spark-1.3-contributor is not supported [type=ModelError]",
+        "opencode",
+        401,
+        { reason: "model_not_found" },
+      );
+
+      const result = classifyConversationError(err, {
+        ...baseCtx,
+        profileName: "custom-profile",
+        connectionName: "opencode-personal",
+      });
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.errorCategory).toBe("provider_model_not_found");
+      expect(result.retryable).toBe(false);
+      expect(result.userMessage).toContain("wasn't found by the provider");
+      expect(result.userMessage).not.toContain("API key");
+    });
+
+    it("classifies a reason-less OpenCode 401 ModelError via the message, not credentials", () => {
+      providerRoutingSources.opencode = "user-key";
+      const err = new ProviderError(
+        "OpenCode API error (401): Model muse-spark-1.3-contributor is not supported [type=ModelError]",
+        "opencode",
+        401,
+      );
+
+      const result = classifyConversationError(err, baseCtx);
+
+      expect(result.code).toBe("PROVIDER_API");
+      expect(result.errorCategory).toBe("provider_model_not_found");
+      expect(result.retryable).toBe(false);
+      expect(result.userMessage).not.toContain("API key");
+    });
+
     it("classifies managed-proxy auth failures as managed credential refresh failures", () => {
       providerRoutingSources.anthropic = "managed-proxy";
       const err = new ProviderError(

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -27,6 +27,7 @@ import {
 import {
   INSUFFICIENT_CREDITS_PATTERNS,
   isChatTemplateFailureError,
+  isModelNotFoundError,
   isVisionNotSupportedError,
 } from "../util/provider-error-patterns.js";
 
@@ -429,6 +430,11 @@ function classifyCore(
       return contextTooLargeClassification();
     }
     if (error.statusCode === 401 || error.statusCode === 403) {
+      // OpenCode (and similar OpenAI-compat endpoints) return 401 for an
+      // unknown model id. That must not read as a rejected key.
+      if (isModelNotFoundError(message)) {
+        return modelNotFoundClassification();
+      }
       // Managed routes through the assistant API key; if that credential is
       // stale, the user cannot fix it from model settings. Everything else is
       // a credential the user owns, so the copy names which one to update and
@@ -675,13 +681,7 @@ function reasonToClassification(
         errorCategory: "provider_network_error",
       };
     case "model_not_found":
-      return {
-        code: "PROVIDER_API",
-        userMessage:
-          "The selected model wasn't found by the provider. Switch models in Settings → Models & Services.",
-        retryable: false,
-        errorCategory: "provider_model_not_found",
-      };
+      return modelNotFoundClassification();
     case "model_restricted": {
       const detail = extractProviderDetail(args.message);
       const prefix = "This model isn't available on your current provider plan";
@@ -887,6 +887,19 @@ function providerServerErrorClassification(): Omit<
     userMessage: "The AI provider returned a server error.",
     retryable: true,
     errorCategory: "provider_server_error",
+  };
+}
+
+function modelNotFoundClassification(): Omit<
+  ClassifiedConversationError,
+  "debugDetails"
+> {
+  return {
+    code: "PROVIDER_API",
+    userMessage:
+      "The selected model wasn't found by the provider. Switch models in Settings → Models & Services.",
+    retryable: false,
+    errorCategory: "provider_model_not_found",
   };
 }
 

--- a/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
+++ b/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
@@ -407,6 +407,27 @@ describe("deriveReason", () => {
     );
   });
 
+  test("500 with apiErrorType=ModelError stays server_error", () => {
+    expect(
+      deriveReason(
+        n({
+          message: "Internal server error",
+          apiErrorType: "ModelError",
+        }),
+        500,
+      ),
+    ).toBe("server_error");
+  });
+
+  test("500 with 'model is not supported' prose stays server_error", () => {
+    expect(
+      deriveReason(
+        n({ message: "Model muse-spark-1.3-contributor is not supported" }),
+        500,
+      ),
+    ).toBe("server_error");
+  });
+
   test("vision-not-supported prose → vision_unsupported", () => {
     expect(
       deriveReason(

--- a/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
+++ b/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
@@ -378,6 +378,35 @@ describe("deriveReason", () => {
     ).toBe("model_not_found");
   });
 
+  test("OpenCode 401 ModelError 'is not supported' → model_not_found", () => {
+    // OpenCode zen returns 401 with type=ModelError for an unknown model
+    // id. That must not fall through to the 401 → invalid_credentials branch.
+    expect(
+      deriveReason(
+        n({
+          message: "Model muse-spark-1.3-contributor is not supported",
+          apiErrorType: "ModelError",
+        }),
+        401,
+      ),
+    ).toBe("model_not_found");
+  });
+
+  test("401 with only apiErrorType=ModelError → model_not_found", () => {
+    expect(
+      deriveReason(
+        n({ message: "Request failed", apiErrorType: "ModelError" }),
+        401,
+      ),
+    ).toBe("model_not_found");
+  });
+
+  test("plain 401 without a model signal stays invalid_credentials", () => {
+    expect(deriveReason(n({ message: "Invalid API key provided" }), 401)).toBe(
+      "invalid_credentials",
+    );
+  });
+
   test("vision-not-supported prose → vision_unsupported", () => {
     expect(
       deriveReason(

--- a/assistant/src/providers/openai/api-error-normalization.ts
+++ b/assistant/src/providers/openai/api-error-normalization.ts
@@ -5,6 +5,7 @@ import {
   DAILY_LIMIT_PATTERNS,
   INSUFFICIENT_CREDITS_PATTERNS,
   isChatTemplateFailureError,
+  isModelNotFoundError,
   VISION_NOT_SUPPORTED_PATTERNS,
 } from "../../util/provider-error-patterns.js";
 
@@ -52,8 +53,8 @@ export function normalizedErrorText(n: NormalizedOpenAIAPIError): string {
 
 /**
  * Map an OpenAI-compatible error to a semantic {@link ProviderErrorReason}.
- * Order matters — the model-restriction check precedes the generic 401/403
- * credential branch, and billing precedes credentials.
+ * Order matters: model restriction and model-not-found precede the generic
+ * 401/403 credential branch, and billing precedes credentials.
  */
 export function deriveReason(
   n: NormalizedOpenAIAPIError,
@@ -72,8 +73,10 @@ export function deriveReason(
   }
 
   if (
-    /model .*(?:not found|does not exist)/i.test(haystack) ||
-    /model_not_found/i.test(`${n.apiErrorCode ?? ""} ${n.apiErrorType ?? ""}`)
+    isModelNotFoundError(haystack) ||
+    /model_not_found|ModelError/i.test(
+      `${n.apiErrorCode ?? ""} ${n.apiErrorType ?? ""}`,
+    )
   ) {
     return "model_not_found";
   }

--- a/assistant/src/providers/openai/api-error-normalization.ts
+++ b/assistant/src/providers/openai/api-error-normalization.ts
@@ -5,7 +5,8 @@ import {
   DAILY_LIMIT_PATTERNS,
   INSUFFICIENT_CREDITS_PATTERNS,
   isChatTemplateFailureError,
-  isModelNotFoundError,
+  MODEL_NOT_FOUND_PATTERNS,
+  UNSUPPORTED_MODEL_ID_PATTERNS,
   VISION_NOT_SUPPORTED_PATTERNS,
 } from "../../util/provider-error-patterns.js";
 
@@ -73,10 +74,21 @@ export function deriveReason(
   }
 
   if (
-    isModelNotFoundError(haystack) ||
-    /model_not_found|ModelError/i.test(
-      `${n.apiErrorCode ?? ""} ${n.apiErrorType ?? ""}`,
-    )
+    MODEL_NOT_FOUND_PATTERNS.some((re) => re.test(haystack)) ||
+    /model_not_found/i.test(`${n.apiErrorCode ?? ""} ${n.apiErrorType ?? ""}`)
+  ) {
+    return "model_not_found";
+  }
+
+  // OpenCode's unsupported-model payload uses type=ModelError on a 401.
+  // Gate on 4xx so a 5xx that happens to carry that type stays server_error
+  // (retryable) instead of model_not_found (not retryable, fallback-eligible).
+  if (
+    status !== undefined &&
+    status >= 400 &&
+    status < 500 &&
+    (UNSUPPORTED_MODEL_ID_PATTERNS.some((re) => re.test(haystack)) ||
+      /ModelError/i.test(`${n.apiErrorCode ?? ""} ${n.apiErrorType ?? ""}`))
   ) {
     return "model_not_found";
   }

--- a/assistant/src/util/provider-error-patterns.ts
+++ b/assistant/src/util/provider-error-patterns.ts
@@ -45,6 +45,27 @@ export function isChatTemplateFailureError(message: string): boolean {
   return CHAT_TEMPLATE_FAILURE_PATTERNS.some((re) => re.test(message));
 }
 
+// Provider prose that indicates the selected model id is unknown to the
+// endpoint. OpenCode returns this as HTTP 401 with `type=ModelError` and
+// "Model <id> is not supported"; treating that as a rejected key sends
+// users to update credentials instead of switching models.
+export const MODEL_NOT_FOUND_PATTERNS = [
+  /model .*(?:not found|does not exist)/i,
+  /model_not_found/i,
+  /model .+ is not supported/i,
+  /\bModelError\b/,
+];
+
+/**
+ * Whether a provider error message indicates the selected model is unknown
+ * to the endpoint. Providers wrap raw upstream rejections in their own
+ * prose, so the classifier matches the full {@link MODEL_NOT_FOUND_PATTERNS}
+ * set rather than any single normalized phrase.
+ */
+export function isModelNotFoundError(message: string): boolean {
+  return MODEL_NOT_FOUND_PATTERNS.some((re) => re.test(message));
+}
+
 // Vendor-neutral (OpenRouter/Anthropic-style) credit-exhaustion prose. Also
 // covers per-key spend caps: OpenRouter returns 403 "Key limit exceeded" when a
 // key's configured credit limit is reached — a billing/budget condition that

--- a/assistant/src/util/provider-error-patterns.ts
+++ b/assistant/src/util/provider-error-patterns.ts
@@ -46,12 +46,20 @@ export function isChatTemplateFailureError(message: string): boolean {
 }
 
 // Provider prose that indicates the selected model id is unknown to the
-// endpoint. OpenCode returns this as HTTP 401 with `type=ModelError` and
-// "Model <id> is not supported"; treating that as a rejected key sends
-// users to update credentials instead of switching models.
+// endpoint. Distinct from OpenCode's `ModelError` / "is not supported"
+// shape, which is only safe to treat as model-not-found on a 4xx.
 export const MODEL_NOT_FOUND_PATTERNS = [
   /model .*(?:not found|does not exist)/i,
   /model_not_found/i,
+];
+
+// OpenCode zen returns HTTP 401 with `type=ModelError` and
+// "Model <id> is not supported". Treating that as a rejected key sends
+// users to update credentials instead of switching models. Do not apply
+// these on 5xx: retry treats a stamped reason as authoritative, so a
+// transient server error with this type would skip retries and may
+// immediately switch profiles.
+export const UNSUPPORTED_MODEL_ID_PATTERNS = [
   /model .+ is not supported/i,
   /\bModelError\b/,
 ];
@@ -60,10 +68,15 @@ export const MODEL_NOT_FOUND_PATTERNS = [
  * Whether a provider error message indicates the selected model is unknown
  * to the endpoint. Providers wrap raw upstream rejections in their own
  * prose, so the classifier matches the full {@link MODEL_NOT_FOUND_PATTERNS}
- * set rather than any single normalized phrase.
+ * and {@link UNSUPPORTED_MODEL_ID_PATTERNS} sets rather than any single
+ * normalized phrase. Callers that see HTTP 5xx must not use this helper
+ * to stamp `model_not_found`.
  */
 export function isModelNotFoundError(message: string): boolean {
-  return MODEL_NOT_FOUND_PATTERNS.some((re) => re.test(message));
+  return (
+    MODEL_NOT_FOUND_PATTERNS.some((re) => re.test(message)) ||
+    UNSUPPORTED_MODEL_ID_PATTERNS.some((re) => re.test(message))
+  );
 }
 
 // Vendor-neutral (OpenRouter/Anthropic-style) credit-exhaustion prose. Also


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Investigate in-product feedback (`01a081b2-26da-771f-96c3-c2c1f424ba15`): the user reported an API error for the Vellum AI Provider that they and doctor could not resolve.

The past-hour dump shows Vellum-managed OpenAI calls succeeding. The hard failures are OpenCode zen: repeated 500s, then a 401 `Model muse-spark-1.3-contributor is not supported [type=ModelError]`. That 401 was classified as `PROVIDER_INVALID_KEY`, so chat told the user their personal OpenCode key was rejected.

OpenCode 500s in the same window are upstream and are not addressed here. The generic 5xx banner ("The AI provider returned a server error") also does not name OpenCode, which likely contributed to the "Vellum AI Provider" report.

## Summary

- Treat OpenCode-style model errors (`type=ModelError`, `Model <id> is not supported`) as `model_not_found` on **4xx only**, before the 401/403 credential branch.
- Leave 5xx with that type as `server_error`. A stamped `model_not_found` reason would skip retries and can immediately switch profiles.
- Share those patterns in `provider-error-patterns.ts` so the reason-less 401 fallback cannot still show an invalid-key banner.
- Keep a real 401 without a model signal as `invalid_credentials`.

## Test plan

- `cd assistant && bun test src/providers/openai/__tests__/api-error-normalization.test.ts src/__tests__/conversation-error.test.ts`
- Covers the production OpenCode 401 payload, `apiErrorType=ModelError` alone, a 500 with `ModelError` staying `server_error`, and a plain invalid-key 401 staying on the credential path.

## Risk

Low. Classification-only. Real credential 401s are unchanged. Unknown-model 4xx turns now surface "switch models" instead of "update that key". Transient OpenCode 5xx stay retryable.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4483ca-14b8-4105-804b-b6368ef12553?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4483ca-14b8-4105-804b-b6368ef12553&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

