### PR TITLE
Carry the assistant's name and notification avatar into desktop notifications

### DIFF
--- a/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * The gate this hook exists to hold: the notification avatar is composited and
+ * held only on Electron with `push-avatar-sender` on. Every other host, and the
+ * flag off, must leave the holder empty so the IPC payload stays what it is
+ * today, and a flag that turns off has to take back what an earlier run stored.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+const AVATAR_PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+let electronHost = true;
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => electronHost,
+}));
+
+let rasterized: Uint8Array | null = AVATAR_PNG;
+const rasterizeNotificationAvatar = mock(
+  async (_src: string, _accentHex: string | null) => rasterized,
+);
+mock.module("@/utils/avatar-raster", () => ({ rasterizeNotificationAvatar }));
+
+const { clearNotificationAvatar, getNotificationAvatar, sha256Hex } =
+  await import("@/runtime/notification-avatar");
+const { useClientFeatureFlagStore } =
+  await import("@/stores/client-feature-flag-store");
+const { useNotificationAvatarSync } =
+  await import("@/hooks/use-notification-avatar-sync");
+
+const IMAGE_URL = "blob:avatar-1";
+const ACCENT = "#E9642F";
+
+const render = (accentHex: string | null = ACCENT) =>
+  renderHook(() => useNotificationAvatarSync(IMAGE_URL, null, null, accentHex));
+
+beforeEach(() => {
+  electronHost = true;
+  rasterized = AVATAR_PNG;
+  rasterizeNotificationAvatar.mockClear();
+  clearNotificationAvatar();
+  useClientFeatureFlagStore.setState({ pushAvatarSender: true });
+});
+
+afterEach(() => {
+  cleanup();
+  clearNotificationAvatar();
+  useClientFeatureFlagStore.setState({ pushAvatarSender: false });
+});
+
+describe("useNotificationAvatarSync", () => {
+  test("holds the composited avatar and its hash on Electron with the flag on", async () => {
+    render();
+
+    await waitFor(() => {
+      expect(getNotificationAvatar()).not.toBeNull();
+    });
+    expect(rasterizeNotificationAvatar).toHaveBeenCalledWith(IMAGE_URL, ACCENT);
+    expect(getNotificationAvatar()).toEqual({
+      avatarBase64: "iVBORw==",
+      avatarHash: await sha256Hex(AVATAR_PNG),
+    });
+  });
+
+  test("does no canvas work and holds nothing off Electron", async () => {
+    electronHost = false;
+
+    render();
+
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).not.toHaveBeenCalled();
+    });
+    expect(getNotificationAvatar()).toBeNull();
+  });
+
+  test("does no canvas work and holds nothing with the flag off", async () => {
+    useClientFeatureFlagStore.setState({ pushAvatarSender: false });
+
+    render();
+
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).not.toHaveBeenCalled();
+    });
+    expect(getNotificationAvatar()).toBeNull();
+  });
+
+  test("takes back a held avatar when the flag turns off", async () => {
+    const { rerender } = render();
+    await waitFor(() => {
+      expect(getNotificationAvatar()).not.toBeNull();
+    });
+
+    act(() => {
+      useClientFeatureFlagStore.setState({ pushAvatarSender: false });
+    });
+    rerender();
+
+    await waitFor(() => {
+      expect(getNotificationAvatar()).toBeNull();
+    });
+  });
+
+  test("holds nothing for an assistant with no avatar to draw", async () => {
+    renderHook(() => useNotificationAvatarSync(null, null, null, ACCENT));
+
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).not.toHaveBeenCalled();
+    });
+    expect(getNotificationAvatar()).toBeNull();
+  });
+
+  test("holds nothing when the rasterizer gives back no bytes", async () => {
+    rasterized = null;
+
+    render();
+
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(1);
+    });
+    expect(getNotificationAvatar()).toBeNull();
+  });
+});

--- a/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
@@ -1,8 +1,8 @@
 /**
  * The gate this hook exists to hold: the notification avatar is composited and
  * held only on Electron with `push-avatar-sender` on. Every other host, and the
- * flag off, must leave the holder empty so the IPC payload stays what it is
- * today, and a flag that turns off has to take back what an earlier run stored.
+ * flag off, must leave the holder empty so the IPC payload carries no `sender`
+ * field, and a flag that turns off has to take back what an earlier run stored.
  * What is held is stamped with the assistant it was drawn for, and a
  * replacement render empties the holder before it starts drawing.
  */

--- a/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
@@ -3,6 +3,8 @@
  * held only on Electron with `push-avatar-sender` on. Every other host, and the
  * flag off, must leave the holder empty so the IPC payload stays what it is
  * today, and a flag that turns off has to take back what an earlier run stored.
+ * What is held is stamped with the assistant it was drawn for, and a
+ * replacement render empties the holder before it starts drawing.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
@@ -15,8 +17,15 @@ mock.module("@/runtime/is-electron", () => ({
 }));
 
 let rasterized: Uint8Array | null = AVATAR_PNG;
+/** Set to stall the rasterizer so the mid-render window can be observed. */
+let rasterizeGate: Promise<void> | null = null;
 const rasterizeNotificationAvatar = mock(
-  async (_src: string, _accentHex: string | null) => rasterized,
+  async (_src: string, _accentHex: string | null) => {
+    if (rasterizeGate) {
+      await rasterizeGate;
+    }
+    return rasterized;
+  },
 );
 mock.module("@/utils/avatar-raster", () => ({ rasterizeNotificationAvatar }));
 
@@ -27,15 +36,19 @@ const { useClientFeatureFlagStore } =
 const { useNotificationAvatarSync } =
   await import("@/hooks/use-notification-avatar-sync");
 
+const ASSISTANT_ID = "assistant-1";
 const IMAGE_URL = "blob:avatar-1";
 const ACCENT = "#E9642F";
 
 const render = (accentHex: string | null = ACCENT) =>
-  renderHook(() => useNotificationAvatarSync(IMAGE_URL, null, null, accentHex));
+  renderHook(() =>
+    useNotificationAvatarSync(ASSISTANT_ID, IMAGE_URL, null, null, accentHex),
+  );
 
 beforeEach(() => {
   electronHost = true;
   rasterized = AVATAR_PNG;
+  rasterizeGate = null;
   rasterizeNotificationAvatar.mockClear();
   clearNotificationAvatar();
   useClientFeatureFlagStore.setState({ pushAvatarSender: true });
@@ -48,7 +61,7 @@ afterEach(() => {
 });
 
 describe("useNotificationAvatarSync", () => {
-  test("holds the composited avatar and its hash on Electron with the flag on", async () => {
+  test("holds the composited avatar, its hash and its assistant on Electron with the flag on", async () => {
     render();
 
     await waitFor(() => {
@@ -56,6 +69,7 @@ describe("useNotificationAvatarSync", () => {
     });
     expect(rasterizeNotificationAvatar).toHaveBeenCalledWith(IMAGE_URL, ACCENT);
     expect(getNotificationAvatar()).toEqual({
+      assistantId: ASSISTANT_ID,
       avatarBase64: "iVBORw==",
       avatarHash: await sha256Hex(AVATAR_PNG),
     });
@@ -100,7 +114,20 @@ describe("useNotificationAvatarSync", () => {
   });
 
   test("holds nothing for an assistant with no avatar to draw", async () => {
-    renderHook(() => useNotificationAvatarSync(null, null, null, ACCENT));
+    renderHook(() =>
+      useNotificationAvatarSync(ASSISTANT_ID, null, null, null, ACCENT),
+    );
+
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).not.toHaveBeenCalled();
+    });
+    expect(getNotificationAvatar()).toBeNull();
+  });
+
+  test("holds nothing while there is no active assistant", async () => {
+    renderHook(() =>
+      useNotificationAvatarSync(null, IMAGE_URL, null, null, ACCENT),
+    );
 
     await waitFor(() => {
       expect(rasterizeNotificationAvatar).not.toHaveBeenCalled();
@@ -117,5 +144,29 @@ describe("useNotificationAvatarSync", () => {
       expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(1);
     });
     expect(getNotificationAvatar()).toBeNull();
+  });
+
+  test("empties the holder before drawing a replacement, then holds the new assistant's avatar", async () => {
+    const { rerender } = renderHook(
+      ({ id, url }: { id: string; url: string }) =>
+        useNotificationAvatarSync(id, url, null, null, ACCENT),
+      { initialProps: { id: ASSISTANT_ID, url: IMAGE_URL } },
+    );
+    await waitFor(() => {
+      expect(getNotificationAvatar()).not.toBeNull();
+    });
+
+    let releaseRasterize = () => {};
+    rasterizeGate = new Promise<void>((resolve) => {
+      releaseRasterize = resolve;
+    });
+    rerender({ id: "assistant-2", url: "blob:avatar-2" });
+
+    expect(getNotificationAvatar()).toBeNull();
+
+    releaseRasterize();
+    await waitFor(() => {
+      expect(getNotificationAvatar()?.assistantId).toBe("assistant-2");
+    });
   });
 });

--- a/clients/web/src/hooks/use-notification-avatar-sync.ts
+++ b/clients/web/src/hooks/use-notification-avatar-sync.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+
+import { isElectron } from "@/runtime/is-electron";
+import {
+  clearNotificationAvatar,
+  setNotificationAvatar,
+  sha256Hex,
+} from "@/runtime/notification-avatar";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { rasterizeNotificationAvatar } from "@/utils/avatar-raster";
+import { resolveAvatarRender } from "@/utils/avatar-render";
+import { NOTIFICATION_AVATAR_SIZE } from "@vellumai/avatar-manifest/notification-avatar";
+
+/**
+ * Composite the assistant's avatar onto its accent disc and hold the result for
+ * the desktop notifications that post it as the sender's icon.
+ *
+ * Shaped like `useElectronIconSync` and mounted beside it, off the same avatar
+ * query, so the notification icon can never show a different assistant than the
+ * one on screen. The canvas work is gated behind Electron and
+ * `push-avatar-sender`: no other host reads the holder, and with the flag off
+ * the IPC payload must be byte-for-byte what it is today.
+ *
+ * Clears on every outcome that is not a stored avatar. The holder outlives this
+ * effect, so a flag turned off, an assistant with no avatar, or a failed
+ * rasterization all have to take back what an earlier run put there.
+ */
+export function useNotificationAvatarSync(
+  customImageUrl: string | null,
+  components: CharacterComponents | null,
+  traits: CharacterTraits | null,
+  accentHex: string | null,
+): void {
+  const enabled = useClientFeatureFlagStore.use.pushAvatarSender();
+
+  useEffect(() => {
+    if (!isElectron() || !enabled) {
+      clearNotificationAvatar();
+      return;
+    }
+
+    const render = resolveAvatarRender(
+      customImageUrl,
+      components,
+      traits,
+      NOTIFICATION_AVATAR_SIZE,
+    );
+    if (render.kind === "none") {
+      clearNotificationAvatar();
+      return;
+    }
+
+    let cancelled = false;
+    const src = render.kind === "character" ? render.dataUri : render.url;
+    void rasterizeNotificationAvatar(src, accentHex)
+      .then(async (png) => {
+        if (cancelled) {
+          return;
+        }
+        if (!png) {
+          clearNotificationAvatar();
+          return;
+        }
+        const hash = await sha256Hex(png);
+        if (!cancelled) {
+          setNotificationAvatar(png, hash);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          clearNotificationAvatar();
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, customImageUrl, components, traits, accentHex]);
+}

--- a/clients/web/src/hooks/use-notification-avatar-sync.ts
+++ b/clients/web/src/hooks/use-notification-avatar-sync.ts
@@ -19,8 +19,8 @@ import { NOTIFICATION_AVATAR_SIZE } from "@vellumai/avatar-manifest/notification
  * Shaped like `useElectronIconSync` and mounted beside it, off the same avatar
  * query, so the notification icon can never show a different assistant than the
  * one on screen. The canvas work is gated behind Electron and
- * `push-avatar-sender`: no other host reads the holder, and with the flag off
- * the IPC payload must be byte-for-byte what it is today.
+ * `push-avatar-sender`: no other host reads the holder, and while the flag is
+ * off the holder stays empty so the IPC payload carries no `sender` field.
  *
  * Every run starts by emptying the holder, and what it stores is stamped with
  * the assistant it was drawn for. The holder outlives this effect, so a flag

--- a/clients/web/src/hooks/use-notification-avatar-sync.ts
+++ b/clients/web/src/hooks/use-notification-avatar-sync.ts
@@ -22,11 +22,15 @@ import { NOTIFICATION_AVATAR_SIZE } from "@vellumai/avatar-manifest/notification
  * `push-avatar-sender`: no other host reads the holder, and with the flag off
  * the IPC payload must be byte-for-byte what it is today.
  *
- * Clears on every outcome that is not a stored avatar. The holder outlives this
- * effect, so a flag turned off, an assistant with no avatar, or a failed
- * rasterization all have to take back what an earlier run put there.
+ * Every run starts by emptying the holder, and what it stores is stamped with
+ * the assistant it was drawn for. The holder outlives this effect, so a flag
+ * turned off, an assistant with no avatar, or a failed rasterization all have
+ * to take back what an earlier run put there; and a replacement render must not
+ * keep serving the old picture across the rasterize-and-hash gap, which is the
+ * window an assistant switch lands in.
  */
 export function useNotificationAvatarSync(
+  assistantId: string | null,
   customImageUrl: string | null,
   components: CharacterComponents | null,
   traits: CharacterTraits | null,
@@ -35,8 +39,9 @@ export function useNotificationAvatarSync(
   const enabled = useClientFeatureFlagStore.use.pushAvatarSender();
 
   useEffect(() => {
-    if (!isElectron() || !enabled) {
-      clearNotificationAvatar();
+    clearNotificationAvatar();
+
+    if (!isElectron() || !enabled || !assistantId) {
       return;
     }
 
@@ -47,7 +52,6 @@ export function useNotificationAvatarSync(
       NOTIFICATION_AVATAR_SIZE,
     );
     if (render.kind === "none") {
-      clearNotificationAvatar();
       return;
     }
 
@@ -55,16 +59,12 @@ export function useNotificationAvatarSync(
     const src = render.kind === "character" ? render.dataUri : render.url;
     void rasterizeNotificationAvatar(src, accentHex)
       .then(async (png) => {
-        if (cancelled) {
-          return;
-        }
-        if (!png) {
-          clearNotificationAvatar();
+        if (cancelled || !png) {
           return;
         }
         const hash = await sha256Hex(png);
         if (!cancelled) {
-          setNotificationAvatar(png, hash);
+          setNotificationAvatar(assistantId, png, hash);
         }
       })
       .catch(() => {
@@ -76,5 +76,5 @@ export function useNotificationAvatarSync(
     return () => {
       cancelled = true;
     };
-  }, [enabled, customImageUrl, components, traits, accentHex]);
+  }, [enabled, assistantId, customImageUrl, components, traits, accentHex]);
 }

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -222,6 +222,7 @@ export function RootLayout() {
   // The same avatar again, composited onto its accent disc, for the desktop
   // notifications that show the assistant as the sender rather than the app.
   useNotificationAvatarSync(
+    assistantId,
     avatar.customImageUrl,
     avatar.components,
     avatar.traits,

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -75,6 +75,7 @@ import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useCompanionMirror } from "@/domains/chat/hooks/use-companion-mirror";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useIslandAvatarSource } from "@/hooks/use-island-avatar-source";
+import { useNotificationAvatarSync } from "@/hooks/use-notification-avatar-sync";
 import { useElectronIdentitySync } from "@/hooks/use-electron-identity-sync";
 import { useLockfileIdentitySync } from "@/hooks/use-lockfile-identity-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
@@ -213,6 +214,14 @@ export function RootLayout() {
   // Feed the same avatar to the Electron Dock + menu-bar icons, and publish
   // the live connection status to the menu-bar dot. Both no-op off Electron.
   useElectronIconSync(
+    avatar.customImageUrl,
+    avatar.components,
+    avatar.traits,
+    avatar.accentHex,
+  );
+  // The same avatar again, composited onto its accent disc, for the desktop
+  // notifications that show the assistant as the sender rather than the app.
+  useNotificationAvatarSync(
     avatar.customImageUrl,
     avatar.components,
     avatar.traits,

--- a/clients/web/src/runtime/notification-avatar.ts
+++ b/clients/web/src/runtime/notification-avatar.ts
@@ -1,0 +1,46 @@
+import { encodeBase64Bytes } from "@/utils/base64";
+
+/**
+ * The notification avatar the Electron host posts as the sender's icon, held
+ * for the one module that needs it.
+ *
+ * Published rather than subscribed, like `use-island-avatar-source.ts`:
+ * `postLocalNotification` runs outside React, and the alternative is a canvas
+ * draw per notification for a picture that only changes when the avatar does.
+ * Nothing here reaches the host; `runtime/notifications.ts` attaches what is
+ * held to the IPC payload it is already sending.
+ *
+ * Empty is the ordinary state. Off Electron, with `push-avatar-sender` off, or
+ * for an assistant with no avatar, nothing is stored and notifications keep
+ * their app-icon look.
+ */
+export interface NotificationAvatar {
+  /** The disc PNG as base64, with no data-URI prefix. */
+  avatarBase64: string;
+  /** SHA-256 of the PNG bytes, lowercase hex, so a host can name a cache file by it. */
+  avatarHash: string;
+}
+
+let current: NotificationAvatar | null = null;
+
+export function setNotificationAvatar(png: Uint8Array, hash: string): void {
+  current = { avatarBase64: encodeBase64Bytes(png), avatarHash: hash };
+}
+
+export function getNotificationAvatar(): NotificationAvatar | null {
+  return current;
+}
+
+export function clearNotificationAvatar(): void {
+  current = null;
+}
+
+/** Lowercase hex SHA-256 of `bytes`. */
+export async function sha256Hex(
+  bytes: Uint8Array<ArrayBuffer>,
+): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}

--- a/clients/web/src/runtime/notification-avatar.ts
+++ b/clients/web/src/runtime/notification-avatar.ts
@@ -15,6 +15,13 @@ import { encodeBase64Bytes } from "@/utils/base64";
  * their app-icon look.
  */
 export interface NotificationAvatar {
+  /**
+   * The assistant this picture was drawn for. `senderPayload()` reads the
+   * active assistant itself, so a held avatar is usable only while the two
+   * agree: after a switch the new assistant's name would otherwise be sent
+   * with the old one's face.
+   */
+  assistantId: string;
   /** The disc PNG as base64, with no data-URI prefix. */
   avatarBase64: string;
   /** SHA-256 of the PNG bytes, lowercase hex, so a host can name a cache file by it. */
@@ -23,8 +30,16 @@ export interface NotificationAvatar {
 
 let current: NotificationAvatar | null = null;
 
-export function setNotificationAvatar(png: Uint8Array, hash: string): void {
-  current = { avatarBase64: encodeBase64Bytes(png), avatarHash: hash };
+export function setNotificationAvatar(
+  assistantId: string,
+  png: Uint8Array,
+  hash: string,
+): void {
+  current = {
+    assistantId,
+    avatarBase64: encodeBase64Bytes(png),
+    avatarHash: hash,
+  };
 }
 
 export function getNotificationAvatar(): NotificationAvatar | null {

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -7,7 +7,9 @@
  * intent arrived (the APNs banner covers that case).
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ShowNotificationPayload } from "@vellumai/ipc-contract";
 
 // ── host platform guards ─────────────────────────────────────────────────────
 //
@@ -15,8 +17,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // under happy-dom, and the Electron branch would return before reaching
 // the code under test.
 
+let electronHost = false;
 mock.module("@/runtime/is-electron", () => ({
-  isElectron: () => false,
+  isElectron: () => electronHost,
 }));
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => true,
@@ -103,6 +106,12 @@ const {
   postLocalNotification,
   __resetNotificationsStateForTests,
 } = await import("@/runtime/notifications");
+const { clearNotificationAvatar, setNotificationAvatar } =
+  await import("@/runtime/notification-avatar");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
 
 const setVisibility = (state: "visible" | "hidden") => {
   Object.defineProperty(document, "visibilityState", {
@@ -120,6 +129,7 @@ const baseArgs = {
 };
 
 beforeEach(() => {
+  electronHost = false;
   nativeAndroid = false;
   sessionConfirmedAssistantId = null;
   scheduleMock.mockClear();
@@ -341,5 +351,61 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     expect(
       scheduleMock.mock.calls[0]?.[0].notifications[0]?.actionTypeId,
     ).toBeUndefined();
+  });
+});
+
+// ── Electron branch: the assistant as the notification's sender ─────────────
+
+describe("postLocalNotification sender (Electron branch)", () => {
+  const AVATAR = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+  const showMock = mock(async (_payload: ShowNotificationPayload) => ({
+    success: true,
+  }));
+
+  beforeEach(() => {
+    electronHost = true;
+    showMock.mockClear();
+    clearNotificationAvatar();
+    useAssistantIdentityStore.getState().setIdentity("Aria", "1.0.0");
+    useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
+    (window as unknown as { vellum?: unknown }).vellum = {
+      notifications: { show: showMock },
+    };
+  });
+
+  afterEach(() => {
+    clearNotificationAvatar();
+    useAssistantIdentityStore.getState().clearIdentity();
+    delete (window as unknown as { vellum?: unknown }).vellum;
+  });
+
+  test("attaches the held avatar, the assistant's name and its id", async () => {
+    setNotificationAvatar(AVATAR, "sha256-abc");
+
+    await postLocalNotification(baseArgs);
+
+    expect(showMock).toHaveBeenCalledTimes(1);
+    expect(showMock.mock.calls[0]?.[0].sender).toEqual({
+      id: "assistant-1",
+      name: "Aria",
+      avatarBase64: "iVBORw==",
+      avatarHash: "sha256-abc",
+    });
+  });
+
+  test("sends no sender key at all when no avatar is held", async () => {
+    await postLocalNotification(baseArgs);
+
+    const payload = showMock.mock.calls[0]?.[0] ?? {};
+    expect("sender" in payload).toBe(false);
+  });
+
+  test("sends no sender when the assistant has no name yet", async () => {
+    setNotificationAvatar(AVATAR, "sha256-abc");
+    useAssistantIdentityStore.getState().clearIdentity();
+
+    await postLocalNotification(baseArgs);
+
+    expect(showMock.mock.calls[0]?.[0].sender).toBeUndefined();
   });
 });

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -380,7 +380,7 @@ describe("postLocalNotification sender (Electron branch)", () => {
   });
 
   test("attaches the held avatar, the assistant's name and its id", async () => {
-    setNotificationAvatar(AVATAR, "sha256-abc");
+    setNotificationAvatar("assistant-1", AVATAR, "sha256-abc");
 
     await postLocalNotification(baseArgs);
 
@@ -401,8 +401,16 @@ describe("postLocalNotification sender (Electron branch)", () => {
   });
 
   test("sends no sender when the assistant has no name yet", async () => {
-    setNotificationAvatar(AVATAR, "sha256-abc");
+    setNotificationAvatar("assistant-1", AVATAR, "sha256-abc");
     useAssistantIdentityStore.getState().clearIdentity();
+
+    await postLocalNotification(baseArgs);
+
+    expect(showMock.mock.calls[0]?.[0].sender).toBeUndefined();
+  });
+
+  test("sends no sender when the held avatar belongs to another assistant", async () => {
+    setNotificationAvatar("assistant-2", AVATAR, "sha256-abc");
 
     await postLocalNotification(baseArgs);
 

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -458,16 +458,26 @@ export async function sendNotificationIntentAck(
  *
  * The name, the id and the avatar all describe the active assistant, and all
  * three are read from the stores that own it rather than from the caller, so
- * the sender cannot name one assistant while wearing another's face.
+ * the sender cannot name one assistant while wearing another's face. The
+ * avatar carries the assistant it was drawn for and is refused when that is
+ * not the active one, which is what closes the window between an assistant
+ * switch and the replacement avatar finishing.
  */
 function senderPayload(): { sender?: NotificationSender } {
   const avatar = getNotificationAvatar();
   const name = useAssistantIdentityStore.getState().name;
   const id = useResolvedAssistantsStore.getState().activeAssistantId;
-  if (!avatar || !name || !id) {
+  if (!avatar || !name || !id || avatar.assistantId !== id) {
     return {};
   }
-  return { sender: { id, name, ...avatar } };
+  return {
+    sender: {
+      id,
+      name,
+      avatarBase64: avatar.avatarBase64,
+      avatarHash: avatar.avatarHash,
+    },
+  };
 }
 
 /**

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -28,6 +28,7 @@ import {
   type LocalNotificationSchema,
 } from "@capacitor/local-notifications";
 import type { PushNotificationSchema } from "@capacitor/push-notifications";
+import type { NotificationSender } from "@vellumai/ipc-contract";
 
 import { notificationintentresultPost } from "@/generated/daemon/sdk.gen";
 import type { NotificationintentresultPostData } from "@/generated/daemon/types.gen";
@@ -38,11 +39,14 @@ import {
 } from "@/runtime/android-notification-channels";
 import { isElectron } from "@/runtime/is-electron";
 import { isNativePlatform } from "@/runtime/native-auth";
+import { getNotificationAvatar } from "@/runtime/notification-avatar";
 import { isNativeAndroid } from "@/runtime/platform-detection";
 import {
   extractPushConversationId,
   hasSessionConfirmedRemotePushRegistration,
 } from "@/runtime/push-registration";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
  * Payload stored alongside each native notification so the tap handler can
@@ -447,6 +451,26 @@ export async function sendNotificationIntentAck(
 }
 
 /**
+ * The assistant to post the Electron notification as, when there is one to
+ * post as: `useNotificationAvatarSync` holds an avatar only on Electron with
+ * `push-avatar-sender` on, so an empty holder is what keeps the payload
+ * unchanged everywhere else.
+ *
+ * The name, the id and the avatar all describe the active assistant, and all
+ * three are read from the stores that own it rather than from the caller, so
+ * the sender cannot name one assistant while wearing another's face.
+ */
+function senderPayload(): { sender?: NotificationSender } {
+  const avatar = getNotificationAvatar();
+  const name = useAssistantIdentityStore.getState().name;
+  const id = useResolvedAssistantsStore.getState().activeAssistantId;
+  if (!avatar || !name || !id) {
+    return {};
+  }
+  return { sender: { id, name, ...avatar } };
+}
+
+/**
  * Display a native notification. On Capacitor iOS this schedules via
  * `UNUserNotificationCenter`; on desktop browsers it calls the Web
  * Notification API. No-ops silently when notifications are unsupported or
@@ -482,6 +506,7 @@ export async function postLocalNotification(
         deliveryId: args.deliveryId,
         conversationId: extractConversationId(args.deepLinkMetadata),
         deepLinkMetadata: args.deepLinkMetadata,
+        ...senderPayload(),
       });
       success = result.success;
       errorMessage = result.errorMessage;

--- a/clients/web/src/utils/avatar-island-encode.ts
+++ b/clients/web/src/utils/avatar-island-encode.ts
@@ -44,6 +44,7 @@
 
 import { rasterizeAvatar } from "@/utils/avatar-raster";
 import type { AvatarRender } from "@/utils/avatar-render";
+import { encodeBase64Bytes } from "@/utils/base64";
 
 /**
  * Byte ceiling for the encoded avatar.
@@ -92,15 +93,6 @@ const CANDIDATES: ReadonlyArray<{
   { size: 48, type: "image/jpeg", quality: 0.6 },
 ];
 
-/** Base64 for bytes, without a data-URI prefix: the bridge carries the payload raw. */
-function toBase64(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary);
-}
-
 /**
  * Rasterize `render` as small as it needs to be to fit `maxBytes`, returning
  * base64 or null.
@@ -148,7 +140,7 @@ export async function encodeAvatarForIsland(
       throw new Error("avatar rasterizer produced no bytes");
     }
     if (bytes.byteLength <= maxBytes) {
-      return toBase64(bytes);
+      return encodeBase64Bytes(bytes);
     }
   }
   return null;

--- a/clients/web/src/utils/avatar-raster.ts
+++ b/clients/web/src/utils/avatar-raster.ts
@@ -13,6 +13,12 @@
  * agrees on which avatar it is drawing.
  */
 
+import {
+  NOTIFICATION_AVATAR_INSET,
+  NOTIFICATION_AVATAR_SIZE,
+  notificationAvatarDiscHex,
+} from "@vellumai/avatar-manifest/notification-avatar";
+
 /**
  * The largest centered square of a `srcW`×`srcH` source, the source rect for
  * an `object-cover` draw, matching the in-app `ChatAvatar` so non-square
@@ -29,6 +35,94 @@ export function coverCropSquare(
   }
   const side = Math.min(srcW, srcH);
   return { sx: (srcW - side) / 2, sy: (srcH - side) / 2, side };
+}
+
+/**
+ * Decode `src`, an SVG data URI or a renderer-owned blob URL. Rejects when the
+ * source cannot be loaded.
+ */
+async function loadImage(src: string): Promise<HTMLImageElement> {
+  const image = new Image();
+  image.decoding = "async";
+  const loaded = new Promise<void>((resolve, reject) => {
+    image.onload = () => {
+      resolve();
+    };
+    image.onerror = () => {
+      reject(new Error("avatar image failed to load"));
+    };
+  });
+  image.src = src;
+  await loaded;
+  return image;
+}
+
+/**
+ * Draw the source's centered square crop (see {@link coverCropSquare}) into
+ * the `size`×`size` box at `x`,`y`, so a portrait or logo renders identically
+ * instead of being stretched. Draws nothing for a degenerate source.
+ *
+ * `naturalWidth/Height` is the decoded pixel size; SVG sources fall back to
+ * `width/height`.
+ */
+function drawCoverSquare(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  x: number,
+  y: number,
+  size: number,
+): void {
+  const crop = coverCropSquare(
+    image.naturalWidth || image.width,
+    image.naturalHeight || image.height,
+  );
+  if (!crop) {
+    return;
+  }
+  ctx.drawImage(
+    image,
+    crop.sx,
+    crop.sy,
+    crop.side,
+    crop.side,
+    x,
+    y,
+    size,
+    size,
+  );
+}
+
+/**
+ * A transparent `size`×`size` canvas and its 2D context, or null when the
+ * browser hands back no context so the caller can fall back.
+ */
+function createSquareCanvas(
+  size: number,
+): { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D } | null {
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    return null;
+  }
+  ctx.clearRect(0, 0, size, size);
+  return { canvas, ctx };
+}
+
+/** Encode the canvas, or null when the browser hands back no blob. */
+async function encodeCanvas(
+  canvas: HTMLCanvasElement,
+  type: "image/png" | "image/jpeg",
+  quality?: number,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  const blob = await new Promise<Blob | null>((resolve) => {
+    canvas.toBlob(resolve, type, quality);
+  });
+  if (!blob) {
+    return null;
+  }
+  return new Uint8Array(await blob.arrayBuffer());
 }
 
 /**
@@ -51,27 +145,13 @@ export async function rasterizeAvatar(
   type: "image/png" | "image/jpeg" = "image/png",
   quality?: number,
 ): Promise<Uint8Array | null> {
-  const image = new Image();
-  image.decoding = "async";
-  const loaded = new Promise<void>((resolve, reject) => {
-    image.onload = () => {
-      resolve();
-    };
-    image.onerror = () => {
-      reject(new Error("avatar image failed to load"));
-    };
-  });
-  image.src = src;
-  await loaded;
+  const image = await loadImage(src);
 
-  const canvas = document.createElement("canvas");
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) {
+  const surface = createSquareCanvas(size);
+  if (!surface) {
     return null;
   }
-  ctx.clearRect(0, 0, size, size);
+  const { canvas, ctx } = surface;
 
   // JPEG has no alpha, so an un-backed transparent avatar would flatten to
   // black. White matches the light-surface treatment the avatar is designed
@@ -81,32 +161,42 @@ export async function rasterizeAvatar(
     ctx.fillRect(0, 0, size, size);
   }
 
-  // `naturalWidth/Height` is the decoded pixel size (SVG sources fall back to
-  // `width/height`, which equal `size` here). Scale the centered square crop
-  // to fill the canvas, preserving aspect ratio.
-  const crop = coverCropSquare(
-    image.naturalWidth || image.width,
-    image.naturalHeight || image.height,
-  );
-  if (crop) {
-    ctx.drawImage(
-      image,
-      crop.sx,
-      crop.sy,
-      crop.side,
-      crop.side,
-      0,
-      0,
-      size,
-      size,
-    );
-  }
+  drawCoverSquare(ctx, image, 0, 0, size);
 
-  const blob = await new Promise<Blob | null>((resolve) => {
-    canvas.toBlob(resolve, type, quality);
-  });
-  if (!blob) {
+  return encodeCanvas(canvas, type, quality);
+}
+
+/**
+ * Draw the notification avatar: the avatar inset into an opaque disc tinted by
+ * its accent, the icon a native notification shows as the sender. Returns null
+ * when the canvas or the encoder gives nothing back, so the caller sends no
+ * sender rather than a broken one.
+ *
+ * The geometry and the disc colour come from
+ * `@vellumai/avatar-manifest/notification-avatar`, the same spec the daemon
+ * rasterizes with resvg, so the picture is one picture on every platform.
+ */
+export async function rasterizeNotificationAvatar(
+  src: string,
+  accentHex: string | null,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  const image = await loadImage(src);
+  const size = NOTIFICATION_AVATAR_SIZE;
+
+  const surface = createSquareCanvas(size);
+  if (!surface) {
     return null;
   }
-  return new Uint8Array(await blob.arrayBuffer());
+  const { canvas, ctx } = surface;
+
+  const radius = size / 2;
+  ctx.fillStyle = notificationAvatarDiscHex(accentHex);
+  ctx.beginPath();
+  ctx.arc(radius, radius, radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  const inset = size * NOTIFICATION_AVATAR_INSET;
+  drawCoverSquare(ctx, image, inset, inset, size - 2 * inset);
+
+  return encodeCanvas(canvas, "image/png");
 }

--- a/clients/web/src/utils/base64.ts
+++ b/clients/web/src/utils/base64.ts
@@ -1,5 +1,6 @@
 /**
- * Decoding the base64 payloads that reach the app as strings.
+ * Encoding bytes as base64 and decoding the base64 payloads that reach the app
+ * as strings.
  *
  * Two shapes arrive and mean the same thing. An attachment carries its bytes as
  * a full `data:` URI; the native camera bridge answers with the payload alone.
@@ -34,4 +35,22 @@ export function decodeBase64Payload(
     bytes[index] = binary.charCodeAt(index);
   }
   return bytes;
+}
+
+/**
+ * Base64 for `bytes`, without a data-URI prefix: the bridges that carry
+ * rasterized images (the Live Activity island, the desktop notification
+ * sender) take the payload raw.
+ *
+ * Encoded in chunks because `String.fromCharCode` is applied to the whole
+ * chunk at once, and a spread of a few hundred thousand arguments overflows
+ * the call stack.
+ */
+export function encodeBase64Bytes(bytes: Uint8Array): string {
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let index = 0; index < bytes.length; index += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + CHUNK));
+  }
+  return btoa(binary);
 }

--- a/clients/web/src/utils/widget-fonts.ts
+++ b/clients/web/src/utils/widget-fonts.ts
@@ -18,6 +18,8 @@
  * widgets fall back to the `system-ui` tail of `--font-sans`.
  */
 
+import { encodeBase64Bytes } from "@/utils/base64";
+
 /** Font families inlined into widgets. Anything else the host loads is ignored. */
 const WIDGET_FONT_FAMILIES = new Set(["dm sans", "dm mono", "instrument serif"]);
 
@@ -116,16 +118,6 @@ function mimeForUrl(url: string): string {
   return MIME_BY_EXTENSION[extension] ?? "application/octet-stream";
 }
 
-function toBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  const CHUNK = 0x8000;
-  let binary = "";
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
-  }
-  return btoa(binary);
-}
-
 /** Rewrite one `@font-face` rule's `src` URL to an inlined `data:` URI. */
 async function inlineFontFace(rule: CSSStyleRule): Promise<string | null> {
   const src = rule.style.getPropertyValue("src");
@@ -145,7 +137,7 @@ async function inlineFontFace(rule: CSSStyleRule): Promise<string | null> {
   if (buffer.byteLength === 0 || buffer.byteLength > MAX_FONT_BYTES) {
     return null;
   }
-  const dataUri = `data:${mimeForUrl(url)};base64,${toBase64(buffer)}`;
+  const dataUri = `data:${mimeForUrl(url)};base64,${encodeBase64Bytes(new Uint8Array(buffer))}`;
   return rule.cssText.replace(match[0], `url("${dataUri}")`);
 }
 

--- a/packages/electron-desktop/src/notifications.test.ts
+++ b/packages/electron-desktop/src/notifications.test.ts
@@ -35,6 +35,7 @@ interface MockNotificationOptions {
   body: string;
   silent: boolean;
   actions: Array<{ type: "button"; text: string }>;
+  icon?: unknown;
 }
 
 /**
@@ -87,8 +88,14 @@ class MockNotification {
 
 const sentMessages: Array<{ channel: string; payload: unknown }> = [];
 
+/** Tagged stand-in for a decoded `NativeImage`, so a test can read its bytes. */
+const createFromBufferMock = mock((buffer: Buffer) => ({
+  nativeImageOf: buffer,
+}));
+
 mock.module("electron", () => ({
   Notification: MockNotification,
+  nativeImage: { createFromBuffer: createFromBufferMock },
   BrowserWindow: {
     getAllWindows: () => [
       {
@@ -134,6 +141,10 @@ const {
   __setDeliveryTimeoutForTesting,
 } = await import("./notifications");
 
+type NotificationCreateOptions =
+  import("./notifications").NotificationCreateOptions;
+type NotificationLike = import("./notifications").NotificationLike;
+
 // --- Helpers ---------------------------------------------------------------
 
 const SHOW_CHANNEL = "vellum:notifications:show";
@@ -166,6 +177,7 @@ beforeEach(() => {
   handleRegistrations.length = 0;
   handleMock.mockClear();
   ensureVisibleMock.mockClear();
+  createFromBufferMock.mockClear();
   at(0);
   configureNotifications({
     ipc,
@@ -394,5 +406,135 @@ describe("interaction broadcast", () => {
       actionText: "Deny",
       deliveryId: "del-9",
     });
+  });
+});
+
+// --- Sender (assistant name + notification avatar) -------------------------
+
+describe("sender", () => {
+  const AVATAR_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+  const sender = {
+    id: "assistant-1",
+    name: "Aria",
+    avatarBase64: AVATAR_PNG.toString("base64"),
+    avatarHash: "sha256-abc",
+  };
+
+  const realPlatform = process.platform;
+  const setPlatform = (value: string): void => {
+    Object.defineProperty(process, "platform", {
+      value,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+  });
+
+  test("the captured schema accepts a sender and rejects a partial one", () => {
+    const { schema } = showHandler();
+    expect(() =>
+      schema.parse([
+        { category: "notificationIntent", title: "t", body: "b", sender },
+      ]),
+    ).not.toThrow();
+    expect(() =>
+      schema.parse([
+        {
+          category: "notificationIntent",
+          title: "t",
+          body: "b",
+          sender: { id: "assistant-1", name: "Aria" },
+        },
+      ]),
+    ).toThrow();
+  });
+
+  test("hands the factory the decoded avatar bytes", async () => {
+    const created: NotificationCreateOptions[] = [];
+    configureNotifications({
+      ipc,
+      ensureVisible: ensureVisibleMock,
+      logger: quietLogger,
+      create: (options) => {
+        created.push(options);
+        return new MockNotification(options) as unknown as NotificationLike;
+      },
+    });
+
+    await show({
+      category: "notificationIntent",
+      title: "T",
+      body: "B",
+      deliveryId: "sender-1",
+      sender,
+    });
+
+    expect(created).toHaveLength(1);
+    expect(created[0]!.sender).toEqual({
+      id: "assistant-1",
+      name: "Aria",
+      avatarPng: AVATAR_PNG,
+      avatarHash: "sha256-abc",
+    });
+  });
+
+  test("omits the sender from the factory options when the payload carries none", async () => {
+    const created: NotificationCreateOptions[] = [];
+    configureNotifications({
+      ipc,
+      ensureVisible: ensureVisibleMock,
+      logger: quietLogger,
+      create: (options) => {
+        created.push(options);
+        return new MockNotification(options) as unknown as NotificationLike;
+      },
+    });
+
+    await show({
+      category: "notificationIntent",
+      title: "T",
+      body: "B",
+      deliveryId: "sender-2",
+    });
+
+    expect(created[0]!.sender).toBeUndefined();
+  });
+
+  test("the default factory gives Linux the avatar as the notification icon", async () => {
+    setPlatform("linux");
+
+    await show({
+      category: "notificationIntent",
+      title: "T",
+      body: "B",
+      deliveryId: "linux-1",
+      sender,
+    });
+
+    expect(createFromBufferMock).toHaveBeenCalledTimes(1);
+    expect(createFromBufferMock.mock.calls[0]![0]).toEqual(AVATAR_PNG);
+    expect(constructed[0]!.options.icon).toEqual({
+      nativeImageOf: AVATAR_PNG,
+    });
+  });
+
+  test("the default factory leaves macOS without an icon, where it would render as a thumbnail", async () => {
+    setPlatform("darwin");
+
+    await show({
+      category: "notificationIntent",
+      title: "T",
+      body: "B",
+      deliveryId: "darwin-1",
+      sender,
+    });
+
+    expect(createFromBufferMock).not.toHaveBeenCalled();
+    expect(constructed[0]!.options.icon).toBeUndefined();
+    expect(
+      (constructed[0]!.options as { sender?: unknown }).sender,
+    ).toBeUndefined();
   });
 });

--- a/packages/electron-desktop/src/notifications.ts
+++ b/packages/electron-desktop/src/notifications.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Notification } from "electron";
+import { BrowserWindow, nativeImage, Notification } from "electron";
 import { z } from "zod";
 
 import {
@@ -59,11 +59,27 @@ export interface NotificationLike {
   show(): void;
 }
 
+/**
+ * The assistant a notification is from, decoded once at the IPC boundary so
+ * every factory works from bytes rather than re-decoding the base64 payload.
+ */
+export interface NotificationSenderImage {
+  id: string;
+  name: string;
+  avatarPng: Buffer;
+  avatarHash: string;
+}
+
 export interface NotificationCreateOptions {
   title: string;
   body: string;
   silent: boolean;
   actions: CategoryAction[];
+  /**
+   * Absent when the renderer sent no notification avatar, which every factory
+   * renders as today's app-icon notification.
+   */
+  sender?: NotificationSenderImage;
 }
 
 export interface NotificationsRuntime {
@@ -240,6 +256,30 @@ interface ShowResult {
   errorMessage?: string;
 }
 
+/**
+ * The `electron.Notification` path, which can show the sender's avatar on
+ * exactly one platform.
+ *
+ * libnotify draws `icon` as the notification's image and takes the app icon
+ * from the desktop entry, which is the treatment the feature asks for. macOS
+ * draws it as a right-side thumbnail beside the app icon instead, so the
+ * avatar must never reach it here (the native addon posts macOS notifications
+ * through Apple's Communication Notifications API). Windows toasts have no
+ * icon slot on this path at all.
+ */
+const createElectronNotification = (
+  options: NotificationCreateOptions,
+): NotificationLike => {
+  const { sender, ...constructorOptions } = options;
+  if (sender && process.platform === "linux") {
+    return new Notification({
+      ...constructorOptions,
+      icon: nativeImage.createFromBuffer(sender.avatarPng),
+    });
+  }
+  return new Notification(constructorOptions);
+};
+
 const showNotification = (
   payload: ShowNotificationPayload,
 ): Promise<ShowResult> => {
@@ -259,14 +299,23 @@ const showNotification = (
   }
 
   const actions = CATEGORY_ACTIONS[payload.category];
+  const sender = payload.sender;
 
-  const notif: NotificationLike = (
-    create ?? ((options) => new Notification(options))
-  )({
+  const notif: NotificationLike = (create ?? createElectronNotification)({
     title: payload.title,
     body: payload.body,
     silent: false,
     actions,
+    ...(sender
+      ? {
+          sender: {
+            id: sender.id,
+            name: sender.name,
+            avatarPng: Buffer.from(sender.avatarBase64, "base64"),
+            avatarHash: sender.avatarHash,
+          },
+        }
+      : {}),
   });
 
   // Build the metadata forwarded on every interaction so the renderer

--- a/packages/electron-desktop/src/notifications.ts
+++ b/packages/electron-desktop/src/notifications.ts
@@ -76,8 +76,8 @@ export interface NotificationCreateOptions {
   silent: boolean;
   actions: CategoryAction[];
   /**
-   * Absent when the renderer sent no notification avatar, which every factory
-   * renders as today's app-icon notification.
+   * Absent when the renderer sent no notification avatar; a factory then
+   * renders the plain app-icon notification.
    */
   sender?: NotificationSenderImage;
 }
@@ -263,9 +263,9 @@ interface ShowResult {
  * libnotify draws `icon` as the notification's image and takes the app icon
  * from the desktop entry, which is the treatment the feature asks for. macOS
  * draws it as a right-side thumbnail beside the app icon instead, so the
- * avatar must never reach it here (the native addon posts macOS notifications
- * through Apple's Communication Notifications API). Windows toasts have no
- * icon slot on this path at all.
+ * avatar never reaches this path there: a client that renders the sender on
+ * macOS or Windows supplies its own `create` factory, and this path ignores
+ * `sender` on both. Windows toasts have no icon slot on this path at all.
  */
 const createElectronNotification = (
   options: NotificationCreateOptions,

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -38,6 +38,13 @@ export const assistantStatusSchema = z.enum(ASSISTANT_STATUSES);
 
 export const notificationCategorySchema = z.enum(NOTIFICATION_CATEGORIES);
 
+export const notificationSenderSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  avatarBase64: z.string(),
+  avatarHash: z.string(),
+});
+
 export const showNotificationPayloadSchema = z.object({
   category: notificationCategorySchema,
   title: z.string(),
@@ -46,6 +53,7 @@ export const showNotificationPayloadSchema = z.object({
   conversationId: z.string().optional(),
   toolCallId: z.string().optional(),
   deepLinkMetadata: z.record(z.string(), z.unknown()).optional(),
+  sender: notificationSenderSchema.optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -675,6 +675,25 @@ export const NOTIFICATION_CATEGORIES = [
 
 export type NotificationCategory = (typeof NOTIFICATION_CATEGORIES)[number];
 
+/**
+ * The assistant a notification is from, for the platforms that render a sender
+ * rather than the app: its name goes on the first line and its notification
+ * avatar becomes the icon.
+ */
+export interface NotificationSender {
+  id: string;
+  name: string;
+  /**
+   * The notification avatar as a base64 PNG with no data prefix, the same
+   * shape {@link VoiceActivityStart.avatarBase64} travels in. The renderer
+   * composites it (avatar on an accent-tinted disc) because main has no
+   * canvas.
+   */
+  avatarBase64: string;
+  /** Content hash of the PNG, so a host can name a cache file by it. */
+  avatarHash: string;
+}
+
 /** Renderer → main payload for posting a native notification. */
 export interface ShowNotificationPayload {
   category: NotificationCategory;
@@ -684,6 +703,11 @@ export interface ShowNotificationPayload {
   conversationId?: string;
   toolCallId?: string;
   deepLinkMetadata?: Record<string, unknown>;
+  /**
+   * Absent unless the renderer has a notification avatar to send, which leaves
+   * the notification with the app icon and the title on line one.
+   */
+  sender?: NotificationSender;
 }
 
 export type TextInsertionResult =


### PR DESCRIPTION
## Summary
- `ShowNotificationPayload` gains an optional `sender` (`{ id, name, avatarBase64, avatarHash }`); the shared electron-desktop module decodes it once into `NotificationCreateOptions.sender` (`avatarPng: Buffer`) and hands it to the per-client factory. The default `electron.Notification` path passes it as `icon` only on Linux, where libnotify renders it as the notification image; macOS and Windows are untouched here.
- The web renderer composites the avatar onto its accent disc (`rasterizeNotificationAvatar`, geometry and disc colour from `@vellumai/avatar-manifest/notification-avatar`) and holds the PNG plus its SHA-256 in `runtime/notification-avatar.ts`. `useNotificationAvatarSync`, mounted beside `useElectronIconSync`, does that work only on Electron with `push-avatar-sender` on, and clears the holder otherwise, so with the flag off the IPC payload is unchanged.
- Drive-by: the third copy of a bytes-to-base64 encoder was avoided by extracting `encodeBase64Bytes` into `utils/base64.ts` and routing `avatar-island-encode.ts` and `widget-fonts.ts` through it.

Part of plan: avatar-notification-icon.md (PR 9 of 11)