### PR TITLE
fix(auth): require settings.write on document comment update and delete

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -72,7 +72,6 @@ describe("route policy coverage", () => {
     // registry had no entry for these endpoints, so `enforcePolicy`
     // returned allowed). Migration preserves behavior. Triage these
     // and assign real policies in a follow-up PR:
-    //   - PATCH/DELETE documents/:id/comments/:commentId
     //   - integrations/a2a/invite/accept
     const INTENTIONALLY_UNPROTECTED = new Set([
       // A — design-intentional
@@ -89,7 +88,6 @@ describe("route policy coverage", () => {
       "playground/seeded-conversations",
       "playground/seeded-conversations/:id",
       // C — pre-existing latent unprotected (follow-up audit owed)
-      "documents/:id/comments/:commentId",
       "integrations/a2a/invite/accept",
     ]);
 

--- a/assistant/src/runtime/routes/document-comments-routes.ts
+++ b/assistant/src/runtime/routes/document-comments-routes.ts
@@ -208,7 +208,10 @@ export const ROUTES: RouteDefinition[] = [
     operationId: "updateDocumentComment",
     endpoint: "documents/:id/comments/:commentId",
     method: "PATCH",
-    policy: null,
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
     summary: "Update a document comment",
     description: "Update the status or content of a comment.",
     tags: ["documents"],
@@ -273,7 +276,10 @@ export const ROUTES: RouteDefinition[] = [
     operationId: "deleteDocumentComment",
     endpoint: "documents/:id/comments/:commentId",
     method: "DELETE",
-    policy: null,
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
     summary: "Delete a document comment",
     description: "Permanently delete a comment.",
     tags: ["documents"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Security report finding 8: PATCH and DELETE `documents/:id/comments/:commentId` were `policy: null` while list/create already required settings scopes. JWT still applied, but any authenticated principal could edit, re-attribute (`resolvedBy`), or delete comments.

## Summary
- PATCH and DELETE now use `settings.write` and `ACTOR_PRINCIPALS`, matching create.
- Removed the endpoint from the `INTENTIONALLY_UNPROTECTED` allowlist in the route-policy guard test.

Authorship on comments is `"user"` / `"assistant"`, not a principal id, so this PR does not add a per-author ownership check.

## Test plan
- `bun test src/runtime/auth/__tests__/guard-tests.test.ts`

## Risk
- Clients that called update/delete with a token that only has `settings.read` (or no settings scopes) will start getting 403. List still uses `settings.read`. Create already required `settings.write`.
- No CLI verb: existing document comment routes.

## CLI verb checklist
- No new routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c8ab155-d408-4ab9-a856-7bef28a22be2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c8ab155-d408-4ab9-a856-7bef28a22be2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

