### PR TITLE
Add the shared notification avatar disc spec to avatar-manifest

### DIFF
--- a/packages/avatar-manifest/package.json
+++ b/packages/avatar-manifest/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./accent": "./src/accent.ts"
+    "./accent": "./src/accent.ts",
+    "./notification-avatar": "./src/notification-avatar.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/avatar-manifest/src/__tests__/notification-avatar.test.ts
+++ b/packages/avatar-manifest/src/__tests__/notification-avatar.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  NOTIFICATION_AVATAR_ACCENT_MIX,
+  NOTIFICATION_AVATAR_FALLBACK_DISC_HEX,
+  NOTIFICATION_AVATAR_INSET,
+  NOTIFICATION_AVATAR_SIZE,
+  notificationAvatarDiscHex,
+  notificationAvatarSvg,
+} from "../notification-avatar.js";
+
+/** The spec's mix, written out again so the module cannot grade its own homework. */
+function mixIntoWhite(hex: string, amount: number): string {
+  const rgb = parseInt(hex.slice(1), 16);
+  const channel = (shift: number) =>
+    Math.round(255 * (1 - amount) + ((rgb >> shift) & 0xff) * amount)
+      .toString(16)
+      .padStart(2, "0")
+      .toUpperCase();
+  return `#${channel(16)}${channel(8)}${channel(0)}`;
+}
+
+function attributes(tag: string, svg: string): Record<string, string> {
+  const match = svg.match(new RegExp(`<${tag}\\s([^>]*)/>`));
+  expect(match).not.toBeNull();
+  const out: Record<string, string> = {};
+  for (const [, name, value] of match![1]!.matchAll(/([\w:-]+)="([^"]*)"/g)) {
+    out[name!] = value!;
+  }
+  return out;
+}
+
+function countOf(tag: string, svg: string): number {
+  return svg.split(`<${tag}`).length - 1;
+}
+
+const PNG_BASE64 = "iVBORw0KGgo=";
+
+describe("notificationAvatarDiscHex", () => {
+  test("mixes the accent into white", () => {
+    expect(notificationAvatarDiscHex("#E9642F")).toBe("#FCE9E2");
+    expect(notificationAvatarDiscHex("#E9642F")).toBe(
+      mixIntoWhite("#E9642F", NOTIFICATION_AVATAR_ACCENT_MIX),
+    );
+  });
+
+  test("is case insensitive and always returns uppercase #RRGGBB", () => {
+    expect(notificationAvatarDiscHex("#e9642f")).toBe("#FCE9E2");
+  });
+
+  test("keeps white white and lifts black to near white", () => {
+    expect(notificationAvatarDiscHex("#FFFFFF")).toBe("#FFFFFF");
+    expect(notificationAvatarDiscHex("#000000")).toBe(
+      mixIntoWhite("#000000", NOTIFICATION_AVATAR_ACCENT_MIX),
+    );
+  });
+
+  test.each([
+    ["null", null],
+    ["short form", "#abc"],
+    ["no hash", "e9642f"],
+    ["garbage", "not a colour"],
+    ["empty", ""],
+  ])("falls back to the neutral disc for %s", (_label, value) => {
+    expect(notificationAvatarDiscHex(value as string | null)).toBe(
+      NOTIFICATION_AVATAR_FALLBACK_DISC_HEX,
+    );
+  });
+});
+
+describe("notificationAvatarSvg", () => {
+  test("draws one disc and one inset avatar at the default size", () => {
+    const svg = notificationAvatarSvg({
+      innerPngBase64: PNG_BASE64,
+      accentHex: "#E9642F",
+    });
+
+    expect(countOf("svg", svg)).toBe(1);
+    expect(countOf("circle", svg)).toBe(1);
+    expect(countOf("image", svg)).toBe(1);
+
+    expect(svg.startsWith("<svg ")).toBe(true);
+    expect(svg).toContain(`width="256" height="256"`);
+    expect(svg).toContain(`viewBox="0 0 256 256"`);
+
+    const circle = attributes("circle", svg);
+    expect(circle).toMatchObject({ cx: "128", cy: "128", r: "128" });
+    expect(circle.fill).toBe("#FCE9E2");
+
+    const inset = NOTIFICATION_AVATAR_SIZE * NOTIFICATION_AVATAR_INSET;
+    const inner = NOTIFICATION_AVATAR_SIZE - 2 * inset;
+    const image = attributes("image", svg);
+    expect(Number(image.x)).toBeCloseTo(inset, 3);
+    expect(Number(image.y)).toBeCloseTo(inset, 3);
+    expect(Number(image.width)).toBeCloseTo(inner, 3);
+    expect(Number(image.height)).toBeCloseTo(inner, 3);
+    expect(image.href).toBe(`data:image/png;base64,${PNG_BASE64}`);
+    expect(image["xlink:href"]).toBe(image.href);
+  });
+
+  test("scales the geometry to a custom size", () => {
+    const svg = notificationAvatarSvg({
+      innerPngBase64: PNG_BASE64,
+      accentHex: "#E9642F",
+      size: 100,
+    });
+
+    expect(svg).toContain(`width="100" height="100"`);
+    expect(attributes("circle", svg)).toMatchObject({
+      cx: "50",
+      cy: "50",
+      r: "50",
+    });
+    expect(attributes("image", svg)).toMatchObject({
+      x: "11",
+      y: "11",
+      width: "78",
+      height: "78",
+    });
+  });
+
+  test("paints the fallback disc when there is no accent", () => {
+    const svg = notificationAvatarSvg({
+      innerPngBase64: PNG_BASE64,
+      accentHex: null,
+    });
+    expect(attributes("circle", svg).fill).toBe(
+      NOTIFICATION_AVATAR_FALLBACK_DISC_HEX,
+    );
+  });
+});

--- a/packages/avatar-manifest/src/notification-avatar.ts
+++ b/packages/avatar-manifest/src/notification-avatar.ts
@@ -1,0 +1,80 @@
+/**
+ * The notification avatar: the assistant's avatar centered on an opaque disc
+ * tinted by its accent, the icon a native notification shows as the sender.
+ *
+ * Every platform draws the same picture with a different rasterizer (resvg in
+ * the daemon, a canvas in the desktop renderer), so the geometry and the disc
+ * colour live here once. Pure arithmetic and string building, no decoder and
+ * no node builtins, so a browser can call it too.
+ */
+
+import { isAvatarAccentHex } from "./accent.js";
+
+/** Output edge in pixels: large enough for an iOS notification thumbnail. */
+export const NOTIFICATION_AVATAR_SIZE = 256;
+
+/** Free disc on each side, as a fraction of the edge; the avatar gets the rest. */
+export const NOTIFICATION_AVATAR_INSET = 0.11;
+
+/** The disc when the assistant has no accent. */
+export const NOTIFICATION_AVATAR_FALLBACK_DISC_HEX = "#ECEFEA";
+
+/** How much of the accent survives the mix into white. */
+export const NOTIFICATION_AVATAR_ACCENT_MIX = 0.14;
+
+/**
+ * The disc fill for an accent: the accent mixed into white, so the avatar reads
+ * against it at notification size. Uppercase `#RRGGBB`; the neutral fallback
+ * when there is no accent or the value is not a hex.
+ */
+export function notificationAvatarDiscHex(accentHex: string | null): string {
+  if (!isAvatarAccentHex(accentHex)) {
+    return NOTIFICATION_AVATAR_FALLBACK_DISC_HEX;
+  }
+  const rgb = parseInt(accentHex.slice(1), 16);
+  const mixed = (shift: number) => {
+    const channel = (rgb >> shift) & 0xff;
+    return Math.round(255 + (channel - 255) * NOTIFICATION_AVATAR_ACCENT_MIX)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${mixed(16)}${mixed(8)}${mixed(0)}`.toUpperCase();
+}
+
+export interface NotificationAvatarSvgOptions {
+  /** The avatar raster to draw inside the disc, base64 PNG with no data prefix. */
+  innerPngBase64: string;
+  accentHex: string | null;
+  size?: number;
+}
+
+/** Trims the float noise a fractional inset leaves in the coordinates. */
+function px(value: number): string {
+  return String(Number(value.toFixed(3)));
+}
+
+/**
+ * The notification avatar as an SVG document: a filled disc with the avatar
+ * drawn inset into it.
+ *
+ * The `<image href="data:...">` shape is the one `downscaleRaster()` in
+ * `assistant/src/platform/sync-avatar.ts` already feeds resvg, so the daemon's
+ * rasterizer is known to render it.
+ */
+export function notificationAvatarSvg({
+  innerPngBase64,
+  accentHex,
+  size = NOTIFICATION_AVATAR_SIZE,
+}: NotificationAvatarSvgOptions): string {
+  const offset = size * NOTIFICATION_AVATAR_INSET;
+  const inner = size - 2 * offset;
+  const radius = size / 2;
+  const href = `data:image/png;base64,${innerPngBase64}`;
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+    `width="${px(size)}" height="${px(size)}" viewBox="0 0 ${px(size)} ${px(size)}">` +
+    `<circle cx="${px(radius)}" cy="${px(radius)}" r="${px(radius)}" fill="${notificationAvatarDiscHex(accentHex)}"/>` +
+    `<image x="${px(offset)}" y="${px(offset)}" width="${px(inner)}" height="${px(inner)}" ` +
+    `href="${href}" xlink:href="${href}"/></svg>`
+  );
+}


### PR DESCRIPTION
## Summary
- Add `notification-avatar.ts`: the geometry and disc colour every platform draws the notification icon with, as pure arithmetic and string building with no node builtins.
- `notificationAvatarDiscHex()` mixes the avatar accent 14% into white (neutral `#ECEFEA` with no accent); `notificationAvatarSvg()` emits the disc plus the avatar inset 11% per side, in the `<image href="data:...">` shape resvg already renders in `sync-avatar.ts`.
- Export it as `@vellumai/avatar-manifest/notification-avatar` beside `./accent`, with tests for the mix, the fallbacks, and the geometry at the default and a custom size.

Part of plan: avatar-notification-icon.md (PR 1 of 11)