### PR TITLE
refactor(web): export the attachment glyph map from chat-attachments utils

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
@@ -1,25 +1,14 @@
-import {
-  Archive,
-  Code2,
-  FileAudio,
-  File as FileIcon,
-  FileImage,
-  FileSpreadsheet,
-  FileText,
-  FileType2,
-  FileVideo,
-  X,
-} from "lucide-react";
-import type { FC, MouseEventHandler, ReactNode } from "react";
+import { X } from "lucide-react";
+import type { FC, MouseEventHandler } from "react";
 
 import { useTranslation } from "@/i18n";
 
 import { Button } from "@vellumai/design-library";
 
 import {
+  ATTACHMENT_ICON_BY_KIND,
   classifyAttachment,
   middleTruncate,
-  type AttachmentIconKind,
 } from "@/domains/chat/components/chat-attachments/utils";
 
 interface AttachmentChipProps {
@@ -37,19 +26,6 @@ interface AttachmentChipProps {
   pressGuard?: MouseEventHandler<HTMLElement>;
 }
 
-const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
-  image: <FileImage className="h-4 w-4" />,
-  video: <FileVideo className="h-4 w-4" />,
-  audio: <FileAudio className="h-4 w-4" />,
-  pdf: <FileType2 className="h-4 w-4" />,
-  code: <Code2 className="h-4 w-4" />,
-  archive: <Archive className="h-4 w-4" />,
-  spreadsheet: <FileSpreadsheet className="h-4 w-4" />,
-  document: <FileText className="h-4 w-4" />,
-  text: <FileText className="h-4 w-4" />,
-  file: <FileIcon className="h-4 w-4" />,
-};
-
 export const AttachmentChip: FC<AttachmentChipProps> = ({
   id,
   filename,
@@ -62,6 +38,7 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
 }) => {
   const { t } = useTranslation("chat");
   const kind = classifyAttachment(mimeType, filename);
+  const Icon = ATTACHMENT_ICON_BY_KIND[kind];
   const displayName = middleTruncate(filename);
   const hasPreview = kind === "image" && previewUrl !== null;
   const isClickable = hasPreview && onPreview != null;
@@ -100,7 +77,7 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
             className="h-full w-full object-cover"
           />
         ) : (
-          ICON_BY_KIND[kind]
+          <Icon className="h-4 w-4" />
         )}
       </div>
       <span className="min-w-0 max-w-[156px] truncate text-body-small-default leading-4 text-[var(--content-secondary)]">

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -1,25 +1,14 @@
-import {
-  Archive,
-  Code2,
-  FileAudio,
-  File as FileIcon,
-  FileImage,
-  FileSpreadsheet,
-  FileText,
-  FileType2,
-  FileVideo,
-} from "lucide-react";
-import type { MouseEvent, ReactNode } from "react";
+import type { MouseEvent } from "react";
 import { useCallback } from "react";
 
 import { Typography } from "@vellumai/design-library";
 import { AttachmentDownloadOverlay } from "@/domains/chat/components/chat-attachments/attachment-download-overlay";
 
 import {
+  ATTACHMENT_ICON_BY_KIND,
   classifyAttachment,
   formatAttachmentSize,
   middleTruncate,
-  type AttachmentIconKind,
 } from "@/domains/chat/components/chat-attachments/utils";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 import { useIsNativePlatform } from "@/runtime/native-auth";
@@ -43,19 +32,6 @@ interface MessageAttachmentSquareProps {
   onPreviewError?: () => void;
 }
 
-const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
-  image: <FileImage className="h-6 w-6" />,
-  video: <FileVideo className="h-6 w-6" />,
-  audio: <FileAudio className="h-6 w-6" />,
-  pdf: <FileType2 className="h-6 w-6" />,
-  code: <Code2 className="h-6 w-6" />,
-  archive: <Archive className="h-6 w-6" />,
-  spreadsheet: <FileSpreadsheet className="h-6 w-6" />,
-  document: <FileText className="h-6 w-6" />,
-  text: <FileText className="h-6 w-6" />,
-  file: <FileIcon className="h-6 w-6" />,
-};
-
 /**
  * Square thumbnail used inside message bubbles. Image attachments render their
  * preview edge-to-edge; non-image attachments fall back to a neutral surface
@@ -71,6 +47,7 @@ export function MessageAttachmentSquare({
   const { filename, mimeType, sizeBytes, previewUrl, thumbnailUrl } =
     attachment;
   const kind = classifyAttachment(mimeType, filename);
+  const Icon = ATTACHMENT_ICON_BY_KIND[kind];
   const hasImagePreview = kind === "image" && previewUrl !== null;
   // Video posters stay a CSS background: there is no fallback to swap to when
   // a poster fails, so an <img> would surface the browser's broken glyph.
@@ -136,7 +113,7 @@ export function MessageAttachmentSquare({
               className="h-full w-full object-cover"
             />
           ) : backgroundImageUrl ? null : (
-            ICON_BY_KIND[kind]
+            <Icon className="h-6 w-6" />
           )}
         </div>
         {onDownload && (

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  ATTACHMENT_ICON_BY_KIND,
   classifyAttachment,
   isImageAttachment,
 } from "@/domains/chat/components/chat-attachments/utils";
@@ -110,5 +111,29 @@ describe("classifyAttachment", () => {
         "photo.jpg",
       ),
     ).toBe("image");
+  });
+});
+
+describe("ATTACHMENT_ICON_BY_KIND", () => {
+  test("carries a glyph for every kind the classifier returns", () => {
+    const samples: Array<[string, string]> = [
+      ["image/png", "shot.png"],
+      ["video/mp4", "clip.mp4"],
+      ["audio/mpeg", "song.mp3"],
+      ["application/pdf", "report.pdf"],
+      ["text/plain", "main.ts"],
+      ["application/zip", "bundle.zip"],
+      ["text/csv", "rows.csv"],
+      ["application/msword", "letter.doc"],
+      ["text/plain", "notes.txt"],
+      ["application/octet-stream", "blob"],
+    ];
+    const seen = new Set<string>();
+    for (const [mimeType, filename] of samples) {
+      const kind = classifyAttachment(mimeType, filename);
+      seen.add(kind);
+      expect(ATTACHMENT_ICON_BY_KIND[kind]).toBeDefined();
+    }
+    expect(seen.size).toBe(Object.keys(ATTACHMENT_ICON_BY_KIND).length);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.ts
@@ -1,4 +1,17 @@
 import {
+  Archive,
+  Code2,
+  FileAudio,
+  File as FileIcon,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  FileType2,
+  FileVideo,
+  type LucideIcon,
+} from "lucide-react";
+
+import {
   baseMimeType,
   extensionOf,
   GENERIC_MIME_TYPES,
@@ -84,6 +97,23 @@ export type AttachmentIconKind =
   | "document"
   | "text"
   | "file";
+
+/**
+ * Glyph every surface draws for an attachment of a given kind. Components
+ * rather than elements, so each caller sizes the icon for its own tile.
+ */
+export const ATTACHMENT_ICON_BY_KIND: Record<AttachmentIconKind, LucideIcon> = {
+  image: FileImage,
+  video: FileVideo,
+  audio: FileAudio,
+  pdf: FileType2,
+  code: Code2,
+  archive: Archive,
+  spreadsheet: FileSpreadsheet,
+  document: FileText,
+  text: FileText,
+  file: FileIcon,
+};
 
 /** The canonical PDF type plus the aliases publishers use in the wild. */
 const PDF_MIME_TYPES = new Set([

--- a/clients/web/src/domains/chat/components/local-file/local-file-icon.tsx
+++ b/clients/web/src/domains/chat/components/local-file/local-file-icon.tsx
@@ -8,19 +8,7 @@
  */
 
 import {
-  Archive,
-  Code2,
-  FileAudio,
-  File as FileIcon,
-  FileImage,
-  FileSpreadsheet,
-  FileText,
-  FileType2,
-  FileVideo,
-  type LucideIcon,
-} from "lucide-react";
-
-import {
+  ATTACHMENT_ICON_BY_KIND,
   classifyAttachment,
   type AttachmentIconKind,
 } from "@/domains/chat/components/chat-attachments/utils";
@@ -28,19 +16,6 @@ import {
   type LocalFileKind,
   resolveLocalFileType,
 } from "@/domains/chat/utils/mime-sniff";
-
-const ICON_BY_KIND: Record<AttachmentIconKind, LucideIcon> = {
-  image: FileImage,
-  video: FileVideo,
-  audio: FileAudio,
-  pdf: FileType2,
-  code: Code2,
-  archive: Archive,
-  spreadsheet: FileSpreadsheet,
-  document: FileText,
-  text: FileText,
-  file: FileIcon,
-};
 
 /** Icon bucket for a classified local file. */
 export function localFileIconKind(
@@ -76,6 +51,6 @@ export function LocalFileIcon({
   filename,
   className,
 }: LocalFileIconProps) {
-  const Icon = ICON_BY_KIND[localFileIconKind(kind, filename)];
+  const Icon = ATTACHMENT_ICON_BY_KIND[localFileIconKind(kind, filename)];
   return <Icon className={className} aria-hidden />;
 }


### PR DESCRIPTION
## Summary
- Lifts the attachment kind-to-glyph map out of MessageAttachmentSquare into chat-attachments utils so the upcoming Chat Info tiles share it
- The same map was copied verbatim in three places (`message-attachment-square.tsx`, `attachment-chip.tsx`, `local-file-icon.tsx`). All three now import the shared `ATTACHMENT_ICON_BY_KIND`, per the repo's Single Source of Truth rule
- The map holds components, not elements, so each caller keeps its own size class (`h-6 w-6`, `h-4 w-4`, or a passed-in `className`)
- No visual change

Part of plan: chat-info-assets-panel.md (PR 3 of 12)