### PR TITLE
Include the notification avatar in the platform avatar sync

### DIFF
--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -59,6 +59,10 @@ mock.module("../avatar/ensure-raster.js", () => ({
     rasterCalls += 1;
     return mockRasterPath;
   },
+  ensureAvatarRaster: async () =>
+    mockRasterPath === null
+      ? null
+      : realReadContainedAvatarRaster(mockRasterPath),
   readContainedAvatarRaster: realReadContainedAvatarRaster,
 }));
 
@@ -144,7 +148,10 @@ const NONE: AvatarState = {
 
 interface Patch {
   path: string;
-  body: { avatar_base64: string | null };
+  body: {
+    avatar_base64: string | null;
+    notification_avatar_base64?: string | null;
+  };
 }
 
 let patches: Patch[];
@@ -251,7 +258,7 @@ describe("syncAvatarToPlatform", () => {
     expect(rasterCalls).toBe(1);
   });
 
-  test("removing the avatar sends avatar_base64: null", async () => {
+  test("removing the avatar nulls both images", async () => {
     syncAvatarToPlatform();
     await settle();
     mockState = NONE;
@@ -259,7 +266,10 @@ describe("syncAvatarToPlatform", () => {
     syncAvatarToPlatform();
     await settle();
 
-    expect(patches[1].body).toEqual({ avatar_base64: null });
+    expect(patches[1].body).toEqual({
+      avatar_base64: null,
+      notification_avatar_base64: null,
+    });
   });
 
   test("an image avatar with a missing PNG is skipped, not cleared", async () => {
@@ -376,6 +386,45 @@ describe("syncAvatarToPlatform", () => {
     await settle();
 
     expect(patches).toHaveLength(0);
+  });
+
+  test("PATCHes the notification avatar alongside the raster", async () => {
+    mockResvgAvailable = true;
+    mockRenderedPng = Buffer.from("disc-a");
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].body).toEqual({
+      avatar_base64: png("a").toString("base64"),
+      notification_avatar_base64: Buffer.from("disc-a").toString("base64"),
+    });
+    expect(lastResvgSvg).toContain("<circle");
+  });
+
+  test("omits the notification avatar when resvg is unavailable", async () => {
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches[0].body).toEqual({
+      avatar_base64: png("a").toString("base64"),
+    });
+  });
+
+  test("a changed notification render re-sends an unchanged raster", async () => {
+    mockResvgAvailable = true;
+    mockRenderedPng = Buffer.from("disc-a");
+    syncAvatarToPlatform();
+    await settle();
+    mockRenderedPng = Buffer.from("disc-b");
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches.map((p) => p.body.notification_avatar_base64)).toEqual([
+      Buffer.from("disc-a").toString("base64"),
+      Buffer.from("disc-b").toString("base64"),
+    ]);
+    expect(patches[1].body.avatar_base64).toBe(png("a").toString("base64"));
   });
 
   test("a restart with the same raster and destination does not re-upload", async () => {

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -18,6 +18,11 @@
  * non-none avatar whose raster is missing (image PNG gone, character
  * re-render unavailable) is skipped so the platform keeps the last synced
  * copy.
+ * The same PATCH carries `notification_avatar_base64`, the disc render the
+ * push pipeline shows as the sender. Its digest is part of the dedup key, so
+ * a change to the disc spec re-uploads even when the raster is unchanged.
+ * When the render is unavailable the key is omitted rather than nulled, so
+ * the platform keeps the copy it holds.
  */
 
 import { createHash } from "node:crypto";
@@ -29,6 +34,7 @@ import {
   ensureAvatarRasterPath,
   readContainedAvatarRaster,
 } from "../avatar/ensure-raster.js";
+import { renderNotificationAvatarPng } from "../avatar/notification-avatar.js";
 import {
   getResvg,
   isResvgAvailable,
@@ -120,7 +126,10 @@ function persistKey(synced: SyncedKey): void {
 async function buildPayload(): Promise<PatchPayload | undefined> {
   const state = readAvatarState();
   if (state.kind === "none") {
-    return { key: NONE_KEY, body: { avatar_base64: null } };
+    return {
+      key: NONE_KEY,
+      body: { avatar_base64: null, notification_avatar_base64: null },
+    };
   }
   const path = await ensureAvatarRasterPath(state);
   if (!path) {
@@ -131,10 +140,12 @@ async function buildPayload(): Promise<PatchPayload | undefined> {
   if (!bytes) {
     return undefined;
   }
+  const notification = await renderNotificationAvatarPng(state);
   // Keyed on content so a same-size, same-mtime rewrite still re-syncs.
-  const digest = createHash("sha256").update(bytes).digest("hex");
+  const digest = sha256(bytes);
+  const notificationDigest = notification ? sha256(notification) : NONE_KEY;
   return {
-    key: `${state.kind}:${digest}`,
+    key: `${state.kind}:${digest}:${notificationDigest}`,
     body: async () => {
       const encoded = encodeForUpload(bytes);
       if (encoded === undefined) {
@@ -144,9 +155,19 @@ async function buildPayload(): Promise<PatchPayload | undefined> {
         );
         return undefined;
       }
-      return { avatar_base64: encoded };
+      if (!notification) {
+        return { avatar_base64: encoded };
+      }
+      return {
+        avatar_base64: encoded,
+        notification_avatar_base64: notification.toString("base64"),
+      };
     },
   };
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 /**


### PR DESCRIPTION
## Summary
- `buildPayload()` renders the notification avatar for the current state and sends it as `notification_avatar_base64` in the same PATCH: the base64 PNG when the render succeeds, `null` when the avatar was removed, and the key omitted when the render is unavailable so an existing platform image is never blanked.
- The dedup key gains the notification PNG digest, so a change to the shared disc spec re-uploads even when the raster is unchanged. The 256 KB cap and downscale path for `avatar_base64` are untouched.
- Tests cover both fields on a present avatar, the null-both removal case, the resvg-unavailable omission, and a re-send driven only by a changed notification digest.

Part of plan: avatar-notification-icon.md (PR 3 of 11)