### PR TITLE
Render the assistant avatar as the notification icon on iOS

### DIFF
--- a/clients/ios/App/AppTests/AvatarCacheTests.swift
+++ b/clients/ios/App/AppTests/AvatarCacheTests.swift
@@ -75,4 +75,72 @@ final class AvatarCacheTests: XCTestCase {
         XCTAssertNil(cache.data(forHash: hashes[3]))
         XCTAssertEqual(cache.data(forHash: hashes[8]), avatar(8))
     }
+
+    func testAReadRefreshesRecencySoTheNextStoreEvictsAnOlderEntry() throws {
+        let hashes = (0..<9).map { AvatarCache.sha256Hex(avatar($0)) }
+        for index in 0..<8 {
+            cache.store(avatar(index), hash: hashes[index])
+        }
+
+        // Spread the entries over a known order so eviction does not depend on
+        // how quickly the writes above landed: entry 0 is oldest, entry 7 newest.
+        for index in 0..<8 {
+            let url = try XCTUnwrap(cache.fileURL(forHash: hashes[index]))
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date(timeIntervalSince1970: TimeInterval(1_000 + index))],
+                ofItemAtPath: url.path
+            )
+        }
+
+        XCTAssertEqual(cache.data(forHash: hashes[0]), avatar(0))
+
+        cache.store(avatar(8), hash: hashes[8])
+        XCTAssertEqual(storedFileCount(), 8)
+        XCTAssertNil(cache.data(forHash: hashes[1]))
+        XCTAssertEqual(cache.data(forHash: hashes[0]), avatar(0))
+    }
+
+    func testReadsUpToTheByteCap() async throws {
+        let atCap = ByteFeed(count: 16)
+        let atCapBytes = try await AvatarCache.readAtMost(16, from: atCap.stream())
+        XCTAssertEqual(atCapBytes?.count, 16)
+        XCTAssertEqual(atCap.produced, 16)
+
+        let underCap = ByteFeed(count: 4)
+        let underCapBytes = try await AvatarCache.readAtMost(16, from: underCap.stream())
+        XCTAssertEqual(underCapBytes?.count, 4)
+    }
+
+    func testStopsReadingPastTheByteCap() async throws {
+        let feed = ByteFeed(count: 4_096)
+        let bytes = try await AvatarCache.readAtMost(16, from: feed.stream())
+        XCTAssertNil(bytes)
+        // One byte past the cap is enough to know the body is too large, so the
+        // rest of the response is never pulled into memory.
+        XCTAssertEqual(feed.produced, 17)
+    }
+}
+
+/// A byte sequence that hands out one byte at a time and counts how many it was
+/// asked for, so a test can assert that a reader stopped early.
+private final class ByteFeed: @unchecked Sendable {
+    private(set) var produced = 0
+    private var remaining: Int
+
+    init(count: Int) {
+        remaining = count
+    }
+
+    func stream() -> AsyncStream<UInt8> {
+        AsyncStream(unfolding: { self.next() })
+    }
+
+    private func next() -> UInt8? {
+        guard remaining > 0 else {
+            return nil
+        }
+        remaining -= 1
+        produced += 1
+        return 0x41
+    }
 }

--- a/clients/ios/App/AppTests/AvatarCacheTests.swift
+++ b/clients/ios/App/AppTests/AvatarCacheTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+final class AvatarCacheTests: XCTestCase {
+    private var root: URL!
+    private var cache: AvatarCache!
+
+    override func setUp() {
+        super.setUp()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AvatarCache-\(UUID().uuidString)", isDirectory: true)
+        cache = AvatarCache(rootURL: root)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: root)
+        super.tearDown()
+    }
+
+    private func avatar(_ index: Int) -> Data {
+        Data("avatar-\(index)".utf8)
+    }
+
+    private func storedFileCount() -> Int {
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return files.count
+    }
+
+    func testStoreAndReadRoundTrip() {
+        let bytes = avatar(1)
+        let hash = AvatarCache.sha256Hex(bytes)
+        cache.store(bytes, hash: hash)
+        XCTAssertEqual(cache.data(forHash: hash), bytes)
+    }
+
+    func testReadsNilForAnUncachedHash() {
+        XCTAssertNil(cache.data(forHash: AvatarCache.sha256Hex(avatar(1))))
+    }
+
+    func testRejectsBytesThatDoNotMatchTheHash() {
+        let hash = AvatarCache.sha256Hex(avatar(1))
+        cache.store(avatar(2), hash: hash)
+        XCTAssertNil(cache.data(forHash: hash))
+        XCTAssertEqual(storedFileCount(), 0)
+    }
+
+    func testRejectsHashesThatAreNotLowercaseHex() {
+        XCTAssertFalse(AvatarCache.isValidHash(String(repeating: "A", count: 64)))
+        XCTAssertFalse(AvatarCache.isValidHash(String(repeating: "a", count: 63)))
+        XCTAssertFalse(AvatarCache.isValidHash("../etc/passwd"))
+        XCTAssertTrue(AvatarCache.isValidHash(AvatarCache.sha256Hex(avatar(1))))
+        XCTAssertNil(cache.fileURL(forHash: "../etc/passwd"))
+    }
+
+    func testEvictsTheOldestEntryOnTheNinthStore() throws {
+        let hashes = (0..<9).map { AvatarCache.sha256Hex(avatar($0)) }
+        for index in 0..<8 {
+            cache.store(avatar(index), hash: hashes[index])
+        }
+        XCTAssertEqual(storedFileCount(), 8)
+
+        // Pin one entry as the oldest so the eviction order does not depend on
+        // how quickly the writes above landed.
+        let oldest = try XCTUnwrap(cache.fileURL(forHash: hashes[3]))
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date.distantPast],
+            ofItemAtPath: oldest.path
+        )
+
+        cache.store(avatar(8), hash: hashes[8])
+        XCTAssertEqual(storedFileCount(), 8)
+        XCTAssertNil(cache.data(forHash: hashes[3]))
+        XCTAssertEqual(cache.data(forHash: hashes[8]), avatar(8))
+    }
+}

--- a/clients/ios/App/AppTests/SenderPayloadTests.swift
+++ b/clients/ios/App/AppTests/SenderPayloadTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+final class SenderPayloadTests: XCTestCase {
+    private let avatarHash = String(repeating: "a", count: 64)
+
+    private func userInfo(sender: [String: Any]?, deepLink: [String: Any]? = nil) -> [AnyHashable: Any] {
+        var info: [AnyHashable: Any] = ["aps": ["alert": ["title": "Gym", "body": "Ready"]]]
+        if let sender {
+            info["sender"] = sender
+        }
+        if let deepLink {
+            info["deep_link"] = deepLink
+        }
+        return info
+    }
+
+    func testParsesACompleteSenderBlock() {
+        let parsed = SenderPayload.parse(
+            userInfo: userInfo(sender: [
+                "id": "asst-123",
+                "name": "Vellum",
+                "avatar_url": "https://storage.example.com/avatar.png",
+                "avatar_hash": avatarHash,
+            ])
+        )
+        XCTAssertEqual(
+            parsed,
+            SenderPayload(
+                id: "asst-123",
+                name: "Vellum",
+                avatarURL: URL(string: "https://storage.example.com/avatar.png"),
+                avatarHash: avatarHash
+            )
+        )
+    }
+
+    func testParsesWithoutAvatarUrl() {
+        let parsed = SenderPayload.parse(
+            userInfo: userInfo(sender: [
+                "id": "asst-123",
+                "name": "Vellum",
+                "avatar_hash": avatarHash,
+            ])
+        )
+        XCTAssertNil(parsed?.avatarURL)
+        XCTAssertEqual(parsed?.avatarHash, avatarHash)
+    }
+
+    func testReturnsNilWithoutASenderBlock() {
+        XCTAssertNil(SenderPayload.parse(userInfo: userInfo(sender: nil)))
+    }
+
+    func testReturnsNilForPartialOrEmptyFields() {
+        XCTAssertNil(
+            SenderPayload.parse(userInfo: userInfo(sender: ["id": "asst-123", "name": "Vellum"]))
+        )
+        XCTAssertNil(
+            SenderPayload.parse(
+                userInfo: userInfo(sender: ["id": "asst-123", "avatar_hash": avatarHash])
+            )
+        )
+        XCTAssertNil(
+            SenderPayload.parse(
+                userInfo: userInfo(sender: ["id": "", "name": "Vellum", "avatar_hash": avatarHash])
+            )
+        )
+        XCTAssertNil(
+            SenderPayload.parse(
+                userInfo: userInfo(sender: ["id": "asst-123", "name": "Vellum", "avatar_hash": ""])
+            )
+        )
+    }
+
+    func testConversationIdentifierPrefersTheDeepLink() {
+        XCTAssertEqual(
+            SenderPayload.conversationIdentifier(
+                userInfo: userInfo(sender: nil, deepLink: ["conversationId": "conv-xyz"]),
+                senderId: "asst-123"
+            ),
+            "conv-xyz"
+        )
+    }
+
+    func testConversationIdentifierFallsBackToTheSenderId() {
+        XCTAssertEqual(
+            SenderPayload.conversationIdentifier(userInfo: userInfo(sender: nil), senderId: "asst-123"),
+            "asst-123"
+        )
+        XCTAssertEqual(
+            SenderPayload.conversationIdentifier(
+                userInfo: userInfo(sender: nil, deepLink: ["conversationId": ""]),
+                senderId: "asst-123"
+            ),
+            "asst-123"
+        )
+        XCTAssertEqual(
+            SenderPayload.conversationIdentifier(
+                userInfo: userInfo(sender: nil, deepLink: ["other": "value"]),
+                senderId: "asst-123"
+            ),
+            "asst-123"
+        )
+    }
+}

--- a/clients/ios/App/NotificationService/AvatarCache.swift
+++ b/clients/ios/App/NotificationService/AvatarCache.swift
@@ -1,0 +1,134 @@
+import CryptoKit
+import Foundation
+
+/// Disk cache of notification avatar PNGs, keyed by the SHA-256 hex digest the
+/// push carries.
+///
+/// It lives in the App Group container so the cache survives the extension
+/// process, which iOS starts and kills per push: a second notification for the
+/// same avatar renders without touching the network. Content addressing makes
+/// invalidation implicit, so a new avatar on the assistant is a new hash and a
+/// new file.
+///
+/// Only 64-character lowercase hex hashes are accepted, which both rejects a
+/// malformed payload and keeps the hash safe to use as a filename. Bytes are
+/// hashed before they are stored, so a truncated or substituted download never
+/// reaches the notification.
+struct AvatarCache {
+    static let directoryName = "notification-avatars"
+    /// Kept small on purpose: one entry per assistant avatar the user has seen
+    /// recently, in a container shared with the app's own data.
+    static let maxEntries = 8
+    static let maxBytes = 512 * 1024
+    static let defaultTimeout: TimeInterval = 8
+
+    let rootURL: URL
+
+    /// The cache inside this bundle's App Group container, or `nil` when the
+    /// bundle declares no group and there is nowhere shared to write.
+    static func inAppGroup() -> AvatarCache? {
+        guard let group = AppGroupID.current,
+              let container = FileManager.default
+                  .containerURL(forSecurityApplicationGroupIdentifier: group)
+        else {
+            return nil
+        }
+        return AvatarCache(
+            rootURL: container
+                .appendingPathComponent("Library/Caches", isDirectory: true)
+                .appendingPathComponent(directoryName, isDirectory: true)
+        )
+    }
+
+    func data(forHash hash: String) -> Data? {
+        guard let url = fileURL(forHash: hash) else {
+            return nil
+        }
+        return try? Data(contentsOf: url)
+    }
+
+    /// Store `data` under `hash`, or do nothing when the bytes do not hash to
+    /// it. Evicts the oldest entries down to ``maxEntries``.
+    func store(_ data: Data, hash: String) {
+        guard let url = fileURL(forHash: hash), Self.sha256Hex(data) == hash else {
+            return
+        }
+        do {
+            try FileManager.default.createDirectory(
+                at: rootURL,
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+        } catch {
+            return
+        }
+        evictOldest()
+    }
+
+    /// Download the avatar at `url`, verify it against `hash`, cache it, and
+    /// return the bytes. Any failure returns `nil` and the caller delivers the
+    /// notification unchanged.
+    ///
+    /// The URL arrives in the push payload, so only `https` is followed and only
+    /// bytes that hash to `hash` are used. The whole body is read into memory,
+    /// bounded by ``maxBytes`` on the way out and by `timeout` on the way in.
+    func fetch(url: URL, hash: String, timeout: TimeInterval = defaultTimeout) async -> Data? {
+        guard Self.isValidHash(hash), url.scheme == "https" else {
+            return nil
+        }
+        let request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: timeout
+        )
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse,
+              http.statusCode == 200,
+              data.count <= Self.maxBytes,
+              Self.sha256Hex(data) == hash
+        else {
+            return nil
+        }
+        store(data, hash: hash)
+        return data
+    }
+
+    func fileURL(forHash hash: String) -> URL? {
+        guard Self.isValidHash(hash) else {
+            return nil
+        }
+        return rootURL.appendingPathComponent("\(hash).png", isDirectory: false)
+    }
+
+    static func isValidHash(_ hash: String) -> Bool {
+        hash.count == 64 && hash.allSatisfy { hexDigits.contains($0) }
+    }
+
+    static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static let hexDigits = Set("0123456789abcdef")
+
+    private func evictOldest() {
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        guard entries.count > Self.maxEntries else {
+            return
+        }
+        let oldestFirst = entries.sorted { lhs, rhs in
+            modificationDate(of: lhs) < modificationDate(of: rhs)
+        }
+        for url in oldestFirst.prefix(entries.count - Self.maxEntries) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private func modificationDate(of url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            .contentModificationDate) ?? .distantPast
+    }
+}

--- a/clients/ios/App/NotificationService/AvatarCache.swift
+++ b/clients/ios/App/NotificationService/AvatarCache.swift
@@ -40,11 +40,19 @@ struct AvatarCache {
         )
     }
 
+    /// The cached bytes for `hash`, or `nil` when nothing is stored under it.
+    ///
+    /// A hit stamps the file with the current time so eviction, which ranks by
+    /// modification date, treats a recently used avatar as recent.
     func data(forHash hash: String) -> Data? {
-        guard let url = fileURL(forHash: hash) else {
+        guard let url = fileURL(forHash: hash), let data = try? Data(contentsOf: url) else {
             return nil
         }
-        return try? Data(contentsOf: url)
+        try? FileManager.default.setAttributes(
+            [.modificationDate: Date()],
+            ofItemAtPath: url.path
+        )
+        return data
     }
 
     /// Store `data` under `hash`, or do nothing when the bytes do not hash to
@@ -70,8 +78,10 @@ struct AvatarCache {
     /// notification unchanged.
     ///
     /// The URL arrives in the push payload, so only `https` is followed and only
-    /// bytes that hash to `hash` are used. The whole body is read into memory,
-    /// bounded by ``maxBytes`` on the way out and by `timeout` on the way in.
+    /// bytes that hash to `hash` are used. The body is streamed and abandoned
+    /// the moment it goes past ``maxBytes``, which keeps an oversized or
+    /// malformed response from filling the extension's memory budget, and
+    /// `timeout` bounds how long the read may take.
     func fetch(url: URL, hash: String, timeout: TimeInterval = defaultTimeout) async -> Data? {
         guard Self.isValidHash(hash), url.scheme == "https" else {
             return nil
@@ -81,15 +91,40 @@ struct AvatarCache {
             cachePolicy: .reloadIgnoringLocalCacheData,
             timeoutInterval: timeout
         )
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
-              let http = response as? HTTPURLResponse,
+        guard let (bytes, response) = try? await URLSession.shared.bytes(for: request) else {
+            return nil
+        }
+        guard let http = response as? HTTPURLResponse,
               http.statusCode == 200,
-              data.count <= Self.maxBytes,
+              http.expectedContentLength <= Int64(Self.maxBytes)
+        else {
+            bytes.task.cancel()
+            return nil
+        }
+        guard let data = try? await Self.readAtMost(Self.maxBytes, from: bytes),
               Self.sha256Hex(data) == hash
         else {
+            bytes.task.cancel()
             return nil
         }
         store(data, hash: hash)
+        return data
+    }
+
+    /// Collect `bytes` until the sequence ends, or return `nil` as soon as more
+    /// than `limit` bytes arrive so an oversized body is never held whole.
+    static func readAtMost<Bytes: AsyncSequence>(
+        _ limit: Int,
+        from bytes: Bytes
+    ) async throws -> Data? where Bytes.Element == UInt8 {
+        var data = Data()
+        data.reserveCapacity(min(limit, 32 * 1024))
+        for try await byte in bytes {
+            if data.count >= limit {
+                return nil
+            }
+            data.append(byte)
+        }
         return data
     }
 

--- a/clients/ios/App/NotificationService/CommunicationContent.swift
+++ b/clients/ios/App/NotificationService/CommunicationContent.swift
@@ -1,0 +1,67 @@
+import Intents
+import UserNotifications
+
+/// Rewrite `content` as a Communication Notification: the assistant's avatar in
+/// a circle with the app icon badged into its corner, the assistant's name on
+/// line one, the conversation title on line two, the body unchanged.
+///
+/// iOS grants that treatment only to a notification updated from a donated
+/// `INSendMessageIntent`, which is why the intent is donated before the content
+/// is rewritten. `updating(from:)` copies the sender, image, and thread onto the
+/// content and leaves `userInfo`, `categoryIdentifier`, and the body alone, so
+/// tap routing is unaffected.
+func communicationContent(
+    from content: UNNotificationContent,
+    sender: SenderPayload,
+    avatar: Data,
+    conversationId: String
+) async throws -> UNNotificationContent {
+    // INImage(url:) reads local files only, so the bytes travel inline.
+    let image = INImage(imageData: avatar)
+    let senderPerson = INPerson(
+        personHandle: INPersonHandle(value: sender.id, type: .unknown),
+        nameComponents: nil,
+        displayName: sender.name,
+        image: image,
+        contactIdentifier: nil,
+        customIdentifier: sender.id,
+        isMe: false,
+        suggestionType: .none
+    )
+    let mePerson = INPerson(
+        personHandle: INPersonHandle(value: nil, type: .unknown),
+        nameComponents: nil,
+        displayName: nil,
+        image: nil,
+        contactIdentifier: nil,
+        customIdentifier: nil,
+        isMe: true,
+        suggestionType: .none
+    )
+
+    // A group conversation is what puts the title on line two, so a titled push
+    // becomes a two-recipient group named after the conversation. Its image has
+    // to be set explicitly or iOS composes a glyph out of the participants
+    // instead of showing the assistant.
+    let title = content.title.trimmingCharacters(in: .whitespacesAndNewlines)
+    let groupName = title.isEmpty ? nil : INSpeakableString(spokenPhrase: title)
+
+    let intent = INSendMessageIntent(
+        recipients: groupName == nil ? [mePerson] : [mePerson, senderPerson],
+        outgoingMessageType: .outgoingMessageText,
+        content: content.body,
+        speakableGroupName: groupName,
+        conversationIdentifier: conversationId,
+        serviceName: "Vellum",
+        sender: senderPerson,
+        attachments: nil
+    )
+    if groupName != nil {
+        intent.setImage(image, forParameterNamed: \.speakableGroupName)
+    }
+
+    let interaction = INInteraction(intent: intent, response: nil)
+    interaction.direction = .incoming
+    try await interaction.donate()
+    return try content.updating(from: intent)
+}

--- a/clients/ios/App/NotificationService/NotificationService.swift
+++ b/clients/ios/App/NotificationService/NotificationService.swift
@@ -1,30 +1,93 @@
 import UserNotifications
+import os
 
 /// Entry point for the Notification Service Extension, which iOS runs for every
 /// push carrying `mutable-content: 1` before the notification is shown.
 ///
-/// This is a passthrough: the content is delivered exactly as it arrived, so a
-/// build carrying the extension renders notifications unchanged. The handler
-/// and content are retained so ``serviceExtensionTimeWillExpire()`` always has
-/// something to deliver.
+/// A push whose payload carries a complete `sender` block is rewritten into a
+/// Communication Notification so the assistant's avatar is the icon. Everything
+/// else, including every push sent while the `push-avatar-sender` flag is off,
+/// is delivered exactly as it arrived.
 final class NotificationService: UNNotificationServiceExtension {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "ai.vellum.assistant",
+        category: "NotificationService"
+    )
+
+    /// Guards the one-shot handler against the rewrite and the expiry callback
+    /// racing on different threads.
+    private let lock = NSLock()
     private var contentHandler: ((UNNotificationContent) -> Void)?
-    private var bestAttemptContent: UNNotificationContent?
+    private var unchangedContent: UNNotificationContent?
 
     override func didReceive(
         _ request: UNNotificationRequest,
         withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
     ) {
+        lock.lock()
         self.contentHandler = contentHandler
-        bestAttemptContent = request.content
-        contentHandler(request.content)
+        unchangedContent = request.content
+        lock.unlock()
+
+        let userInfo = request.content.userInfo
+        guard let sender = SenderPayload.parse(userInfo: userInfo),
+              let cache = AvatarCache.inAppGroup()
+        else {
+            deliver(request.content)
+            return
+        }
+        let conversationId = SenderPayload.conversationIdentifier(
+            userInfo: userInfo,
+            senderId: sender.id
+        )
+
+        Task {
+            var avatar = cache.data(forHash: sender.avatarHash)
+            if avatar == nil, let url = sender.avatarURL {
+                avatar = await cache.fetch(url: url, hash: sender.avatarHash)
+            }
+            guard let avatar else {
+                Self.logger.info("No avatar for the push sender, delivering unchanged")
+                self.deliver(request.content)
+                return
+            }
+            do {
+                self.deliver(
+                    try await communicationContent(
+                        from: request.content,
+                        sender: sender,
+                        avatar: avatar,
+                        conversationId: conversationId
+                    )
+                )
+            } catch {
+                Self.logger.error(
+                    "Communication notification rewrite failed: \(error.localizedDescription, privacy: .public)"
+                )
+                self.deliver(request.content)
+            }
+        }
     }
 
-    /// Called when the extension runs out of its budget. Delivering the best
-    /// attempt so far is the only alternative to the system dropping the
-    /// modification silently.
+    /// Called when the extension runs out of its budget. Delivering the push as
+    /// it arrived is the only alternative to the system dropping it silently.
     override func serviceExtensionTimeWillExpire() {
-        guard let contentHandler, let bestAttemptContent else { return }
-        contentHandler(bestAttemptContent)
+        lock.lock()
+        let content = unchangedContent
+        lock.unlock()
+        if let content {
+            deliver(content)
+        }
+    }
+
+    /// Hands `content` to the system once. Later calls are dropped: iOS accepts
+    /// a single delivery per push, and the rewrite can finish just as the
+    /// expiry callback fires.
+    private func deliver(_ content: UNNotificationContent) {
+        lock.lock()
+        let handler = contentHandler
+        contentHandler = nil
+        lock.unlock()
+        handler?(content)
     }
 }

--- a/clients/ios/App/NotificationService/SenderPayload.swift
+++ b/clients/ios/App/NotificationService/SenderPayload.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// The assistant identity a push carries, read from the top-level `sender`
+/// object the platform attaches beside `aps`.
+///
+/// Shape: `{ "id", "name", "avatar_url", "avatar_hash" }`. `avatar_url` is the
+/// first field the platform drops when a payload exceeds the APNs size limit,
+/// so it is optional: the hash alone still hits a warm avatar cache. A push
+/// without a complete `sender` (feature flag off, older platform) parses to
+/// `nil` and the notification is delivered untouched.
+struct SenderPayload: Equatable {
+    let id: String
+    let name: String
+    let avatarURL: URL?
+    let avatarHash: String
+
+    static func parse(userInfo: [AnyHashable: Any]) -> SenderPayload? {
+        guard let sender = userInfo["sender"] as? [AnyHashable: Any],
+              let id = nonEmptyString(sender["id"]),
+              let name = nonEmptyString(sender["name"]),
+              let avatarHash = nonEmptyString(sender["avatar_hash"])
+        else {
+            return nil
+        }
+        return SenderPayload(
+            id: id,
+            name: name,
+            avatarURL: nonEmptyString(sender["avatar_url"]).flatMap { URL(string: $0) },
+            avatarHash: avatarHash
+        )
+    }
+
+    /// Thread the rewritten notification belongs to, read from the same
+    /// `deep_link.conversationId` a tap routes through
+    /// (`extractPushConversationId` in `clients/web/src/runtime/push-registration.ts`).
+    ///
+    /// The sender id is the fallback so notifications from one assistant still
+    /// group together when the platform dropped the deep link to fit the
+    /// payload budget.
+    static func conversationIdentifier(
+        userInfo: [AnyHashable: Any],
+        senderId: String
+    ) -> String {
+        guard let deepLink = userInfo["deep_link"] as? [AnyHashable: Any],
+              let conversationId = nonEmptyString(deepLink["conversationId"])
+        else {
+            return senderId
+        }
+        return conversationId
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let text = value as? String, !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+}

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -322,6 +322,11 @@ targets:
       - path: AppTests
       - path: App/Attribution.swift
       - path: App/NotificationCategories.swift
+      # The Foundation-only halves of the Notification Service Extension. The
+      # Intents rewrite next to them stays out: donating an interaction needs a
+      # real notification, which a host-less bundle has no way to produce.
+      - path: NotificationService/AvatarCache.swift
+      - path: NotificationService/SenderPayload.swift
       - path: App/Shared
         includes:
           - AppGroupID.swift


### PR DESCRIPTION
## Summary

- The Notification Service Extension turns a push carrying a top-level `sender` block into a Communication Notification: the assistant's avatar in a circle with the app icon badged into its corner, the assistant's name on line one, the conversation title on line two, the body unchanged. A titled push becomes a two-recipient group named after the conversation, which is what puts the title on line two, and the group image is set explicitly so iOS shows the avatar instead of a composed glyph.
- `AvatarCache` keeps up to 8 avatar PNGs in the App Group container keyed by the SHA-256 the push carries, so only the first notification for a given avatar touches the network. Downloads are https only, capped at 512 KB, bounded by an 8 second per-request timeout, and verified against the hash before they are stored or shown.
- Every other push is delivered byte for byte as it arrived: no `sender` block (the `push-avatar-sender` flag off, or an older platform), an incomplete one, no App Group, an empty cache with no `avatar_url`, or any failure in the rewrite. The expiry callback delivers the unchanged content, and delivery is one-shot so the two paths cannot race.

`SenderPayload` and `AvatarCache` are Foundation only and compile into the `AppTests` bundle, which covers payload parsing, the conversation id fallback, the cache round trip, hash rejection, and eviction.

## Validation

- `xcodegen generate`
- `xcodebuild build -scheme "App Dev" -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild test -scheme AppTests -destination "platform=iOS Simulator,name=iPhone 17"`: 34 tests, 0 failures (11 new)

## Device QA checklist

- [ ] Push arrives with the app killed, backgrounded, and foregrounded
- [ ] Cache miss then hit: the second push for the same avatar makes no network call (verify in Console)
- [ ] Changing the avatar on the daemon updates the notification icon on the next push
- [ ] An oversized payload without `avatar_url` and an empty cache falls back to today's look
- [ ] Tapping the notification opens the conversation
- [ ] Long-pressing the notification shows the assistant as the sender

Part of plan: avatar-notification-icon.md (PR 6 of 11)