### PR TITLE
Render a notification-ready avatar PNG in the daemon

### DIFF
--- a/assistant/src/avatar/notification-avatar.test.ts
+++ b/assistant/src/avatar/notification-avatar.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for renderNotificationAvatarPng.
+ *
+ * Rendering routes through the native @resvg/resvg-js binding, so the cases
+ * that need a real raster are gated on `isResvgAvailable()` and the suite
+ * stays deterministic on an install that skipped the optional dependency.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import sharp from "sharp";
+
+import { renderNotificationAvatarPng } from "./notification-avatar.js";
+import { renderCharacterPng } from "./png-renderer.js";
+import {
+  __resetResvgCacheForTests,
+  __setResvgCacheForTests,
+  isResvgAvailable,
+} from "./resvg-lazy.js";
+
+/** The render cases need the native binding; without it there is nothing to assert. */
+const nativeTest = test.if(isResvgAvailable());
+
+const IMAGE_FILENAME = "avatar-image.png";
+const MANIFEST_FILENAME = "avatar.json";
+const NATIVE_RENDER_TEST_TIMEOUT_MS = 15_000;
+
+const TRAITS = { bodyShape: "blob", eyeStyle: "curious", color: "green" };
+/** The palette green (#4C9B50) mixed 14% into white. */
+const GREEN_DISC = { r: 0xe6, g: 0xf1, b: 0xe7 };
+/** #E9642F mixed 14% into white. */
+const ORANGE_DISC = { r: 0xfc, g: 0xe9, b: 0xe2 };
+/** The neutral disc every accent-less avatar wears. */
+const FALLBACK_DISC = { r: 0xec, g: 0xef, b: 0xea };
+
+/** On the disc and clear of the inset avatar square, which starts at y = 28.16. */
+const DISC_SAMPLE = { x: 128, y: 8 };
+
+type Accent = { hex: string; source: string } | null;
+
+interface Pixel {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+async function pixels(png: Buffer): Promise<{
+  width: number;
+  height: number;
+  at: (x: number, y: number) => Pixel;
+}> {
+  const { data, info } = await sharp(png)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  return {
+    width: info.width,
+    height: info.height,
+    at: (x, y) => {
+      const i = (y * info.width + x) * info.channels;
+      return { r: data[i]!, g: data[i + 1]!, b: data[i + 2]!, a: data[i + 3]! };
+    },
+  };
+}
+
+describe("renderNotificationAvatarPng", () => {
+  let workspaceDir: string;
+  let avatarDir: string;
+  let prevWorkspaceDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "notification-avatar-test-"));
+    avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+    prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    __resetResvgCacheForTests();
+    if (prevWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+    }
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  const writeManifestFile = (manifest: Record<string, unknown>) => {
+    writeFileSync(join(avatarDir, MANIFEST_FILENAME), JSON.stringify(manifest));
+  };
+
+  const writeUploadManifest = (accent: Accent) => {
+    writeManifestFile({
+      kind: "image",
+      traits: null,
+      source: "upload",
+      image: { updatedAt: new Date().toISOString(), etag: "0123456789abcdef" },
+      accent,
+    });
+  };
+
+  const writeCharacter = (accent: Accent) => {
+    writeFileSync(
+      join(avatarDir, IMAGE_FILENAME),
+      renderCharacterPng(TRAITS.bodyShape, TRAITS.eyeStyle, TRAITS.color),
+    );
+    writeManifestFile({
+      kind: "character",
+      traits: TRAITS,
+      source: "builder",
+      image: null,
+      accent,
+    });
+  };
+
+  const writeUpload = async (format: "png" | "webp", accent: Accent) => {
+    const image = sharp({
+      create: {
+        width: 64,
+        height: 64,
+        channels: 4,
+        background: { r: 0x20, g: 0x60, b: 0xc0, alpha: 1 },
+      },
+    });
+    const bytes =
+      format === "webp"
+        ? await image.webp().toBuffer()
+        : await image.png().toBuffer();
+    writeFileSync(join(avatarDir, IMAGE_FILENAME), bytes);
+    writeUploadManifest(accent);
+  };
+
+  nativeTest(
+    "renders a character on its palette disc",
+    async () => {
+      writeCharacter(null);
+
+      const png = await renderNotificationAvatarPng();
+      expect(png).not.toBeNull();
+      expect(png!.subarray(0, 4)).toEqual(
+        Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      );
+      expect(png!.length).toBeLessThan(64 * 1024);
+
+      const image = await pixels(png!);
+      expect(image.width).toBe(256);
+      expect(image.height).toBe(256);
+      expect(image.at(DISC_SAMPLE.x, DISC_SAMPLE.y)).toEqual({
+        ...GREEN_DISC,
+        a: 255,
+      });
+      expect(image.at(128, 128).a).toBe(255);
+    },
+    NATIVE_RENDER_TEST_TIMEOUT_MS,
+  );
+
+  nativeTest(
+    "prefers the manifest accent over the palette colour",
+    async () => {
+      writeCharacter({ hex: "#e9642f", source: "custom" });
+
+      const image = await pixels((await renderNotificationAvatarPng())!);
+      expect(image.at(DISC_SAMPLE.x, DISC_SAMPLE.y)).toEqual({
+        ...ORANGE_DISC,
+        a: 255,
+      });
+    },
+    NATIVE_RENDER_TEST_TIMEOUT_MS,
+  );
+
+  nativeTest(
+    "renders an uploaded image on the neutral disc when it has no accent",
+    async () => {
+      await writeUpload("png", null);
+
+      const png = await renderNotificationAvatarPng();
+      expect(png).not.toBeNull();
+
+      const image = await pixels(png!);
+      expect(image.width).toBe(256);
+      expect(image.height).toBe(256);
+      expect(image.at(DISC_SAMPLE.x, DISC_SAMPLE.y)).toEqual({
+        ...FALLBACK_DISC,
+        a: 255,
+      });
+      expect(image.at(128, 128)).toEqual({ r: 0x20, g: 0x60, b: 0xc0, a: 255 });
+    },
+    NATIVE_RENDER_TEST_TIMEOUT_MS,
+  );
+
+  nativeTest(
+    "returns null for an upload resvg cannot decode",
+    async () => {
+      await writeUpload("webp", null);
+
+      expect(await renderNotificationAvatarPng()).toBeNull();
+    },
+    NATIVE_RENDER_TEST_TIMEOUT_MS,
+  );
+
+  test("returns null for kind none", async () => {
+    expect(
+      await renderNotificationAvatarPng({
+        kind: "none",
+        traits: null,
+        source: null,
+        image: null,
+        accent: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null when there is no avatar raster", async () => {
+    writeUploadManifest(null);
+
+    expect(await renderNotificationAvatarPng()).toBeNull();
+  });
+
+  nativeTest(
+    "returns null when the native rasterizer is unavailable",
+    async () => {
+      writeCharacter(null);
+      __setResvgCacheForTests({
+        available: false,
+        error: new Error("Cannot require module @resvg/resvg-js-darwin-x64"),
+      });
+
+      expect(await renderNotificationAvatarPng()).toBeNull();
+    },
+    NATIVE_RENDER_TEST_TIMEOUT_MS,
+  );
+});

--- a/assistant/src/avatar/notification-avatar.ts
+++ b/assistant/src/avatar/notification-avatar.ts
@@ -1,0 +1,85 @@
+/**
+ * The notification-ready avatar: the assistant's avatar on an opaque
+ * accent-tinted disc, the icon a native notification shows as the sender.
+ *
+ * The geometry and the disc colour come from `@vellumai/avatar-manifest` so
+ * the daemon, the desktop renderer, and every mobile client draw the same
+ * picture. This module only resolves the current avatar and rasterizes it.
+ *
+ * Best-effort throughout: a missing raster, an undecodable upload, or a
+ * missing native rasterizer yields null so callers keep whatever the platform
+ * already holds rather than blanking it.
+ */
+
+import {
+  NOTIFICATION_AVATAR_SIZE,
+  notificationAvatarSvg,
+} from "@vellumai/avatar-manifest/notification-avatar";
+
+import { detectMediaType } from "../tools/shared/filesystem/image-read.js";
+import { getLogger } from "../util/logger.js";
+import { paletteAccent } from "./avatar-accent.js";
+import { type AvatarState, readAvatarState } from "./avatar-manifest.js";
+import { ensureAvatarRaster } from "./ensure-raster.js";
+import {
+  getResvg,
+  isResvgAvailable,
+  isResvgDecodableType,
+} from "./resvg-lazy.js";
+
+const log = getLogger("notification-avatar");
+
+/**
+ * The accent the disc is tinted with. A character built before accents were
+ * persisted carries none in its manifest, so its palette colour stands in.
+ */
+function resolveAccentHex(state: AvatarState): string | null {
+  if (state.accent) {
+    return state.accent.hex;
+  }
+  if (state.kind === "character" && state.traits) {
+    return paletteAccent(state.traits.color)?.hex ?? null;
+  }
+  return null;
+}
+
+/**
+ * Renders the current avatar as a 256x256 notification PNG, or null when
+ * there is no avatar, its raster is unreadable or in a format resvg cannot
+ * decode (a WebP upload), or the native rasterizer is unavailable.
+ */
+export async function renderNotificationAvatarPng(
+  state: AvatarState = readAvatarState(),
+): Promise<Buffer | null> {
+  if (state.kind === "none" || !isResvgAvailable()) {
+    return null;
+  }
+  const bytes = await ensureAvatarRaster(state);
+  if (!bytes) {
+    return null;
+  }
+  const mediaType = detectMediaType(bytes);
+  if (!isResvgDecodableType(mediaType)) {
+    log.warn(
+      { mediaType },
+      "Avatar raster format is not decodable by resvg; skipping the notification avatar",
+    );
+    return null;
+  }
+
+  try {
+    const Resvg = getResvg();
+    const resvg = new Resvg(
+      notificationAvatarSvg({
+        innerPngBase64: bytes.toString("base64"),
+        innerMediaType: mediaType,
+        accentHex: resolveAccentHex(state),
+      }),
+      { fitTo: { mode: "width", value: NOTIFICATION_AVATAR_SIZE } },
+    );
+    return Buffer.from(resvg.render().asPng());
+  } catch (err) {
+    log.warn({ err }, "Failed to render the notification avatar");
+    return null;
+  }
+}

--- a/assistant/src/avatar/resvg-lazy.ts
+++ b/assistant/src/avatar/resvg-lazy.ts
@@ -1,8 +1,23 @@
 import type { Resvg as ResvgType } from "@resvg/resvg-js";
+import type { NotificationAvatarMediaType } from "@vellumai/avatar-manifest/notification-avatar";
 
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("resvg-lazy");
+
+/** Raster formats resvg decodes inside an `<image>` href; anything else renders blank. */
+export const RESVG_DECODABLE_TYPES: ReadonlySet<string> = new Set<string>([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+]);
+
+/** Whether a sniffed media type is one resvg can draw into an SVG. */
+export function isResvgDecodableType(
+  mediaType: string | null,
+): mediaType is NotificationAvatarMediaType {
+  return mediaType !== null && RESVG_DECODABLE_TYPES.has(mediaType);
+}
 
 type ResvgLoadResult =
   | { available: true; Resvg: typeof ResvgType }

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -23,6 +23,7 @@ import {
 
 import type { AvatarState } from "../avatar/avatar-manifest.js";
 import * as realEnsureRaster from "../avatar/ensure-raster.js";
+import * as realResvgLazy from "../avatar/resvg-lazy.js";
 
 // Captured before mock.module swaps the module so the real, fd-validated
 // read path is what the sync exercises.
@@ -63,6 +64,8 @@ mock.module("../avatar/ensure-raster.js", () => ({
 
 mock.module("../avatar/resvg-lazy.js", () => ({
   isResvgAvailable: () => mockResvgAvailable,
+  isResvgDecodableType: realResvgLazy.isResvgDecodableType,
+  RESVG_DECODABLE_TYPES: realResvgLazy.RESVG_DECODABLE_TYPES,
   getResvg: () =>
     class {
       constructor(svg: string) {

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -29,7 +29,12 @@ import {
   ensureAvatarRasterPath,
   readContainedAvatarRaster,
 } from "../avatar/ensure-raster.js";
-import { getResvg, isResvgAvailable } from "../avatar/resvg-lazy.js";
+import {
+  getResvg,
+  isResvgAvailable,
+  isResvgDecodableType,
+  RESVG_DECODABLE_TYPES,
+} from "../avatar/resvg-lazy.js";
 import { detectMediaType } from "../tools/shared/filesystem/image-read.js";
 import { getLogger } from "../util/logger.js";
 import { getProtectedDir } from "../util/platform.js";
@@ -46,12 +51,6 @@ const log = getLogger("sync-avatar");
 const MAX_AVATAR_UPLOAD_BYTES = 256 * 1024;
 const DOWNSCALE_PX = 128;
 const NONE_KEY = "none";
-/** Raster formats resvg decodes inside an `<image>`; anything else renders blank. */
-const RESVG_DECODABLE_TYPES: ReadonlySet<string> = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-]);
 /** Only bytes that sniff as a raster image are ever uploaded. */
 const UPLOADABLE_TYPES: ReadonlySet<string> = new Set([
   ...RESVG_DECODABLE_TYPES,
@@ -177,7 +176,7 @@ function downscaleRaster(bytes: Buffer): Buffer | null {
     return null;
   }
   const mediaType = detectMediaType(bytes);
-  if (mediaType === null || !RESVG_DECODABLE_TYPES.has(mediaType)) {
+  if (!isResvgDecodableType(mediaType)) {
     log.warn(
       { mediaType },
       "Avatar raster format is not decodable by resvg; skipping downscale",

--- a/packages/avatar-manifest/src/__tests__/notification-avatar.test.ts
+++ b/packages/avatar-manifest/src/__tests__/notification-avatar.test.ts
@@ -119,6 +119,18 @@ describe("notificationAvatarSvg", () => {
     });
   });
 
+  test("carries a non-PNG inner raster with its own media type", () => {
+    const svg = notificationAvatarSvg({
+      innerPngBase64: PNG_BASE64,
+      innerMediaType: "image/jpeg",
+      accentHex: "#E9642F",
+    });
+
+    const image = attributes("image", svg);
+    expect(image.href).toBe(`data:image/jpeg;base64,${PNG_BASE64}`);
+    expect(image["xlink:href"]).toBe(image.href);
+  });
+
   test("paints the fallback disc when there is no accent", () => {
     const svg = notificationAvatarSvg({
       innerPngBase64: PNG_BASE64,

--- a/packages/avatar-manifest/src/notification-avatar.ts
+++ b/packages/avatar-manifest/src/notification-avatar.ts
@@ -41,9 +41,17 @@ export function notificationAvatarDiscHex(accentHex: string | null): string {
   return `#${mixed(16)}${mixed(8)}${mixed(0)}`.toUpperCase();
 }
 
+/** Raster formats an `<image>` href carries here; what resvg and a canvas both decode. */
+export type NotificationAvatarMediaType =
+  | "image/png"
+  | "image/jpeg"
+  | "image/gif";
+
 export interface NotificationAvatarSvgOptions {
-  /** The avatar raster to draw inside the disc, base64 PNG with no data prefix. */
+  /** The avatar raster to draw inside the disc, base64 with no data prefix. */
   innerPngBase64: string;
+  /** What `innerPngBase64` holds; PNG unless an upload arrived as a JPEG or a GIF. */
+  innerMediaType?: NotificationAvatarMediaType;
   accentHex: string | null;
   size?: number;
 }
@@ -63,13 +71,14 @@ function px(value: number): string {
  */
 export function notificationAvatarSvg({
   innerPngBase64,
+  innerMediaType = "image/png",
   accentHex,
   size = NOTIFICATION_AVATAR_SIZE,
 }: NotificationAvatarSvgOptions): string {
   const offset = size * NOTIFICATION_AVATAR_INSET;
   const inner = size - 2 * offset;
   const radius = size / 2;
-  const href = `data:image/png;base64,${innerPngBase64}`;
+  const href = `data:${innerMediaType};base64,${innerPngBase64}`;
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
     `width="${px(size)}" height="${px(size)}" viewBox="0 0 ${px(size)} ${px(size)}">` +


### PR DESCRIPTION
## Summary
- Add `renderNotificationAvatarPng()` in `assistant/src/avatar/notification-avatar.ts`: resolves the current avatar raster, tints the shared disc with the manifest accent (palette colour as the fallback for characters), and rasterizes the shared SVG spec with resvg at 256x256. Returns null for `none`, a missing or unreadable raster, a format resvg cannot decode (a WebP upload), or a build without the native addon, so a caller never blanks an avatar the platform already holds.
- Extend the shared `notificationAvatarSvg()` with an optional `innerMediaType` so a JPEG or GIF upload lands in the data URL with its own media type. PR 1's exports are unchanged and default to PNG.
- Move the `RESVG_DECODABLE_TYPES` rule out of `sync-avatar.ts` into `resvg-lazy.ts` as `isResvgDecodableType()`, now that a second caller needs it.

Note for reviewers: the disc is a circle inscribed in the 256x256 box, so the square's corners are transparent by the shared spec while everything the disc covers is fully opaque. Every consumer circle-crops the icon (iOS `INImage`, Android `MessagingStyle` person, Windows `hint-crop=\"circle\"`).

Part of plan: avatar-notification-icon.md (PR 2 of 11)