### PR TITLE
feat(web): add a chat-info overlay view to the viewer store

### DIFF
--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -615,6 +615,15 @@ describe("closeActiveOverlay", () => {
     expect(getState().activeMessageFiles).toBeNull();
   });
 
+  it("closes the chat-info overlay and restores its prior view", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+
+    expect(getState().closeActiveOverlay()).toBe(true);
+    expect(getState().mainView).toBe("app");
+    expect(getState().activeChatInfo).toBeNull();
+  });
+
   it("returns false without changing a non-overlay view", () => {
     useViewerStore.setState({ mainView: "app", activeAppId: "app-1" });
 
@@ -871,6 +880,83 @@ describe("openMessageFiles / toggleMessageFiles / closeMessageFiles", () => {
     expect(state.activeActivitySteps).toBeNull();
     expect(state.activeToolDetail).toBeNull();
     expect(state.mainView).toBe("message-files");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chat info panel
+// ---------------------------------------------------------------------------
+
+const SAMPLE_CHAT_INFO = { assistantId: "a1", conversationId: "c1" };
+
+describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", () => {
+  it("opens the panel at the top level and records the prior view", () => {
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    const state = getState();
+    expect(state.mainView).toBe("chat-info");
+    expect(state.activeChatInfo).toEqual({
+      ...SAMPLE_CHAT_INFO,
+      category: null,
+    });
+    expect(state.viewBeforeChatInfo).toBe("chat");
+  });
+
+  it("opens the panel drilled into a category", () => {
+    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+    expect(getState().activeChatInfo?.category).toBe("apps");
+  });
+
+  it("close restores the prior view and clears the payload", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    expect(getState().viewBeforeChatInfo).toBe("app");
+    getState().closeChatInfo();
+    const state = getState();
+    expect(state.mainView).toBe("app");
+    expect(state.activeChatInfo).toBeNull();
+  });
+
+  it("toggle closes the panel when targeting the SAME conversation", () => {
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().toggleChatInfo({ ...SAMPLE_CHAT_INFO });
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeChatInfo).toBeNull();
+  });
+
+  it("toggle switches to a DIFFERENT conversation at the top level", () => {
+    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "files" });
+    getState().toggleChatInfo({ ...SAMPLE_CHAT_INFO, conversationId: "c2" });
+    const state = getState();
+    expect(state.mainView).toBe("chat-info");
+    expect(state.activeChatInfo).toEqual({
+      assistantId: "a1",
+      conversationId: "c2",
+      category: null,
+    });
+  });
+
+  it("setChatInfoCategory drills in and back out on the open payload", () => {
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().setChatInfoCategory("frames");
+    expect(getState().activeChatInfo?.category).toBe("frames");
+    getState().setChatInfoCategory(null);
+    expect(getState().activeChatInfo?.category).toBeNull();
+  });
+
+  it("setChatInfoCategory does not notify when the category is unchanged", () => {
+    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+    const before = getState().activeChatInfo;
+    getState().setChatInfoCategory("apps");
+    expect(getState().activeChatInfo).toBe(before);
+  });
+
+  it("setChatInfoCategory does nothing while the panel is closed", () => {
+    useViewerStore.setState({ mainView: "chat" });
+    getState().setChatInfoCategory("apps");
+    const state = getState();
+    expect(state.mainView).toBe("chat");
+    expect(state.activeChatInfo).toBeNull();
   });
 });
 

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -26,9 +26,8 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   documentsByIdGet: () => documentResult(),
 }));
 
-const { isAppNotFoundError, useViewerStore } = await import(
-  "@/stores/viewer-store"
-);
+const { isAppNotFoundError, useViewerStore } =
+  await import("@/stores/viewer-store");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -934,6 +933,12 @@ describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", 
       conversationId: "c2",
       category: null,
     });
+  });
+
+  it("clearTranscriptPanelPayloads drops the chat-info payload on a conversation switch", () => {
+    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+    getState().clearTranscriptPanelPayloads();
+    expect(getState().activeChatInfo).toBeNull();
   });
 
   it("toggle treats the same conversation id under another assistant as a new target", () => {

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -936,6 +936,18 @@ describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", 
     });
   });
 
+  it("toggle treats the same conversation id under another assistant as a new target", () => {
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().toggleChatInfo({ ...SAMPLE_CHAT_INFO, assistantId: "a2" });
+    const state = getState();
+    expect(state.mainView).toBe("chat-info");
+    expect(state.activeChatInfo).toEqual({
+      assistantId: "a2",
+      conversationId: "c1",
+      category: null,
+    });
+  });
+
   it("setChatInfoCategory drills in and back out on the open payload", () => {
     getState().openChatInfo(SAMPLE_CHAT_INFO);
     getState().setChatInfoCategory("frames");

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -1270,9 +1270,11 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   toggleChatInfo: (target) => {
     const state = get();
+    // Conversation ids are assistant-scoped, so both halves name the target.
     const isSameTarget =
       state.mainView === "chat-info" &&
-      state.activeChatInfo?.conversationId === target.conversationId;
+      state.activeChatInfo?.assistantId === target.assistantId &&
+      state.activeChatInfo.conversationId === target.conversationId;
     if (isSameTarget) {
       get().closeChatInfo();
     } else {

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -62,7 +62,8 @@ type OverlayView =
   | "background-task-detail"
   | "skill-detail"
   | "channel-setup"
-  | "channel-transcript";
+  | "channel-transcript"
+  | "chat-info";
 
 /**
  * Resolve the "view before" value for overlay navigation.
@@ -135,7 +136,8 @@ function resolveViewBefore(
     | "viewBeforeBackgroundTaskDetail"
     | "viewBeforeSkillDetail"
     | "viewBeforeChannelSetup"
-    | "viewBeforeChannelTranscript",
+    | "viewBeforeChannelTranscript"
+    | "viewBeforeChatInfo",
 ): Exclude<MainView, OverlayView> {
   const mv = state.mainView;
   if (
@@ -149,7 +151,8 @@ function resolveViewBefore(
     mv === "background-task-detail" ||
     mv === "skill-detail" ||
     mv === "channel-setup" ||
-    mv === "channel-transcript"
+    mv === "channel-transcript" ||
+    mv === "chat-info"
   ) {
     return state[field];
   }
@@ -174,7 +177,8 @@ export type MainView =
   | "background-task-detail"
   | "skill-detail"
   | "channel-setup"
-  | "channel-transcript";
+  | "channel-transcript"
+  | "chat-info";
 
 export type IntelligenceTab = "identity" | "skills" | "workspace" | "contacts";
 
@@ -456,6 +460,20 @@ export function sameMessageFilesTarget(
   return a.messageId === b.messageId;
 }
 
+/** The asset categories the chat-info panel groups a conversation into. */
+export type ChatInfoCategory = "apps" | "files" | "frames";
+
+/** What the chat-info panel is showing: one conversation, at one level. */
+export interface ChatInfoPayload {
+  assistantId: string;
+  conversationId: string;
+  /**
+   * The category drilled into through See All. `null` is the top level, where
+   * every category shows one truncated row.
+   */
+  category: ChatInfoCategory | null;
+}
+
 /** The identity fields a thinking drawer target is matched on. */
 type ThinkingTarget = Pick<
   ToolDetailPayload,
@@ -506,6 +524,8 @@ export interface ViewerState {
   viewBeforeActivitySteps: Exclude<MainView, OverlayView>;
   activeMessageFiles: MessageFilesPayload | null;
   viewBeforeMessageFiles: Exclude<MainView, OverlayView>;
+  activeChatInfo: ChatInfoPayload | null;
+  viewBeforeChatInfo: Exclude<MainView, OverlayView>;
   activeWorkflowRunId: string | null;
   viewBeforeWorkflowDetail: Exclude<MainView, OverlayView>;
   activeAcpRunId: string | null;
@@ -621,6 +641,25 @@ export interface ViewerActions {
   toggleMessageFiles: (payload: MessageFilesPayload) => void;
   closeMessageFiles: () => void;
 
+  // --- Chat info panel ---
+  openChatInfo: (target: {
+    assistantId: string;
+    conversationId: string;
+    category?: ChatInfoCategory | null;
+  }) => void;
+  /**
+   * Open the chat-info panel for `target`, or close it when it is already
+   * showing the SAME conversation. Powers the header trigger, where clicking
+   * the already-active control dismisses the panel.
+   */
+  toggleChatInfo: (target: {
+    assistantId: string;
+    conversationId: string;
+  }) => void;
+  closeChatInfo: () => void;
+  /** Drill into a category (See All) or back out (`null`). No-op unless the panel is open. */
+  setChatInfoCategory: (category: ChatInfoCategory | null) => void;
+
   /**
    * Drop the payloads of the panels whose content is scoped to one
    * conversation's transcript. Called on conversation switch: overlay
@@ -723,6 +762,8 @@ const INITIAL_STATE: ViewerState = {
   viewBeforeActivitySteps: "chat",
   activeMessageFiles: null,
   viewBeforeMessageFiles: "chat",
+  activeChatInfo: null,
+  viewBeforeChatInfo: "chat",
   activeWorkflowRunId: null,
   viewBeforeWorkflowDetail: "chat",
   activeAcpRunId: null,
@@ -1013,6 +1054,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       case "channel-transcript":
         get().closeChannelTranscript();
         return true;
+      case "chat-info":
+        get().closeChatInfo();
+        return true;
       default:
         return false;
     }
@@ -1208,6 +1252,52 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       mainView: get().viewBeforeMessageFiles,
       activeMessageFiles: null,
     });
+  },
+
+  // --- Chat info panel ---
+
+  openChatInfo: (target) => {
+    set({
+      mainView: "chat-info",
+      activeChatInfo: {
+        assistantId: target.assistantId,
+        conversationId: target.conversationId,
+        category: target.category ?? null,
+      },
+      viewBeforeChatInfo: resolveViewBefore(get(), "viewBeforeChatInfo"),
+    });
+  },
+
+  toggleChatInfo: (target) => {
+    const state = get();
+    const isSameTarget =
+      state.mainView === "chat-info" &&
+      state.activeChatInfo?.conversationId === target.conversationId;
+    if (isSameTarget) {
+      get().closeChatInfo();
+    } else {
+      get().openChatInfo(target);
+    }
+  },
+
+  closeChatInfo: () => {
+    set({
+      mainView: get().viewBeforeChatInfo,
+      activeChatInfo: null,
+    });
+  },
+
+  setChatInfoCategory: (category) => {
+    const state = get();
+    const active = state.activeChatInfo;
+    if (
+      state.mainView !== "chat-info" ||
+      active == null ||
+      active.category === category
+    ) {
+      return;
+    }
+    set({ activeChatInfo: { ...active, category } });
   },
 
   clearTranscriptPanelPayloads: () => {

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -1307,6 +1307,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeMessageFiles: null,
       activeActivitySteps: null,
       activeToolDetail: null,
+      activeChatInfo: null,
     });
   },
 


### PR DESCRIPTION
## Summary
- Adds the `chat-info` overlay view, its payload (conversation plus See All category), and open/toggle/close/set-category actions to the viewer store
- Escape handling through closeActiveOverlay

Part of plan: chat-info-assets-panel.md (PR 1 of 12)