### PR TITLE
ci: publish preview-channel web SPA to the production bucket on dev releases

### DIFF
--- a/.github/workflows/deploy-platform-web-spa.yaml
+++ b/.github/workflows/deploy-platform-web-spa.yaml
@@ -11,16 +11,12 @@ name: Deploy Web SPA (reusable)
 # a $GITHUB_ENV/$GITHUB_PATH/BASH_ENV hook (or a fake `gcloud`) that would fire
 # in the post-auth publish step and exfiltrate the short-lived GCP credentials.
 #
-# Three single-environment callers, one per environment: `deploy-web-spa` in
-# dev-release.yaml deploys `dev` on every hourly dev release (hard-gated on
-# ci-web alone, ordered after register-release, so web changes still reach dev
-# when the backend half of the release fails); release.yml's
-# `deploy-web-spa-staging` deploys `staging` on staging releases and
-# `deploy-web-spa-production` deploys `production` when a release goes live —
-# last, after the GitHub Release is published and the release is registered
-# with the platform, so a failed go-live never leaves the prod UI ahead of the
-# backend. The `environment:` binding only resolves each environment's
-# secrets/vars; no environment gates on required reviewers.
+# The default `stable` channel overwrites the root index.html. Any other channel
+# writes `<channel>/index.html` beside an untouched root index and uploads its
+# assets with --no-clobber, so a channel publish adds objects but never replaces
+# what the last stable release put in the bucket. The `environment:` binding only
+# resolves that environment's secrets and vars; no environment gates on required
+# reviewers.
 on:
   workflow_call:
     inputs:
@@ -28,6 +24,13 @@ on:
         description: Target GitHub environment (dev | staging | production).
         required: true
         type: string
+      channel:
+        description: >-
+          Publish channel: stable overwrites the root index.html; any other
+          value writes <channel>/index.html and leaves root untouched.
+        required: false
+        type: string
+        default: stable
 
 jobs:
   build-and-package:
@@ -82,6 +85,9 @@ jobs:
       #                              or the live-voice WS upgrade 503s "offline".
       #   - VITE_APP_VERSION         commit SHA baked into the browser bundle
       #                              for Sentry event release tagging.
+      #   - VITE_CHANNEL             the publish channel this bundle was built
+      #                              for, so the running app can identify itself
+      #                              as stable or as a preview build.
       #   - SENTRY_UPLOAD_SOURCE_MAPS  deploy-only opt-in for source-map upload
       #                              and Sentry release side effects.
       #   - SENTRY_AUTH_TOKEN        repo-level secret; unprefixed, so Vite never
@@ -106,6 +112,7 @@ jobs:
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           VITE_VELAY_HOST: ${{ vars.VITE_VELAY_HOST }}
           VITE_APP_VERSION: ${{ github.sha }}
+          VITE_CHANNEL: ${{ inputs.channel }}
           SENTRY_UPLOAD_SOURCE_MAPS: "true"
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run build
@@ -115,7 +122,7 @@ jobs:
       - name: Upload SPA artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: web-dist-${{ inputs.environment }}
+          name: web-dist-${{ inputs.environment }}-${{ inputs.channel }}
           path: clients/web/dist
           if-no-files-found: error
 
@@ -133,7 +140,7 @@ jobs:
       - name: Download SPA artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: web-dist-${{ inputs.environment }}
+          name: web-dist-${{ inputs.environment }}-${{ inputs.channel }}
           path: dist
 
       - name: Authenticate to GCP
@@ -146,6 +153,7 @@ jobs:
         env:
           PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           TARGET_ENV: ${{ inputs.environment }}
+          CHANNEL: ${{ inputs.channel }}
         run: |
           set -euo pipefail
           BUCKET="${PROJECT_ID}-assistant-spa"
@@ -153,6 +161,17 @@ jobs:
           if [ ! -f dist/index.html ]; then
             echo "::error::dist/index.html not found — the build produced no output."
             exit 1
+          fi
+
+          # A non-stable channel gets its own entrypoint and must leave the
+          # stable release alone, so its assets upload with --no-clobber. New
+          # hashed chunks are added, and the unhashed public/ files at the bucket
+          # root stay whatever the last stable release put there.
+          INDEX_DEST="index.html"
+          RSYNC_EXTRA=""
+          if [ "${CHANNEL}" != "stable" ]; then
+            INDEX_DEST="${CHANNEL}/index.html"
+            RSYNC_EXTRA="--no-clobber"
           fi
 
           # 1. Upload everything EXCEPT index.html with a long immutable cache,
@@ -164,12 +183,15 @@ jobs:
           gcloud storage rsync -r \
             --exclude="^index\.html$" \
             --cache-control="public, max-age=31536000, immutable" \
+            ${RSYNC_EXTRA} \
             dist "gs://${BUCKET}"
 
           # 2. Upload the HTML entrypoint last, with no-cache, so the new release
           #    only goes live once its assets exist and is always revalidated.
+          #    This stays a plain overwrite, so each publish replaces its own
+          #    channel's entrypoint.
           gcloud storage cp \
             --cache-control="no-cache, max-age=0, must-revalidate" \
-            dist/index.html "gs://${BUCKET}/index.html"
+            dist/index.html "gs://${BUCKET}/${INDEX_DEST}"
 
-          echo "Published SPA to gs://${BUCKET}/ (environment=${TARGET_ENV})"
+          echo "Published SPA to gs://${BUCKET}/${INDEX_DEST} (environment=${TARGET_ENV}, channel=${CHANNEL})"

--- a/.github/workflows/deploy-platform-web-spa.yaml
+++ b/.github/workflows/deploy-platform-web-spa.yaml
@@ -11,12 +11,10 @@ name: Deploy Web SPA (reusable)
 # a $GITHUB_ENV/$GITHUB_PATH/BASH_ENV hook (or a fake `gcloud`) that would fire
 # in the post-auth publish step and exfiltrate the short-lived GCP credentials.
 #
-# The default `stable` channel overwrites the root index.html. Any other channel
-# writes `<channel>/index.html` beside an untouched root index and uploads its
-# assets with --no-clobber, so a channel publish adds objects but never replaces
-# what the last stable release put in the bucket. The `environment:` binding only
-# resolves that environment's secrets and vars; no environment gates on required
-# reviewers.
+# The `stable` channel overwrites the root index.html. Any other channel writes
+# `<channel>/index.html` and uploads assets with --no-clobber, leaving the stable
+# release untouched. `environment:` only resolves secrets and vars; none gate on
+# required reviewers.
 on:
   workflow_call:
     inputs:
@@ -85,9 +83,7 @@ jobs:
       #                              or the live-voice WS upgrade 503s "offline".
       #   - VITE_APP_VERSION         commit SHA baked into the browser bundle
       #                              for Sentry event release tagging.
-      #   - VITE_CHANNEL             the publish channel this bundle was built
-      #                              for, so the running app can identify itself
-      #                              as stable or as a preview build.
+      #   - VITE_CHANNEL             publish channel baked into the bundle.
       #   - SENTRY_UPLOAD_SOURCE_MAPS  deploy-only opt-in for source-map upload
       #                              and Sentry release side effects.
       #   - SENTRY_AUTH_TOKEN        repo-level secret; unprefixed, so Vite never
@@ -163,10 +159,8 @@ jobs:
             exit 1
           fi
 
-          # A non-stable channel gets its own entrypoint and must leave the
-          # stable release alone, so its assets upload with --no-clobber. New
-          # hashed chunks are added, and the unhashed public/ files at the bucket
-          # root stay whatever the last stable release put there.
+          # A non-stable channel gets its own entrypoint and never overwrites
+          # objects the stable release put in the bucket.
           INDEX_DEST="index.html"
           RSYNC_EXTRA=""
           if [ "${CHANNEL}" != "stable" ]; then
@@ -188,8 +182,6 @@ jobs:
 
           # 2. Upload the HTML entrypoint last, with no-cache, so the new release
           #    only goes live once its assets exist and is always revalidated.
-          #    This stays a plain overwrite, so each publish replaces its own
-          #    channel's entrypoint.
           gcloud storage cp \
             --cache-control="no-cache, max-age=0, must-revalidate" \
             dist/index.html "gs://${BUCKET}/${INDEX_DEST}"

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1528,7 +1528,7 @@ jobs:
           # ci-web fails the dev SPA warning above already says so.
           if [ "${PREVIEW_SPA_RESULT}" != "success" ] && [ "${PREVIEW_SPA_RESULT}" != "skipped" ]; then
             HEADER_EMOJI="⚠️"
-            PREVIEW_SPA_WARNING=$(jq -n --arg result "$PREVIEW_SPA_RESULT" '{ type: "section", text: { type: "mrkdwn", text: ("⚠️ *Preview web SPA was not published* (result: " + $result + ") — the dev release shipped but prod `/preview/` is unchanged. See the workflow run for details.") } }')
+            PREVIEW_SPA_WARNING=$(jq -n --arg result "$PREVIEW_SPA_RESULT" '{ type: "section", text: { type: "mrkdwn", text: ("⚠️ *Preview web SPA was not published* (result: " + $result + "). The dev release shipped but prod `/preview/` is unchanged. See the workflow run for details.") } }')
           else
             PREVIEW_SPA_WARNING=""
           fi

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -835,19 +835,11 @@ jobs:
     secrets: inherit
 
   # ── Web SPA (production preview channel) ─────────────────────────────
-  # Internal devs run their assistants on preview releases, so the UI they load
-  # from production has to move at the same hourly cadence. This publishes that
-  # preview UI into the PRODUCTION bucket under `/preview/`, leaving the root
-  # index.html of the live stable release untouched. The bundle self-identifies
-  # through the baked VITE_CHANNEL=preview, and its version stays the commit SHA
-  # like every other dev-lane build.
-  #
-  # Gating follows deploy-web-spa above: ci-web is the only hard gate, and
-  # register-preview-release sits in `needs` for ordering alone, so a failed
-  # backend preview registration does not strand green web commits. The ref
-  # guard mirrors publish-production-preview-image-tags and
-  # register-preview-release, so a manual dispatch on a release branch cannot
-  # publish that branch's UI to production.
+  # Publishes the preview UI into the PRODUCTION bucket under `/preview/` on
+  # every hourly dev release, leaving the stable root index.html untouched. The
+  # bundle self-identifies via VITE_CHANNEL=preview; its version is the commit
+  # SHA. Gating matches deploy-web-spa above. The ref guard matches the other
+  # production-preview jobs so a release-branch dispatch cannot publish here.
   deploy-web-spa-preview:
     name: Deploy Web SPA (production /preview)
     needs: [ci-web, register-preview-release]
@@ -1524,8 +1516,8 @@ jobs:
             SPA_WARNING=""
           fi
 
-          # `skipped` stays quiet: the job skips off main by design, and when
-          # ci-web fails the dev SPA warning above already says so.
+          # `skipped` is quiet: the job skips off main, and a ci-web failure is
+          # already covered by the dev SPA warning above.
           if [ "${PREVIEW_SPA_RESULT}" != "success" ] && [ "${PREVIEW_SPA_RESULT}" != "skipped" ]; then
             HEADER_EMOJI="⚠️"
             PREVIEW_SPA_WARNING=$(jq -n --arg result "$PREVIEW_SPA_RESULT" '{ type: "section", text: { type: "mrkdwn", text: ("⚠️ *Preview web SPA was not published* (result: " + $result + "). The dev release shipped but prod `/preview/` is unchanged. See the workflow run for details.") } }')

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -834,6 +834,33 @@ jobs:
       environment: dev
     secrets: inherit
 
+  # ── Web SPA (production preview channel) ─────────────────────────────
+  # Internal devs run their assistants on preview releases, so the UI they load
+  # from production has to move at the same hourly cadence. This publishes that
+  # preview UI into the PRODUCTION bucket under `/preview/`, leaving the root
+  # index.html of the live stable release untouched. The bundle self-identifies
+  # through the baked VITE_CHANNEL=preview, and its version stays the commit SHA
+  # like every other dev-lane build.
+  #
+  # Gating follows deploy-web-spa above: ci-web is the only hard gate, and
+  # register-preview-release sits in `needs` for ordering alone, so a failed
+  # backend preview registration does not strand green web commits. The ref
+  # guard mirrors publish-production-preview-image-tags and
+  # register-preview-release, so a manual dispatch on a release branch cannot
+  # publish that branch's UI to production.
+  deploy-web-spa-preview:
+    name: Deploy Web SPA (production /preview)
+    needs: [ci-web, register-preview-release]
+    if: ${{ !cancelled() && github.ref_name == 'main' && needs.ci-web.result == 'success' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/deploy-platform-web-spa.yaml
+    with:
+      environment: production
+      channel: preview
+    secrets: inherit
+
   publish-production-preview-image-tags:
     needs: [compute-version, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     if: ${{ always() && !cancelled() && github.ref_name == 'main' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' }}
@@ -1304,7 +1331,7 @@ jobs:
   # SLACK_RELEASES_WEBHOOK_URL (releases). The job no-ops if the secret is unset.
 
   notify-dev-release:
-    needs: [compute-version, register-release, register-preview-release, build-electron, upload-electron-updates, deploy-web-spa]
+    needs: [compute-version, register-release, register-preview-release, build-electron, upload-electron-updates, deploy-web-spa, deploy-web-spa-preview]
     # Run on success and failure alike, but not when the run was cancelled
     # (e.g. superseded by a newer hourly run via cancel-in-progress) — a
     # cancelled run is not a real failure and should not alert the channel.
@@ -1339,6 +1366,7 @@ jobs:
           ELECTRON_RESULT: ${{ needs.build-electron.result }}
           UPDATES_RESULT: ${{ needs.upload-electron-updates.result }}
           SPA_RESULT: ${{ needs.deploy-web-spa.result }}
+          PREVIEW_SPA_RESULT: ${{ needs.deploy-web-spa-preview.result }}
         run: |
           set -euo pipefail
 
@@ -1466,7 +1494,7 @@ jobs:
           # Commit list lives in an attachment so Slack auto-collapses it behind
           # a "show more" toggle (see Slack docs on attachments truncation).
           # When the release registered but the Electron build, the Electron
-          # update feed upload, or the web SPA deploy did not succeed, swap the
+          # update feed upload, or either web SPA publish did not succeed, swap the
           # header emoji and append a warning so the notification surfaces the
           # failure instead of looking fully green. The warnings are
           # independent — any subset can fire (e.g. a build-electron failure
@@ -1496,6 +1524,15 @@ jobs:
             SPA_WARNING=""
           fi
 
+          # `skipped` stays quiet: the job skips off main by design, and when
+          # ci-web fails the dev SPA warning above already says so.
+          if [ "${PREVIEW_SPA_RESULT}" != "success" ] && [ "${PREVIEW_SPA_RESULT}" != "skipped" ]; then
+            HEADER_EMOJI="⚠️"
+            PREVIEW_SPA_WARNING=$(jq -n --arg result "$PREVIEW_SPA_RESULT" '{ type: "section", text: { type: "mrkdwn", text: ("⚠️ *Preview web SPA was not published* (result: " + $result + ") — the dev release shipped but prod `/preview/` is unchanged. See the workflow run for details.") } }')
+          else
+            PREVIEW_SPA_WARNING=""
+          fi
+
           BLOCKS=$(jq -n \
             --arg version "$VERSION" \
             --arg header "$HEADER_TEXT" \
@@ -1521,6 +1558,10 @@ jobs:
 
           if [ -n "$SPA_WARNING" ]; then
             BLOCKS=$(echo "$BLOCKS" | jq --argjson warn "$SPA_WARNING" '. += [$warn]')
+          fi
+
+          if [ -n "$PREVIEW_SPA_WARNING" ]; then
+            BLOCKS=$(echo "$BLOCKS" | jq --argjson warn "$PREVIEW_SPA_WARNING" '. += [$warn]')
           fi
 
           # Attachment blocks: the actual commit list, chunked into sections to


### PR DESCRIPTION
## Summary
- `deploy-platform-web-spa.yaml` gains a `channel` input (default `stable`). A non-stable channel writes `<channel>/index.html`, leaves the root index alone, and uploads assets with `--no-clobber`.
- `dev-release.yaml` publishes the preview UI to the production bucket under `/preview/` on every dev release from `main`. The Slack notification warns when that publish fails.
- The bundle self-identifies via `VITE_CHANNEL`. Existing callers in `release.yml` need no changes.
- Accepted risks: the opt-in cookie is self-serve, and hourly preview chunks accumulate in the shared asset pool without pruning.

Part of plan: preview-web-spa.md (PR 1 of 2)