### PR TITLE
feat(voice): log where a camera frame's time went, and which frame a turn read

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -29,6 +29,7 @@ import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assem
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import {
+  newestPersistedSightFrame,
   pendingStandaloneImagePersist,
   SIGHT_FRAME_TURN_HOLD_MS,
 } from "../live-voice/live-voice-photo.js";
@@ -803,6 +804,10 @@ export async function startVoiceTurn(
     conversationReadyAt: 0,
     admissionClearAt: 0,
     sightHoldMs: 0,
+    // The camera frame this turn will read as the current view, and how old it
+    // was when the turn went past the sight hold. Null when the conversation
+    // carries no frame.
+    newestSightFrame: null as { attachmentId: string; ageMs: number } | null,
     persistDoneAt: 0,
   };
   const eventSink: VoiceRunEventSink = {
@@ -1042,6 +1047,15 @@ export async function startVoiceTurn(
     ]);
     clearTimeout(holdTimer);
     dispatch.sightHoldMs = Date.now() - holdStartedAt;
+  }
+  // Read after the hold, so a frame the hold waited for is the one reported.
+  // One indexed query, which a conversation with no camera answers empty.
+  const newestFrame = newestPersistedSightFrame(opts.conversationId);
+  if (newestFrame) {
+    dispatch.newestSightFrame = {
+      attachmentId: newestFrame.attachmentId,
+      ageMs: Date.now() - newestFrame.capturedAt,
+    };
   }
 
   // Releases the per-turn state of a voice turn that OWNED the conversation,
@@ -1851,6 +1865,7 @@ export async function startVoiceTurn(
         admissionWaitMs:
           dispatch.admissionClearAt - dispatch.conversationReadyAt,
         sightHoldMs: dispatch.sightHoldMs,
+        newestSightFrame: dispatch.newestSightFrame,
         persistMs:
           dispatch.persistDoneAt -
           dispatch.admissionClearAt -

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -804,8 +804,8 @@ export async function startVoiceTurn(
     conversationReadyAt: 0,
     admissionClearAt: 0,
     sightHoldMs: 0,
-    // The camera frame this turn will read as the current view, and how old it
-    // was when the turn went past the sight hold. Null when the conversation
+    // The camera frame this turn reads as the current view, and how old it
+    // was when the turn's own message landed. Null when the conversation
     // carries no frame.
     newestSightFrame: null as { attachmentId: string; ageMs: number } | null,
     persistDoneAt: 0,
@@ -1047,15 +1047,6 @@ export async function startVoiceTurn(
     ]);
     clearTimeout(holdTimer);
     dispatch.sightHoldMs = Date.now() - holdStartedAt;
-  }
-  // Read after the hold, so a frame the hold waited for is the one reported.
-  // One indexed query, which a conversation with no camera answers empty.
-  const newestFrame = newestPersistedSightFrame(opts.conversationId);
-  if (newestFrame) {
-    dispatch.newestSightFrame = {
-      attachmentId: newestFrame.attachmentId,
-      ageMs: Date.now() - newestFrame.capturedAt,
-    };
   }
 
   // Releases the per-turn state of a voice turn that OWNED the conversation,
@@ -1439,6 +1430,26 @@ export async function startVoiceTurn(
     }
   }
   dispatch.persistDoneAt = Date.now();
+  // Read now, under the flag this turn holds, rather than after the sight
+  // hold: a frame can still land between the hold and the persist, when its
+  // acquire beats this turn's and the turn retries behind it. What the loop
+  // below reads is what the rows hold at this moment, so this is the frame the
+  // answer is about. One indexed row; a log-only read that fails must not
+  // take the turn down with it.
+  try {
+    const newestFrame = newestPersistedSightFrame(opts.conversationId);
+    if (newestFrame) {
+      dispatch.newestSightFrame = {
+        attachmentId: newestFrame.attachmentId,
+        ageMs: dispatch.persistDoneAt - newestFrame.capturedAt,
+      };
+    }
+  } catch (err) {
+    log.warn(
+      { err, turnId, conversationId: opts.conversationId },
+      "Could not read the newest camera frame for the dispatch timing log",
+    );
+  }
   try {
     opts.callbacks?.persisted_user_message_id?.(messageId);
   } catch (err) {

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -53,6 +53,7 @@ import {
   _pendingFrameReclaimCountForTests,
   _setProcessingWaitMsForTests,
   _standaloneImageQueueSizeForTests,
+  newestPersistedSightFrame,
   pendingStandaloneImagePersist,
   persistAmbientSightFrame,
   persistLiveVoicePhoto,
@@ -462,6 +463,39 @@ describe("persistLiveVoicePhoto", () => {
 });
 
 describe("persistAmbientSightFrame", () => {
+  test("reports where the daemon's half of the persist went", async () => {
+    const live = liveConversation("Live voice sight frame timing");
+    try {
+      const attachment = await uploadAttachment(
+        "frame.png",
+        "image/png",
+        IMAGE_BASE64,
+      );
+
+      const result = await persistAmbientSightFrame(
+        live.id,
+        attachment.id,
+        "voice",
+      );
+      expect(result.ok).toBe(true);
+      // Three legs, each a whole non-negative number of milliseconds: nothing
+      // was queued ahead of it and no turn held the flag, so the first two are
+      // near zero, and the write is whatever the store took.
+      expect(result.timing).toBeDefined();
+      for (const leg of Object.values(result.timing!)) {
+        expect(Number.isInteger(leg)).toBe(true);
+        expect(leg).toBeGreaterThanOrEqual(0);
+      }
+      expect(Object.keys(result.timing!).sort()).toEqual([
+        "flagWaitMs",
+        "queueWaitMs",
+        "writeMs",
+      ]);
+    } finally {
+      live.dispose();
+    }
+  });
+
   test("tags the row with the attachment it carries", async () => {
     const live = liveConversation("Live voice sight frame");
     try {
@@ -1590,6 +1624,44 @@ describe("standalone image persists are serialized per conversation", () => {
 
       // Nothing is left behind for a call that ended.
       expect(_standaloneImageQueueSizeForTests()).toBe(0);
+    } finally {
+      live.dispose();
+    }
+  });
+});
+
+describe("newestPersistedSightFrame", () => {
+  test("is null for a conversation that carries no frame", () => {
+    const live = liveConversation("Sight newest none");
+    try {
+      expect(newestPersistedSightFrame(live.id)).toBeNull();
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("names the last frame written, by the id the row carries", async () => {
+    const live = liveConversation("Sight newest");
+    try {
+      const first = await uploadFrame("first.png");
+      const second = await uploadFrame("second.png");
+      expect((await persistAmbientSightFrame(live.id, first, "voice")).ok).toBe(
+        true,
+      );
+      expect(
+        (await persistAmbientSightFrame(live.id, second, "voice")).ok,
+      ).toBe(true);
+
+      // A frame already linked elsewhere is stored under a fresh id, so the
+      // answer is read from the rows rather than assumed from the argument.
+      const rows = getMessages(live.id);
+      const storedSecond = sightFrameAttachmentIdsFromMetadata(
+        metadataOf(rows[1]),
+      )[0];
+      expect(newestPersistedSightFrame(live.id)).toEqual({
+        attachmentId: storedSecond,
+        capturedAt: rows[1].createdAt,
+      });
     } finally {
       live.dispose();
     }

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame.test.ts
@@ -212,6 +212,87 @@ describe("live-voice sight_frame frame", () => {
       expect(result.error.frameType).toBe("sight_frame");
     }
   });
+
+  test("carries the client's timing through as sent", () => {
+    const timing = {
+      reason: "forced",
+      armToKeepMs: 40,
+      keepToEncodedMs: 30,
+      encodedToUploadedMs: 200,
+      uploadedToSentMs: 0,
+      bytes: 12345,
+    };
+    const result = validateLiveVoiceClientFrame({
+      type: "sight_frame",
+      attachmentId: "att-1",
+      timing,
+    });
+    expect(result).toEqual({
+      ok: true,
+      frame: { type: "sight_frame", attachmentId: "att-1", timing },
+    });
+  });
+
+  test("an ambient keep's timing has no arm", () => {
+    const timing = {
+      reason: "novel",
+      keepToEncodedMs: 30,
+      encodedToUploadedMs: 200,
+      uploadedToSentMs: 12,
+      bytes: 12345,
+    };
+    const result = validateLiveVoiceClientFrame({
+      type: "sight_frame",
+      attachmentId: "att-1",
+      timing,
+    });
+    expect(result).toEqual({
+      ok: true,
+      frame: { type: "sight_frame", attachmentId: "att-1", timing },
+    });
+  });
+
+  test("rejects a timing with a negative or fractional duration, naming the field", () => {
+    for (const bad of [
+      { keepToEncodedMs: -1 },
+      { encodedToUploadedMs: 1.5 },
+      { uploadedToSentMs: "0" },
+      { armToKeepMs: -5 },
+      { bytes: null },
+      { reason: "" },
+    ]) {
+      const result = validateLiveVoiceClientFrame({
+        type: "sight_frame",
+        attachmentId: "att-1",
+        timing: {
+          reason: "novel",
+          keepToEncodedMs: 30,
+          encodedToUploadedMs: 200,
+          uploadedToSentMs: 0,
+          bytes: 1,
+          ...bad,
+        },
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("invalid_field");
+        expect(result.error.field).toBe("timing");
+        expect(result.error.frameType).toBe("sight_frame");
+      }
+    }
+  });
+
+  test("rejects a timing that is not an object", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "sight_frame",
+      attachmentId: "att-1",
+      timing: "fast",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.field).toBe("timing");
+    }
+  });
 });
 
 describe("live-voice camera frames kept mid-call", () => {

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -90,6 +90,7 @@ import {
   getMessageById,
   MessageInsertPreconditionError,
   recordConversationPersistedSeq,
+  selectSightFrameCaptureTimes,
 } from "../persistence/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
@@ -134,6 +135,29 @@ const SIGHT_FRAME_MESSAGE_CONTENT = "(camera frame)";
 export interface LiveVoicePhotoResult {
   readonly ok: boolean;
   readonly messageId?: string;
+  /**
+   * Where the daemon's half of a persist went, on the ordinary success path.
+   * Absent on failure and on the recovery path that reports a row the write
+   * threw after landing, where the marks say nothing about the row.
+   */
+  readonly timing?: LiveVoicePhotoPersistTiming;
+}
+
+/**
+ * The daemon leg of one standalone image, as durations between its marks.
+ *
+ * Together with the client leg a `sight_frame` can carry (see
+ * `LiveVoiceSightFrameTiming` in `protocol.ts`) and the session's own
+ * distance-from-speech-onset, this is what says which leg a frame that missed
+ * its turn was lost in.
+ */
+export interface LiveVoicePhotoPersistTiming {
+  /** Behind this conversation's earlier standalone images. */
+  readonly queueWaitMs: number;
+  /** Polling for the processing flag, which a running turn holds. */
+  readonly flagWaitMs: number;
+  /** Materializing the attachment and inserting the row. */
+  readonly writeMs: number;
 }
 
 /**
@@ -175,8 +199,9 @@ async function enqueueStandaloneImagePersist(
   attachmentId: string,
   kind: "photo" | "sight_frame",
   content: string,
-  job: () => Promise<LiveVoicePhotoResult>,
+  job: (queueWaitMs: number) => Promise<LiveVoicePhotoResult>,
 ): Promise<LiveVoicePhotoResult> {
+  const queuedAtMs = Date.now();
   let queue = standaloneImageQueues.get(conversationId);
   if (!queue) {
     queue = {
@@ -215,7 +240,7 @@ async function enqueueStandaloneImagePersist(
       );
       return { ok: false };
     }
-    return job();
+    return job(Date.now() - queuedAtMs);
   });
   // The tail must survive a failed job, or one rejection would strand every
   // image queued behind it.
@@ -265,6 +290,37 @@ export const SIGHT_FRAME_TURN_HOLD_MS = 800;
  * Settles, never rejects: the caller is choosing how long to wait, not whether
  * the image landed.
  */
+/** The newest camera frame a conversation's rows carry. */
+export interface NewestSightFrame {
+  readonly attachmentId: string;
+  /** When the row carrying it was written, in wall-clock milliseconds. */
+  readonly capturedAt: number;
+}
+
+/**
+ * The camera frame a turn launching now would read as the current view, or
+ * null when the conversation carries none.
+ *
+ * For the turn's own log: which frame the answer is about is otherwise
+ * invisible, and the failure this instruments is exactly a turn reading the
+ * frame before the one the question was asked about. Read from the rows, the
+ * same source retention ranks frames by, so a frame the hold above waited for
+ * is counted and a frame still in flight is not.
+ */
+export function newestPersistedSightFrame(
+  conversationId: string,
+): NewestSightFrame | null {
+  let newest: NewestSightFrame | null = null;
+  for (const [attachmentId, capturedAt] of selectSightFrameCaptureTimes(
+    conversationId,
+  )) {
+    if (newest === null || capturedAt > newest.capturedAt) {
+      newest = { attachmentId, capturedAt };
+    }
+  }
+  return newest;
+}
+
 export function pendingStandaloneImagePersist(
   conversationId: string,
 ): Promise<void> | null {
@@ -672,13 +728,14 @@ function persistStandaloneImage(
     attachmentId,
     kind,
     persistOptions.content,
-    () =>
+    (queueWaitMs) =>
       writeStandaloneImage(
         conversationId,
         attachmentId,
         kind,
         incarnation,
         persistOptions,
+        queueWaitMs,
       ),
   );
 }
@@ -718,6 +775,7 @@ async function writeStandaloneImage(
     | "insertPrecondition"
     | "onUndiscardedAttachments"
   >,
+  queueWaitMs: number,
 ): Promise<LiveVoicePhotoResult> {
   const { content } = persistOptions;
   // The id the row is inserted under, so a failure can ask whether the insert
@@ -768,7 +826,9 @@ async function writeStandaloneImage(
     // A turn holds the lock for its whole run. Waiting rather than queueing:
     // the conversation's queue drains into a turn, which is the one thing this
     // must not cause.
+    const flagWaitStartedAtMs = Date.now();
     const owner = await acquireProcessingFlag(conversation);
+    const flagAcquiredAtMs = Date.now();
     if (owner === null) {
       log.warn(
         { conversationId, attachmentId, kind },
@@ -828,7 +888,15 @@ async function writeStandaloneImage(
 
       announcePersistedImage(conversationId, content, persisted.id);
 
-      return { ok: true, messageId: persisted.id };
+      return {
+        ok: true,
+        messageId: persisted.id,
+        timing: {
+          queueWaitMs,
+          flagWaitMs: flagAcquiredAtMs - flagWaitStartedAtMs,
+          writeMs: Date.now() - flagAcquiredAtMs,
+        },
+      };
     } finally {
       // Only this job's own hold is released. A turn that claimed the flag
       // away mid-write owns it now, and clearing there would free a turn that

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -90,7 +90,7 @@ import {
   getMessageById,
   MessageInsertPreconditionError,
   recordConversationPersistedSeq,
-  selectSightFrameCaptureTimes,
+  selectNewestSightFrameCapture,
 } from "../persistence/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
@@ -304,21 +304,17 @@ export interface NewestSightFrame {
  * For the turn's own log: which frame the answer is about is otherwise
  * invisible, and the failure this instruments is exactly a turn reading the
  * frame before the one the question was asked about. Read from the rows, the
- * same source retention ranks frames by, so a frame the hold above waited for
- * is counted and a frame still in flight is not.
+ * same source retention ranks frames by, so a frame that landed is counted
+ * and a frame still in flight is not. One indexed row, since it runs on every
+ * voice turn.
  */
 export function newestPersistedSightFrame(
   conversationId: string,
 ): NewestSightFrame | null {
-  let newest: NewestSightFrame | null = null;
-  for (const [attachmentId, capturedAt] of selectSightFrameCaptureTimes(
-    conversationId,
-  )) {
-    if (newest === null || capturedAt > newest.capturedAt) {
-      newest = { attachmentId, capturedAt };
-    }
-  }
-  return newest;
+  const newest = selectNewestSightFrameCapture(conversationId);
+  return newest === null
+    ? null
+    : { attachmentId: newest.attachmentId, capturedAt: newest.createdAt };
 }
 
 export function pendingStandaloneImagePersist(

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1323,6 +1323,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // older one is simply out of date. Consumed (and cleared) when a turn
   // launches, handed back if that turn is rolled back, and cleared on close.
   private pendingTurnAttachmentId: string | null = null;
+  // When `speech_started` last went to the client, for the sight-frame log:
+  // the distance from it to a keep arriving is the client leg of the frame the
+  // onset asked for, measured from the daemon's own clock.
+  private lastSpeechStartedAtMs: number | null = null;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -1719,11 +1723,32 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * same fact.
    */
   private persistSightFrame(frame: LiveVoiceClientSightFrameFrame): void {
+    const receivedAtMs = Date.now();
+    // One line per keep, written when the row lands, carrying the whole
+    // timeline: the client leg the frame reported, the daemon leg the persist
+    // measured, and the distance from the speech onset the frame may have
+    // been asked for. Together with the turn's own "Voice turn dispatch
+    // timing" line this says whether a frame missed its turn and where.
+    const sinceSpeechStartedMs =
+      this.lastSpeechStartedAtMs === null
+        ? null
+        : receivedAtMs - this.lastSpeechStartedAtMs;
     void persistAmbientSightFrame(
       this.conversationId,
       frame.attachmentId,
       "voice",
     ).then((result) => {
+      log.info(
+        {
+          attachmentId: frame.attachmentId,
+          persisted: result.ok,
+          sinceSpeechStartedMs,
+          client: frame.timing ?? null,
+          daemon: result.timing ?? null,
+          daemonTotalMs: Date.now() - receivedAtMs,
+        },
+        "Sight frame timing",
+      );
       if (!result.ok && !this.isClosed) {
         void this.sendFrame({
           type: "error",
@@ -2790,10 +2815,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     this.pendingBargeIn = null;
     this.assistantPlaybackTailUntilMs = 0;
-    void this.sendFrame({ type: "speech_started" });
+    this.sendSpeechStarted();
     if (bargeableTurn) {
       this.bargeIn(bargeableTurn);
     }
+  }
+
+  /**
+   * Tell the client the caller started speaking, and remember when, so a
+   * camera frame that follows can be logged against the onset it answers.
+   */
+  private sendSpeechStarted(): void {
+    this.lastSpeechStartedAtMs = Date.now();
+    void this.sendFrame({ type: "speech_started" });
   }
 
   // Advance the sustained-speech barge-in guard by one server-VAD chunk.
@@ -2841,7 +2875,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     this.pendingBargeIn = null;
     this.assistantPlaybackTailUntilMs = 0;
-    void this.sendFrame({ type: "speech_started" });
+    this.sendSpeechStarted();
     const { turn } = guard;
     if (turn && turn === this.activeAssistantTurn && !turn.finalized) {
       this.bargeIn(turn);

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -312,6 +312,44 @@ export interface LiveVoiceClientAttachFrameFrame {
 export interface LiveVoiceClientSightFrameFrame {
   readonly type: "sight_frame";
   readonly attachmentId: string;
+  /**
+   * How long the client's half of the frame took, for the daemon's log. The
+   * daemon adds its own half and the distance from the speech onset it
+   * announced, which is what makes a frame that answered the wrong question
+   * legible after the fact. Optional: an older client sends none.
+   */
+  readonly timing?: LiveVoiceSightFrameTiming;
+}
+
+/**
+ * The client leg of one kept frame, as durations between its own marks.
+ *
+ * Durations rather than timestamps because the two clocks are not the same
+ * clock: the client stamps from `performance.now` and the daemon from wall
+ * time, and only the client can say how long its encode and upload took.
+ * Every field is a non-negative whole number of milliseconds.
+ */
+export interface LiveVoiceSightFrameTiming {
+  /**
+   * Why the gate kept the frame: `forced` is the keep a speech onset asked
+   * for, everything else is the ambient cadence. Free-form so a new gate
+   * reason needs no daemon change to be logged.
+   */
+  readonly reason: string;
+  /**
+   * From the arm that asked for this keep to the keep itself. Present only on
+   * a forced keep, where it is the distance from the client hearing
+   * `speech_started` to a frame that postdates it.
+   */
+  readonly armToKeepMs?: number;
+  /** From the keep to a JPEG in hand, sized for upload. */
+  readonly keepToEncodedMs: number;
+  /** From the JPEG to the attachment id, which is the HTTP upload. */
+  readonly encodedToUploadedMs: number;
+  /** From the id to the send, which is the wait for older keeps to go first. */
+  readonly uploadedToSentMs: number;
+  /** The JPEG that was uploaded, in bytes. */
+  readonly bytes: number;
 }
 
 /**
@@ -932,9 +970,68 @@ function validateSightFrameFrame(
     );
   }
 
+  if (!("timing" in value) || value.timing === undefined) {
+    return {
+      ok: true,
+      frame: { type: "sight_frame", attachmentId: value.attachmentId },
+    };
+  }
+
+  const timing = validateSightFrameTiming(value.timing);
+  if (timing === null) {
+    return protocolError(
+      "invalid_field",
+      "sight_frame frame field timing must carry non-negative integer durations and a reason",
+      "timing",
+      "sight_frame",
+    );
+  }
+
   return {
     ok: true,
-    frame: { type: "sight_frame", attachmentId: value.attachmentId },
+    frame: { type: "sight_frame", attachmentId: value.attachmentId, timing },
+  };
+}
+
+/**
+ * Parse a `sight_frame`'s `timing`. Null for anything off-shape: a timing is
+ * for the log, so nothing about it is coerced, but a malformed one still
+ * refuses the frame, since a client that sends one means to send a whole one.
+ */
+function validateSightFrameTiming(
+  value: unknown,
+): LiveVoiceSightFrameTiming | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const isDuration = (duration: unknown): duration is number =>
+    isIntInRange(duration, 0, Number.MAX_SAFE_INTEGER);
+  const {
+    reason,
+    armToKeepMs,
+    keepToEncodedMs,
+    encodedToUploadedMs,
+    uploadedToSentMs,
+    bytes,
+  } = record;
+  if (
+    !isNonEmptyString(reason) ||
+    !isDuration(keepToEncodedMs) ||
+    !isDuration(encodedToUploadedMs) ||
+    !isDuration(uploadedToSentMs) ||
+    !isDuration(bytes) ||
+    (armToKeepMs !== undefined && !isDuration(armToKeepMs))
+  ) {
+    return null;
+  }
+  return {
+    reason,
+    ...(armToKeepMs !== undefined ? { armToKeepMs } : {}),
+    keepToEncodedMs,
+    encodedToUploadedMs,
+    uploadedToSentMs,
+    bytes,
   };
 }
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -2706,6 +2706,44 @@ export function selectSightFrameCaptureTimes(
 }
 
 /**
+ * The newest camera frame in the conversation, by the `createdAt` of the row
+ * that carries it, or null when no row carries one.
+ *
+ * The one-row form of {@link selectSightFrameCaptureTimes}, for a caller that
+ * wants only the latest and runs on every voice turn: every stored frame stays
+ * a row for the life of the conversation, so the full scan grows with the
+ * call. Same narrowing and the same validation, so the two agree on what a
+ * frame is. A row carrying several frames answers with the last attached.
+ */
+export function selectNewestSightFrameCapture(
+  conversationId: string,
+): { attachmentId: string; createdAt: number } | null {
+  const db = getDb();
+  const row = db
+    .select({ metadata: messages.metadata, createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        lineageFilter(conversationId),
+        like(messages.metadata, `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`),
+      ),
+    )
+    .orderBy(desc(messages.createdAt))
+    .limit(1)
+    .get();
+  if (!row) {
+    return null;
+  }
+  const ids = sightFrameAttachmentIdsFromMetadata(
+    parseMessageMetadata(row.metadata),
+  );
+  const attachmentId = ids.at(-1);
+  return attachmentId === undefined
+    ? null
+    : { attachmentId, createdAt: row.createdAt };
+}
+
+/**
  * Count messages in a conversation that were created strictly after the
  * `afterMessageId` reference message. If `afterMessageId` is `null` or empty,
  * counts all messages in the conversation. If the referenced message no

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -562,6 +562,25 @@ describe("server frame dispatch", () => {
     });
   });
 
+  test("sightFrame carries the frame's timing when it has one", async () => {
+    const { client, ws } = await ready();
+    const timing = {
+      reason: "forced",
+      armToKeepMs: 40,
+      keepToEncodedMs: 30,
+      encodedToUploadedMs: 200,
+      uploadedToSentMs: 0,
+      bytes: 12345,
+    };
+
+    expect(client.sightFrame("att-1", timing)).toBe(true);
+    expect(ws.sentJson.at(-1)).toEqual({
+      type: "sight_frame",
+      attachmentId: "att-1",
+      timing,
+    });
+  });
+
   test("a rejected sight_frame is a routine drop, not a settings or session error", async () => {
     // The daemon reclaims the attachment on the path that sends this, so there
     // is nothing to retry and nothing to give back. What matters is where the

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -140,6 +140,28 @@ export interface LiveVoiceTextTurnRejected {
  * frame: it could not persist this one, and it has already reclaimed the
  * attachment itself.
  */
+/**
+ * The client leg of one kept frame, sent with the `sight_frame` for the
+ * daemon's log. Durations rather than timestamps: the daemon's clock is not
+ * this one, and only this side can say how long its encode and upload took.
+ * Whole milliseconds, never negative. Mirrors `LiveVoiceSightFrameTiming` in
+ * the daemon's `live-voice/protocol.ts`.
+ */
+export interface LiveVoiceSightFrameTiming {
+  /** Why the frame was kept: a gate reason, or a source's own word for it. */
+  readonly reason: string;
+  /** From the arm that asked for this keep to the keep. Forced keeps only. */
+  readonly armToKeepMs?: number;
+  /** From the keep to a JPEG sized for upload. */
+  readonly keepToEncodedMs: number;
+  /** From the JPEG to an attachment id, which is the HTTP upload. */
+  readonly encodedToUploadedMs: number;
+  /** From the id to the send, which is the wait for older keeps to go first. */
+  readonly uploadedToSentMs: number;
+  /** The JPEG that was uploaded, in bytes. */
+  readonly bytes: number;
+}
+
 export interface LiveVoiceSightFrameRejected {
   readonly unsupported: boolean;
   /**
@@ -485,11 +507,20 @@ export class LiveVoiceChannelClient {
    * below keeps that out of the `update_config` bucket, an ungated sampler
    * would still be sending a frame every few seconds into a void.
    */
-  sightFrame(attachmentId: string): boolean {
+  sightFrame(
+    attachmentId: string,
+    timing?: LiveVoiceSightFrameTiming,
+  ): boolean {
     if (this.state !== "active") {
       return false;
     }
-    return this.trySend(JSON.stringify({ type: "sight_frame", attachmentId }));
+    return this.trySend(
+      JSON.stringify({
+        type: "sight_frame",
+        attachmentId,
+        ...(timing ? { timing } : {}),
+      }),
+    );
   }
 
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -26,6 +26,7 @@ import type {
   LiveVoiceClientEventMap,
   LiveVoiceClientEventName,
   LiveVoiceConnectArgs,
+  LiveVoiceSightFrameTiming,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
 import type {
   LiveVoiceAudioCaptureOptions,
@@ -347,7 +348,9 @@ export function makeControlsSpies() {
     // Defaults to delivered. The reconnect-gap case (false) is asserted by the
     // tests that care, so the common path stays uncluttered.
     attachImage: mock((_attachmentId: string) => true),
-    sightFrame: mock((_attachmentId: string) => true),
+    sightFrame: mock(
+      (_attachmentId: string, _timing?: LiveVoiceSightFrameTiming) => true,
+    ),
   } satisfies LiveVoiceSessionControls;
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -618,8 +618,18 @@ describe("sendLiveVoiceSightFrame", () => {
     useLiveVoiceStore.getState().setControls(controls);
     const kept = useLiveVoiceStore.getState().sessionGeneration;
 
-    expect(sendLiveVoiceSightFrame("att-1", kept)).toBe(true);
-    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+    const timing = {
+      reason: "forced",
+      armToKeepMs: 40,
+      keepToEncodedMs: 30,
+      encodedToUploadedMs: 200,
+      uploadedToSentMs: 0,
+      bytes: 12345,
+    };
+    expect(sendLiveVoiceSightFrame("att-1", kept, timing)).toBe(true);
+    // The timing rides the frame as given: the daemon's log is where it is
+    // read, and nothing here has a reason to reshape it.
+    expect(controls.sightFrame).toHaveBeenCalledWith("att-1", timing);
   });
 
   test("refuses a frame kept in a session that ended", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -23,6 +23,7 @@
 
 import { create } from "zustand";
 
+import type { LiveVoiceSightFrameTiming } from "@/domains/chat/voice/live-voice/live-voice-client";
 import type {
   LiveVoiceEntry,
   LiveVoiceMetricsServerFrame,
@@ -230,7 +231,10 @@ export interface LiveVoiceSessionControls {
    *
    * Callers must gate on `useSupportsSightStream`.
    */
-  sightFrame: (attachmentId: string) => boolean;
+  sightFrame: (
+    attachmentId: string,
+    timing?: LiveVoiceSightFrameTiming,
+  ) => boolean;
 }
 
 /**
@@ -1596,6 +1600,7 @@ export function setLiveVoiceScreenShare(
 export function sendLiveVoiceSightFrame(
   attachmentId: string,
   sessionGeneration: number,
+  timing?: LiveVoiceSightFrameTiming,
 ): boolean {
   const state = useLiveVoiceStore.getState();
   if (state.sessionGeneration !== sessionGeneration) {
@@ -1606,7 +1611,7 @@ export function sendLiveVoiceSightFrame(
   if (state.sightFramesUnsupported) {
     return false;
   }
-  const sent = state.controls?.sightFrame(attachmentId) ?? false;
+  const sent = state.controls?.sightFrame(attachmentId, timing) ?? false;
   if (sent) {
     state.noteSightFrameSent(attachmentId);
   }

--- a/clients/web/src/domains/chat/voice/live-voice/sight-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/sight-capture.ts
@@ -349,10 +349,14 @@ export function createSightCapture(errorContext: string): SightCapture {
           }
           // The renderer console reaches the desktop shell's log, so the
           // client leg can be read beside the daemon's without a debugger.
-          console.info("[live-voice sight] frame sent", {
-            attachmentId: uploaded.id,
-            ...timing,
-          });
+          // One string: the shell's forwarder joins console arguments with
+          // their string form, and an object's is "[object Object]".
+          console.info(
+            `[live-voice sight] frame sent ${JSON.stringify({
+              attachmentId: uploaded.id,
+              ...timing,
+            })}`,
+          );
           onShared({ attachmentId: uploaded.id, frame });
         },
       };

--- a/clients/web/src/domains/chat/voice/live-voice/sight-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/sight-capture.ts
@@ -51,6 +51,7 @@ import { prepareImageAttachmentForUpload } from "@/domains/chat/components/chat-
 import { recordFrameGateKeep } from "@/lib/camera/frame-gate-debug";
 import { captureError } from "@/lib/sentry/capture-error";
 
+import type { LiveVoiceSightFrameTiming } from "./live-voice-client";
 import { sendLiveVoiceSightFrame, useLiveVoiceStore } from "./live-voice-store";
 
 /**
@@ -79,9 +80,26 @@ export interface SightSharedFrame {
   readonly frame: File;
 }
 
+/** Why a frame was kept, for the timing it reports. */
+export interface SightKeepOrigin {
+  /**
+   * The gate's reason, or a source's own word for a keep no gate judged. Goes
+   * to the daemon's log as-is.
+   */
+  readonly reason: string;
+  /**
+   * When the arm this keep answers was taken, on `performance.now`'s clock.
+   * Set only for a keep a speech onset asked for: the distance from it to the
+   * keep is the first leg of the frame the question is about.
+   */
+  readonly armedAtMs?: number;
+}
+
 export interface SightCaptureRequest {
   /** The assistant the frame is uploaded against, which is the session's. */
   readonly assistantId: string;
+  /** Why this frame was kept, carried to the daemon with the frame's timing. */
+  readonly keep: SightKeepOrigin;
   /**
    * The JPEG: the browser path encodes the `<video>` it is watching, the
    * native path wraps the sample the gate has already judged. Null is a frame
@@ -126,6 +144,38 @@ export interface SightCapture {
    * and the frames in flight stale: a flipped camera, a transport reconnect.
    */
   invalidate(): void;
+}
+
+/** The marks one capture stamps on its way to the send. */
+interface SightCaptureMarks {
+  readonly keptAtMs: number;
+  readonly encodedAtMs: number;
+  readonly uploadedAtMs: number;
+  readonly sentAtMs: number;
+  readonly bytes: number;
+}
+
+/**
+ * Fold a capture's marks into the durations the wire carries. Rounded to whole
+ * milliseconds and floored at zero, which is what the daemon accepts; a mark
+ * never runs backwards on one clock, so the floor is for the rounding alone.
+ */
+export function sightFrameTiming(
+  keep: SightKeepOrigin,
+  marks: SightCaptureMarks,
+): LiveVoiceSightFrameTiming {
+  const between = (from: number, to: number): number =>
+    Math.max(0, Math.round(to - from));
+  return {
+    reason: keep.reason,
+    ...(keep.armedAtMs === undefined
+      ? {}
+      : { armToKeepMs: between(keep.armedAtMs, marks.keptAtMs) }),
+    keepToEncodedMs: between(marks.keptAtMs, marks.encodedAtMs),
+    encodedToUploadedMs: between(marks.encodedAtMs, marks.uploadedAtMs),
+    uploadedToSentMs: between(marks.uploadedAtMs, marks.sentAtMs),
+    bytes: marks.bytes,
+  };
 }
 
 /**
@@ -208,6 +258,7 @@ export function createSightCapture(errorContext: string): SightCapture {
 
   async function capture({
     assistantId,
+    keep,
     produceFrame,
     onShared,
   }: SightCaptureRequest): Promise<void> {
@@ -234,6 +285,10 @@ export function createSightCapture(errorContext: string): SightCapture {
     // them in.
     const seq = captureSeq;
     captureSeq += 1;
+    // The marks of this frame's client leg, reported to the daemon with the
+    // frame. The keep is now; the encode, the upload and the send each stamp
+    // their own, and the daemon adds its half.
+    const keptAtMs = performance.now();
     let pending: PendingSightSend | null = null;
     try {
       frameCount += 1;
@@ -248,11 +303,13 @@ export function createSightCapture(errorContext: string): SightCapture {
       // attachment rather than like a special case.
       const prepared = await prepareImageAttachmentForUpload(frame);
       const file = prepared.status === "failed" ? frame : prepared.file;
+      const encodedAtMs = performance.now();
 
       const uploaded = await uploadChatAttachment(assistantId, file);
       if (!uploaded.ok) {
         return;
       }
+      const uploadedAtMs = performance.now();
       const abandonUpload = (): void => reclaimUpload(assistantId, uploaded.id);
       // The guards run when the turn comes, not now, so a frame that waited
       // is still checked against the session and camera of the moment it
@@ -274,13 +331,28 @@ export function createSightCapture(errorContext: string): SightCapture {
             abandonUpload();
             return;
           }
+          const timing = sightFrameTiming(keep, {
+            keptAtMs,
+            encodedAtMs,
+            uploadedAtMs,
+            sentAtMs: performance.now(),
+            bytes: file.size,
+          });
           // Sent before it is shown, and shown only if it was sent. During a
           // reconnect gap it has not been, and a frame that never left is this
           // module's to give back, since the daemon never saw it.
-          if (!sendLiveVoiceSightFrame(uploaded.id, sessionGeneration)) {
+          if (
+            !sendLiveVoiceSightFrame(uploaded.id, sessionGeneration, timing)
+          ) {
             abandonUpload();
             return;
           }
+          // The renderer console reaches the desktop shell's log, so the
+          // client leg can be read beside the daemon's without a debugger.
+          console.info("[live-voice sight] frame sent", {
+            attachmentId: uploaded.id,
+            ...timing,
+          });
           onShared({ attachmentId: uploaded.id, frame });
         },
       };

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
@@ -92,16 +92,13 @@ mock.module("@/domains/chat/api/messages", () => ({
   deleteChatAttachment,
 }));
 
-const { useLiveVoiceScreenShare, SCREEN_SHARE_MIN_FRAME_GAP_MS } = await import(
-  "./use-live-voice-screen-share"
-);
+const { useLiveVoiceScreenShare, SCREEN_SHARE_MIN_FRAME_GAP_MS } =
+  await import("./use-live-voice-screen-share");
 const { useLiveVoiceStore } = await import("./live-voice-store");
-const { makeControlsSpies, seedLiveVoiceSession } = await import(
-  "./live-voice-fakes.test-helper"
-);
-const { useAssistantIdentityStore } = await import(
-  "@/stores/assistant-identity-store"
-);
+const { makeControlsSpies, seedLiveVoiceSession } =
+  await import("./live-voice-fakes.test-helper");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
 
 const ASSISTANT_ID = "asst_share";
 /** A dev build off `main` published after the `sight_frame` handler merged. */
@@ -207,7 +204,10 @@ describe("useLiveVoiceScreenShare: starting", () => {
     const file = uploadChatAttachment.mock.calls[0]?.[1];
     expect(file?.type).toBe("image/jpeg");
     expect(await file?.text()).toBe("jpeg");
-    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+    expect(controls.sightFrame).toHaveBeenCalledWith(
+      "att-1",
+      expect.objectContaining({ reason: "screen" }),
+    );
   });
 
   /**
@@ -220,7 +220,10 @@ describe("useLiveVoiceScreenShare: starting", () => {
     share(WINDOW);
     await flush();
 
-    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+    expect(controls.sightFrame).toHaveBeenCalledWith(
+      "att-1",
+      expect.objectContaining({ reason: "screen" }),
+    );
     expect(sharedFrames).toEqual([WINDOW]);
   });
 
@@ -385,7 +388,12 @@ describe("useLiveVoiceScreenShare: a mark drawn on the shared surface", () => {
     release();
     await flush();
     expect(captureCompanionScreen).toHaveBeenCalledTimes(2);
-    expect(controls.sightFrame).toHaveBeenLastCalledWith("att-2");
+    // And the frame says it was the mark's, so the daemon's log can tell a
+    // drawn frame from the cadence's.
+    expect(controls.sightFrame).toHaveBeenLastCalledWith(
+      "att-2",
+      expect.objectContaining({ reason: "drawing" }),
+    );
   });
 
   /**
@@ -609,6 +617,9 @@ describe("useLiveVoiceScreenShare: the boundary a frame in flight can cross", ()
     });
     speak(true);
     await flush();
-    expect(controls.sightFrame).toHaveBeenCalledWith("att-2");
+    expect(controls.sightFrame).toHaveBeenCalledWith(
+      "att-2",
+      expect.objectContaining({ reason: "screen" }),
+    );
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
@@ -163,6 +163,9 @@ export function useLiveVoiceScreenShare(): void {
       void sight
         .capture({
           assistantId,
+          // No gate here; the word says which of this hook's own occasions
+          // took the frame.
+          keep: { reason: drawing === null ? "screen" : "drawing" },
           produceFrame: async (filename) => {
             const frame = await produceSharedFrame(target, filename, drawing);
             missed = frame === null;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -86,6 +86,7 @@ import {
   LiveVoiceChannelClient,
   RETRYABLE_LIVE_VOICE_CLOSE_CODES,
   type LiveVoiceClientError,
+  type LiveVoiceSightFrameTiming,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
 import {
   LiveVoiceAudioCapture,
@@ -725,9 +726,14 @@ export function useLiveVoice(
    * reconnect gap is right to drop, since the fresh session is the one that
    * would persist it and the moment it belonged to has passed.
    */
-  const sightFrame = useCallback((attachmentId: string): boolean => {
-    return sessionRef.current?.client.sightFrame(attachmentId) ?? false;
-  }, []);
+  const sightFrame = useCallback(
+    (attachmentId: string, timing?: LiveVoiceSightFrameTiming): boolean => {
+      return (
+        sessionRef.current?.client.sightFrame(attachmentId, timing) ?? false
+      );
+    },
+    [],
+  );
 
   const createPlayer = useCallback(
     () =>

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
@@ -244,6 +244,13 @@ async function keepFrame(): Promise<void> {
   await flush();
 }
 
+/** The ids the session was handed, in send order, without their timings. */
+function sentFrameIds(spies: {
+  sightFrame: { mock: { calls: unknown[][] } };
+}): unknown[] {
+  return spies.sightFrame.mock.calls.map(([id]) => id);
+}
+
 /**
  * Replace the running gate's `reset` with a spy.
  *
@@ -549,7 +556,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
     await keepFrame();
 
     expect(uploadChatAttachment).toHaveBeenCalledTimes(1);
-    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-1");
     // The daemon owns a frame it was told about and reclaims it if the
     // persist fails, so nothing here may delete the row.
@@ -591,7 +598,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
     });
     await flush();
 
-    expect(controls.sightFrame.mock.calls).toEqual([["att-1"], ["att-2"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-1", "att-2"]);
   });
 
   test("ignores frames the gate skipped", async () => {
@@ -617,7 +624,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
 
     await keepFrame();
 
-    expect(controls.sightFrame).toHaveBeenNthCalledWith(2, "att-2");
+    expect(sentFrameIds(controls)[1]).toBe("att-2");
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-2");
     expect(revoke).toHaveBeenCalledWith(first!.previewUrl);
     revoke.mockRestore();
@@ -631,7 +638,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
 
     await keepFrame();
 
-    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
     expect(view.result.current.heldFrame).toBeNull();
     // The daemon never saw this id, so nothing there will ever collect it.
     expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
@@ -667,10 +674,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(controls.sightFrame.mock.calls).toEqual([
-      ["att-older"],
-      ["att-newer"],
-    ]);
+    expect(sentFrameIds(controls)).toEqual(["att-older", "att-newer"]);
     // The pulse follows the sends, so it settles on the newest scene.
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-newer");
     expect(deleteChatAttachment).not.toHaveBeenCalled();
@@ -729,7 +733,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(controls.sightFrame.mock.calls).toEqual([["att-newer"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-newer"]);
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-newer");
   });
 
@@ -761,7 +765,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
     });
 
     // The pre-flip frame is a view of somewhere the camera is not pointing.
-    expect(controls.sightFrame.mock.calls).toEqual([["att-after-flip"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-after-flip"]);
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-after-flip");
     expect(deleteChatAttachment).toHaveBeenCalledWith(
       ASSISTANT_ID,
@@ -800,7 +804,7 @@ describe("useVoiceRoomSight: sharing a keep", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(successor.sightFrame.mock.calls).toEqual([["att-new-session"]]);
+    expect(sentFrameIds(successor)).toEqual(["att-new-session"]);
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-new-session");
   });
 
@@ -826,12 +830,12 @@ describe("useVoiceRoomSight: sharing a keep", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(controls.sightFrame.mock.calls).toEqual([
-      ["att-1"],
-      ["att-2"],
-      ["att-3"],
-      ["att-4"],
-      ["att-5"],
+    expect(sentFrameIds(controls)).toEqual([
+      "att-1",
+      "att-2",
+      "att-3",
+      "att-4",
+      "att-5",
     ]);
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-5");
 
@@ -1176,7 +1180,7 @@ describe("useVoiceRoomSight: an assistant that cannot take the frame", () => {
     // reclaim, one orphan per keep, while the room implies it is sharing.
     const { view } = renderSight();
     await keepFrame();
-    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
 
     act(() => {
       useLiveVoiceStore.getState().noteSightFrameRefused(true);
@@ -1384,7 +1388,7 @@ describe("useVoiceRoomSight: a keep the assistant could not persist", () => {
 
     await keepFrame();
 
-    expect(controls.sightFrame).toHaveBeenLastCalledWith("att-2");
+    expect(sentFrameIds(controls).at(-1)).toBe("att-2");
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-2");
   });
 });
@@ -1501,7 +1505,7 @@ describe("useVoiceRoomSight: transport reconnect", () => {
 
     await keepFrame();
 
-    expect(controls.sightFrame).toHaveBeenLastCalledWith("att-2");
+    expect(sentFrameIds(controls).at(-1)).toBe("att-2");
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-2");
   });
 
@@ -1538,7 +1542,7 @@ describe("useVoiceRoomSight: closing and flipping", () => {
       view.rerender({ cameraOpen: false, facing: "environment" });
     });
 
-    expect(controls.sightFrame.mock.calls).toEqual([["att-1"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
     expect(view.result.current.heldFrame).toBeNull();
     expect(revoke).toHaveBeenCalledWith(held!.previewUrl);
     expect(deleteChatAttachment).not.toHaveBeenCalled();
@@ -1581,7 +1585,7 @@ describe("useVoiceRoomSight: closing and flipping", () => {
       view.unmount();
     });
 
-    expect(controls.sightFrame.mock.calls).toEqual([["att-1"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
   });
 
   test("clears the pulse when the camera flips", async () => {
@@ -1596,7 +1600,7 @@ describe("useVoiceRoomSight: closing and flipping", () => {
       view.rerender({ cameraOpen: true, facing: "user" });
     });
 
-    expect(controls.sightFrame.mock.calls).toEqual([["att-1"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
     expect(view.result.current.heldFrame).toBeNull();
     expect(reset).toHaveBeenCalledTimes(1);
     expect(deleteChatAttachment).not.toHaveBeenCalled();
@@ -1632,7 +1636,7 @@ describe("useVoiceRoomSight: closing and flipping", () => {
     });
 
     expect(successor.sightFrame).not.toHaveBeenCalled();
-    expect(controls.sightFrame.mock.calls).toEqual([["att-1"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -1675,7 +1679,7 @@ describe("useVoiceRoomSight: the native preview", () => {
     expect(new Uint8Array(await uploaded!.arrayBuffer())).toEqual(
       new Uint8Array([9, 8, 7]),
     );
-    expect(controls.sightFrame.mock.calls).toEqual([["att-1"]]);
+    expect(sentFrameIds(controls)).toEqual(["att-1"]);
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-1");
     // The pulse is an object URL over those same bytes, given back by the same
     // `hold` the browser path uses.
@@ -1990,6 +1994,36 @@ describe("useVoiceRoomSight: a frame for the question being asked", () => {
     openUtterance(true);
 
     expect(nativeSampleNow).not.toHaveBeenCalled();
+  });
+
+  test("the keep that answers the arm reports the distance from it", async () => {
+    // Which frame a turn read is the daemon's to log; how long the question's
+    // own frame took to reach it is this side's. A forced keep carries the
+    // arm it answers, and an ambient keep says it was the cadence's.
+    goHandsFree();
+    renderSight({ live: true });
+
+    openUtterance(true);
+    act(() => {
+      samplerOptions?.onDecision(
+        { ...KEEP, reason: "forced" as const },
+        performance.now(),
+      );
+    });
+    await flush();
+    await keepFrame();
+
+    const [forced, ambient] = controls.sightFrame.mock.calls;
+    expect(forced).toEqual([
+      "att-1",
+      expect.objectContaining({
+        reason: "forced",
+        armToKeepMs: expect.any(Number),
+        bytes: expect.any(Number),
+      }),
+    ]);
+    expect(ambient?.[1]).toEqual(expect.objectContaining({ reason: "novel" }));
+    expect(ambient?.[1]).not.toHaveProperty("armToKeepMs");
   });
 
   test("does not arm for an utterance that was already open when Live began", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
@@ -84,14 +84,21 @@ import {
   isLiveVoiceUserSpeaking,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { createSightCapture } from "@/domains/chat/voice/live-voice/sight-capture";
+import {
+  createSightCapture,
+  type SightKeepOrigin,
+} from "@/domains/chat/voice/live-voice/sight-capture";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import {
   isVisionModeOn,
   useVisionModeVariant,
 } from "@/hooks/use-vision-mode-flag";
 import { useSupportsSightStream } from "@/lib/backwards-compat/use-supports-sight-stream";
-import { type FrameGate, createFrameGate } from "@/lib/camera/frame-gate";
+import {
+  type FrameGate,
+  type FrameGateDecision,
+  createFrameGate,
+} from "@/lib/camera/frame-gate";
 import {
   FRAME_GATE_LIVE_OPTIONS,
   recordFrameGateDecision,
@@ -198,6 +205,12 @@ export function useVoiceRoomSight(
   // cannot close over a render's value.
   const heldRef = useRef<VoiceRoomSightFrame | null>(null);
   const gateRef = useRef<FrameGate | null>(null);
+  /**
+   * When the gate was last armed for a question, so the keep that answers it
+   * can report how long the answer took. Read by the sampler's continuation,
+   * which is why it is a ref rather than a render's value.
+   */
+  const armedAtRef = useRef<number | null>(null);
   /**
    * The running native poll, so a change it cannot see can reach the sample it
    * has on the bridge.
@@ -466,6 +479,15 @@ export function useVoiceRoomSight(
     const gate = createFrameGate(FRAME_GATE_LIVE_OPTIONS);
     gate.reset(performance.now());
     gateRef.current = gate;
+    /**
+     * Why a keep was made, for the timing it reports. A forced keep is the
+     * one an arm asked for, so it carries when the arm was taken; every other
+     * keep is the cadence's own.
+     */
+    const keepOrigin = (decision: FrameGateDecision): SightKeepOrigin =>
+      decision.reason === "forced" && armedAtRef.current !== null
+        ? { reason: decision.reason, armedAtMs: armedAtRef.current }
+        : { reason: decision.reason };
 
     let stopSampling: () => void;
     if (video) {
@@ -478,6 +500,7 @@ export function useVoiceRoomSight(
           }
           void sight.capture({
             assistantId,
+            keep: keepOrigin(decision),
             produceFrame: (filename) => captureVideoFrame(video, filename),
             onShared,
           });
@@ -499,6 +522,7 @@ export function useVoiceRoomSight(
           // frame the transcript ends up with is the one the gate said yes to.
           void sight.capture({
             assistantId,
+            keep: keepOrigin(decision),
             produceFrame: async (filename) =>
               new File([sample], filename, { type: "image/jpeg" }),
             onShared,
@@ -578,7 +602,9 @@ export function useVoiceRoomSight(
     if (muted) {
       return;
     }
-    gateRef.current?.armForcedKeep(performance.now());
+    const armedAtMs = performance.now();
+    armedAtRef.current = armedAtMs;
+    gateRef.current?.armForcedKeep(armedAtMs);
     // The browser sampler needs no nudge: its next candidate frame is one
     // video frame away and will consume the arm on its own.
     nativeSourceRef.current?.sampleNow();


### PR DESCRIPTION
## Why

A live-vision question in a voice call is often answered about the frame before the one it was asked about. Audit (JARVIS-1760): the speech-onset forced keep (#42095) races the silence-boundary turn dispatch, and the daemon's 800ms sight hold (#42094) only sees frames whose socket message has already arrived. A frame still encoding or uploading on the client is invisible to the hold, lands after the reply, and becomes the "newest" frame for the next question.

Nothing in the logs could show that. The client leg of a frame was unmeasured, and the daemon knew when a frame arrived but not which frame a launching turn would read.

## What

- `sight_frame` carries an optional `timing`: the gate's reason (`forced` is the onset keep), arm-to-keep, keep-to-encoded, encoded-to-uploaded, uploaded-to-sent, and bytes. Durations, not timestamps, since the two clocks differ. An older daemon ignores the field; an older client sends none.
- Daemon writes one `Sight frame timing` line per keep when its row lands: the client leg, its own queue / flag / write legs, and the distance from the last `speech_started` it sent.
- `Voice turn dispatch timing` gains `newestSightFrame` (attachment id and age), read after the sight hold, so a turn says which frame it answered against.
- Renderer logs `[live-voice sight] frame sent` per frame, so the desktop shell's log shows the client leg beside the daemon's.

## How to read it

For a turn that answered about the wrong frame, find its `Voice turn dispatch timing` line. If `sightHoldMs` is ~0 and `newestSightFrame.ageMs` is older than the utterance, the frame had not reached the daemon; the matching `Sight frame timing` line then says which client leg ate the time.

## Follow-ups on this branch

Announce the frame to the daemon at arm time so the hold can wait for it; encode a reduced frame straight from the canvas; arm from local amplitude instead of the server round trip.

Part of JARVIS-1760

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCKw5aftuZknGTgSGMWBLD
