### PR TITLE
feat(skills): probe skill retrieval offline

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -17,6 +17,7 @@
     "generate:openapi": "bun run scripts/generate-openapi.ts",
     "sync:llm-catalog": "bun run scripts/sync-llm-catalog.ts",
     "sync:web-search-catalog": "bun run scripts/sync-web-search-catalog.ts",
+    "probe:skill-retrieval": "bun run scripts/probe-skill-retrieval.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint",

--- a/assistant/scripts/probe-skill-retrieval.ts
+++ b/assistant/scripts/probe-skill-retrieval.ts
@@ -1,0 +1,361 @@
+// ---------------------------------------------------------------------------
+// Skill retrieval probe: rank skill capability cards against a query offline.
+//
+// Skills are surfaced to a turn by embedding one capability card per skill into
+// the concept-page collection and retrieving against it. The card is built from
+// SKILL.md frontmatter only (`description` + `activation-hints` + `avoid-when`),
+// never the body, and is hard-truncated to a character budget. This script
+// builds the same cards from SKILL.md on disk, embeds them with the same local
+// backend, and prints the ranking, so frontmatter wording can be validated
+// without a running assistant.
+//
+// The dense lane is one of several retrieval lanes and its pool is handed to an
+// LLM selector. A skill ranking well here is necessary for it to be surfaced,
+// not sufficient.
+//
+// Usage (from assistant/):
+//   bun run scripts/probe-skill-retrieval.ts -q "help me connect stripe link"
+//   bun run scripts/probe-skill-retrieval.ts --queries queries.json --top 10
+//   bun run scripts/probe-skill-retrieval.ts -q "..." --only stripe
+//   bun run scripts/probe-skill-retrieval.ts --queries q.json --save before.json
+//   ...edit SKILL.md...
+//   bun run scripts/probe-skill-retrieval.ts --queries q.json --baseline before.json
+// ---------------------------------------------------------------------------
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { getConfig } from "../src/config/loader.js";
+import {
+  type ParsedFrontmatter,
+  parseFrontmatter,
+} from "../src/config/skills.js";
+import { LocalEmbeddingBackend } from "../src/persistence/embeddings/embedding-local.js";
+import {
+  ALWAYS_CANDIDATE_CARD_CHARS,
+  buildSkillContent,
+  DEFAULT_CARD_CHARS,
+  renderSkillCard,
+} from "../src/plugins/defaults/memory/substrate/skill-content.js";
+
+interface ProbeOptions {
+  queries: string[];
+  skillDirs: string[];
+  top: number;
+  only?: string;
+  json: boolean;
+  truncationReport: boolean;
+  save?: string;
+  baseline?: string;
+}
+
+interface Card {
+  name: string;
+  text: string;
+  budget: number;
+  /** Characters the budget cut from the end of the card, 0 when it fits. */
+  lostChars: number;
+}
+
+interface Ranked {
+  name: string;
+  score: number;
+  rank: number;
+}
+
+/** Score deltas below this are rounding, not signal, and are not reported. */
+const DELTA_EPSILON = 0.0005;
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..");
+
+const DEFAULT_SKILL_DIRS = [
+  join(REPO_ROOT, "skills"),
+  join(REPO_ROOT, "assistant", "src", "config", "bundled-skills"),
+];
+
+function usage(): never {
+  console.error(
+    [
+      "Usage: bun run scripts/probe-skill-retrieval.ts [options]",
+      "",
+      "  -q, --query <text>      Query to rank (repeatable)",
+      "      --queries <file>    JSON array of queries, or one query per line",
+      "      --skills-dir <dir>  Directory of <skill>/SKILL.md (repeatable)",
+      "      --top <n>           Rows to print per query (default 8)",
+      "      --only <substr>     Always print skills matching this substring",
+      "      --save <file>       Write scores to a JSON baseline",
+      "      --baseline <file>   Compare against a saved baseline",
+      "      --json              Emit JSON instead of a table",
+      "      --truncation-report List every card the budget truncates",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): ProbeOptions {
+  const queries: string[] = [];
+  const skillDirs: string[] = [];
+  let top = 8;
+  let only: string | undefined;
+  let json = false;
+  let truncationReport = false;
+  let save: string | undefined;
+  let baseline: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const value = argv[++i];
+      if (value === undefined) {
+        usage();
+      }
+      return value;
+    };
+    switch (arg) {
+      case "-q":
+      case "--query":
+        queries.push(next());
+        break;
+      case "--queries":
+        queries.push(...readQueryFile(next()));
+        break;
+      case "--skills-dir":
+        skillDirs.push(resolve(next()));
+        break;
+      case "--top":
+        top = Number.parseInt(next(), 10);
+        break;
+      case "--only":
+        only = next();
+        break;
+      case "--save":
+        save = resolve(next());
+        break;
+      case "--baseline":
+        baseline = resolve(next());
+        break;
+      case "--json":
+        json = true;
+        break;
+      case "--truncation-report":
+        truncationReport = true;
+        break;
+      default:
+        usage();
+    }
+  }
+
+  if (queries.length === 0 || !Number.isFinite(top) || top < 1) {
+    usage();
+  }
+
+  return {
+    queries,
+    skillDirs: skillDirs.length > 0 ? skillDirs : DEFAULT_SKILL_DIRS,
+    top,
+    only,
+    json,
+    truncationReport,
+    save,
+    baseline,
+  };
+}
+
+function readQueryFile(path: string): string[] {
+  const raw = readFileSync(resolve(path), "utf8");
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("[")) {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) {
+      throw new Error(`${path}: JSON must be an array of query strings`);
+    }
+    return parsed.map(String);
+  }
+  return trimmed
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+function loadSkills(dirs: string[]): ParsedFrontmatter[] {
+  const byName = new Map<string, ParsedFrontmatter>();
+  for (const dir of dirs) {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      console.error(`warning: skipping unreadable skills dir ${dir}`);
+      continue;
+    }
+    for (const entry of entries) {
+      const skillPath = join(dir, entry, "SKILL.md");
+      try {
+        if (!statSync(skillPath).isFile()) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      const parsed = parseFrontmatter(
+        readFileSync(skillPath, "utf8"),
+        skillPath,
+      );
+      if (parsed) {
+        byName.set(parsed.name, parsed);
+      }
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function buildCard(skill: ParsedFrontmatter): Card {
+  const budget = skill.alwaysCandidate
+    ? ALWAYS_CANDIDATE_CARD_CHARS
+    : DEFAULT_CARD_CHARS;
+  const input = {
+    id: skill.name,
+    displayName: skill.displayName,
+    description: skill.description,
+    activationHints: skill.activationHints,
+    avoidWhen: skill.avoidWhen,
+  };
+  const text = buildSkillContent(input, budget);
+  // A card at exactly the budget was not truncated, so compare against the
+  // untruncated render rather than testing `length >= budget`.
+  const full = renderSkillCard(input, budget);
+  return {
+    name: skill.name,
+    text,
+    budget,
+    lostChars: full.length - text.length,
+  };
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+function rank(
+  queryVec: number[],
+  cards: Card[],
+  cardVecs: number[][],
+): Ranked[] {
+  return cards
+    .map((card, i) => ({
+      name: card.name,
+      score: cosine(queryVec, cardVecs[i]),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .map((row, i) => ({ ...row, rank: i + 1 }));
+}
+
+function formatDelta(
+  current: Ranked,
+  baseline: Record<string, number> | undefined,
+): string {
+  if (!baseline) {
+    return "";
+  }
+  const before = baseline[current.name];
+  if (before === undefined) {
+    return "  (new)";
+  }
+  const delta = current.score - before;
+  if (Math.abs(delta) < DELTA_EPSILON) {
+    return "";
+  }
+  return `  (${delta > 0 ? "+" : ""}${delta.toFixed(4)})`;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const skills = loadSkills(options.skillDirs);
+  if (skills.length === 0) {
+    throw new Error(
+      `No SKILL.md files found under: ${options.skillDirs.join(", ")}`,
+    );
+  }
+  const cards = skills.map(buildCard);
+
+  const truncated = cards
+    .filter((card) => card.lostChars > 0)
+    .sort((a, b) => b.lostChars - a.lostChars);
+  if (truncated.length > 0 && !options.json) {
+    console.error(
+      `${truncated.length} of ${cards.length} cards overrun their budget and lose trailing hints` +
+        (options.truncationReport
+          ? ":"
+          : " (--truncation-report to list them)"),
+    );
+    if (options.truncationReport) {
+      for (const card of truncated) {
+        console.error(
+          `  ${card.name}: ${card.budget + card.lostChars}/${card.budget} chars, ${card.lostChars} lost`,
+        );
+      }
+    }
+  }
+
+  const baseline: Record<string, Record<string, number>> | undefined =
+    options.baseline
+      ? JSON.parse(readFileSync(options.baseline, "utf8"))
+      : undefined;
+
+  const model = getConfig().memory.embeddings.localModel;
+  const backend = new LocalEmbeddingBackend(model);
+  const results: Record<string, Record<string, number>> = {};
+
+  try {
+    const cardVecs = await backend.embed(cards.map((card) => card.text));
+    for (const query of options.queries) {
+      const [queryVec] = await backend.embed([query]);
+      const ranked = rank(queryVec, cards, cardVecs);
+      results[query] = Object.fromEntries(
+        ranked.map((row) => [row.name, row.score]),
+      );
+
+      if (options.json) {
+        continue;
+      }
+
+      console.log(`\nQ: ${query}`);
+      const shown = new Set<string>();
+      for (const row of ranked.slice(0, options.top)) {
+        shown.add(row.name);
+        console.log(
+          `  ${String(row.rank).padStart(3)}. ${row.score.toFixed(4)}  ${row.name}${formatDelta(row, baseline?.[query])}`,
+        );
+      }
+      if (options.only) {
+        for (const row of ranked) {
+          if (!shown.has(row.name) && row.name.includes(options.only)) {
+            console.log(
+              `  ${String(row.rank).padStart(3)}. ${row.score.toFixed(4)}  ${row.name}${formatDelta(row, baseline?.[query])}`,
+            );
+          }
+        }
+      }
+    }
+  } finally {
+    backend.dispose();
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(results, null, 2));
+  }
+  if (options.save) {
+    writeFileSync(options.save, `${JSON.stringify(results, null, 2)}\n`);
+    console.error(`\nSaved baseline to ${options.save}`);
+  }
+}
+
+await main();

--- a/assistant/scripts/probe-skill-retrieval.ts
+++ b/assistant/scripts/probe-skill-retrieval.ts
@@ -5,13 +5,17 @@
 // the concept-page collection and retrieving against it. The card is built from
 // SKILL.md frontmatter only (`description` + `activation-hints` + `avoid-when`),
 // never the body, and is hard-truncated to a character budget. This script
-// builds the same cards from SKILL.md on disk, embeds them with the same local
-// backend, and prints the ranking, so frontmatter wording can be validated
-// without a running assistant.
+// builds the same cards from SKILL.md on disk, embeds them with the assistant's
+// local backend, and prints the ranking, so frontmatter wording can be validated
+// without a running assistant. `--provider configured` ranks in the workspace's
+// own embedding space instead, which needs a host that can reach its provider.
 //
-// The dense lane is one of several retrieval lanes and its pool is handed to an
-// LLM selector. A skill ranking well here is necessary for it to be surfaced,
-// not sufficient.
+// Two limits on what a run proves. The dense lane is one of several retrieval
+// lanes and its pool is handed to an LLM selector, so a skill ranking well here
+// is necessary for it to be surfaced, not sufficient. And the pool is every
+// SKILL.md on disk that this platform can run, where a real workspace also
+// resolves feature flags, plugin ownership, and per-skill enabled state, so a
+// host with skills disabled sees a slightly smaller field than this.
 //
 // Usage (from assistant/):
 //   bun run scripts/probe-skill-retrieval.ts -q "help me connect stripe link"
@@ -30,13 +34,14 @@ import {
   type ParsedFrontmatter,
   parseFrontmatter,
 } from "../src/config/skills.js";
-import { LocalEmbeddingBackend } from "../src/persistence/embeddings/embedding-local.js";
 import {
   ALWAYS_CANDIDATE_CARD_CHARS,
+  augmentMcpSetupDescription,
   buildSkillContent,
   DEFAULT_CARD_CHARS,
   renderSkillCard,
 } from "../src/plugins/defaults/memory/substrate/skill-content.js";
+import { filterSkillsByPlatform } from "../src/skills/platform-compatibility.js";
 
 interface ProbeOptions {
   queries: string[];
@@ -45,9 +50,18 @@ interface ProbeOptions {
   only?: string;
   json: boolean;
   truncationReport: boolean;
+  platform: NodeJS.Platform;
+  useConfiguredProvider: boolean;
   save?: string;
   baseline?: string;
 }
+
+/** `--platform` takes the skill-facing names, not node's `process.platform`. */
+const PLATFORM_ALIASES: Record<string, NodeJS.Platform> = {
+  macos: "darwin",
+  windows: "win32",
+  linux: "linux",
+};
 
 interface Card {
   name: string;
@@ -61,6 +75,12 @@ interface Ranked {
   name: string;
   score: number;
   rank: number;
+}
+
+/** An embedding backend plus the teardown that lets the process exit. */
+interface Embedder {
+  embed: (texts: string[]) => Promise<number[][]>;
+  dispose: () => Promise<void> | void;
 }
 
 /** Score deltas below this are rounding, not signal, and are not reported. */
@@ -87,6 +107,8 @@ function usage(): never {
       "      --baseline <file>   Compare against a saved baseline",
       "      --json              Emit JSON instead of a table",
       "      --truncation-report List every card the budget truncates",
+      "      --platform <name>   Rank as macos | windows | linux (default: this host)",
+      "      --provider <name>   local (default, no daemon) | configured (workspace provider)",
     ].join("\n"),
   );
   process.exit(1);
@@ -99,6 +121,8 @@ function parseArgs(argv: string[]): ProbeOptions {
   let only: string | undefined;
   let json = false;
   let truncationReport = false;
+  let platform: NodeJS.Platform = process.platform;
+  let useConfiguredProvider = false;
   let save: string | undefined;
   let baseline: string | undefined;
 
@@ -140,6 +164,29 @@ function parseArgs(argv: string[]): ProbeOptions {
       case "--truncation-report":
         truncationReport = true;
         break;
+      case "--provider": {
+        const value = next();
+        if (value !== "local" && value !== "configured") {
+          console.error(
+            `Unknown --provider "${value}". Expected "local" or "configured".`,
+          );
+          process.exit(1);
+        }
+        useConfiguredProvider = value === "configured";
+        break;
+      }
+      case "--platform": {
+        const value = next();
+        const resolved = PLATFORM_ALIASES[value];
+        if (!resolved) {
+          console.error(
+            `Unknown --platform "${value}". Expected one of: ${Object.keys(PLATFORM_ALIASES).join(", ")}`,
+          );
+          process.exit(1);
+        }
+        platform = resolved;
+        break;
+      }
       default:
         usage();
     }
@@ -156,6 +203,8 @@ function parseArgs(argv: string[]): ProbeOptions {
     only,
     json,
     truncationReport,
+    platform,
+    useConfiguredProvider,
     save,
     baseline,
   };
@@ -177,7 +226,10 @@ function readQueryFile(path: string): string[] {
     .filter((line) => line.length > 0 && !line.startsWith("#"));
 }
 
-function loadSkills(dirs: string[]): ParsedFrontmatter[] {
+function loadSkills(
+  dirs: string[],
+  platform: NodeJS.Platform,
+): ParsedFrontmatter[] {
   const byName = new Map<string, ParsedFrontmatter>();
   for (const dir of dirs) {
     let entries: string[];
@@ -205,20 +257,26 @@ function loadSkills(dirs: string[]): ParsedFrontmatter[] {
       }
     }
   }
-  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  // Production never seeds a card for a skill the host cannot run, so leaving
+  // the other platforms' skills in would put candidates in the pool that no
+  // real retrieval could return, shifting every rank below them.
+  const eligible = filterSkillsByPlatform([...byName.values()], platform);
+  return eligible.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function buildCard(skill: ParsedFrontmatter): Card {
   const budget = skill.alwaysCandidate
     ? ALWAYS_CANDIDATE_CARD_CHARS
     : DEFAULT_CARD_CHARS;
-  const input = {
+  // Mirrors `buildInstalledSkillCards`: mcp-setup's card carries the configured
+  // server names, so a query naming a server has to score against them here too.
+  const input = augmentMcpSetupDescription({
     id: skill.name,
     displayName: skill.displayName,
     description: skill.description,
     activationHints: skill.activationHints,
     avoidWhen: skill.avoidWhen,
-  };
+  });
   const text = buildSkillContent(input, budget);
   // A card at exactly the budget was not truncated, so compare against the
   // untruncated render rather than testing `length >= budget`.
@@ -276,9 +334,73 @@ function formatDelta(
   return `  (${delta > 0 ? "+" : ""}${delta.toFixed(4)})`;
 }
 
+/**
+ * Embed through the provider the workspace config selects, which is what
+ * production ranks in, and fall back to the in-process local backend when that
+ * provider is unreachable (no key, no network, billing breaker open). Scores
+ * are not comparable across embedding models, so the provider actually used is
+ * always reported rather than assumed.
+ */
+/**
+ * Pick the embedding space the ranking is measured in.
+ *
+ * Local is the default because it is the only backend that runs with no
+ * daemon: `embedWithBackend` resolves provider credentials through the
+ * credential store, which blocks when no assistant is running. `--provider
+ * configured` opts into the full production path on a host that has one.
+ *
+ * Scores are not comparable across embedding models, so the provider actually
+ * used is reported rather than assumed, and a saved baseline should only be
+ * diffed against a run that used the same one.
+ */
+async function resolveEmbedder(
+  config: ReturnType<typeof getConfig>,
+  useConfiguredProvider: boolean,
+  quiet: boolean,
+): Promise<Embedder> {
+  const announce = (message: string): void => {
+    if (!quiet) {
+      console.error(message);
+    }
+  };
+  if (useConfiguredProvider) {
+    // Imported here rather than at module scope: the memory embeddings module
+    // pulls in the Qdrant client, whose import-time setup stalls with no
+    // assistant running, which would hang the local path too.
+    const { embedWithBackend } =
+      await import("../src/plugins/defaults/memory/embeddings.js");
+    const probe = await embedWithBackend(config, ["probe"]);
+    announce(`Embedding with ${probe.provider} / ${probe.model}`);
+    const { shutdownEmbeddingBackends } =
+      await import("../src/persistence/embeddings/embedding-backend.js");
+    return {
+      embed: async (texts) => (await embedWithBackend(config, texts)).vectors,
+      dispose: () => shutdownEmbeddingBackends(),
+    };
+  }
+  const localModel = config.memory.embeddings.localModel;
+  announce(
+    `Embedding with local / ${localModel}. Pass --provider configured to rank in the workspace's own embedding space.`,
+  );
+  const { LocalEmbeddingBackend } =
+    await import("../src/persistence/embeddings/embedding-local.js");
+  const backend = new LocalEmbeddingBackend(localModel);
+  return {
+    embed: (texts) => backend.embed(texts),
+    // The backend is constructed here rather than handed out by
+    // `selectEmbeddingBackend`, so the shared shutdown path does not know about
+    // it. A one-shot script has nothing to drain, so the worker is killed
+    // outright: `dispose()` only closes it once idle, which leaves it running
+    // and the process alive.
+    dispose: () => {
+      backend.terminateNow();
+    },
+  };
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
-  const skills = loadSkills(options.skillDirs);
+  const skills = loadSkills(options.skillDirs, options.platform);
   if (skills.length === 0) {
     throw new Error(
       `No SKILL.md files found under: ${options.skillDirs.join(", ")}`,
@@ -310,14 +432,23 @@ async function main(): Promise<void> {
       ? JSON.parse(readFileSync(options.baseline, "utf8"))
       : undefined;
 
-  const model = getConfig().memory.embeddings.localModel;
-  const backend = new LocalEmbeddingBackend(model);
+  // Embed through the same entry point production uses, so the provider the
+  // workspace config selects is the provider the ranking is measured in.
+  // Scores are not comparable across embedding models, which is why the
+  // provider and model are reported alongside them.
+  const config = getConfig();
+  const embedder = await resolveEmbedder(
+    config,
+    options.useConfiguredProvider,
+    options.json,
+  );
+  const embed = embedder.embed;
   const results: Record<string, Record<string, number>> = {};
 
   try {
-    const cardVecs = await backend.embed(cards.map((card) => card.text));
+    const cardVecs = await embed(cards.map((card) => card.text));
     for (const query of options.queries) {
-      const [queryVec] = await backend.embed([query]);
+      const [queryVec] = await embed([query]);
       const ranked = rank(queryVec, cards, cardVecs);
       results[query] = Object.fromEntries(
         ranked.map((row) => [row.name, row.score]),
@@ -346,7 +477,9 @@ async function main(): Promise<void> {
       }
     }
   } finally {
-    backend.dispose();
+    const { shutdownEmbeddingBackends } =
+      await import("../src/persistence/embeddings/embedding-backend.js");
+    await shutdownEmbeddingBackends();
   }
 
   if (options.json) {
@@ -359,3 +492,7 @@ async function main(): Promise<void> {
 }
 
 await main();
+
+// The embedding worker leaves handles the runtime still counts as live work, so
+// a one-shot run would otherwise sit at an idle event loop after printing.
+process.exit(0);

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -250,7 +250,7 @@ export function getBundledSkillsDir(): string {
 
 // ─── Frontmatter parsing ─────────────────────────────────────────────────────
 
-interface ParsedFrontmatter {
+export interface ParsedFrontmatter {
   name: string;
   displayName: string;
   description: string;
@@ -278,7 +278,7 @@ function normalizeStringArray(raw: unknown): string[] | undefined {
   return result.length > 0 ? result : undefined;
 }
 
-function parseFrontmatter(
+export function parseFrontmatter(
   content: string,
   skillFilePath: string,
 ): ParsedFrontmatter | null {

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/skill-content.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/skill-content.test.ts
@@ -122,9 +122,8 @@ describe("augmentMcpSetupDescription", () => {
 
 describe("SKILLS_INJECTION_CATALOG_HINT", () => {
   test("points a missing product at plugin and skill search", async () => {
-    const { SKILLS_INJECTION_CATALOG_HINT } = await import(
-      "../skill-content.js"
-    );
+    const { SKILLS_INJECTION_CATALOG_HINT } =
+      await import("../skill-content.js");
     expect(SKILLS_INJECTION_CATALOG_HINT).toContain(
       "assistant plugins search <name>",
     );
@@ -133,6 +132,53 @@ describe("SKILLS_INJECTION_CATALOG_HINT", () => {
     );
     expect(SKILLS_INJECTION_CATALOG_HINT.toLowerCase()).toContain(
       "currently in the workspace",
+    );
+  });
+});
+
+describe("renderSkillCard", () => {
+  test("keeps the hints the budget would cut", async () => {
+    const { buildSkillContent, renderSkillCard } =
+      await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "verbose",
+      displayName: "Verbose",
+      description: "x".repeat(480),
+      activationHints: ["the user asks for the verbose thing"],
+      avoidWhen: ["anything else"],
+    };
+    const budgeted = buildSkillContent(input, 500);
+    const full = renderSkillCard(input, 500);
+
+    expect(budgeted.length).toBe(500);
+    expect(full.length).toBeGreaterThan(500);
+    expect(full.startsWith(budgeted)).toBe(true);
+    expect(full).toContain("Use when: the user asks for the verbose thing.");
+    expect(full).toContain("Avoid when: anything else.");
+  });
+
+  test("matches buildSkillContent when the card fits the budget", async () => {
+    const { buildSkillContent, renderSkillCard } =
+      await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "short",
+      displayName: "Short",
+      description: "Does one small thing",
+      activationHints: ["the user asks for it"],
+    };
+    expect(renderSkillCard(input, 500)).toBe(buildSkillContent(input, 500));
+  });
+
+  test("uses the bulleted layout at the always-candidate budget", async () => {
+    const { renderSkillCard } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "pinned",
+      displayName: "Pinned",
+      description: "Always in the pool",
+      activationHints: ["first mode", "second mode"],
+    };
+    expect(renderSkillCard(input, 900)).toContain(
+      "Use when:\n- first mode\n- second mode",
     );
   });
 });

--- a/assistant/src/plugins/defaults/memory/substrate/skill-content.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/skill-content.ts
@@ -48,6 +48,24 @@ export function buildSkillContent(
   input: SkillCapabilityInput,
   maxChars: number = DEFAULT_CARD_CHARS,
 ): string {
+  const content = renderSkillCard(input, maxChars);
+  if (content.length > maxChars) {
+    return content.slice(0, maxChars);
+  }
+  return content;
+}
+
+/**
+ * The capability statement a skill would carry if the budget were unlimited,
+ * rendered in the layout `maxChars` selects. Tooling compares this against
+ * {@link buildSkillContent} to report how much of a card the budget cuts. The
+ * budgeted render cannot express that on its own, since raising `maxChars`
+ * past 500 also switches the hint layout.
+ */
+export function renderSkillCard(
+  input: SkillCapabilityInput,
+  maxChars: number = DEFAULT_CARD_CHARS,
+): string {
   const list = maxChars > 500;
   let content = `The "${input.displayName}" skill (${input.id}) is available. ${input.description}.`;
   if (input.activationHints && input.activationHints.length > 0) {
@@ -59,9 +77,6 @@ export function buildSkillContent(
     content += list
       ? `\nAvoid when:\n${input.avoidWhen.map((a) => `- ${a}`).join("\n")}`
       : ` Avoid when: ${input.avoidWhen.join("; ")}.`;
-  }
-  if (content.length > maxChars) {
-    content = content.slice(0, maxChars);
   }
   return content;
 }

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -262,3 +262,26 @@
   - If you must do something Vellum-system specific, use the `metadata` field to connect the skill in a structured way
   - **`metadata.vellum.category`** (required): every skill must declare a category slug matching an entry in `skills/skill-categories-catalog.yaml`. The linter validates this in both directions — skills must reference a valid category, and every category must be used by at least one skill. Pass `--skip-category` to the linter to skip this check for external/third-party skills.
   - **`metadata.vellum.platforms`** (optional): restrict a skill to the host operating systems it supports. Allowed values are `macos`, `windows`, and `linux`. Omit the field for portable skills.
+
+- **Checking how a skill gets retrieved**
+
+  A skill is surfaced to a turn through its capability card, built from `description` plus `metadata.vellum.activation-hints` and `avoid-when`. The SKILL.md body is never a retrieval signal, and the card is hard-truncated to 500 characters (900 for `always-candidate`), so a long description silently costs a skill its hints.
+
+  Rank the cards against a query offline, with no assistant running:
+
+  ```bash
+  cd assistant
+  bun run probe:skill-retrieval -q "help me connect stripe link" --only stripe
+  bun run probe:skill-retrieval --queries queries.json --truncation-report
+  ```
+
+  To check that a wording change did what you intended, save a baseline first, edit SKILL.md, then re-run against it:
+
+  ```bash
+  bun run probe:skill-retrieval --queries queries.json --save before.json
+  bun run probe:skill-retrieval --queries queries.json --baseline before.json
+  ```
+
+  Two things to watch for. `avoid-when` text is embedded along with everything else, so phrasing it in the vocabulary you want to repel ("avoid when the user wants to spend money") pulls the skill *toward* those queries. Name the other skill or the other domain instead. And two skills in one product area need hints that separate them, since a shared product name puts both near every query that mentions it.
+
+  The probe covers the dense retrieval lane only. Its pool still goes to an LLM selector, so ranking well here is necessary for a skill to be surfaced, not sufficient.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -715,7 +715,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-07T16:38:32.000Z"
+      "updatedAt": "2026-09-08T18:39:32.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T15:29:43.000Z"
+      "updatedAt": "2026-09-08T18:29:56.000Z"
     },
     {
       "id": "public-ingress",


### PR DESCRIPTION
## Why

Which skills get surfaced into a turn is decided by a **capability card**, not by the SKILL.md body. The card is built from frontmatter only:

```
The "<display-name>" skill (<id>) is available. <description>. Use when: <activation-hints>. Avoid when: <avoid-when>.
```

It is embedded into the concept-page collection, retrieved by the dense + BM25 lanes, and handed to the LLM selector. Two consequences were invisible until now:

1. Wording changes to `description` / `activation-hints` could only be evaluated by booting an assistant, re-seeding, and trying prompts by hand.
2. The card is hard-truncated at 500 characters (900 for `always-candidate`). A long description silently costs a skill its `Use when:` hints, which is the highest-signal routing text it has. **25 of 98 cards are truncated today.**

This came out of a concrete miss: "help me set up Stripe Link" routes to `stripe-app-setup` (the merchant API key skill) instead of `stripe-link-wallet`. The wallet skill has a full `link-cli auth login` flow in its body, but nothing about setup in its card, and its card is cut at 500 characters. The wording fix for that is a separate PR; this one is the tool that lets us verify it.

## What

`bun run probe:skill-retrieval` ranks every skill card against a query offline. No daemon, no Qdrant, no API key. It reads SKILL.md from `skills/` and `assistant/src/config/bundled-skills/`, builds cards with the production renderer, and embeds with the same local ONNX backend the assistant uses.

```bash
cd assistant
bun run probe:skill-retrieval -q "help me connect stripe link" --only stripe
```

```
Q: help me connect stripe link
    1. 0.6989  stripe-link-wallet
    2. 0.6943  stripe-app-setup
    3. 0.6229  slack-app-setup
```

To check a wording change did what you intended:

```bash
bun run probe:skill-retrieval --queries q.json --save before.json
# edit SKILL.md
bun run probe:skill-retrieval --queries q.json --baseline before.json
```

`--truncation-report` lists every card the budget cuts and by how much, which is the input to the follow-up PR that fixes the 25.

## Notes for review

- **`renderSkillCard` extraction** (`skill-content.ts`) is the only production change with any behavior surface, and it has none: `buildSkillContent` now calls it and truncates. It exists because the untruncated length cannot be recovered from `buildSkillContent` alone. Raising `maxChars` past 500 also flips the hint layout from inline to bulleted, so `buildSkillContent(input, Infinity)` measures a differently-formatted string. Three tests cover the equivalence and the layout boundary.
- **`parseFrontmatter` is now exported** from `config/skills.ts`, so the probe parses SKILL.md exactly as the runtime does rather than carrying its own copy.
- **Scope limit, stated in the script header and the docs:** this covers the dense lane only. The pool still goes to an LLM selector, so ranking well here is necessary for a skill to be surfaced, not sufficient.
- The probe downloads/upgrades the local embedding runtime on first run via the existing `EmbeddingRuntimeManager`, same as the daemon.

## Testing

- `bun test src/plugins/defaults/memory/substrate/__tests__/skill-content.test.ts` (11 pass)
- `bun test src/plugins/defaults/memory/substrate/__tests__/skill-store.test.ts` (38 pass)
- `bun run typecheck:fast`, `bun run lint` clean
- Probe run by hand against real skills; output above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B4QFL62YsTH1hn1dtzgQi

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->