### PR TITLE
fix(schedules): refuse run-now while a drain quiesce lease is active

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29009,7 +29009,8 @@ paths:
       summary: Run schedule now
       description:
         Trigger an immediate execution of a schedule. A plugin-sourced schedule is rejected with a 400 when its
-        plugin is disabled or no longer declares it.
+        plugin is disabled or no longer declares it. Returns 503 while a drain quiesce lease is active so run-now cannot
+        start work the shutdown snapshot would miss.
       tags:
         - schedules
       parameters:
@@ -29205,6 +29206,8 @@ paths:
                 required:
                   - schedules
                 additionalProperties: false
+        "503":
+          description: A drain quiesce lease is active, so run-now is not starting new work.
   /v1/schedules/{id}/runs:
     get:
       operationId: schedules_by_id_runs_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -29009,7 +29009,7 @@ paths:
       summary: Run schedule now
       description:
         Trigger an immediate execution of a schedule. A plugin-sourced schedule is rejected with a 400 when its
-        plugin is disabled or no longer declares it. Returns 503 while a drain quiesce lease is active so run-now cannot
+        plugin is disabled or no longer declares it. Returns 409 while a drain quiesce lease is active so run-now cannot
         start work the shutdown snapshot would miss.
       tags:
         - schedules
@@ -29206,7 +29206,7 @@ paths:
                 required:
                   - schedules
                 additionalProperties: false
-        "503":
+        "409":
           description: A drain quiesce lease is active, so run-now is not starting new work.
   /v1/schedules/{id}/runs:
     get:

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -74,8 +74,8 @@ import { rawRun } from "../persistence/raw-query.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import {
   BadRequestError,
+  ConflictError,
   NotFoundError,
-  ServiceUnavailableError,
 } from "../runtime/routes/errors.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "../runtime/routes/heartbeat-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "../runtime/routes/schedule-routes.js";
@@ -1690,9 +1690,7 @@ describe("plugin-sourced schedules over routes", () => {
 
       setLifecycleQuiesce();
       try {
-        await expect(runNow(imperative.id)).rejects.toThrow(
-          ServiceUnavailableError,
-        );
+        await expect(runNow(imperative.id)).rejects.toThrow(ConflictError);
         await expect(runNow(imperative.id)).rejects.toThrow(
           "The assistant is shutting down and is not starting new schedule runs.",
         );

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -65,10 +65,18 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
+import {
+  clearLifecycleQuiesce,
+  setLifecycleQuiesce,
+} from "../persistence/lifecycle-quiesce.js";
 import { recordUsageEvent } from "../persistence/llm-usage-store.js";
 import { rawRun } from "../persistence/raw-query.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
-import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
+import {
+  BadRequestError,
+  NotFoundError,
+  ServiceUnavailableError,
+} from "../runtime/routes/errors.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "../runtime/routes/heartbeat-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "../runtime/routes/schedule-routes.js";
 import type { RouteDefinition } from "../runtime/routes/types.js";
@@ -1669,6 +1677,29 @@ describe("plugin-sourced schedules over routes", () => {
       await runNow(imperative.id);
 
       expect(existsSync(RUN_MARKER)).toBe(true);
+    });
+
+    test("refuses run-now while a drain quiesce lease is active", async () => {
+      const imperative = await createSchedule({
+        name: "Quiesced script",
+        cronExpression: "* * * * *",
+        message: "",
+        mode: "script",
+        script: `touch ${RUN_MARKER}`,
+      });
+
+      setLifecycleQuiesce();
+      try {
+        await expect(runNow(imperative.id)).rejects.toThrow(
+          ServiceUnavailableError,
+        );
+        await expect(runNow(imperative.id)).rejects.toThrow(
+          "The assistant is shutting down and is not starting new schedule runs.",
+        );
+        expect(existsSync(RUN_MARKER)).toBe(false);
+      } finally {
+        clearLifecycleQuiesce();
+      }
     });
   });
 });

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -14,6 +14,7 @@ import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { bootstrapConversation } from "../../persistence/conversation-bootstrap.js";
 import { getConversation } from "../../persistence/conversation-crud.js";
+import { isLifecycleQuiesced } from "../../persistence/lifecycle-quiesce.js";
 import {
   getUsageCostForRun,
   listRunConversationIds,
@@ -65,6 +66,7 @@ import {
   ForbiddenError,
   InternalError,
   NotFoundError,
+  ServiceUnavailableError,
 } from "./errors.js";
 import {
   paginateRuns,
@@ -1302,11 +1304,17 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Run schedule now",
     description:
-      "Trigger an immediate execution of a schedule. A plugin-sourced schedule is rejected with a 400 when its plugin is disabled or no longer declares it.",
+      "Trigger an immediate execution of a schedule. A plugin-sourced schedule is rejected with a 400 when its plugin is disabled or no longer declares it. Returns 503 while a drain quiesce lease is active so run-now cannot start work the shutdown snapshot would miss.",
     tags: ["schedules"],
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
     }),
+    additionalResponses: {
+      "503": {
+        description:
+          "A drain quiesce lease is active, so run-now is not starting new work.",
+      },
+    },
     handler: ({ pathParams, headers }: RouteHandlerArgs) =>
       handleRunScheduleNow(pathParams!.id, headers),
   },
@@ -1319,6 +1327,12 @@ async function handleRunScheduleNow(
   const schedule = getSchedule(id);
   if (!schedule) {
     throw new NotFoundError("Schedule not found");
+  }
+
+  if (isLifecycleQuiesced()) {
+    throw new ServiceUnavailableError(
+      "The assistant is shutting down and is not starting new schedule runs.",
+    );
   }
 
   // A plugin-sourced row runs the plugin's own script or prompt, so run-now is

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -63,10 +63,10 @@ import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { parseEpochMillisRange } from "./epoch-millis-range.js";
 import {
   BadRequestError,
+  ConflictError,
   ForbiddenError,
   InternalError,
   NotFoundError,
-  ServiceUnavailableError,
 } from "./errors.js";
 import {
   paginateRuns,
@@ -1304,13 +1304,13 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Run schedule now",
     description:
-      "Trigger an immediate execution of a schedule. A plugin-sourced schedule is rejected with a 400 when its plugin is disabled or no longer declares it. Returns 503 while a drain quiesce lease is active so run-now cannot start work the shutdown snapshot would miss.",
+      "Trigger an immediate execution of a schedule. A plugin-sourced schedule is rejected with a 400 when its plugin is disabled or no longer declares it. Returns 409 while a drain quiesce lease is active so run-now cannot start work the shutdown snapshot would miss.",
     tags: ["schedules"],
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
     }),
     additionalResponses: {
-      "503": {
+      "409": {
         description:
           "A drain quiesce lease is active, so run-now is not starting new work.",
       },
@@ -1330,7 +1330,7 @@ async function handleRunScheduleNow(
   }
 
   if (isLifecycleQuiesced()) {
-    throw new ServiceUnavailableError(
+    throw new ConflictError(
       "The assistant is shutting down and is not starting new schedule runs.",
     );
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Security report finding 5 claimed manual schedule run-now bypasses the "lease system" and can double-fire host scripts. The lease in `scheduler.ts` is the lifecycle drain quiesce lease (`isLifecycleQuiesced()`), not a per-job mutex. Automatic ticks already refuse to claim or start work while that lease is armed. `handleRunScheduleNow` did not.

## Summary
- `POST /schedules/:id/run` returns 409 while a drain quiesce lease is active and does not create a run row or execute the script.
- 409 is used instead of 503 so `daemonUnreachableInterceptor` does not treat a successful drain refusal as a transport outage.
- Unknown schedule ids still 404 (checked before the quiesce gate).
- Regenerated `assistant/openapi.yaml` for the 409 response.

This does not add a per-job mutex or idempotency key. Overlapping run-now versus an already-claimed tick is unchanged.

## Test plan
- `bun test src/__tests__/schedule-routes.test.ts --grep "run now"`

## Risk
- A user who clicks Run now during `vellum sleep --wait` now gets 409 instead of a start. That is the drain contract.
- Heartbeat `force=true` still bypasses quiesce. Schedule run-now follows the claim gate instead, because it can start host scripts.

## CLI verb checklist
- No new routes. Existing `schedules/:id/run`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c8ab155-d408-4ab9-a856-7bef28a22be2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c8ab155-d408-4ab9-a856-7bef28a22be2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

