### PR TITLE
fix(skills): route Stripe Link setup to the wallet skill

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -715,7 +715,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-07T16:38:32.000Z"
+      "updatedAt": "2026-09-08T18:39:32.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T15:29:43.000Z"
+      "updatedAt": "2026-09-08T18:29:56.000Z"
     },
     {
       "id": "public-ingress",
@@ -943,26 +943,34 @@
         "vellum": {
           "category": "commerce",
           "display-name": "Stripe App Setup",
-          "user-invocable": "true"
+          "user-invocable": "true",
+          "activation-hints": [
+            "the user wants the assistant to read or manage their Stripe merchant account: customers, subscriptions, refunds, invoices, payouts"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T21:17:09.000Z"
+      "updatedAt": "2026-09-08T19:30:15.000Z"
     },
     {
       "id": "stripe-link-wallet",
       "name": "stripe-link-wallet",
-      "description": "Use the Stripe Link CLI as an agent wallet to create spend requests, generate one-time-use payment credentials, and complete 402 / Machine Payment Protocol (MPP) payment flows on the user's behalf. Triggers on intents like \"buy\", \"purchase\", \"pay for\", \"spend up to <amount>\", \"complete this 402\", or any flow involving link-cli, spend-request, mpp pay, shared payment tokens, or @stripe/link-sdk. Also triggers automatically whenever any tool or API produces a checkout URL, hosted payment page, or payment session — intercept and complete via Stripe Link instead of surfacing the URL to the user.",
+      "description": "Agent wallet on the Stripe Link CLI (link-cli). Connect the wallet, then buy, purchase and pay for things on the user's behalf via approved spend requests, one-time-use cards, and 402 / Machine Payment Protocol (MPP) payments",
       "metadata": {
         "icon": "assets/icon.svg",
         "emoji": "💳",
         "vellum": {
           "category": "commerce",
-          "display-name": "Stripe Link Wallet"
+          "display-name": "Stripe Link Wallet",
+          "activation-hints": [
+            "the user wants to set up, connect, or log in to Stripe Link",
+            "the user asks to buy, purchase, pay for, or spend up to an amount",
+            "a tool returns a checkout URL or payment session"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T20:01:47.000Z"
+      "updatedAt": "2026-09-08T19:30:15.000Z"
     },
     {
       "id": "telegram-setup",

--- a/skills/stripe-app-setup/SKILL.md
+++ b/skills/stripe-app-setup/SKILL.md
@@ -9,6 +9,8 @@ metadata:
     category: "commerce"
     display-name: "Stripe App Setup"
     user-invocable: true
+    activation-hints:
+      - "the user wants the assistant to read or manage their Stripe merchant account: customers, subscriptions, refunds, invoices, payouts"
 ---
 
 ## Overview

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: "stripe-link-wallet"
-description: 'Use the Stripe Link CLI as an agent wallet to create spend requests, generate one-time-use payment credentials, and complete 402 / Machine Payment Protocol (MPP) payment flows on the user''s behalf. Triggers on intents like "buy", "purchase", "pay for", "spend up to <amount>", "complete this 402", or any flow involving link-cli, spend-request, mpp pay, shared payment tokens, or @stripe/link-sdk. Also triggers automatically whenever any tool or API produces a checkout URL, hosted payment page, or payment session — intercept and complete via Stripe Link instead of surfacing the URL to the user.'
+description: "Agent wallet on the Stripe Link CLI (link-cli). Connect the wallet, then buy, purchase and pay for things on the user's behalf via approved spend requests, one-time-use cards, and 402 / Machine Payment Protocol (MPP) payments"
 metadata:
   icon: assets/icon.svg
   emoji: "💳"
   vellum:
     category: "commerce"
     display-name: "Stripe Link Wallet"
+    activation-hints:
+      - "the user wants to set up, connect, or log in to Stripe Link"
+      - "the user asks to buy, purchase, pay for, or spend up to an amount"
+      - "a tool returns a checkout URL or payment session"
 compatibility: "Designed for Vellum personal assistants"
 ---
 


### PR DESCRIPTION
## The bug

Asking the assistant to "help me set up / connect Stripe Link" surfaces **`stripe-app-setup`** (the merchant restricted-API-key skill) instead of **`stripe-link-wallet`**, so the assistant walks the user through creating a Stripe API key rather than connecting the Link wallet.

## Why it happened

Skill routing reads a **capability card** built from frontmatter only. The SKILL.md body is never a retrieval signal:

```
The "<display-name>" skill (<id>) is available. <description>. Use when: <activation-hints>. Avoid when: <avoid-when>.
```

Three things stacked up:

1. **Neither skill declared `activation-hints`.** Both were matched on `description` alone.
2. **The wallet's description had no setup vocabulary.** It triggered on spending only ("buy", "purchase", "pay for", "402", checkout URL), even though the body owns a complete `link-cli auth login` device flow. `stripe-app-setup`'s description opens with "Create and configure a Stripe restricted API key", which is near-verbatim the user's phrasing.
3. **The wallet's card was truncated.** At 665 characters against a 500-character budget, it was cut mid-sentence at "…whenever", losing the entire checkout-interception clause.

Same `category: commerce`, same 💳 emoji, so nothing else separated them.

Worth noting for reviewers: this was **not** a recall failure. Both skills were already retrieved in the top 2 for setup queries. The wallet lost the *choice*, because its card gave the selector no reason to prefer it.

## The fix

Activation hints that split the two by intent, and a shortened wallet description so the whole card fits the budget (497 → within 500, nothing truncated).

| | claims |
|---|---|
| `stripe-link-wallet` | connect / log in to Stripe Link; buy, purchase, pay for, spend up to; a tool returns a checkout URL or payment session |
| `stripe-app-setup` | read or manage the Stripe merchant account: customers, subscriptions, refunds, invoices, payouts |

## Why no `avoid-when`

This is the non-obvious part and the one I'd most like a second opinion on.

`avoid-when` text is embedded along with the rest of the card, so phrasing it in the vocabulary it means to repel pulls the skill **toward** those queries. Measured, not assumed:

- `avoid-when: "the user wants to spend money…"` on app-setup moved it *up* to #4 on "buy me a coffee subscription" and knocked the wallet from #5 to #9.
- Rephrasing it to name the wallet instead still moved app-setup from #35 to #12 on "run link-cli spend-request", for no gain.
- Keeping both `avoid-when` lists pushed the wallet's card to 528 characters, back over budget, which would silently drop the hints again.

So the disambiguation is carried by the hints, which the selector reads just as well.

## Measured before → after

Via `bun run probe:skill-retrieval` from #42280:

| query | before | after |
|---|---|---|
| help me setup stripe link | **app-setup #1** by 0.054 | **wallet #1** by 0.005 |
| help me connect stripe link | wallet #1 by 0.005 | wallet #1 by 0.072 |
| connect my stripe link wallet | wallet #1 by 0.065 | wallet #1 by 0.138 |
| run link-cli spend-request | wallet #1, app-setup #35 | wallet #1, app-setup #25 |
| pay this 402 endpoint | wallet #1 by 0.108 | wallet #1 by 0.015 |
| refund a customer in stripe | app-setup #1 by 0.040 | app-setup #1 by 0.087 |
| list my stripe subscriptions | app-setup #1 by 0.047 | app-setup #1 by 0.067 |

The target query flips, wallet-specific queries widen their lead, and merchant queries separate *better* than before.

**One honest regression:** "pay this 402 endpoint" narrows from a 0.108 lead to 0.015. The wallet still ranks #1, and the shortened description is what buys the budget headroom, but it is a real loss of margin on that phrasing.

## Caveats

- The probe covers the dense retrieval lane. The pool still goes to an LLM selector, so this improves the odds rather than guaranteeing the pick. Worth a real end-to-end check on a live assistant before we call the original report closed.
- `metadata.vellum.user-invocable` (set on `stripe-app-setup`, absent on the wallet) is read nowhere in the codebase, so it plays no part here. Left alone.

## Testing

- `node scripts/skills/lint-skill-spec.mjs` — 75 skills conform
- `node scripts/skills/check-catalog.mjs` — catalog.json up to date (regenerated)
- Probe runs above, against the real SKILL.md files on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B4QFL62YsTH1hn1dtzgQi

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->