### PR TITLE
fix(web): avoid false failure banners during upgrades and restarts

### DIFF
--- a/clients/web/src/assistant/use-operational-transition.ts
+++ b/clients/web/src/assistant/use-operational-transition.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+
+import type { AssistantOperationalStatus } from "./operational-status";
+
+type TransitionState = "restarting" | "upgrading_assistant_version";
+
+interface RecentTransition {
+  assistantId: string;
+  state: TransitionState;
+}
+
+function transitionState(state: string | undefined): TransitionState | null {
+  switch (state) {
+    case "restarting":
+    case "restart":
+      return "restarting";
+    case "upgrading_assistant_version":
+    case "upgrade_assistant_version":
+      return "upgrading_assistant_version";
+    default:
+      return null;
+  }
+}
+
+/** Keep a known restart or upgrade visible through a bounded health gap. */
+export function useOperationalTransition(
+  assistantId: string | null,
+  status: AssistantOperationalStatus | null | undefined,
+  isError: boolean,
+): TransitionState | null {
+  const [recent, setRecent] = useState<RecentTransition | null>(null);
+  const [expired, setExpired] = useState<RecentTransition | null>(null);
+  const failed =
+    status?.detail_state === "failed" ||
+    status?.active_operation?.phase === "failed";
+  const healthGap =
+    isError ||
+    status?.state === "crash_loop" ||
+    status?.state === "unreachable";
+  const reportedTransition = transitionState(status?.state);
+  const markerTransition = transitionState(status?.active_operation?.operation);
+
+  const knownTransition =
+    reportedTransition ?? (healthGap ? markerTransition : null);
+
+  useEffect(() => {
+    if (!assistantId || failed || (!healthGap && !knownTransition)) {
+      setRecent(null);
+    } else if (!isError && knownTransition) {
+      setRecent((previous) =>
+        previous?.assistantId === assistantId &&
+        previous.state === knownTransition
+          ? previous
+          : { assistantId, state: knownTransition },
+      );
+    } else {
+      setRecent((previous) =>
+        previous?.assistantId === assistantId ? previous : null,
+      );
+    }
+  }, [assistantId, failed, healthGap, isError, knownTransition]);
+
+  const candidate = failed
+    ? null
+    : (reportedTransition ??
+      markerTransition ??
+      (recent?.assistantId === assistantId ? recent.state : null));
+  const graceExpired =
+    expired?.assistantId === assistantId && expired?.state === candidate;
+
+  useEffect(() => {
+    if (!healthGap) {
+      setExpired(null);
+      return;
+    }
+    if (!assistantId || !candidate || graceExpired) {
+      return;
+    }
+    // One deadline across failed polls and alternating health errors.
+    const timeout = setTimeout(() => {
+      setExpired({ assistantId, state: candidate });
+    }, 60_000);
+    return () => clearTimeout(timeout);
+  }, [assistantId, candidate, graceExpired, healthGap]);
+
+  return assistantId && healthGap && !graceExpired ? candidate : null;
+}

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -4,6 +4,7 @@ import {
   beforeEach,
   describe,
   expect,
+  jest,
   mock,
   test,
 } from "bun:test";
@@ -51,6 +52,7 @@ let operationalStatusQueryMock: {
     | {
         state: string;
         detail_state?: string;
+        active_operation?: { operation: string; phase: string };
         detail?: { reason?: string | null; message?: string | null };
       }
     | null
@@ -620,50 +622,166 @@ describe("StatusBanner", () => {
     expect(screen.queryByText("Assistant is unreachable")).toBeNull();
   });
 
-  test("shows restarting banner instead of fatal error when a restart briefly reads as crash_loop", async () => {
-    // GIVEN the operational status is restarting
-    operationalStatusQueryMock = {
-      data: { state: "restarting" },
-      isError: false,
-    };
+  describe.each([
+    ["restarting", "restart", "Assistant is restarting"],
+    [
+      "upgrading_assistant_version",
+      "upgrade_assistant_version",
+      "Assistant is upgrading",
+    ],
+  ])("%s transition", (state, operation, title) => {
+    test.each(["crash_loop", "unreachable"])(
+      "keeps the operation visible through %s",
+      (gap) => {
+        operationalStatusQueryMock = {
+          data: { state: "active" },
+          isError: false,
+        };
+        const { rerender } = render(<StatusBanner />);
+        operationalStatusQueryMock.data = { state };
+        rerender(<StatusBanner />);
+        operationalStatusQueryMock.data = { state: gap };
+        rerender(<StatusBanner />);
 
-    const { rerender } = render(<StatusBanner />);
+        expect(screen.getByText(title)).toBeTruthy();
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(screen.queryByText("Go to Doctor")).toBeNull();
+        expect(screen.queryByText("Assistant is sleeping")).toBeNull();
+      },
+    );
 
-    // WHEN the pod bounce is briefly classified as a crash loop
-    operationalStatusQueryMock = {
-      data: { state: "crash_loop" },
-      isError: false,
-    };
-    rerender(<StatusBanner />);
-
-    // THEN the banner keeps showing "restarting" instead of the fatal error
-    await waitFor(() => {
-      expect(screen.getByText("Assistant is restarting")).toBeTruthy();
+    test("uses an active operation on the first poll and remembers it after the marker clears", () => {
+      operationalStatusQueryMock = {
+        data: {
+          state: "crash_loop",
+          active_operation: { operation, phase: "waiting_for_ready" },
+        },
+        isError: false,
+      };
+      const { rerender } = render(<StatusBanner />);
+      expect(screen.getByText(title)).toBeTruthy();
+      operationalStatusQueryMock.data = { state: "unreachable" };
+      rerender(<StatusBanner />);
+      expect(screen.getByText(title)).toBeTruthy();
+      expect(screen.queryByRole("alert")).toBeNull();
     });
-    expect(screen.queryByText("Assistant fatal error")).toBeNull();
-  });
 
-  test("shows fatal error when crash_loop follows a failed restart", async () => {
-    // GIVEN the restart has terminally failed
-    operationalStatusQueryMock = {
-      data: { state: "restarting", detail_state: "failed" },
-      isError: false,
-    };
+    test("retains the operation through a failed status refetch", () => {
+      operationalStatusQueryMock = { data: { state }, isError: false };
+      const { rerender } = render(<StatusBanner />);
+      operationalStatusQueryMock.isError = true;
+      rerender(<StatusBanner />);
+      expect(screen.getByText(title)).toBeTruthy();
+      expect(screen.queryByText("Assistant status is unavailable")).toBeNull();
+    });
 
-    const { rerender } = render(<StatusBanner />);
+    test("does not extend the grace window when health errors alternate or polls fail", () => {
+      jest.useFakeTimers();
+      try {
+        operationalStatusQueryMock = { data: { state }, isError: false };
+        const { rerender } = render(<StatusBanner />);
+        operationalStatusQueryMock.data = { state: "crash_loop" };
+        rerender(<StatusBanner />);
+        act(() => jest.advanceTimersByTime(30_000));
+        operationalStatusQueryMock.isError = true;
+        rerender(<StatusBanner />);
+        act(() => jest.advanceTimersByTime(15_000));
+        operationalStatusQueryMock = {
+          data: { state: "unreachable" },
+          isError: false,
+        };
+        rerender(<StatusBanner />);
+        act(() => jest.advanceTimersByTime(14_999));
+        expect(screen.getByText(title)).toBeTruthy();
+        act(() => jest.advanceTimersByTime(1));
+        expect(screen.getByText("Assistant is unreachable")).toBeTruthy();
+        expect(screen.getByText("Go to Doctor")).toBeTruthy();
+      } finally {
+        cleanup();
+        jest.useRealTimers();
+      }
+    });
 
-    // WHEN the assistant subsequently reports a crash loop
-    operationalStatusQueryMock = {
-      data: { state: "crash_loop" },
-      isError: false,
-    };
-    rerender(<StatusBanner />);
+    test.each([false, true])(
+      "bounds errors even with a cached operation (query failure: %s)",
+      (isError) => {
+        jest.useFakeTimers();
+        try {
+          operationalStatusQueryMock = {
+            data: isError
+              ? { state }
+              : {
+                  state: "crash_loop",
+                  active_operation: { operation, phase: "waiting_for_ready" },
+                },
+            isError,
+          };
+          const { rerender } = render(<StatusBanner />);
+          expect(screen.getByText(title)).toBeTruthy();
+          act(() => jest.advanceTimersByTime(60_000));
+          rerender(<StatusBanner />);
+          expect(
+            screen.getByText(
+              isError
+                ? "Assistant status is unavailable"
+                : "Assistant fatal error",
+            ),
+          ).toBeTruthy();
+          expect(screen.queryByText(title)).toBeNull();
+        } finally {
+          cleanup();
+          jest.useRealTimers();
+        }
+      },
+    );
 
-    // THEN the fatal error is not suppressed
-    await waitFor(() => {
+    test("surfaces a failed operation immediately and disarms its grace window", () => {
+      operationalStatusQueryMock = { data: { state }, isError: false };
+      const { rerender } = render(<StatusBanner />);
+      operationalStatusQueryMock.data = { state, detail_state: "failed" };
+      rerender(<StatusBanner />);
+      expect(screen.getByRole("alert")).toBeTruthy();
+      expect(screen.queryByText(title)).toBeNull();
+      operationalStatusQueryMock.data = { state: "crash_loop" };
+      rerender(<StatusBanner />);
       expect(screen.getByText("Assistant fatal error")).toBeTruthy();
     });
-    expect(screen.queryByText("Assistant is restarting")).toBeNull();
+
+    test("does not suppress a crash with a failed operation marker", () => {
+      operationalStatusQueryMock = { data: { state }, isError: false };
+      const { rerender } = render(<StatusBanner />);
+      operationalStatusQueryMock.data = {
+        state: "crash_loop",
+        active_operation: { operation, phase: "failed" },
+      };
+      rerender(<StatusBanner />);
+      expect(screen.getByText("Assistant fatal error")).toBeTruthy();
+    });
+
+    test.each(["active", "sleeping", "not_found", "maintenance_mode"])(
+      "clears operation history on %s",
+      (settled) => {
+        operationalStatusQueryMock = { data: { state }, isError: false };
+        const { rerender } = render(<StatusBanner />);
+        operationalStatusQueryMock.data = { state: settled };
+        rerender(<StatusBanner />);
+        operationalStatusQueryMock.data = { state: "crash_loop" };
+        rerender(<StatusBanner />);
+        expect(screen.getByText("Assistant fatal error")).toBeTruthy();
+      },
+    );
+
+    test("does not carry operation history across assistant switches", () => {
+      operationalStatusQueryMock = { data: { state }, isError: false };
+      const { rerender } = render(<StatusBanner />);
+      activeAssistantIdMock = "assistant-456";
+      operationalStatusQueryMock.data = { state: "crash_loop" };
+      rerender(<StatusBanner />);
+      expect(screen.getByText("Assistant fatal error")).toBeTruthy();
+      activeAssistantIdMock = "assistant-123";
+      rerender(<StatusBanner />);
+      expect(screen.getByText("Assistant fatal error")).toBeTruthy();
+    });
   });
 
   test("shows waking instead of unreachable within the resume grace window", async () => {
@@ -827,7 +945,9 @@ describe("StatusBanner", () => {
       expect(html).toContain('data-tone="neutral"');
       expect(html).toContain("bg-[var(--surface-active)]");
       expect(html).toContain("items-center");
-      expect(html).toContain("[&amp;_[data-slot=button]]:text-body-small-default");
+      expect(html).toContain(
+        "[&amp;_[data-slot=button]]:text-body-small-default",
+      );
       expect(html).not.toContain("[&amp;_[data-slot=button]]:uppercase");
       expect(html).not.toContain(
         "[&amp;_[data-slot=button]]:hover:bg-[color-mix(in_srgb,var(--status-banner-action-color)_12%,transparent)]",
@@ -875,9 +995,7 @@ describe("StatusBanner", () => {
 
       const { container } = render(<StatusBanner />);
 
-      expect(
-        screen.getByText("Your assistant can't be reached"),
-      ).toBeTruthy();
+      expect(screen.getByText("Your assistant can't be reached")).toBeTruthy();
       expect(
         screen.getByText(
           "The connection to the paired assistant's host is down. Check the host machine and its tunnel.",
@@ -904,9 +1022,7 @@ describe("StatusBanner", () => {
 
       const { container } = render(<StatusBanner />);
 
-      expect(
-        screen.getByText("Your assistant can't be reached"),
-      ).toBeTruthy();
+      expect(screen.getByText("Your assistant can't be reached")).toBeTruthy();
       expect(container.innerHTML).toContain("lucide-cloud-off");
       expect(container.innerHTML).toContain('data-tone="neutral"');
       expect(screen.queryByText("Your assistant is asleep")).toBeNull();
@@ -929,9 +1045,7 @@ describe("StatusBanner", () => {
 
       render(<StatusBanner />);
 
-      expect(
-        screen.getByText("Your assistant can't be reached"),
-      ).toBeTruthy();
+      expect(screen.getByText("Your assistant can't be reached")).toBeTruthy();
       expect(screen.queryByText("Your assistant runs locally")).toBeNull();
       expect(screen.queryByRole("button", { name: "Wake up" })).toBeNull();
     });
@@ -971,9 +1085,7 @@ describe("StatusBanner", () => {
       localHealthMock = "unreachable";
       rerender(<StatusBanner />);
 
-      expect(
-        screen.getByText("Your assistant can't be reached"),
-      ).toBeTruthy();
+      expect(screen.getByText("Your assistant can't be reached")).toBeTruthy();
       expect(screen.queryByText("Your assistant is waking up")).toBeNull();
       expect(screen.queryByRole("button", { name: "Wake up" })).toBeNull();
     });

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -33,6 +33,7 @@ import {
   type AssistantOperationalStatus,
   useAssistantOperationalStatus,
 } from "@/assistant/operational-status";
+import { useOperationalTransition } from "@/assistant/use-operational-transition";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { assistantsMaintenanceModeExitCreate } from "@/generated/api/sdk.gen";
@@ -602,7 +603,9 @@ function useAssistantBannerConfig(): BannerConfig | null {
     } else if (
       operationalStatus?.state === "active" ||
       operationalStatus?.state === "crash_loop" ||
-      operationalStatus?.state === "not_found"
+      operationalStatus?.state === "not_found" ||
+      operationalStatus?.state === "restarting" ||
+      operationalStatus?.state === "upgrading_assistant_version"
     ) {
       setWasRecentlySleeping(false);
     }
@@ -630,7 +633,9 @@ function useAssistantBannerConfig(): BannerConfig | null {
     } else if (
       operationalStatus?.state === "sleeping" ||
       operationalStatus?.state === "crash_loop" ||
-      operationalStatus?.state === "not_found"
+      operationalStatus?.state === "not_found" ||
+      operationalStatus?.state === "restarting" ||
+      operationalStatus?.state === "upgrading_assistant_version"
     ) {
       setWasRecentlyActive(false);
     }
@@ -654,45 +659,12 @@ function useAssistantBannerConfig(): BannerConfig | null {
   // the preceding reading.
   const isResumeGraceActive = useResumeGrace();
 
-  // Suppress the brief "crash_loop" flash during a restart. The pod bounce
-  // bumps the container restart counter, which the platform can briefly
-  // classify as a crash loop before the assistant settles back to active.
-  // Keyed by assistant id so a polling-target switch can't carry the
-  // suppression over to a different assistant's genuine crash loop.
-  const [recentlyRestartingAssistantId, setRecentlyRestartingAssistantId] =
-    useState<string | null>(null);
-  useEffect(() => {
-    if (!assistantId) {
-      return;
-    }
-    if (operationalStatus?.state === "restarting") {
-      // A failed restart disarms the suppression so a follow-up
-      // crash_loop surfaces immediately instead of reading as a restart.
-      setRecentlyRestartingAssistantId(
-        operationalStatus.detail_state === "failed" ? null : assistantId,
-      );
-    } else if (
-      operationalStatus?.state === "active" ||
-      operationalStatus?.state === "sleeping" ||
-      operationalStatus?.state === "not_found"
-    ) {
-      setRecentlyRestartingAssistantId(null);
-    }
-  }, [assistantId, operationalStatus?.state, operationalStatus?.detail_state]);
-  const wasRecentlyRestarting =
-    recentlyRestartingAssistantId !== null &&
-    recentlyRestartingAssistantId === assistantId;
+  const operationalTransition = useOperationalTransition(
+    assistantId,
+    operationalStatus,
+    operationalStatusIsError,
+  );
 
-  // Auto-clear after 60s so a genuine crash loop surfaces the fatal error.
-  useEffect(() => {
-    if (!wasRecentlyRestarting || operationalStatus?.state !== "crash_loop") {
-      return;
-    }
-    const timeout = setTimeout(() => {
-      setRecentlyRestartingAssistantId(null);
-    }, 60_000);
-    return () => clearTimeout(timeout);
-  }, [wasRecentlyRestarting, operationalStatus?.state]);
   // Track dismissed failed-operation banners so the user can clear
   // terminal error messages (e.g. "Assistant upgrade failed"). The
   // dismissal is keyed on the operation state so it auto-resets when
@@ -940,6 +912,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
   if (
     operationalStatusIsError &&
     !shouldUseLifecycleMaintenanceMode &&
+    !operationalTransition &&
     !isResumeGraceActive
   ) {
     return {
@@ -949,31 +922,17 @@ function useAssistantBannerConfig(): BannerConfig | null {
     };
   }
 
-  // When the status transitions from sleeping directly to unreachable, the
-  // assistant is in the final phase of waking (pod ready per k8s but the
-  // application healthz hasn't responded ok yet). Show "waking" so the user
-  // sees a smooth sleeping → waking → active progression.
-  // Conversely, when the status transitions from active directly to
-  // unreachable, the pod is shutting down for sleep. Show "sleeping" so
-  // the user sees a smooth active → sleeping progression.
-  // Similarly, a restart can briefly read as "crash_loop"; keep showing
-  // "restarting" until the grace window expires.
-  // Finally, within the resume grace window a transient "unreachable" reads
-  // as "waking" so returning to a backgrounded client shows the info/spinner
-  // treatment rather than the "unreachable" error banner.
+  // A known operation takes precedence over inferred sleep or resume states.
   const effectiveStatus =
-    operationalStatus?.state === "unreachable" &&
-    (wasRecentlySleeping || isResumeGraceActive)
-      ? { ...operationalStatus, state: "waking" as AssistantOperationalState }
-      : operationalStatus?.state === "unreachable" && wasRecentlyActive
-        ? {
-            ...operationalStatus,
-            state: "sleeping" as AssistantOperationalState,
-          }
-        : operationalStatus?.state === "crash_loop" && wasRecentlyRestarting
+    operationalStatus && operationalTransition
+      ? { ...operationalStatus, state: operationalTransition }
+      : operationalStatus?.state === "unreachable" &&
+          (wasRecentlySleeping || isResumeGraceActive)
+        ? { ...operationalStatus, state: "waking" as AssistantOperationalState }
+        : operationalStatus?.state === "unreachable" && wasRecentlyActive
           ? {
               ...operationalStatus,
-              state: "restarting" as AssistantOperationalState,
+              state: "sleeping" as AssistantOperationalState,
             }
           : operationalStatus;
 


### PR DESCRIPTION
## Summary

- Keep a known restart or upgrade visible when operational status briefly reports `crash_loop` or `unreachable`, or a status refetch fails. The existing banner only protected restart-to-crash-loop transitions.
- Read the existing `active_operation` field so opening the app mid-operation also works. The platform can return a crash-loop state alongside an active restart or upgrade marker because pod health is evaluated before operation markers.
- Share one 60-second grace deadline across changing health errors and failed polls. Explicit operation failures, settled states, and assistant switches clear the protection; persistent errors still expose the Doctor action.

## Validation

- 81 status-banner tests passed, including restart/upgrade transitions, first-poll operation markers, failed refetches, deadline expiry, explicit failures, and assistant switches.
- ESLint passed for all three changed files; `git diff --check` passed.
- Reuses existing platform response fields and existing banner copy. No API or native-client contract changes.

## Original prompt

Investigate reports that the status banner in vellum-assistant says the assistant is broken while it is actually upgrading or restarting. Fix the incorrect status handling in an isolated worktree and open a PR using the /do workflow.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->