### PR TITLE
Add the Notification Service Extension target and Communication Notifications entitlement

### DIFF
--- a/.github/workflows/ci-main-native-drift.yaml
+++ b/.github/workflows/ci-main-native-drift.yaml
@@ -24,6 +24,11 @@ on:
       # The xcconfigs name the icon bundle each environment builds against,
       # and the desktop shells keep their own per-environment icon manifests.
       - 'clients/ios/App/App/Config/**'
+      # The Communication Notifications guard pins the app entitlements and
+      # Info.plist to each other.
+      - 'clients/ios/App/App/App.entitlements'
+      - 'clients/ios/App/App/App-Dev.entitlements'
+      - 'clients/ios/App/App/Info.plist'
       - 'clients/macos/build-resources/icons/**'
       - 'clients/linux/build-resources/icons/**'
       # Linux converts its ground at build time, and the drift guard runs that

--- a/.github/workflows/pr-native-drift.yaml
+++ b/.github/workflows/pr-native-drift.yaml
@@ -23,6 +23,11 @@ on:
       # The xcconfigs name the icon bundle each environment builds against,
       # and the desktop shells keep their own per-environment icon manifests.
       - 'clients/ios/App/App/Config/**'
+      # The Communication Notifications guard pins the app entitlements and
+      # Info.plist to each other.
+      - 'clients/ios/App/App/App.entitlements'
+      - 'clients/ios/App/App/App-Dev.entitlements'
+      - 'clients/ios/App/App/Info.plist'
       - 'clients/macos/build-resources/icons/**'
       - 'clients/linux/build-resources/icons/**'
       # Linux converts its ground at build time, and the drift guard runs that

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -45,12 +45,13 @@ jobs:
           fi
           echo "Building iOS $ENVIRONMENT release, version $VERSION"
 
-      # Every environment resolves three bundle IDs and three provisioning
-      # profiles: the app's, the VoiceActivity extension, and the Share
-      # extension. The profile names must match character for character both
-      # the Apple Developer portal and the `PROVISIONING_PROFILE_SPECIFIER_Manual`
-      # values in `clients/ios/App/App/Config/*.xcconfig`. See "Signing: three
-      # profiles per environment" in `clients/ios/README.md`.
+      # Every environment resolves four bundle IDs and four provisioning
+      # profiles: the app's, the VoiceActivity extension, the Share extension,
+      # and the NotificationService extension. The profile names must match
+      # character for character both the Apple Developer portal and the
+      # `PROVISIONING_PROFILE_SPECIFIER_Manual` values in
+      # `clients/ios/App/App/Config/*.xcconfig`. See "Signing: four profiles per
+      # environment" in `clients/ios/README.md`.
       - name: Resolve environment config
         id: config
         env:
@@ -68,6 +69,9 @@ jobs:
               echo "share_bundle_id=ai.vocify-inc.vellum-assistant-ios.Share" >> "$GITHUB_OUTPUT"
               echo "share_profile_key=IOS_PROVISIONING_PROFILE_SHARE" >> "$GITHUB_OUTPUT"
               echo "share_profile_name=Vellum Assistant iOS Share Distribution" >> "$GITHUB_OUTPUT"
+              echo "nse_bundle_id=ai.vocify-inc.vellum-assistant-ios.NotificationService" >> "$GITHUB_OUTPUT"
+              echo "nse_profile_key=IOS_PROVISIONING_PROFILE_NSE" >> "$GITHUB_OUTPUT"
+              echo "nse_profile_name=Vellum Assistant iOS NotificationService Distribution" >> "$GITHUB_OUTPUT"
               echo "apple_app_id_key=APPLE_APP_ID_PROD" >> "$GITHUB_OUTPUT"
               echo "vellum_env=production" >> "$GITHUB_OUTPUT"
               echo "testflight_internal=false" >> "$GITHUB_OUTPUT"
@@ -83,6 +87,9 @@ jobs:
               echo "share_bundle_id=ai.vocify-inc.vellum-assistant-ios.staging.Share" >> "$GITHUB_OUTPUT"
               echo "share_profile_key=IOS_PROVISIONING_PROFILE_SHARE_STAGING" >> "$GITHUB_OUTPUT"
               echo "share_profile_name=Vellum Assistant iOS Staging Share Distribution" >> "$GITHUB_OUTPUT"
+              echo "nse_bundle_id=ai.vocify-inc.vellum-assistant-ios.staging.NotificationService" >> "$GITHUB_OUTPUT"
+              echo "nse_profile_key=IOS_PROVISIONING_PROFILE_NSE_STAGING" >> "$GITHUB_OUTPUT"
+              echo "nse_profile_name=Vellum Assistant iOS Staging NotificationService Distribution" >> "$GITHUB_OUTPUT"
               echo "apple_app_id_key=APPLE_APP_ID_STAGING" >> "$GITHUB_OUTPUT"
               echo "vellum_env=staging" >> "$GITHUB_OUTPUT"
               echo "testflight_internal=true" >> "$GITHUB_OUTPUT"
@@ -98,6 +105,9 @@ jobs:
               echo "share_bundle_id=ai.vocify-inc.vellum-assistant-ios.dev.Share" >> "$GITHUB_OUTPUT"
               echo "share_profile_key=IOS_PROVISIONING_PROFILE_SHARE_DEV" >> "$GITHUB_OUTPUT"
               echo "share_profile_name=Vellum Assistant iOS Dev Share Distribution" >> "$GITHUB_OUTPUT"
+              echo "nse_bundle_id=ai.vocify-inc.vellum-assistant-ios.dev.NotificationService" >> "$GITHUB_OUTPUT"
+              echo "nse_profile_key=IOS_PROVISIONING_PROFILE_NSE_DEV" >> "$GITHUB_OUTPUT"
+              echo "nse_profile_name=Vellum Assistant iOS Dev NotificationService Distribution" >> "$GITHUB_OUTPUT"
               echo "apple_app_id_key=APPLE_APP_ID_DEV" >> "$GITHUB_OUTPUT"
               echo "vellum_env=dev" >> "$GITHUB_OUTPUT"
               echo "testflight_internal=true" >> "$GITHUB_OUTPUT"
@@ -183,6 +193,9 @@ jobs:
           IOS_PROVISIONING_PROFILE_SHARE: ${{ secrets.IOS_PROVISIONING_PROFILE_SHARE }}
           IOS_PROVISIONING_PROFILE_SHARE_STAGING: ${{ secrets.IOS_PROVISIONING_PROFILE_SHARE_STAGING }}
           IOS_PROVISIONING_PROFILE_SHARE_DEV: ${{ secrets.IOS_PROVISIONING_PROFILE_SHARE_DEV }}
+          IOS_PROVISIONING_PROFILE_NSE: ${{ secrets.IOS_PROVISIONING_PROFILE_NSE }}
+          IOS_PROVISIONING_PROFILE_NSE_STAGING: ${{ secrets.IOS_PROVISIONING_PROFILE_NSE_STAGING }}
+          IOS_PROVISIONING_PROFILE_NSE_DEV: ${{ secrets.IOS_PROVISIONING_PROFILE_NSE_DEV }}
         run: |
           PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$PROFILE_DIR"
@@ -233,6 +246,14 @@ jobs:
             echo "::warning::Provisioning profile secret $SHARE_PROFILE_KEY is empty, so the Share extension profile was not installed and is omitted from ExportOptions.plist. THIS RELEASE WILL STILL FAIL: every app target embeds the extension, so 'xcodebuild archive' stops at signing with \"No profile for team ... matching '${{ steps.config.outputs.share_profile_name }}' found ... (in target 'Share ...')\". No iOS release of any environment can be produced until the portal setup lands. Fix: follow 'Manual Apple Developer portal setup' in clients/ios/README.md to create the App ID and profile, then add $SHARE_PROFILE_KEY."
           fi
 
+          NSE_PROFILE_KEY="${{ steps.config.outputs.nse_profile_key }}"
+          if install_profile "$NSE_PROFILE_KEY" ios_distribution_nse.mobileprovision; then
+            echo "nse_profile_installed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "nse_profile_installed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Provisioning profile secret $NSE_PROFILE_KEY is empty, so the NotificationService extension profile was not installed and is omitted from ExportOptions.plist. THIS RELEASE WILL STILL FAIL: every app target embeds the extension, so 'xcodebuild archive' stops at signing with \"No profile for team ... matching '${{ steps.config.outputs.nse_profile_name }}' found ... (in target 'NotificationService ...')\". No iOS release of any environment can be produced until the portal setup lands. Fix: follow 'Manual Apple Developer portal setup' in clients/ios/README.md to create the App ID and profile, then add $NSE_PROFILE_KEY."
+          fi
+
       - name: Set version
         id: version
         env:
@@ -265,6 +286,9 @@ jobs:
           SHARE_BUNDLE_ID: ${{ steps.config.outputs.share_bundle_id }}
           SHARE_PROFILE_NAME: ${{ steps.config.outputs.share_profile_name }}
           SHARE_PROFILE_INSTALLED: ${{ steps.profiles.outputs.share_profile_installed }}
+          NSE_BUNDLE_ID: ${{ steps.config.outputs.nse_bundle_id }}
+          NSE_PROFILE_NAME: ${{ steps.config.outputs.nse_profile_name }}
+          NSE_PROFILE_INSTALLED: ${{ steps.profiles.outputs.nse_profile_installed }}
           TESTFLIGHT_INTERNAL: ${{ steps.config.outputs.testflight_internal }}
         run: |
           EXT_ENTRY=""
@@ -276,6 +300,11 @@ jobs:
           if [ "$SHARE_PROFILE_INSTALLED" = "true" ]; then
             SHARE_ENTRY="<key>$SHARE_BUNDLE_ID</key>
                   <string>$SHARE_PROFILE_NAME</string>"
+          fi
+          NSE_ENTRY=""
+          if [ "$NSE_PROFILE_INSTALLED" = "true" ]; then
+            NSE_ENTRY="<key>$NSE_BUNDLE_ID</key>
+                  <string>$NSE_PROFILE_NAME</string>"
           fi
 
           INTERNAL_ENTRY=""
@@ -300,6 +329,7 @@ jobs:
                   <string>$PROFILE_NAME</string>
                   $EXT_ENTRY
                   $SHARE_ENTRY
+                  $NSE_ENTRY
               </dict>
               $INTERNAL_ENTRY
           </dict>
@@ -308,10 +338,11 @@ jobs:
 
       # PROVISIONING_PROFILE_SPECIFIER is deliberately NOT passed here. An
       # xcodebuild CLI override applies to every target in the archive, so a
-      # single specifier would push the app profile onto the embedded
-      # VoiceActivity or Share appex, which it does not cover. The per-target mapping
-      # lives in `clients/ios/App/App/Config/*.xcconfig` instead, next to the
-      # per-target bundle IDs it has to agree with. Those xcconfigs key the
+      # single specifier would push the app profile onto an embedded
+      # VoiceActivity, Share or NotificationService appex, which it does not
+      # cover. The per-target mapping lives in
+      # `clients/ios/App/App/Config/*.xcconfig` instead, next to the per-target
+      # bundle IDs it has to agree with. Those xcconfigs key the
       # specifier off CODE_SIGN_STYLE, so the `CODE_SIGN_STYLE=Manual`
       # override below is what activates it — local Xcode builds stay on
       # automatic signing and pick up no specifier at all.

--- a/clients/ios/App/App/App-Dev.entitlements
+++ b/clients/ios/App/App/App-Dev.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>applinks:$(ASSOCIATED_DOMAIN)</string>
 	</array>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_ID)</string>

--- a/clients/ios/App/App/App.entitlements
+++ b/clients/ios/App/App/App.entitlements
@@ -8,6 +8,8 @@
 	<array>
 		<string>applinks:$(ASSOCIATED_DOMAIN)</string>
 	</array>
+	<key>com.apple.developer.usernotifications.communication</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_ID)</string>

--- a/clients/ios/App/App/Config/NotificationService-Base.xcconfig
+++ b/clients/ios/App/App/Config/NotificationService-Base.xcconfig
@@ -1,0 +1,50 @@
+// NotificationService-Base.xcconfig - shared build settings for the three
+// Notification Service Extension targets. Per-target xcconfigs #include this
+// file, then override the values that differ: above all the bundle ID, which
+// iOS requires to be prefixed by its containing app's. That prefix rule is why
+// there are three of these appexes rather than one shared bundle.
+//
+// This deliberately does NOT #include Base.xcconfig. That file points
+// CODE_SIGN_ENTITLEMENTS, INFOPLIST_FILE and ASSOCIATED_DOMAIN at the app's own
+// values, which are wrong or actively harmful on an appex. Keep
+// DEVELOPMENT_TEAM, SWIFT_VERSION, TARGETED_DEVICE_FAMILY and
+// IPHONEOS_DEPLOYMENT_TARGET in sync with Base.xcconfig, Extension-Base.xcconfig
+// and Share-Base.xcconfig.
+//
+// APP_GROUP_ID and BUNDLE_DISPLAY_NAME are restated verbatim from the matching
+// App*.xcconfig by each per-environment file. A container is shared only
+// between bundles naming the identical group. There is no BUNDLE_URL_SCHEME:
+// this appex builds no deep links, and tap routing stays with the containing
+// app.
+//
+// The entitlements file is the same App Group-only file the VoiceActivity and
+// Share extensions use. Push stays off: the system hands this extension an
+// already-delivered payload, so it registers for nothing itself. The
+// Communication Notifications entitlement that makes the rewrite legal belongs
+// to the containing app, not here.
+//
+// MARKETING_VERSION and CURRENT_PROJECT_VERSION are local-build placeholders,
+// for the same reason as in Base.xcconfig: release builds inject them as
+// xcodebuild CLI overrides at archive time. Empty values make the app
+// uninstallable outright, since iOS rejects an embedded appex whose
+// CFBundleVersion is missing.
+MARKETING_VERSION = 0.0.0
+CURRENT_PROJECT_VERSION = 1
+
+CODE_SIGN_ENTITLEMENTS = App/Extension.entitlements
+CODE_SIGN_STYLE = Automatic
+DEVELOPMENT_TEAM = 7FZDXZR8P5
+INFOPLIST_FILE = NotificationService/Info.plist
+IPHONEOS_DEPLOYMENT_TARGET = 17.0
+
+// Manual-signing provisioning profile, resolved per target. Each
+// per-environment xcconfig sets PROVISIONING_PROFILE_SPECIFIER_Manual to the
+// profile for its environment: the appex has its own bundle ID, so the app's
+// profile does not cover it. Keying off CODE_SIGN_STYLE leaves local Xcode
+// builds on automatic signing with no specifier at all.
+PROVISIONING_PROFILE_SPECIFIER = $(PROVISIONING_PROFILE_SPECIFIER_$(CODE_SIGN_STYLE))
+
+APPLICATION_EXTENSION_API_ONLY = YES
+SKIP_INSTALL = YES
+SWIFT_VERSION = 5.0
+TARGETED_DEVICE_FAMILY = 1,2

--- a/clients/ios/App/App/Config/NotificationService-Dev.xcconfig
+++ b/clients/ios/App/App/Config/NotificationService-Dev.xcconfig
@@ -1,0 +1,12 @@
+// NotificationService-Dev.xcconfig - dev Notification Service Extension
+// overrides. The bundle ID must stay prefixed by App-Dev.xcconfig's, and the App
+// Group must match that app's value exactly.
+
+#include "NotificationService-Base.xcconfig"
+
+APP_GROUP_ID = group.ai.vocify-inc.vellum-assistant-ios.dev
+BUNDLE_DISPLAY_NAME = Vellum Dev
+PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev.NotificationService
+
+// Exact portal profile name; must equal release-ios.yaml's `nse_profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS Dev NotificationService Distribution

--- a/clients/ios/App/App/Config/NotificationService-Staging.xcconfig
+++ b/clients/ios/App/App/Config/NotificationService-Staging.xcconfig
@@ -1,0 +1,12 @@
+// NotificationService-Staging.xcconfig - staging Notification Service Extension
+// overrides. The bundle ID must stay prefixed by App-Staging.xcconfig's, and the
+// App Group must match that app's value exactly.
+
+#include "NotificationService-Base.xcconfig"
+
+APP_GROUP_ID = group.ai.vocify-inc.vellum-assistant-ios.staging
+BUNDLE_DISPLAY_NAME = Vellum Staging
+PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging.NotificationService
+
+// Exact portal profile name; must equal release-ios.yaml's `nse_profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS Staging NotificationService Distribution

--- a/clients/ios/App/App/Config/NotificationService.xcconfig
+++ b/clients/ios/App/App/Config/NotificationService.xcconfig
@@ -1,0 +1,12 @@
+// NotificationService.xcconfig - production Notification Service Extension
+// overrides. The bundle ID must stay prefixed by App.xcconfig's, and the App
+// Group must match App.xcconfig's character for character.
+
+#include "NotificationService-Base.xcconfig"
+
+APP_GROUP_ID = group.ai.vocify-inc.vellum-assistant-ios
+BUNDLE_DISPLAY_NAME = Vellum
+PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.NotificationService
+
+// Exact portal profile name; must equal release-ios.yaml's `nse_profile_name`.
+PROVISIONING_PROFILE_SPECIFIER_Manual = Vellum Assistant iOS NotificationService Distribution

--- a/clients/ios/App/App/Info.plist
+++ b/clients/ios/App/App/Info.plist
@@ -71,6 +71,13 @@
 	<true/>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<!-- Required alongside the com.apple.developer.usernotifications.communication
+	     entitlement: App Store validation rejects the upload with ITMS-90894
+	     when the entitlement is present and this key does not list the intent. -->
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>INSendMessageIntent</string>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/clients/ios/App/NotificationService/Info.plist
+++ b/clients/ios/App/NotificationService/Info.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<!-- Required on an appex: App Store Connect rejects the whole upload
+	     ("Missing Info.plist value ... CFBundleDisplayName") when an extension
+	     omits it, and the failure lands at the altool step long after the
+	     archive has built and signed. Distinct from CFBundleName below, which
+	     XcodeGen derives from the target name. -->
+	<key>CFBundleDisplayName</key>
+	<string>$(BUNDLE_DISPLAY_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<!-- Declares that this extension rewrites notifications into
+			     Communication Notifications via INSendMessageIntent. -->
+			<key>IntentsSupported</key>
+			<array>
+				<string>INSendMessageIntent</string>
+			</array>
+		</dict>
+	</dict>
+	<!-- The App Group this appex shares with its containing app, so code here
+	     can open the shared container. The entitlement grants access but is not
+	     readable from Swift, so the identifier travels as this plain string,
+	     populated from the same $(APP_GROUP_ID) variable that fills the
+	     entitlement. -->
+	<key>VellumAppGroupId</key>
+	<string>$(APP_GROUP_ID)</string>
+</dict>
+</plist>

--- a/clients/ios/App/NotificationService/NotificationService.swift
+++ b/clients/ios/App/NotificationService/NotificationService.swift
@@ -4,10 +4,9 @@ import UserNotifications
 /// push carrying `mutable-content: 1` before the notification is shown.
 ///
 /// This is a passthrough: the content is delivered exactly as it arrived, so a
-/// build carrying the extension renders today's notifications unchanged. The
-/// handler and content are held anyway because the async rewrite that lands
-/// next needs them, and because ``serviceExtensionTimeWillExpire()`` has
-/// nothing else to deliver from.
+/// build carrying the extension renders notifications unchanged. The handler
+/// and content are retained so ``serviceExtensionTimeWillExpire()`` always has
+/// something to deliver.
 final class NotificationService: UNNotificationServiceExtension {
     private var contentHandler: ((UNNotificationContent) -> Void)?
     private var bestAttemptContent: UNNotificationContent?

--- a/clients/ios/App/NotificationService/NotificationService.swift
+++ b/clients/ios/App/NotificationService/NotificationService.swift
@@ -1,0 +1,31 @@
+import UserNotifications
+
+/// Entry point for the Notification Service Extension, which iOS runs for every
+/// push carrying `mutable-content: 1` before the notification is shown.
+///
+/// This is a passthrough: the content is delivered exactly as it arrived, so a
+/// build carrying the extension renders today's notifications unchanged. The
+/// handler and content are held anyway because the async rewrite that lands
+/// next needs them, and because ``serviceExtensionTimeWillExpire()`` has
+/// nothing else to deliver from.
+final class NotificationService: UNNotificationServiceExtension {
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttemptContent: UNNotificationContent?
+
+    override func didReceive(
+        _ request: UNNotificationRequest,
+        withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+    ) {
+        self.contentHandler = contentHandler
+        bestAttemptContent = request.content
+        contentHandler(request.content)
+    }
+
+    /// Called when the extension runs out of its budget. Delivering the best
+    /// attempt so far is the only alternative to the system dropping the
+    /// modification silently.
+    override func serviceExtensionTimeWillExpire() {
+        guard let contentHandler, let bestAttemptContent else { return }
+        contentHandler(bestAttemptContent)
+    }
+}

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -160,6 +160,30 @@ targetTemplates:
     # targets, so the three app schemes are the only ones worth having.
     preBuildScripts: *projectSpecFreshnessGuard
 
+  # Notification Service Extension. iOS runs it for every push carrying
+  # `mutable-content: 1`. One per environment for the same prefix rule as
+  # VoiceActivity. From `App/Shared` it compiles only `AppGroupID.swift`, so it
+  # can resolve the container it shares with its host app; the App Intents and
+  # ActivityKit files there belong to VoiceActivity.
+  NotificationServiceEnvironment:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: NotificationService
+        excludes:
+          - "Info.plist"
+      - path: App/Shared
+        includes:
+          - AppGroupID.swift
+    settings:
+      configs:
+        Debug:
+          OTHER_SWIFT_FLAGS: '$(inherited) "-DDEBUG"'
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG NOTIFICATION_SERVICE_EXTENSION
+        Release:
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: NOTIFICATION_SERVICE_EXTENSION
+    preBuildScripts: *projectSpecFreshnessGuard
+
   # Share Sheet extension. One per environment for the same prefix rule as
   # VoiceActivity. Compiles only the Shared files it needs: App Intents and
   # ActivityKit in that folder belong to VoiceActivity, and compiling them
@@ -200,6 +224,8 @@ targets:
         embed: true
       - target: Share
         embed: true
+      - target: NotificationService
+        embed: true
 
   "App Staging":
     templates: [AppEnvironment]
@@ -213,6 +239,8 @@ targets:
         embed: true
       - target: "Share Staging"
         embed: true
+      - target: "NotificationService Staging"
+        embed: true
 
   "App Dev":
     templates: [AppEnvironment]
@@ -225,6 +253,8 @@ targets:
       - target: "VoiceActivity Dev"
         embed: true
       - target: "Share Dev"
+        embed: true
+      - target: "NotificationService Dev"
         embed: true
 
   VoiceActivity:
@@ -262,6 +292,24 @@ targets:
     configFiles:
       Debug: App/Config/Share-Dev.xcconfig
       Release: App/Config/Share-Dev.xcconfig
+
+  NotificationService:
+    templates: [NotificationServiceEnvironment]
+    configFiles:
+      Debug: App/Config/NotificationService.xcconfig
+      Release: App/Config/NotificationService.xcconfig
+
+  "NotificationService Staging":
+    templates: [NotificationServiceEnvironment]
+    configFiles:
+      Debug: App/Config/NotificationService-Staging.xcconfig
+      Release: App/Config/NotificationService-Staging.xcconfig
+
+  "NotificationService Dev":
+    templates: [NotificationServiceEnvironment]
+    configFiles:
+      Debug: App/Config/NotificationService-Dev.xcconfig
+      Release: App/Config/NotificationService-Dev.xcconfig
 
   # Logic-only unit tests for the framework-free helpers under `App/`.
   # Sources are listed file by file rather than as the whole `App`

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -283,13 +283,14 @@ experience works. Do not enable it.
 The Xcode project has three _app_ targets — one per environment. Each has its own
 bundle ID, display name, and icon colour so they can be installed side by
 side on the same device. Each also embeds its own `VoiceActivity` widget
-extension (`<app bundle id>.VoiceActivity`) and `Share` extension
-(`<app bundle id>.Share`). With the host-less `AppTests` logic-test
-bundle, `xcodegen generate` produces ten targets and four schemes in
-total; of those, the three app schemes are the ones worth building,
-since the extensions build as embedded dependencies. See
+extension (`<app bundle id>.VoiceActivity`), `Share` extension
+(`<app bundle id>.Share`), and `NotificationService` extension
+(`<app bundle id>.NotificationService`). With the host-less `AppTests`
+logic-test bundle, `xcodegen generate` produces thirteen targets and four
+schemes in total; of those, the three app schemes are the ones worth
+building, since the extensions build as embedded dependencies. See
 [`docs/NATIVE_VOICE.md`](docs/NATIVE_VOICE.md) for the widget extension
-and [Signing: three profiles per environment](#signing-three-profiles-per-environment)
+and [Signing: four profiles per environment](#signing-four-profiles-per-environment)
 for what the extra App IDs cost at release time.
 
 | Target | Bundle ID | Display Name | Icon | Server |
@@ -668,22 +669,24 @@ workflow called from the release pipelines — it intentionally has no
 extracted into their own reusable workflow because it's the only iOS
 workflow.
 
-### Signing: three profiles per environment
+### Signing: four profiles per environment
 
-Each app target embeds a `VoiceActivity` widget extension and a `Share`
-extension, each whose bundle ID is prefixed by its host app's
-(`<app bundle id>.VoiceActivity`, `<app bundle id>.Share`). Apple treats
+Each app target embeds a `VoiceActivity` widget extension, a `Share`
+extension, and a `NotificationService` extension, each whose bundle ID is
+prefixed by its host app's (`<app bundle id>.VoiceActivity`,
+`<app bundle id>.Share`, `<app bundle id>.NotificationService`). Apple treats
 each appex as its own App ID with its own provisioning profile, so
-**every environment signs with three profiles, not one**: the app's and
+**every environment signs with four profiles, not one**: the app's and
 one per embedded extension.
 
 That has three consequences in the pipeline:
 
-- The **install step** writes all three profiles into
+- The **install step** writes all four profiles into
   `~/Library/MobileDevice/Provisioning Profiles/` under distinct
   filenames (`ios_distribution.mobileprovision`,
-  `ios_distribution_ext.mobileprovision`, and
-  `ios_distribution_share.mobileprovision`). Writing two to one name
+  `ios_distribution_ext.mobileprovision`,
+  `ios_distribution_share.mobileprovision`, and
+  `ios_distribution_nse.mobileprovision`). Writing two to one name
   silently clobbers the first.
 - **`ExportOptions.plist`** carries a `provisioningProfiles` entry for
   each bundle ID. `xcodebuild -exportArchive` fails when an embedded
@@ -692,7 +695,8 @@ That has three consequences in the pipeline:
   override.** A CLI override applies to every target in the archive,
   which would push the app profile onto the appex it does not cover.
   Instead each target's specifier lives in its own xcconfig
-  (`App/App/Config/App*.xcconfig` and `Extension*.xcconfig`), next to the
+  (`App/App/Config/App*.xcconfig`, `Extension*.xcconfig`,
+  `Share*.xcconfig`, and `NotificationService*.xcconfig`), next to the
   `PRODUCT_BUNDLE_IDENTIFIER` it has to agree with. Those files set
   `PROVISIONING_PROFILE_SPECIFIER_Manual` and resolve
   `PROVISIONING_PROFILE_SPECIFIER =
@@ -703,10 +707,28 @@ That has three consequences in the pipeline:
   machines.
 
 Profile names are therefore written down in three places that must agree
-character for character: the Apple Developer portal, the xcconfig, and
-the `profile_name` / `ext_profile_name` / `share_profile_name` outputs of
-the `config` step in `release-ios.yaml`. A mismatch fails the build with
-an unhelpful message.
+character for character: the Apple Developer portal, the xcconfig, and the
+`profile_name` / `ext_profile_name` / `share_profile_name` /
+`nse_profile_name` outputs of the `config` step in `release-ios.yaml`. A
+mismatch fails the build with an unhelpful message.
+
+#### The NotificationService extension also changes the app's own App ID
+
+The other two appexes need only their own App IDs. This one also makes the
+containing app claim a restricted entitlement,
+`com.apple.developer.usernotifications.communication`, which is what lets
+`UNNotificationContent.updating(from:)` rewrite a push into a Communication
+Notification. That capability has to be enabled on the three **main app**
+App IDs, and a capability added to an App ID does not reach profiles already
+issued against it, so the three main app distribution profiles must be
+reissued and their `IOS_PROVISIONING_PROFILE*` secrets replaced. Skipping
+that leaves the app signing against a profile that does not grant the
+entitlement, and the manual-signing archive fails on the app itself even
+once every extension row is complete.
+
+The appex's own entitlements file stays App Group-only, the same file the
+other two extensions use: the extension reads cached avatars out of the
+shared container and needs nothing more.
 
 ### Manual Apple Developer portal setup
 
@@ -742,18 +764,29 @@ build of the affected environment fails while signing or exporting.
 | production | `ai.vocify-inc.vellum-assistant-ios.Share` | `Vellum Assistant iOS Share Distribution` | `IOS_PROVISIONING_PROFILE_SHARE` |
 | staging | `ai.vocify-inc.vellum-assistant-ios.staging.Share` | `Vellum Assistant iOS Staging Share Distribution` | `IOS_PROVISIONING_PROFILE_SHARE_STAGING` |
 | dev | `ai.vocify-inc.vellum-assistant-ios.dev.Share` | `Vellum Assistant iOS Dev Share Distribution` | `IOS_PROVISIONING_PROFILE_SHARE_DEV` |
+| production | `ai.vocify-inc.vellum-assistant-ios.NotificationService` | `Vellum Assistant iOS NotificationService Distribution` | `IOS_PROVISIONING_PROFILE_NSE` |
+| staging | `ai.vocify-inc.vellum-assistant-ios.staging.NotificationService` | `Vellum Assistant iOS Staging NotificationService Distribution` | `IOS_PROVISIONING_PROFILE_NSE_STAGING` |
+| dev | `ai.vocify-inc.vellum-assistant-ios.dev.NotificationService` | `Vellum Assistant iOS Dev NotificationService Distribution` | `IOS_PROVISIONING_PROFILE_NSE_DEV` |
 
 The containing app App IDs already exist, and each one already carries
-the App Group from the VoiceActivity row. A new Share App ID still
-needs that same group assigned. A capability added to an App ID does
-not reach profiles already issued against it, so a first-time Share
-row also issues the Share distribution profile:
+the App Group from the VoiceActivity row. A new Share or
+NotificationService App ID still needs that same group assigned. A
+capability added to an App ID does not reach profiles already issued
+against it, so a first-time extension row also issues that extension's
+distribution profile:
 
 | Environment | App bundle ID | Profile name (exact) | GitHub secret |
 |-------------|--------------|----------------------|---------------|
 | production | `ai.vocify-inc.vellum-assistant-ios` | `Vellum Assistant iOS Distribution` | `IOS_PROVISIONING_PROFILE` |
 | staging | `ai.vocify-inc.vellum-assistant-ios.staging` | `Vellum Assistant iOS Staging Distribution` | `IOS_PROVISIONING_PROFILE_STAGING` |
 | dev | `ai.vocify-inc.vellum-assistant-ios.dev` | `Vellum Assistant iOS Dev Distribution` | `IOS_PROVISIONING_PROFILE_DEV` |
+
+For the NotificationService rows only, step 2 below also enables
+**Communication Notifications** on the containing app's App ID, and step 4
+is what carries that capability into the app's profile. Both are required:
+the app entitlements file now declares
+`com.apple.developer.usernotifications.communication`, and a build
+declaring an entitlement its profile does not grant fails to sign.
 
 Repeat these steps once per row (start with **dev** — it is the only
 track that releases hourly, so it is the fastest way to prove the setup):
@@ -777,7 +810,9 @@ track that releases hourly, so it is the fastest way to prove the setup):
    **Identifiers** → the app bundle ID from the second table →
    **App Groups** → tick it, **Edit**, and assign the same group as
    step 1 → **Save**. A container is shared only between bundles naming
-   the identical group, so both bundle IDs carry the same one.
+   the identical group, so both bundle IDs carry the same one. On a
+   NotificationService row, also tick **Communication Notifications** on
+   this same App ID (not on the extension's) before saving.
 3. **Create the extension's distribution profile.** **Profiles** → **+**
    → **Distribution → App Store Connect** → pick the App ID from step 1 →
    pick the Apple Distribution certificate that matches the
@@ -837,6 +872,7 @@ All iOS signing secrets are stored as GitHub Actions secrets:
 - `IOS_PROVISIONING_PROFILE_STAGING` / `_DEV` — Per-environment profiles
 - `IOS_PROVISIONING_PROFILE_EXT` / `_EXT_STAGING` / `_EXT_DEV` — Per-environment profiles for the embedded `VoiceActivity` widget extension. See [Manual Apple Developer portal setup](#manual-apple-developer-portal-setup).
 - `IOS_PROVISIONING_PROFILE_SHARE` / `_SHARE_STAGING` / `_SHARE_DEV` — Per-environment profiles for the embedded Share Sheet extension. Same portal setup as VoiceActivity (App Group only; no push).
+- `IOS_PROVISIONING_PROFILE_NSE` / `_NSE_STAGING` / `_NSE_DEV`: per-environment profiles for the embedded Notification Service Extension. Same portal setup as Share (App Group only), plus Communication Notifications on the containing app's App ID and reissued `IOS_PROVISIONING_PROFILE*` secrets. See [Manual Apple Developer portal setup](#manual-apple-developer-portal-setup).
 - `APPLE_APP_ID_PROD` / `_STAGING` / `_DEV` — Numeric App Store Connect app IDs (e.g. `123456789`), passed as `--apple-id` to [`xcrun altool --upload-package`](https://keith.github.io/xcode-man-pages/altool.7.html). Each environment has its own ASC app record with its own ID.
 - `SLACK_WEBHOOK_URL` — Slack incoming webhook for `#build-alerts` notifications
 

--- a/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
+++ b/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { readSetting } from "./xcconfig-fixtures";
+
+const APP_DIR = join(import.meta.dir, "../../App/App");
+
+const PAIRS = [
+  { app: "App.xcconfig", nse: "NotificationService.xcconfig" },
+  { app: "App-Staging.xcconfig", nse: "NotificationService-Staging.xcconfig" },
+  { app: "App-Dev.xcconfig", nse: "NotificationService-Dev.xcconfig" },
+] as const;
+
+describe("NotificationService xcconfigs stay prefixed by their host app", () => {
+  for (const { app, nse } of PAIRS) {
+    test(`${nse} bundle id and App Group match ${app}`, () => {
+      const appId = readSetting(app, "PRODUCT_BUNDLE_IDENTIFIER");
+      expect(readSetting(nse, "PRODUCT_BUNDLE_IDENTIFIER")).toBe(
+        `${appId}.NotificationService`,
+      );
+      expect(readSetting(nse, "APP_GROUP_ID")).toBe(
+        readSetting(app, "APP_GROUP_ID"),
+      );
+    });
+  }
+});
+
+describe("Communication Notifications is declared on both sides", () => {
+  // App and App Staging sign against App.entitlements, App Dev against
+  // App-Dev.entitlements, so the pair covers all three app targets. Without the
+  // entitlement `UNNotificationContent.updating(from:)` silently returns the
+  // unmodified content.
+  for (const file of ["App.entitlements", "App-Dev.entitlements"]) {
+    test(`${file} carries the communication entitlement`, () => {
+      expect(readFileSync(join(APP_DIR, file), "utf8")).toContain(
+        "<key>com.apple.developer.usernotifications.communication</key>",
+      );
+    });
+  }
+
+  // App Store validation rejects the upload with ITMS-90894 when the
+  // entitlement is present and NSUserActivityTypes omits the intent.
+  test("the app Info.plist lists INSendMessageIntent", () => {
+    const plist = readFileSync(join(APP_DIR, "Info.plist"), "utf8");
+    expect(plist).toContain("<key>NSUserActivityTypes</key>");
+    expect(plist).toContain("<string>INSendMessageIntent</string>");
+  });
+});

--- a/clients/ios/scripts/__tests__/share-bundle-ids.test.ts
+++ b/clients/ios/scripts/__tests__/share-bundle-ids.test.ts
@@ -1,17 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
-const CONFIG_DIR = join(import.meta.dir, "../../App/App/Config");
-
-function readSetting(xcconfig: string, key: string): string {
-  const contents = readFileSync(join(CONFIG_DIR, xcconfig), "utf8");
-  const line = contents
-    .split("\n")
-    .find((entry) => entry.startsWith(`${key} =`));
-  expect(line).toBeDefined();
-  return line!.slice(key.length + 3).trim();
-}
+import { readSetting } from "./xcconfig-fixtures";
 
 const PAIRS = [
   { app: "App.xcconfig", share: "Share.xcconfig" },

--- a/clients/ios/scripts/__tests__/xcconfig-fixtures.ts
+++ b/clients/ios/scripts/__tests__/xcconfig-fixtures.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared reader for the per-target xcconfigs the bundle-id guards pin against.
+ *
+ * Every appex restates its host app's `PRODUCT_BUNDLE_IDENTIFIER` and
+ * `APP_GROUP_ID`, so each extension gets a guard that reads both sides the same
+ * way. The reader lives here rather than once per guard.
+ */
+import { expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CONFIG_DIR = join(import.meta.dir, "../../App/App/Config");
+
+export function readSetting(xcconfig: string, key: string): string {
+  const contents = readFileSync(join(CONFIG_DIR, xcconfig), "utf8");
+  const line = contents
+    .split("\n")
+    .find((entry) => entry.startsWith(`${key} =`));
+  expect(line).toBeDefined();
+  return line!.slice(key.length + 3).trim();
+}


### PR DESCRIPTION
## Summary
- Adds three `NotificationService` app-extension targets (one per environment, bundle ID prefixed by its host app) with their own xcconfigs, Info.plist, and a passthrough `UNNotificationServiceExtension`. Behaviour lands in the next PR; this one proves the target builds, embeds, and signs.
- Declares `com.apple.developer.usernotifications.communication` on both app entitlements files and `NSUserActivityTypes = [INSendMessageIntent]` in the app Info.plist (App Store validation rejects the entitlement without it, ITMS-90894).
- Extends `release-ios.yaml` with the fourth profile per environment (`IOS_PROVISIONING_PROFILE_NSE[_STAGING|_DEV]`), mirroring the Share extension handling, and adds a drift guard pinning the extension bundle IDs and App Groups to their host app's.

Verified locally: `xcodegen generate` produces thirteen targets and four schemes; the unsigned `App Dev` build succeeds with `NotificationService Dev.appex` embedded and its Info.plist resolving to `ai.vocify-inc.vellum-assistant-ios.dev.NotificationService`; `bun test scripts/__tests__/` green (110 tests).

## Ops prerequisite before the feature branch merges
- Register the three NotificationService App IDs and distribution profiles, enable Communication Notifications on the three main App IDs and reissue their profiles, add the IOS_PROVISIONING_PROFILE_NSE secrets (see README).

Part of plan: avatar-notification-icon.md (PR 5 of 11)