### PR TITLE
feat(companion): Reset Position in the surface's right-click menu (JARVIS-1766)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -490,6 +490,7 @@ const {
   dialOnTalk,
   glideProgress,
   introOnAdvance,
+  resetCompanionSurfacePosition,
   setCompanionSurfaceSize,
   shouldShowCompanionSurface,
   showCompanionCoachmarks,
@@ -1113,6 +1114,65 @@ describe("the surface a call takes", () => {
     send("vellum:voiceActivity:start", START);
     expect(centre()).toEqual(bottomCentre);
     send("vellum:voiceActivity:end");
+  });
+});
+
+/**
+ * The menu's "Reset Position": the pill goes back to where the surface opens,
+ * the bottom centre of its display, from wherever the user dragged it.
+ *
+ * Under "Reduce motion", as the call's cases are, so each reset lands in the
+ * beat it is asked for; the reset moves the surface the way the call does,
+ * and the glide has its own cases below.
+ */
+describe("resetCompanionSurfacePosition", () => {
+  const SCREEN = { x: 0, y: 0, width: 1440, height: 900 };
+  const centre = (): { x: number; y: number } => ({
+    x: origin.x + GEOMETRY.canvasWidth / 2,
+    y: origin.y + avatarOffsetFor(state().cardGrowth, GEOMETRY),
+  });
+  const bottomCentre = defaultAvatarCentre(SCREEN, GEOMETRY);
+  const park = (): { x: number; y: number } => {
+    send("vellum:companion:moveBy", 300 - centre().x, 200 - centre().y);
+    return centre();
+  };
+
+  beforeEach(() => {
+    mainWindowOpen = true;
+    send("vellum:voiceActivity:end");
+    send("vellum:voiceActivity:control", { action: "endSession" });
+  });
+
+  test("takes a parked pill back to the bottom centre of its display", () => {
+    park();
+    expect(centre()).not.toEqual(bottomCentre);
+    resetCompanionSurfacePosition();
+    expect(centre()).toEqual(bottomCentre);
+  });
+
+  test("leaves a pill already there where it is", () => {
+    resetCompanionSurfacePosition();
+    const before = centre();
+    resetCompanionSurfacePosition();
+    expect(centre()).toEqual(before);
+    expect(centre()).toEqual(bottomCentre);
+  });
+
+  /**
+   * A call holds the place the pill goes back to when it ends. A reset during
+   * the call is the user saying where the surface belongs, so the call's end
+   * leaves it there rather than sending it back to where it was parked.
+   */
+  test("mid-call, is where the call ends too", () => {
+    park();
+    send("vellum:companion:startVoice");
+    send("vellum:voiceActivity:start", START);
+    send("vellum:companion:moveBy", -200, -100);
+    expect(centre()).not.toEqual(bottomCentre);
+    resetCompanionSurfacePosition();
+    expect(centre()).toEqual(bottomCentre);
+    send("vellum:voiceActivity:end");
+    expect(centre()).toEqual(bottomCentre);
   });
 });
 
@@ -2039,13 +2099,14 @@ describe("geometryFor with the two axes apart", () => {
 
 /**
  * The menu a right-click on the surface pops, which is where a user actually
- * reaches for the two things a floating avatar offers: a different size, and
- * making it go away.
+ * reaches for the three things a floating avatar offers: a different size,
+ * its place on the screen back, and making it go away.
  *
  * The template rather than the menu: a menu is a native window, and what is
  * worth stating is what this menu adds to the size pickers it shares with the
- * tray, which is where they sit and the item that takes the surface away. The
- * pickers themselves have their own suite in `companion-menu.test.ts`.
+ * tray, which is where they sit and the items that put the surface back and
+ * take it away. The pickers themselves have their own suite in
+ * `companion-menu.test.ts`.
  */
 describe("companionContextMenuTemplate", () => {
   /** Only what a menu item is read for here. */
@@ -2063,16 +2124,25 @@ describe("companionContextMenuTemplate", () => {
   ) => {
     let hidden = false;
     let opened = false;
+    let reset = false;
     const items = companionContextMenuTemplate(current, {
       open: () => {
         opened = true;
       },
       setSize: () => {},
+      resetPosition: () => {
+        reset = true;
+      },
       hide: () => {
         hidden = true;
       },
     }) as MenuItem[];
-    return { items, wasHidden: () => hidden, wasOpened: () => opened };
+    return {
+      items,
+      wasHidden: () => hidden,
+      wasOpened: () => opened,
+      wasReset: () => reset,
+    };
   };
 
   /**
@@ -2093,8 +2163,19 @@ describe("companionContextMenuTemplate", () => {
     expect(
       build()
         .items.map((item) => item.label ?? item.type)
-        .slice(4),
+        .slice(5),
     ).toEqual(["separator", "Hide Companion"]);
+  });
+
+  /**
+   * In the group with the sizes rather than beside the way out: it is about
+   * how the surface sits on the screen, which is what the headings are about.
+   */
+  test("offers the surface's place back, right after the headings", () => {
+    const { items, wasReset } = build();
+    expect(items[4]?.label).toBe("Reset Position");
+    items[4]?.click?.();
+    expect(wasReset()).toBe(true);
   });
 
   /**
@@ -2111,7 +2192,7 @@ describe("companionContextMenuTemplate", () => {
 
   test("the last item takes the surface away", () => {
     const menu = build();
-    menu.items[5]?.click?.();
+    menu.items[6]?.click?.();
     expect(menu.wasHidden()).toBe(true);
   });
 });

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1666,6 +1666,7 @@ export const companionContextMenuTemplate = (
   actions: {
     open: () => void;
     setSize: (axis: CompanionSizeAxis, size: CompanionSize) => void;
+    resetPosition: () => void;
     hide: () => void;
   },
 ): MenuItemConstructorOptions[] => [
@@ -1680,9 +1681,19 @@ export const companionContextMenuTemplate = (
   },
   { type: "separator" as const },
   // The size pickers the tray offers too, from the one builder both read. They
-  // leave the top level short enough to read at a glance: two headings, and the
-  // one item that is not a size.
+  // leave the top level short enough to read at a glance: two headings, and
+  // two items that are not a size.
   ...companionSizeSubmenus(current, actions.setSize),
+  {
+    // Grouped with the sizes, since it is about the same thing they are: how
+    // the surface sits on the screen. The way back for a pill dragged
+    // somewhere it is in the way, or lost behind a window the user has since
+    // closed, without hiding and showing it again to get there.
+    label: "Reset Position",
+    click: () => {
+      actions.resetPosition();
+    },
+  },
   { type: "separator" as const },
   {
     // Named for what it does to the thing under the cursor. The tray's item is
@@ -2083,6 +2094,7 @@ export const installCompanionWindow = (): void => {
         {
           open: openVellum,
           setSize: setCompanionSurfaceSize,
+          resetPosition: resetCompanionSurfacePosition,
           hide: () => {
             setCompanionSurfaceVisible(false);
           },
@@ -2485,6 +2497,40 @@ export const setCompanionSurfaceSize = (
     height: geometry.canvasHeight,
   });
   pushState();
+};
+
+/**
+ * Take the avatar back to where the surface opens: the bottom centre of the
+ * display it is on (see {@link defaultAvatarCentre}). The right-click menu's
+ * "Reset Position".
+ *
+ * The display it is on rather than the one under the cursor, which is what
+ * the open reads: the menu was popped from the pill, so the two are the same
+ * display, and measuring from the pill keeps the reset answerable without a
+ * pointer. Where the pill rests, for a glide in flight, is where the glide is
+ * headed, as every other reader of its resting place has it.
+ *
+ * During a call the surface is already at this point unless the user dragged
+ * it away, and the call is holding the place the pill goes back to when the
+ * call ends. A reset asked for mid-call makes the default that place too:
+ * the user has just said where the surface belongs, and a call ending by
+ * sending it back to wherever it was before would undo that.
+ *
+ * A glide rather than a jump, the way the call moves it, and instant under
+ * "Reduce motion" for the same reason.
+ */
+export const resetCompanionSurfacePosition = (): void => {
+  const win = getFloatingWindow(COMPANION_KIND);
+  if (win === null || win.isDestroyed()) {
+    return;
+  }
+  const resting = glide === null ? avatarCentre(win) : glide.to;
+  const { workArea } = displayUnder(resting);
+  const home = defaultAvatarCentre(workArea, geometry);
+  if (callHome !== null) {
+    callHome = home;
+  }
+  glideAvatarTo(win, home, workArea);
 };
 
 /**


### PR DESCRIPTION
## Summary

A right-click on the macOS companion surface now offers **Reset Position**, which takes the pill back to where the surface opens: the bottom centre of the display it is on.

- New item sits in the group with the size headings, before the separator and "Hide Companion".
- The move is the same glide the call uses (`glideAvatarTo`), so it is clamped per frame against the display under it and instant under Reduce motion.
- A reset during a call also updates the place the pill goes back to when the call ends, so the call ending does not undo the reset.

Closes JARVIS-1766

## Test plan

- [x] `bun test src/main/companion-window.test.ts` in `clients/macos` (211 pass): template order, the click reaches the action, a parked pill lands on the bottom centre, a pill already there stays put, a mid-call reset survives the call ending.
- [x] `bun run typecheck` in `clients/macos`.
- [ ] Manual: drag the companion somewhere, right-click, Reset Position; repeat mid-call and end the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9B3eY2m7hVVFfjfuabnj4
