### PR TITLE
Advertise native notification rendering on Android token registration

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
@@ -1,6 +1,8 @@
 package ai.vellum.assistant;
 
 import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -9,6 +11,13 @@ import java.util.function.Consumer;
 
 @CapacitorPlugin(name = "AndroidPushRegistration")
 public class AndroidPushRegistrationPlugin extends Plugin {
+    /**
+     * Advertised on token registration. The platform sends data-only pushes
+     * only to tokens claiming this, so a build that cannot render them
+     * natively must never claim it.
+     */
+    static final String NATIVE_NOTIFICATION_RENDER = "native-notification-render";
+
     @PluginMethod
     public void register(PluginCall call) {
         invokeSafely(call, plugin -> plugin.register(call));
@@ -17,6 +26,19 @@ public class AndroidPushRegistrationPlugin extends Plugin {
     @PluginMethod
     public void unregister(PluginCall call) {
         invokeSafely(call, plugin -> plugin.unregister(call));
+    }
+
+    @PluginMethod
+    public void getCapabilities(PluginCall call) {
+        call.resolve(capabilitiesPayload());
+    }
+
+    static JSObject capabilitiesPayload() {
+        JSArray capabilities = new JSArray();
+        capabilities.put(NATIVE_NOTIFICATION_RENDER);
+        JSObject payload = new JSObject();
+        payload.put("capabilities", capabilities);
+        return payload;
     }
 
     private void invokeSafely(PluginCall call, Consumer<PushNotificationsPlugin> operation) {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AndroidPushRegistrationPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AndroidPushRegistrationPluginTest.java
@@ -1,0 +1,19 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertEquals;
+
+import com.getcapacitor.JSObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.junit.Test;
+
+public class AndroidPushRegistrationPluginTest {
+    @Test
+    public void capabilitiesPayloadAdvertisesNativeRenderingOnly() throws JSONException {
+        JSObject payload = AndroidPushRegistrationPlugin.capabilitiesPayload();
+
+        JSONArray capabilities = payload.getJSONArray("capabilities");
+        assertEquals(1, capabilities.length());
+        assertEquals("native-notification-render", capabilities.getString(0));
+    }
+}

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -290,6 +290,24 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     );
   });
 
+  test("a foreground data-only push reads its title and body from data", async () => {
+    nativeAndroid = true;
+    postForegroundRemotePush({
+      id: "message-2",
+      data: {
+        title: "Ada",
+        body: "Standup notes are up",
+        delivery_id: "delivery-data-only",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(scheduleMock).toHaveBeenCalledTimes(1);
+    const scheduled = scheduleMock.mock.calls[0]?.[0].notifications[0];
+    expect(scheduled?.title).toBe("Ada");
+    expect(scheduled?.body).toBe("Standup notes are up");
+  });
+
   test("a concurrent waiter retries after scheduling fails", async () => {
     nativeAndroid = true;
     let rejectFirst!: (error: Error) => void;

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -633,17 +633,17 @@ export function postForegroundRemotePush(
     typeof notification.data === "object" && notification.data !== null
       ? (notification.data as Record<string, unknown>)
       : {};
-  const deliveryId =
-    typeof data.delivery_id === "string" ? data.delivery_id : notification.id;
-  const sourceEventName =
-    typeof data.source_event_name === "string"
-      ? data.source_event_name
-      : "remote_push";
+  const text = (value: unknown): string | undefined =>
+    typeof value === "string" ? value : undefined;
+  const deliveryId = text(data.delivery_id) ?? notification.id;
+  const sourceEventName = text(data.source_event_name) ?? "remote_push";
   const conversationId = extractPushConversationId(data);
 
   void postLocalNotification({
-    title: notification.title ?? "Vellum",
-    body: notification.body ?? "",
+    // A data-only push carries no notification block, so the copy the OS
+    // would have rendered lives in `data`.
+    title: notification.title ?? text(data.title) ?? "Vellum",
+    body: notification.body ?? text(data.body) ?? "",
     sourceEventName,
     deliveryId,
     correlationId: deliveryId,

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -13,6 +13,10 @@ let platform = "ios";
 let androidPushRegistrationAvailable = true;
 const androidRegisterMock = mock(async () => {});
 const androidUnregisterMock = mock(async () => {});
+let androidCapabilities: unknown = {
+  capabilities: ["native-notification-render"],
+};
+const androidGetCapabilitiesMock = mock(async () => androidCapabilities);
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNative,
@@ -31,6 +35,7 @@ mock.module("@capacitor/core", () => ({
     return {
       register: androidRegisterMock,
       unregister: androidUnregisterMock,
+      getCapabilities: androidGetCapabilitiesMock,
     };
   },
 }));
@@ -129,6 +134,7 @@ interface UpsertArg {
     platform: string;
     bundle_id: string;
     apns_environment?: string;
+    capabilities?: string[];
   };
   throwOnError: boolean;
 }
@@ -235,6 +241,8 @@ beforeEach(() => {
   unregisterMock.mockClear();
   androidRegisterMock.mockClear();
   androidUnregisterMock.mockClear();
+  androidCapabilities = { capabilities: ["native-notification-render"] };
+  androidGetCapabilitiesMock.mockClear();
   ensureAndroidAlertsChannelMock.mockClear();
   callOrder.length = 0;
   getInfoMock.mockClear();
@@ -292,6 +300,7 @@ describe("registerForRemotePush", () => {
       },
       throwOnError: false,
     });
+    expect(androidGetCapabilitiesMock).not.toHaveBeenCalled();
   });
 
   test("creates the Android channel before registering and omits APNs fields", async () => {
@@ -312,10 +321,36 @@ describe("registerForRemotePush", () => {
       token: "fcm-token-abc",
       platform: "android",
       bundle_id: "ai.vellum.assistant.dev",
+      capabilities: ["native-notification-render"],
     });
     expect(resolveSignedApnsEnvironmentMock).not.toHaveBeenCalled();
     receivedHandler?.({ id: "message-1", data: { delivery_id: "delivery-1" } });
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("advertises no capabilities when the shell's plugin lacks the method", async () => {
+    platform = "android";
+    androidGetCapabilitiesMock.mockImplementationOnce(async () => {
+      throw new Error("not implemented");
+    });
+
+    await registerForRemotePush("11111111-1111-4111-8111-111111111111");
+    registrationHandler?.({ value: "fcm-token-abc" });
+    await flushMicrotasks();
+
+    expect(lastUpsertArg?.body.capabilities).toEqual([]);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("advertises no capabilities when the plugin answers with a non-array", async () => {
+    platform = "android";
+    androidCapabilities = {};
+
+    await registerForRemotePush("11111111-1111-4111-8111-111111111111");
+    registrationHandler?.({ value: "fcm-token-abc" });
+    await flushMicrotasks();
+
+    expect(lastUpsertArg?.body.capabilities).toEqual([]);
   });
 
   test("installs listeners but skips registration on Android shells without the guarded plugin", async () => {

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -66,6 +66,7 @@ interface RegisteredToken {
 interface AndroidPushRegistrationPlugin {
   register(): Promise<void>;
   unregister(): Promise<void>;
+  getCapabilities(): Promise<{ capabilities: string[] }>;
 }
 
 const ANDROID_PUSH_REGISTRATION_PLUGIN = "AndroidPushRegistration";
@@ -163,6 +164,27 @@ export function isRemotePushSupported(): boolean {
 }
 
 /**
+ * What this Android build can do with a push, advertised on the token row.
+ *
+ * The platform sends data-only FCM messages only to tokens claiming
+ * `native-notification-render`, so an older shell whose plugin lacks the
+ * method must report nothing and keep receiving notification-block pushes.
+ */
+async function readAndroidCapabilities(): Promise<string[]> {
+  if (!Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)) {
+    return [];
+  }
+  try {
+    const { capabilities } = await AndroidPushRegistration.getCapabilities();
+    return Array.isArray(capabilities)
+      ? capabilities.filter((value) => typeof value === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Upsert a freshly-minted native token to the platform for the given assistant.
  * Best-effort: a non-2xx response or thrown error is reported and swallowed.
  */
@@ -182,6 +204,7 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
             token,
             platform: "android" as const,
             bundle_id: bundleId,
+            capabilities: await readAndroidCapabilities(),
           }
         : {
             token,


### PR DESCRIPTION
## Summary
- `AndroidPushRegistrationPlugin.getCapabilities()` resolves `{ capabilities: ["native-notification-render"] }`, the single place the capability string is spelled, so only a shell that renders data-only FCM messages natively (PR 7) can claim it.
- The Android token upsert now carries `capabilities`, read through a guarded call that resolves to `[]` when an older shell's plugin lacks the method or rejects. iOS bodies are unchanged.
- Foreground remote pushes fall back to `data.title` / `data.body`, so a data-only message that arrives while the app is in front still shows real copy instead of "Vellum" with an empty body.

Part of plan: avatar-notification-icon.md (PR 8 of 11)