### PR TITLE
fix(host): bind untargeted proxy results to the source actor

### DIFF
--- a/assistant/src/__tests__/host-app-control-proxy.test.ts
+++ b/assistant/src/__tests__/host-app-control-proxy.test.ts
@@ -1398,7 +1398,7 @@ describe("HostAppControlProxy", () => {
       proxy.dispose();
     });
 
-    test("request() without targetClientId: does not register targetActorPrincipalId", async () => {
+    test("request() without targetClientId: registers the source actor principal", async () => {
       const proxy = new HostAppControlProxy("conv-1");
       const ctrl = new AbortController();
 
@@ -1413,7 +1413,7 @@ describe("HostAppControlProxy", () => {
 
       const sent = sentMessages[0] as Record<string, unknown>;
       expect(registeredInteractions[0].targetClientId).toBeUndefined();
-      expect(registeredInteractions[0].targetActorPrincipalId).toBeUndefined();
+      expect(registeredInteractions[0].targetActorPrincipalId).toBe("user-1");
 
       proxy.resolve(sent.requestId as string, payload({ pngBase64: PNG_A }));
       await resultPromise;

--- a/assistant/src/__tests__/host-app-control-routes.test.ts
+++ b/assistant/src/__tests__/host-app-control-routes.test.ts
@@ -405,6 +405,47 @@ describe("handleHostAppControlResult — same-actor guard", () => {
     expect(resolveCalls).toHaveLength(1);
   });
 
+  test("non-targeted with recorded source actor: rejects a different principal", () => {
+    const requestId = "ac-req-untargeted-actor-mismatch";
+    const conversationId = "conv-untargeted-actor";
+    pending.set(requestId, {
+      conversationId,
+      kind: "host_app_control",
+      targetActorPrincipalId: "user-owner",
+    });
+    const resolveCalls: Array<{ requestId: string; payload: unknown }> = [];
+    setupConversation(conversationId, resolveCalls);
+
+    expect(() =>
+      handleHostAppControlResult({
+        body: { requestId, state: "running" },
+        headers: { "x-vellum-actor-principal-id": "user-attacker" },
+      }),
+    ).toThrow(ForbiddenError);
+    expect(resolveCalls).toHaveLength(0);
+    expect(pending.has(requestId)).toBe(true);
+  });
+
+  test("non-targeted with recorded source actor: accepts the matching principal", async () => {
+    const requestId = "ac-req-untargeted-actor-match";
+    const conversationId = "conv-untargeted-actor-match";
+    pending.set(requestId, {
+      conversationId,
+      kind: "host_app_control",
+      targetActorPrincipalId: "user-owner",
+    });
+    const resolveCalls: Array<{ requestId: string; payload: unknown }> = [];
+    setupConversation(conversationId, resolveCalls);
+
+    const result = await handleHostAppControlResult({
+      body: { requestId, state: "running" },
+      headers: { "x-vellum-actor-principal-id": "user-owner" },
+    });
+
+    expect(result).toEqual({ accepted: true });
+    expect(resolveCalls).toHaveLength(1);
+  });
+
   // ── Targeted + correct headers → 200 ─────────────────────────────────
 
   test("targeted + matching client id and actor principal: returns 200", async () => {

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -381,7 +381,7 @@ describe("handleHostBashResult", () => {
 
   // ── Untargeted-request behavior (regression for new check) ─────────
 
-  describe("untargeted request — actor principal check is skipped", () => {
+  describe("untargeted request — source actor still binds when recorded", () => {
     test("accepts even when submitting actor is absent and no target client is set", async () => {
       const requestId = "req-untargeted-no-actor";
       registerPending(requestId);
@@ -394,6 +394,35 @@ describe("handleHostBashResult", () => {
       expect(result).toEqual({ accepted: true });
       expect(resolveSpy).toHaveLength(1);
       expect(resolvedIds).toContain(requestId);
+    });
+
+    test("rejects a different actor when the pending request recorded a source actor", () => {
+      const requestId = "req-untargeted-actor-mismatch";
+      registerPending(requestId, {
+        targetActorPrincipalId: "principal-owner",
+      });
+
+      expect(() =>
+        handleHostBashResult({
+          body: bashBody(requestId),
+          headers: { "x-vellum-actor-principal-id": "principal-attacker" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("accepts the recorded source actor on an untargeted pending request", async () => {
+      const requestId = "req-untargeted-actor-match";
+      registerPending(requestId, {
+        targetActorPrincipalId: "principal-owner",
+      });
+
+      const result = await handleHostBashResult({
+        body: bashBody(requestId),
+        headers: { "x-vellum-actor-principal-id": "principal-owner" },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(resolveSpy).toHaveLength(1);
     });
   });
 

--- a/assistant/src/__tests__/host-bash-routes.test.ts
+++ b/assistant/src/__tests__/host-bash-routes.test.ts
@@ -381,7 +381,7 @@ describe("handleHostBashResult", () => {
 
   // ── Untargeted-request behavior (regression for new check) ─────────
 
-  describe("untargeted request — source actor still binds when recorded", () => {
+  describe("untargeted request: source actor still binds when recorded", () => {
     test("accepts even when submitting actor is absent and no target client is set", async () => {
       const requestId = "req-untargeted-no-actor";
       registerPending(requestId);

--- a/assistant/src/__tests__/host-browser-routes.test.ts
+++ b/assistant/src/__tests__/host-browser-routes.test.ts
@@ -421,5 +421,39 @@ describe("handleHostBrowserResult — same-actor guard", () => {
       expect(result).toEqual({ accepted: true });
       expect(pendingInteractions.get(requestId)).toBeUndefined();
     });
+
+    test("rejects a different actor when the pending request recorded a source actor", () => {
+      const requestId = "browser-req-untargeted-actor-mismatch";
+      pendingInteractions.register(requestId, {
+        conversationId: "conv-1",
+        kind: "host_browser",
+        targetActorPrincipalId: "user-owner",
+      });
+
+      expect(() =>
+        handleHostBrowserResult({
+          body: { requestId, content: "ok", isError: false },
+          headers: { "x-vellum-actor-principal-id": "user-attacker" },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(pendingInteractions.get(requestId)).toBeDefined();
+    });
+
+    test("accepts the recorded source actor on an untargeted pending request", async () => {
+      const requestId = "browser-req-untargeted-actor-match";
+      pendingInteractions.register(requestId, {
+        conversationId: "conv-1",
+        kind: "host_browser",
+        targetActorPrincipalId: "user-owner",
+      });
+
+      const result = await handleHostBrowserResult({
+        body: { requestId, content: "ok", isError: false },
+        headers: { "x-vellum-actor-principal-id": "user-owner" },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(pendingInteractions.get(requestId)).toBeUndefined();
+    });
   });
 });

--- a/assistant/src/__tests__/host-cu-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-cu-routes-targeted.test.ts
@@ -417,6 +417,35 @@ describe("handleHostCuResult — Phase 2 targetClientId guard", () => {
       expect(result).toEqual({ accepted: true });
       expect(cuResolveSpy).toHaveLength(1);
     });
+
+    test("rejects a different actor when the pending request recorded a source actor", () => {
+      const requestId = "req-cu-untargeted-actor-mismatch";
+      registerPending(requestId, {
+        targetActorPrincipalId: "principal-owner",
+      });
+
+      expect(() =>
+        handleHostCuResult({
+          body: cuBody(requestId),
+          headers: { "x-vellum-actor-principal-id": "principal-attacker" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("accepts the recorded source actor on an untargeted pending request", async () => {
+      const requestId = "req-cu-untargeted-actor-match";
+      registerPending(requestId, {
+        targetActorPrincipalId: "principal-owner",
+      });
+
+      const result = await handleHostCuResult({
+        body: cuBody(requestId),
+        headers: { "x-vellum-actor-principal-id": "principal-owner" },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(cuResolveSpy).toHaveLength(1);
+    });
   });
 });
 

--- a/assistant/src/__tests__/host-file-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-file-routes-targeted.test.ts
@@ -279,6 +279,35 @@ describe("handleHostFileResult — targetClientId guard", () => {
       expect(result).toEqual({ accepted: true });
       expect(resolveSpy).toHaveLength(1);
     });
+
+    test("rejects a different actor when the pending request recorded a source actor", () => {
+      const requestId = "req-file-untargeted-actor-mismatch";
+      registerPending(requestId, {
+        targetActorPrincipalId: "principal-owner",
+      });
+
+      expect(() =>
+        handleHostFileResult({
+          body: fileBody(requestId),
+          headers: { "x-vellum-actor-principal-id": "principal-attacker" },
+        }),
+      ).toThrow(ForbiddenError);
+    });
+
+    test("accepts the recorded source actor on an untargeted pending request", async () => {
+      const requestId = "req-file-untargeted-actor-match";
+      registerPending(requestId, {
+        targetActorPrincipalId: "principal-owner",
+      });
+
+      const result = await handleHostFileResult({
+        body: fileBody(requestId),
+        headers: { "x-vellum-actor-principal-id": "principal-owner" },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(resolveSpy).toHaveLength(1);
+    });
   });
 
   // ── 5. Targeted + matching client but mismatched actor → 403 ──────────────

--- a/assistant/src/__tests__/host-proxy-base.test.ts
+++ b/assistant/src/__tests__/host-proxy-base.test.ts
@@ -9,6 +9,7 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   assistantEventHub: {
     getMostRecentClientByCapability: (cap: string) =>
       cap === "host_cu" && mockHasClient ? { id: "mock-client" } : null,
+    getActorPrincipalIdForClient: () => undefined,
   },
 }));
 

--- a/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
+++ b/assistant/src/__tests__/host-transfer-routes-targeted.test.ts
@@ -35,6 +35,7 @@ mock.module("../runtime/pending-interactions.js", () => ({
 
 // Per-test controls for the proxy stub
 let stubTargetClientId: string | null = null;
+let stubTargetActorPrincipalId: string | undefined;
 const getTransferContentCalls: string[] = [];
 const receiveTransferContentCalls: string[] = [];
 const resolveTransferResultCalls: string[] = [];
@@ -50,6 +51,9 @@ mock.module("../daemon/host-transfer-proxy.js", () => ({
           return stubTargetClientId;
         },
         getTargetActorPrincipalIdForTransfer(_transferId: string) {
+          if (stubTargetActorPrincipalId !== undefined) {
+            return stubTargetActorPrincipalId;
+          }
           return stubTargetClientId
             ? clientActors.get(stubTargetClientId)
             : undefined;
@@ -139,6 +143,7 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
   beforeEach(() => {
     pendingStore.clear();
     stubTargetClientId = null;
+    stubTargetActorPrincipalId = undefined;
     getTransferContentCalls.length = 0;
     clientActors.clear();
   });
@@ -236,6 +241,30 @@ describe("handleTransferContentGet — Phase 3 targetClientId guard", () => {
       expect(result).toBeInstanceOf(Uint8Array);
       expect(getTransferContentCalls).toContain(TEST_TRANSFER_ID);
     });
+
+    test("rejects a different actor when the transfer recorded a source actor", () => {
+      stubTargetClientId = null;
+      stubTargetActorPrincipalId = "principal-owner";
+      expect(() =>
+        handleTransferContentGet({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: { "x-vellum-actor-principal-id": "principal-attacker" },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(getTransferContentCalls).toHaveLength(0);
+    });
+
+    test("accepts the recorded source actor on an untargeted transfer", async () => {
+      stubTargetClientId = null;
+      stubTargetActorPrincipalId = "principal-owner";
+      const result = await handleTransferContentGet({
+        pathParams: { transferId: TEST_TRANSFER_ID },
+        headers: { "x-vellum-actor-principal-id": "principal-owner" },
+      });
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(getTransferContentCalls).toContain(TEST_TRANSFER_ID);
+    });
   });
 
   // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
@@ -289,6 +318,7 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
   beforeEach(() => {
     pendingStore.clear();
     stubTargetClientId = null;
+    stubTargetActorPrincipalId = undefined;
     receiveTransferContentCalls.length = 0;
     clientActors.clear();
   });
@@ -408,6 +438,38 @@ describe("handleTransferContentPut — Phase 3 targetClientId guard", () => {
       expect(result).toEqual({ accepted: true });
       expect(receiveTransferContentCalls).toContain(TEST_TRANSFER_ID);
     });
+
+    test("rejects a different actor when the transfer recorded a source actor", async () => {
+      stubTargetClientId = null;
+      stubTargetActorPrincipalId = "principal-owner";
+      await expect(
+        handleTransferContentPut({
+          pathParams: { transferId: TEST_TRANSFER_ID },
+          headers: {
+            "x-vellum-actor-principal-id": "principal-attacker",
+            "x-transfer-sha256": "abc",
+          },
+          rawBody: new Uint8Array(Buffer.from("data")),
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenError);
+      expect(receiveTransferContentCalls).toHaveLength(0);
+    });
+
+    test("accepts the recorded source actor on an untargeted transfer", async () => {
+      stubTargetClientId = null;
+      stubTargetActorPrincipalId = "principal-owner";
+      const result = await handleTransferContentPut({
+        pathParams: { transferId: TEST_TRANSFER_ID },
+        headers: {
+          "x-vellum-actor-principal-id": "principal-owner",
+          "x-transfer-sha256": "abc",
+        },
+        rawBody: new Uint8Array(Buffer.from("data")),
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(receiveTransferContentCalls).toContain(TEST_TRANSFER_ID);
+    });
   });
 
   // ── 5. Same-user actor binding (defense-in-depth) ─────────────────────────
@@ -469,6 +531,7 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
   beforeEach(() => {
     pendingStore.clear();
     stubTargetClientId = null;
+    stubTargetActorPrincipalId = undefined;
     resolveTransferResultCalls.length = 0;
     clientActors.clear();
   });
@@ -598,6 +661,29 @@ describe("handleTransferResult — Phase 3 targetClientId guard", () => {
       });
 
       expect(result).toEqual({ accepted: true });
+    });
+
+    test("rejects a different actor when the pending request recorded a source actor", () => {
+      registerPending({ targetActorPrincipalId: "principal-owner" });
+      expect(() =>
+        handleTransferResult({
+          body: resultBody(),
+          headers: { "x-vellum-actor-principal-id": "principal-attacker" },
+        }),
+      ).toThrow(ForbiddenError);
+      expect(resolveTransferResultCalls).toHaveLength(0);
+      expect(pendingStore.has(TEST_REQUEST_ID)).toBe(true);
+    });
+
+    test("accepts the recorded source actor on an untargeted pending request", async () => {
+      registerPending({ targetActorPrincipalId: "principal-owner" });
+      const result = await handleTransferResult({
+        body: resultBody(),
+        headers: { "x-vellum-actor-principal-id": "principal-owner" },
+      });
+
+      expect(result).toEqual({ accepted: true });
+      expect(resolveTransferResultCalls).toContain(TEST_REQUEST_ID);
     });
   });
 

--- a/assistant/src/daemon/host-app-control-proxy.ts
+++ b/assistant/src/daemon/host-app-control-proxy.ts
@@ -398,6 +398,8 @@ export class HostAppControlProxy extends HostProxyBase<
         signal,
         undefined,
         resolvedTargetClientId,
+        undefined,
+        sourceActorPrincipalId,
       );
       if (input.tool === "start") {
         if (payload.state === "running") {

--- a/assistant/src/daemon/host-bash-proxy.ts
+++ b/assistant/src/daemon/host-bash-proxy.ts
@@ -152,6 +152,7 @@ export class HostBashProxy extends HostProxyBase<
         extraFields,
         resolvedTargetClientId,
         proxyTimeoutMs,
+        sourceActorPrincipalId,
       );
       return formatShellOutput(
         payload.stdout,

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -23,6 +23,7 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import { snapshotHostProxyActorPrincipalId } from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { POINT_AT_PROXY_TOOL } from "../tools/computer-use/skill-proxy-bridge.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -356,12 +357,11 @@ export class HostCuProxy {
         conversationId,
         kind: "host_cu",
         targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
+        targetActorPrincipalId: snapshotHostProxyActorPrincipalId({
+          hub: assistantEventHub,
+          targetClientId: resolvedTargetClientId,
+          sourceActorPrincipalId,
+        }),
         rpcResolve: resolve as (v: unknown) => void,
         rpcReject: reject,
         timer,

--- a/assistant/src/daemon/host-file-proxy.ts
+++ b/assistant/src/daemon/host-file-proxy.ts
@@ -9,6 +9,7 @@ import {
   ambiguousSameUserError,
   enforceSameActorOrErrorResult,
   pickSameUserAutoResolve,
+  snapshotHostProxyActorPrincipalId,
 } from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { readAudioBase64 } from "../tools/shared/filesystem/audio-read.js";
@@ -183,12 +184,11 @@ export class HostFileProxy {
         conversationId,
         kind: "host_file",
         targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
+        targetActorPrincipalId: snapshotHostProxyActorPrincipalId({
+          hub: assistantEventHub,
+          targetClientId: resolvedTargetClientId,
+          sourceActorPrincipalId,
+        }),
         rpcResolve: resolve as (v: unknown) => void,
         rpcReject: reject,
         timer,

--- a/assistant/src/daemon/host-proxy-base.ts
+++ b/assistant/src/daemon/host-proxy-base.ts
@@ -21,6 +21,7 @@ import {
   assistantEventHub,
   broadcastMessage,
 } from "../runtime/assistant-event-hub.js";
+import { snapshotHostProxyActorPrincipalId } from "../runtime/auth/same-actor.js";
 import type { PendingInteraction } from "../runtime/pending-interactions.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
@@ -142,6 +143,7 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
     extraFields?: Record<string, unknown>,
     targetClientId?: string,
     timeoutMsOverride?: number,
+    sourceActorPrincipalId?: string,
   ): Promise<TResultPayload> {
     const requestId = uuid();
     const effectiveTimeoutMs = timeoutMsOverride ?? this.timeoutMs;
@@ -206,15 +208,14 @@ export abstract class HostProxyBase<TRequest, TResultPayload> {
       // (HostCuProxy bypasses dispatchRequest entirely with its own inline
       //  request method that registers directly, which is why CU works
       //  without this base-level fix.)
-      // Snapshot the target's actorPrincipalId at registration time so the
-      // result-route same-actor check has a stable value to compare against —
-      // the target client's SSE subscription may briefly disconnect between
-      // dispatch and result submission, which would make a live hub lookup
-      // falsely 403 a legitimate result.
-      const targetActorPrincipalId =
-        targetClientId != null
-          ? assistantEventHub.getActorPrincipalIdForClient(targetClientId)
-          : undefined;
+      // Snapshot the actor principal at registration so the result-route
+      // same-actor check has a stable value. Targeted dispatch uses the
+      // target client; untargeted dispatch uses the turn's source actor.
+      const targetActorPrincipalId = snapshotHostProxyActorPrincipalId({
+        hub: assistantEventHub,
+        targetClientId,
+        sourceActorPrincipalId,
+      });
       pendingInteractions.register(requestId, {
         conversationId,
         kind: this.resultPendingKind,

--- a/assistant/src/daemon/host-transfer-proxy.ts
+++ b/assistant/src/daemon/host-transfer-proxy.ts
@@ -13,6 +13,7 @@ import {
   ambiguousSameUserError,
   enforceSameActorOrErrorResult,
   pickSameUserAutoResolve,
+  snapshotHostProxyActorPrincipalId,
 } from "../runtime/auth/same-actor.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
@@ -259,24 +260,22 @@ export class HostTransferProxy {
             sha256,
             fileBuffer,
             targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId:
-              resolvedTargetClientId != null
-                ? assistantEventHub.getActorPrincipalIdForClient(
-                    resolvedTargetClientId,
-                  )
-                : undefined,
+            targetActorPrincipalId: snapshotHostProxyActorPrincipalId({
+              hub: assistantEventHub,
+              targetClientId: resolvedTargetClientId,
+              sourceActorPrincipalId,
+            }),
           });
 
           pendingInteractions.register(requestId, {
             conversationId: input.conversationId,
             kind: "host_transfer",
             targetClientId: resolvedTargetClientId,
-            targetActorPrincipalId:
-              resolvedTargetClientId != null
-                ? assistantEventHub.getActorPrincipalIdForClient(
-                    resolvedTargetClientId,
-                  )
-                : undefined,
+            targetActorPrincipalId: snapshotHostProxyActorPrincipalId({
+              hub: assistantEventHub,
+              targetClientId: resolvedTargetClientId,
+              sourceActorPrincipalId,
+            }),
             rpcResolve: resolve as (v: unknown) => void,
             rpcReject: reject,
             timer,
@@ -450,24 +449,22 @@ export class HostTransferProxy {
         filePath: input.destPath,
         overwrite: input.overwrite,
         targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
+        targetActorPrincipalId: snapshotHostProxyActorPrincipalId({
+          hub: assistantEventHub,
+          targetClientId: resolvedTargetClientId,
+          sourceActorPrincipalId,
+        }),
       });
 
       pendingInteractions.register(requestId, {
         conversationId: input.conversationId,
         kind: "host_transfer",
         targetClientId: resolvedTargetClientId,
-        targetActorPrincipalId:
-          resolvedTargetClientId != null
-            ? assistantEventHub.getActorPrincipalIdForClient(
-                resolvedTargetClientId,
-              )
-            : undefined,
+        targetActorPrincipalId: snapshotHostProxyActorPrincipalId({
+          hub: assistantEventHub,
+          targetClientId: resolvedTargetClientId,
+          sourceActorPrincipalId,
+        }),
         rpcResolve: resolve as (v: unknown) => void,
         rpcReject: reject,
         timer,

--- a/assistant/src/runtime/auth/same-actor.ts
+++ b/assistant/src/runtime/auth/same-actor.ts
@@ -103,7 +103,7 @@ export interface SameActorLiveArgs {
 export interface SameActorPersistedArgs {
   sourceActorPrincipalId: string | undefined;
   targetActorPrincipalId: string | undefined;
-  targetClientId: string;
+  targetClientId?: string;
   op: SameActorOp;
   /**
    * Fill-if-missing fallback for dev-bypass deployments: when the PERSISTED
@@ -136,12 +136,15 @@ function isLive(
 function detectRejection(
   args: SameActorLiveArgs | SameActorPersistedArgs,
 ): RejectionReason | undefined {
-  const { sourceActorPrincipalId, targetClientId, op } = args;
+  const { sourceActorPrincipalId, op } = args;
+  const targetClientId = args.targetClientId;
   const targetActorPrincipalId = isLive(args)
-    ? args.hub.getActorPrincipalIdForClient(targetClientId)
+    ? args.hub.getActorPrincipalIdForClient(args.targetClientId)
     : (args.targetActorPrincipalId ??
-      (isHttpAuthDisabled()
-        ? args.hubForMissingTarget?.getActorPrincipalIdForClient(targetClientId)
+      (isHttpAuthDisabled() && targetClientId
+        ? args.hubForMissingTarget?.getActorPrincipalIdForClient(
+            targetClientId,
+          )
         : undefined));
 
   let reason: RejectionReason | undefined;
@@ -259,6 +262,27 @@ export function pickSameUserAutoResolve(args: {
     return { kind: "match", clientId: sameUser[0].clientId };
   }
   return { kind: "ambiguous" };
+}
+
+/**
+ * Actor principal persisted on a host-proxy pending interaction.
+ *
+ * Targeted dispatch snapshots the target client's actor. Untargeted dispatch
+ * snapshots the turn's source actor so result routes can still reject a
+ * different principal even when no `targetClientId` was bound.
+ */
+export function snapshotHostProxyActorPrincipalId(args: {
+  hub: Pick<AssistantEventHub, "getActorPrincipalIdForClient">;
+  targetClientId?: string;
+  sourceActorPrincipalId?: string;
+}): string | undefined {
+  if (args.targetClientId != null) {
+    return (
+      args.hub.getActorPrincipalIdForClient(args.targetClientId) ??
+      args.sourceActorPrincipalId
+    );
+  }
+  return args.sourceActorPrincipalId;
 }
 
 /**

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -110,11 +110,10 @@ export interface PendingInteraction {
   /** When set, the host_bash request should be routed to this specific client. */
   targetClientId?: string;
   /**
-   * Snapshot of `targetClientId`'s `actorPrincipalId` taken at registration
-   * time. Persisted so the result-route same-actor check compares against
-   * a stable value rather than the live hub — the target client's SSE
-   * subscription may have briefly disconnected between dispatch and result
-   * submission, which would otherwise 403 a legitimate result.
+   * Actor principal captured at registration. Targeted requests snapshot the
+   * target client's actor so a brief SSE reconnect does not 403 a legitimate
+   * result. Untargeted requests snapshot the turn's source actor so a
+   * different principal cannot forge stdout/stderr/exitCode.
    */
   targetActorPrincipalId?: string;
 

--- a/assistant/src/runtime/routes/host-app-control-routes.ts
+++ b/assistant/src/runtime/routes/host-app-control-routes.ts
@@ -19,15 +19,10 @@ import type {
   HostAppControlResultPayload,
   HostAppControlState,
 } from "../../daemon/message-types/host-app-control.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import {
-  enforceSameActorOrThrow,
-  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
-} from "../auth/same-actor.js";
-import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import { SAME_ACTOR_FORBIDDEN_DESCRIPTION } from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import { BadRequestError, ForbiddenError } from "./errors.js";
+import { assertHostProxyResultBinding } from "./host-proxy-result-binding.js";
 import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -93,35 +88,14 @@ async function handleHostAppControlResult({ body, headers }: RouteHandlerArgs) {
     return { accepted: true };
   }
 
-  // Same-actor binding: when the pending interaction has a targetClientId,
-  // validate the submitting client matches and the actor principals align.
-  // Mirrors host-browser / host-cu / host-bash result routes.
-  if (peeked.targetClientId != null) {
-    const headerMap = headers ?? {};
-    const submittingClientId =
-      headerMap["x-vellum-client-id"]?.trim() || undefined;
-    if (!submittingClientId) {
-      throw new BadRequestError(
-        "x-vellum-client-id header is missing for a targeted host app-control request.",
-      );
-    }
-    if (submittingClientId !== peeked.targetClientId) {
-      throw new ForbiddenError(
-        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
-      );
-    }
-    const submittingActorPrincipalId =
-      await resolveActorPrincipalIdForLocalGuardian(
-        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-      );
-    enforceSameActorOrThrow({
-      sourceActorPrincipalId: submittingActorPrincipalId,
-      targetActorPrincipalId: peeked.targetActorPrincipalId,
-      targetClientId: peeked.targetClientId,
-      op: "host_app_control",
-      hubForMissingTarget: assistantEventHub,
-    });
-  }
+  await assertHostProxyResultBinding({
+    headers,
+    targetClientId: peeked.targetClientId,
+    targetActorPrincipalId: peeked.targetActorPrincipalId,
+    op: "host_app_control",
+    missingClientIdMessage:
+      "x-vellum-client-id header is missing for a targeted host app-control request.",
+  });
 
   const interaction = pendingInteractions.resolve(requestId, "answered")!;
   const conversation = findConversation(interaction.conversationId);

--- a/assistant/src/runtime/routes/host-bash-routes.ts
+++ b/assistant/src/runtime/routes/host-bash-routes.ts
@@ -7,20 +7,11 @@
 import { z } from "zod";
 
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import {
-  enforceSameActorOrThrow,
-  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
-} from "../auth/same-actor.js";
-import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import { SAME_ACTOR_FORBIDDEN_DESCRIPTION } from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import {
-  BadRequestError,
-  ConflictError,
-  ForbiddenError,
-  NotFoundError,
-} from "./errors.js";
+import { ConflictError, NotFoundError } from "./errors.js";
+import { assertHostProxyResultBinding } from "./host-proxy-result-binding.js";
 import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -59,13 +50,6 @@ async function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     body,
   );
 
-  const submittingClientId =
-    headers?.["x-vellum-client-id"]?.trim() || undefined;
-  const submittingActorPrincipalId =
-    await resolveActorPrincipalIdForLocalGuardian(
-      headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
-    );
-
   const peeked = pendingInteractions.get(requestId);
   if (!peeked) {
     throw new NotFoundError("No pending interaction found for this requestId");
@@ -77,32 +61,14 @@ async function handleHostBashResult({ body, headers }: RouteHandlerArgs) {
     );
   }
 
-  const { targetClientId } = peeked;
-  if (targetClientId) {
-    if (!submittingClientId) {
-      throw new BadRequestError(
-        "x-vellum-client-id header is required for targeted host bash requests",
-      );
-    }
-    if (submittingClientId !== targetClientId) {
-      throw new ForbiddenError(
-        `Client "${submittingClientId}" is not the target for this request (expected "${targetClientId}"). The targeted client must submit the result.`,
-      );
-    }
-
-    // Defense-in-depth on top of the client-id header binding above: the
-    // submitting actor's principal must match the actor principal stored
-    // for the target client at SSE subscription time. This prevents a
-    // cross-user submission even when the attacker can guess or spoof the
-    // target's client ID.
-    enforceSameActorOrThrow({
-      sourceActorPrincipalId: submittingActorPrincipalId,
-      targetActorPrincipalId: peeked.targetActorPrincipalId,
-      targetClientId,
-      op: "host_bash",
-      hubForMissingTarget: assistantEventHub,
-    });
-  }
+  await assertHostProxyResultBinding({
+    headers,
+    targetClientId: peeked.targetClientId,
+    targetActorPrincipalId: peeked.targetActorPrincipalId,
+    op: "host_bash",
+    missingClientIdMessage:
+      "x-vellum-client-id header is required for targeted host bash requests",
+  });
 
   HostBashProxy.instance.resolveResult(requestId, {
     stdout: stdout ?? "",

--- a/assistant/src/runtime/routes/host-browser-routes.ts
+++ b/assistant/src/runtime/routes/host-browser-routes.ts
@@ -149,6 +149,30 @@ export async function resolveHostBrowserResultByRequestId(
         message: err instanceof Error ? err.message : "Same-actor check failed",
       };
     }
+  } else if (peeked.targetActorPrincipalId) {
+    const headerMap = headers ?? {};
+    const submittingClientId =
+      headerMap["x-vellum-client-id"]?.trim() || undefined;
+    const submittingActorPrincipalId =
+      await resolveActorPrincipalIdForLocalGuardian(
+        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
+      );
+    try {
+      enforceSameActorOrThrow({
+        sourceActorPrincipalId: submittingActorPrincipalId,
+        targetActorPrincipalId: peeked.targetActorPrincipalId,
+        targetClientId: submittingClientId ?? "",
+        op: "host_browser",
+        hubForMissingTarget: assistantEventHub,
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        code: "FORBIDDEN",
+        status: 403,
+        message: err instanceof Error ? err.message : "Same-actor check failed",
+      };
+    }
   }
 
   const normalizedContent = typeof content === "string" ? content : "";

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -7,20 +7,11 @@
 import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-registry.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import {
-  enforceSameActorOrThrow,
-  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
-} from "../auth/same-actor.js";
-import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import { SAME_ACTOR_FORBIDDEN_DESCRIPTION } from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import {
-  BadRequestError,
-  ConflictError,
-  ForbiddenError,
-  NotFoundError,
-} from "./errors.js";
+import { ConflictError, NotFoundError } from "./errors.js";
+import { assertHostProxyResultBinding } from "./host-proxy-result-binding.js";
 import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -78,39 +69,14 @@ async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     );
   }
 
-  // Validate submitting client matches the targeted client (if any).
-  if (peeked.targetClientId != null) {
-    const headerMap = (headers as Record<string, string | undefined>) ?? {};
-    const submittingClientId =
-      headerMap["x-vellum-client-id"]?.trim() || undefined;
-    if (!submittingClientId) {
-      throw new BadRequestError(
-        "x-vellum-client-id header is missing for a targeted host CU request.",
-      );
-    }
-    if (submittingClientId !== peeked.targetClientId) {
-      throw new ForbiddenError(
-        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
-      );
-    }
-
-    // Defense-in-depth: require the submitting actor's principal id to match
-    // the actor principal id captured when the target client opened its SSE
-    // stream. This prevents a different authenticated user with knowledge of
-    // both the requestId and target clientId from submitting a result on
-    // behalf of the targeted client.
-    const submittingActorPrincipalId =
-      await resolveActorPrincipalIdForLocalGuardian(
-        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-      );
-    enforceSameActorOrThrow({
-      sourceActorPrincipalId: submittingActorPrincipalId,
-      targetActorPrincipalId: peeked.targetActorPrincipalId,
-      targetClientId: peeked.targetClientId,
-      op: "host_cu",
-      hubForMissingTarget: assistantEventHub,
-    });
-  }
+  await assertHostProxyResultBinding({
+    headers: headers as Record<string, string | undefined> | undefined,
+    targetClientId: peeked.targetClientId,
+    targetActorPrincipalId: peeked.targetActorPrincipalId,
+    op: "host_cu",
+    missingClientIdMessage:
+      "x-vellum-client-id header is missing for a targeted host CU request.",
+  });
 
   // Conversation-agnostic observation (see `runtime/host-observe.ts`): the
   // request was raised outside any turn, so there is no conversation and no CU

--- a/assistant/src/runtime/routes/host-file-routes.ts
+++ b/assistant/src/runtime/routes/host-file-routes.ts
@@ -7,20 +7,11 @@
 import { z } from "zod";
 
 import { HostFileProxy } from "../../daemon/host-file-proxy.js";
-import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import {
-  enforceSameActorOrThrow,
-  SAME_ACTOR_FORBIDDEN_DESCRIPTION,
-} from "../auth/same-actor.js";
-import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import { SAME_ACTOR_FORBIDDEN_DESCRIPTION } from "../auth/same-actor.js";
 import * as pendingInteractions from "../pending-interactions.js";
-import {
-  BadRequestError,
-  ConflictError,
-  ForbiddenError,
-  NotFoundError,
-} from "./errors.js";
+import { ConflictError, NotFoundError } from "./errors.js";
+import { assertHostProxyResultBinding } from "./host-proxy-result-binding.js";
 import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -69,38 +60,14 @@ async function handleHostFileResult({ body, headers }: RouteHandlerArgs) {
     );
   }
 
-  // Validate submitting client matches the targeted client (if any).
-  if (peeked.targetClientId != null) {
-    const headerMap = (headers as Record<string, string | undefined>) ?? {};
-    const submittingClientId =
-      headerMap["x-vellum-client-id"]?.trim() || undefined;
-    if (!submittingClientId) {
-      throw new BadRequestError(
-        "x-vellum-client-id header is missing for a targeted host file request.",
-      );
-    }
-    if (submittingClientId !== peeked.targetClientId) {
-      throw new ForbiddenError(
-        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}"). The targeted client must submit the result.`,
-      );
-    }
-
-    // Defense-in-depth: also require the submitting actor's principal id to
-    // match the actor that opened the target client's SSE stream. This blocks
-    // cross-user submissions even if a different user somehow obtains the
-    // target client id.
-    const submittingActorPrincipalId =
-      await resolveActorPrincipalIdForLocalGuardian(
-        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-      );
-    enforceSameActorOrThrow({
-      sourceActorPrincipalId: submittingActorPrincipalId,
-      targetActorPrincipalId: peeked.targetActorPrincipalId,
-      targetClientId: peeked.targetClientId,
-      op: "host_file",
-      hubForMissingTarget: assistantEventHub,
-    });
-  }
+  await assertHostProxyResultBinding({
+    headers: headers as Record<string, string | undefined> | undefined,
+    targetClientId: peeked.targetClientId,
+    targetActorPrincipalId: peeked.targetActorPrincipalId,
+    op: "host_file",
+    missingClientIdMessage:
+      "x-vellum-client-id header is missing for a targeted host file request.",
+  });
 
   HostFileProxy.instance.resolve(requestId, {
     content: content ?? "",

--- a/assistant/src/runtime/routes/host-proxy-result-binding.ts
+++ b/assistant/src/runtime/routes/host-proxy-result-binding.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared binding checks for host-proxy result (and transfer content) routes.
+ *
+ * Targeted requests still require the submitting client id to match the
+ * pending `targetClientId`. When a request was dispatched untargeted, the
+ * pending interaction may still carry `targetActorPrincipalId` (the turn's
+ * source actor). In that case the same-actor check still runs so a different
+ * principal cannot forge stdout/stderr/exitCode for someone else's command.
+ *
+ * Identity-less local flows (neither target client nor source actor recorded)
+ * keep the open path.
+ */
+import { assistantEventHub } from "../assistant-event-hub.js";
+import {
+  enforceSameActorOrThrow,
+  type SameActorOp,
+} from "../auth/same-actor.js";
+import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
+import { BadRequestError, ForbiddenError } from "./errors.js";
+
+export async function assertHostProxyResultBinding(args: {
+  headers?: Record<string, string | undefined>;
+  targetClientId?: string;
+  targetActorPrincipalId?: string;
+  op: SameActorOp;
+  missingClientIdMessage: string;
+}): Promise<void> {
+  const submittingClientId =
+    args.headers?.["x-vellum-client-id"]?.trim() || undefined;
+  const submittingActorPrincipalId =
+    await resolveActorPrincipalIdForLocalGuardian(
+      args.headers?.["x-vellum-actor-principal-id"]?.trim() || undefined,
+    );
+
+  if (args.targetClientId) {
+    if (!submittingClientId) {
+      throw new BadRequestError(args.missingClientIdMessage);
+    }
+    if (submittingClientId !== args.targetClientId) {
+      throw new ForbiddenError(
+        `Client "${submittingClientId}" is not the target for this request (expected "${args.targetClientId}"). The targeted client must submit the result.`,
+      );
+    }
+  }
+
+  if (!args.targetClientId && !args.targetActorPrincipalId) {
+    return;
+  }
+
+  enforceSameActorOrThrow({
+    sourceActorPrincipalId: submittingActorPrincipalId,
+    targetActorPrincipalId: args.targetActorPrincipalId,
+    targetClientId: args.targetClientId ?? submittingClientId ?? "",
+    op: args.op,
+    hubForMissingTarget: assistantEventHub,
+  });
+}

--- a/assistant/src/runtime/routes/host-transfer-routes.ts
+++ b/assistant/src/runtime/routes/host-transfer-routes.ts
@@ -22,6 +22,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "./errors.js";
+import { assertHostProxyResultBinding } from "./host-proxy-result-binding.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 /**
@@ -86,6 +87,18 @@ async function handleTransferContentGet({
       op: "host_transfer",
       hubForMissingTarget: assistantEventHub,
     });
+  } else {
+    const targetActorPrincipalId =
+      match.proxy.getTargetActorPrincipalIdForTransfer(transferId);
+    if (targetActorPrincipalId) {
+      await assertHostProxyResultBinding({
+        headers: headers as Record<string, string | undefined>,
+        targetActorPrincipalId,
+        op: "host_transfer",
+        missingClientIdMessage:
+          "x-vellum-client-id header required for targeted transfer",
+      });
+    }
   }
 
   const content = match.proxy.getTransferContent(transferId);
@@ -172,6 +185,18 @@ async function handleTransferContentPut({
       op: "host_transfer",
       hubForMissingTarget: assistantEventHub,
     });
+  } else {
+    const targetActorPrincipalId =
+      match.proxy.getTargetActorPrincipalIdForTransfer(transferId);
+    if (targetActorPrincipalId) {
+      await assertHostProxyResultBinding({
+        headers: headers as Record<string, string | undefined>,
+        targetActorPrincipalId,
+        op: "host_transfer",
+        missingClientIdMessage:
+          "x-vellum-client-id header required for targeted transfer",
+      });
+    }
   }
 
   const data = rawBody ? Buffer.from(rawBody) : Buffer.alloc(0);
@@ -221,31 +246,14 @@ async function handleTransferResult({ body, headers }: RouteHandlerArgs) {
     );
   }
 
-  if (peeked.targetClientId != null) {
-    const headerMap = (headers as Record<string, string | undefined>) ?? {};
-    const rawClientId = headerMap["x-vellum-client-id"];
-    const submittingClientId = rawClientId?.trim() || undefined;
-    if (!submittingClientId) {
-      throw new BadRequestError(
-        "x-vellum-client-id header is missing for a targeted host transfer request.",
-      );
-    }
-    if (submittingClientId !== peeked.targetClientId) {
-      throw new ForbiddenError(
-        `Client "${submittingClientId}" is not the target for this request (expected "${peeked.targetClientId}").`,
-      );
-    }
-
-    enforceSameActorOrThrow({
-      sourceActorPrincipalId: await resolveActorPrincipalIdForLocalGuardian(
-        headerMap["x-vellum-actor-principal-id"]?.trim() || undefined,
-      ),
-      targetActorPrincipalId: peeked.targetActorPrincipalId,
-      targetClientId: peeked.targetClientId,
-      op: "host_transfer",
-      hubForMissingTarget: assistantEventHub,
-    });
-  }
+  await assertHostProxyResultBinding({
+    headers: headers as Record<string, string | undefined> | undefined,
+    targetClientId: peeked.targetClientId,
+    targetActorPrincipalId: peeked.targetActorPrincipalId,
+    op: "host_transfer",
+    missingClientIdMessage:
+      "x-vellum-client-id header is missing for a targeted host transfer request.",
+  });
 
   HostTransferProxy.instance.resolveTransferResult(requestId, {
     isError: isError ?? false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Security report finding 6: untargeted `host_bash` (and sibling host-proxy) result routes had no client or actor binding. Any principal with `approval.write` could resolve a pending request with attacker-controlled stdout/stderr/exitCode. The same pattern existed on host-file, host-cu, host-app-control, host-browser, and host-transfer result routes.

Failing closed on `targetClientId == null` would break identity-less local desktop flows. This change keeps untargeted dispatch, but snapshots the turn's source actor on the pending interaction and enforces same-actor on result submission when that snapshot exists.

## Summary
- Untargeted host-proxy dispatch records `targetActorPrincipalId` from the turn's source actor.
- Result routes share `assertHostProxyResultBinding()`: targeted requests still require a matching `x-vellum-client-id`; untargeted requests with a recorded actor require the same principal; identity-less pendings stay open.
- Covers bash, file, CU, app-control, browser, and transfer result (and transfer GET/PUT content) paths.

## Test plan
- `bun test` on host-bash/file/cu/app-control/browser/transfer result route tests (run one file at a time; bun `mock.module` leaks `pendingInteractions` across files in a combined run).
- `bun test` on host-bash/file/cu/app-control/transfer/browser proxy tests.
- `bun run typecheck:fast` in `assistant/`.

## Risk
- Residual: identity-less local flows (no target client and no source actor) can still be resolved by any `approval.write` principal. That is the same local-desktop contract as before.
- ClawHub / unsigned skill install is out of scope here (separate PRs).
- No CLI verb: these are existing result-callback routes, not new IPC surfaces.

## CLI verb checklist
- No new routes. Binding checks land on existing host-*-result and transfer content endpoints.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c8ab155-d408-4ab9-a856-7bef28a22be2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c8ab155-d408-4ab9-a856-7bef28a22be2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

