### PR TITLE
feat(web): derive a conversation's apps, documents, attachments, and frames in one hook

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
@@ -207,6 +207,33 @@ describe("useConversationAssets", () => {
 });
 
 describe("toConversationFileAssets", () => {
+  test("keeps legacy rehydrated attachments from different rows apart by id", () => {
+    const { files } = toConversationFileAssets(
+      [],
+      [
+        {
+          attachment: makeDisplayAttachment({
+            id: "rehydrated:0",
+            filename: "old.pdf",
+          }),
+          messageId: "msg-old",
+          capturedAt: null,
+          sightFrame: false,
+        },
+        {
+          attachment: makeDisplayAttachment({
+            id: "rehydrated:0",
+            filename: "new.pdf",
+          }),
+          messageId: "msg-new",
+          capturedAt: null,
+          sightFrame: false,
+        },
+      ],
+    );
+    expect(new Set(files.map((file) => file.id)).size).toBe(2);
+  });
+
   test("routes a camera frame to frames and nowhere else", () => {
     const frame = makeDisplayAttachment({ id: "shot", filename: "shot.jpg" });
     const upload = makeDisplayAttachment({

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Tests for `useConversationAssets`.
+ *
+ * Apps and documents come from two TanStack queries, so the suite seeds the
+ * cache with `staleTime: Infinity` instead of mocking the SDK: nothing
+ * refetches on mount and the derived lists are exactly what a test asks for.
+ * The transcript hook behind the attachments is mocked the same way its own
+ * suite mocks it.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type * as TranscriptMessages from "@/domains/chat/transcript/use-transcript-messages";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import type { AppSummary } from "@/types/app-types";
+import type { DocumentSummary } from "@/types/document-types";
+
+const messagesRef: { value: DisplayMessage[] } = { value: [] };
+
+mock.module(
+  "@/domains/chat/transcript/use-transcript-messages",
+  (): Partial<typeof TranscriptMessages> => ({
+    useTranscriptMessages: () => messagesRef.value,
+  }),
+);
+
+const { useConversationAssets, toConversationFileAssets } =
+  await import("@/domains/chat/hooks/use-conversation-assets");
+const { makeDisplayAttachment } =
+  await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
+const {
+  appsGetOptions,
+  appsGetQueryKey,
+  documentsGetOptions,
+  documentsGetQueryKey,
+} = await import("@/generated/daemon/@tanstack/react-query.gen");
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+
+function makeApp(id: string, updatedAt: number): AppSummary {
+  return {
+    id,
+    name: `App ${id}`,
+    createdAt: updatedAt - 1,
+    updatedAt,
+    version: "1.0.0",
+    contentId: `content-${id}`,
+    origin: "workspace",
+  };
+}
+
+function makeDocument(surfaceId: string, updatedAt: number): DocumentSummary {
+  return {
+    surfaceId,
+    conversationId: CONVERSATION_ID,
+    title: `Doc ${surfaceId}`,
+    wordCount: 12,
+    createdAt: updatedAt - 1,
+    updatedAt,
+  };
+}
+
+/**
+ * `staleTime: Infinity` keeps the seeded entries fresh, so the queries resolve
+ * from cache and never reach the generated SDK.
+ */
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+    },
+  });
+}
+
+function seedConversation(
+  client: QueryClient,
+  apps: AppSummary[],
+  documents: DocumentSummary[],
+) {
+  const queryArgs = {
+    path: { assistant_id: ASSISTANT_ID },
+    query: { conversationId: CONVERSATION_ID },
+  };
+  client.setQueryData(appsGetOptions(queryArgs).queryKey, { apps });
+  client.setQueryData(documentsGetOptions(queryArgs).queryKey, { documents });
+}
+
+function renderAssets({
+  apps = [],
+  documents = [],
+  refreshKey,
+}: {
+  apps?: AppSummary[];
+  documents?: DocumentSummary[];
+  refreshKey?: number;
+} = {}) {
+  const client = makeQueryClient();
+  seedConversation(client, apps, documents);
+
+  const view = renderHook(
+    (props: { refreshKey?: number }) =>
+      useConversationAssets({
+        assistantId: ASSISTANT_ID,
+        conversationId: CONVERSATION_ID,
+        refreshKey: props.refreshKey,
+      }),
+    {
+      initialProps: { refreshKey },
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    },
+  );
+
+  return { ...view, client };
+}
+
+afterEach(() => {
+  cleanup();
+  messagesRef.value = [];
+});
+
+describe("useConversationAssets", () => {
+  test("lists documents before attachments, each newest first", () => {
+    messagesRef.value = [
+      {
+        id: "msg-1",
+        role: "user",
+        timestamp: 1_000,
+        attachments: [makeDisplayAttachment({ id: "att-old" })],
+      },
+      {
+        id: "msg-2",
+        role: "user",
+        timestamp: 2_000,
+        attachments: [makeDisplayAttachment({ id: "att-new" })],
+      },
+    ];
+
+    const { result } = renderAssets({
+      documents: [
+        makeDocument("doc-old", 1_000),
+        makeDocument("doc-new", 2_000),
+      ],
+    });
+
+    expect(result.current.files.map((file) => file.id)).toEqual([
+      "doc-doc-new",
+      "doc-doc-old",
+      "att-att-new",
+      "att-att-old",
+    ]);
+    expect(result.current.frames).toHaveLength(0);
+  });
+
+  test("sorts apps newest first", () => {
+    const { result } = renderAssets({
+      apps: [makeApp("a", 1_000), makeApp("b", 3_000), makeApp("c", 2_000)],
+    });
+
+    expect(result.current.apps.map((app) => app.id)).toEqual(["b", "c", "a"]);
+  });
+
+  test("counts every category and sums them", () => {
+    messagesRef.value = [
+      {
+        id: "msg-1",
+        role: "user",
+        attachments: [
+          makeDisplayAttachment({ id: "att-1" }),
+          makeDisplayAttachment({ id: "att-2" }),
+        ],
+      },
+    ];
+
+    const { result } = renderAssets({
+      apps: [makeApp("a", 1_000)],
+      documents: [makeDocument("doc-1", 1_000)],
+    });
+
+    expect(result.current.counts).toEqual({ apps: 1, files: 3, frames: 0 });
+    expect(result.current.count).toBe(4);
+  });
+
+  test("invalidates both queries when the refresh key changes", () => {
+    const { rerender, client } = renderAssets({ refreshKey: 1 });
+    const invalidated: unknown[] = [];
+    client.invalidateQueries = (filters) => {
+      invalidated.push(filters);
+      return Promise.resolve();
+    };
+
+    rerender({ refreshKey: 2 });
+
+    const queryArgs = {
+      path: { assistant_id: ASSISTANT_ID },
+      query: { conversationId: CONVERSATION_ID },
+    };
+    expect(invalidated).toEqual([
+      { queryKey: appsGetQueryKey(queryArgs) },
+      { queryKey: documentsGetQueryKey(queryArgs) },
+    ]);
+  });
+});
+
+describe("toConversationFileAssets", () => {
+  test("routes a camera frame to frames and nowhere else", () => {
+    const frame = makeDisplayAttachment({ id: "shot", filename: "shot.jpg" });
+    const upload = makeDisplayAttachment({
+      id: "shot",
+      filename: "upload.png",
+    });
+
+    const { files, frames } = toConversationFileAssets(
+      [makeDocument("shot", 1_000)],
+      [
+        {
+          attachment: frame,
+          messageId: "msg-1",
+          capturedAt: 5_000,
+          sightFrame: true,
+        },
+        {
+          attachment: upload,
+          messageId: "msg-2",
+          capturedAt: null,
+          sightFrame: false,
+        },
+      ],
+    );
+
+    expect(frames).toEqual([
+      {
+        kind: "frame",
+        id: "frame-shot",
+        title: "shot.jpg",
+        attachment: frame,
+        capturedAt: 5_000,
+      },
+    ]);
+    // One shared underlying id across all three kinds, three distinct keys.
+    expect(files.map((file) => file.id)).toEqual(["doc-shot", "att-shot"]);
+    expect(files.some((file) => file.kind === "frame")).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
@@ -216,6 +216,7 @@ describe("toConversationFileAssets", () => {
             id: "rehydrated:0",
             filename: "old.pdf",
           }),
+          key: "msg-old:0",
           messageId: "msg-old",
           capturedAt: null,
           sightFrame: false,
@@ -225,6 +226,7 @@ describe("toConversationFileAssets", () => {
             id: "rehydrated:0",
             filename: "new.pdf",
           }),
+          key: "msg-new:0",
           messageId: "msg-new",
           capturedAt: null,
           sightFrame: false,
@@ -245,12 +247,14 @@ describe("toConversationFileAssets", () => {
       [makeDocument("shot", 1_000)],
       [
         {
+          key: "shot",
           attachment: frame,
           messageId: "msg-1",
           capturedAt: 5_000,
           sightFrame: true,
         },
         {
+          key: "shot",
           attachment: upload,
           messageId: "msg-2",
           capturedAt: null,

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
@@ -1,0 +1,175 @@
+/**
+ * A conversation's assets in the three categories the chat-info panel lists:
+ * apps, files (daemon documents plus the attachments that are not camera
+ * frames), and camera frames. Frames stay empty while attachments come from
+ * the transcript, which cannot see the camera-frame tag.
+ */
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
+
+import {
+  appsGetOptions,
+  appsGetQueryKey,
+  documentsGetOptions,
+  documentsGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  type ConversationAttachmentEntry,
+  useConversationAttachments,
+} from "@/domains/chat/hooks/use-conversation-attachments";
+import type { AppSummary } from "@/types/app-types";
+import type { DisplayAttachment } from "@/types/attachment-types";
+import type { DocumentSummary } from "@/types/document-types";
+
+export type ConversationFileAsset =
+  | { kind: "document"; id: string; title: string; doc: DocumentSummary }
+  | {
+      kind: "attachment";
+      id: string;
+      title: string;
+      attachment: DisplayAttachment;
+    }
+  | {
+      kind: "frame";
+      id: string;
+      title: string;
+      attachment: DisplayAttachment;
+      capturedAt: number | null;
+    };
+
+export interface ConversationAssets {
+  apps: AppSummary[];
+  /** Documents, newest first, then the attachments that are not frames. */
+  files: ConversationFileAsset[];
+  frames: ConversationFileAsset[];
+  counts: { apps: number; files: number; frames: number };
+  /** Sum of `counts`: what the header pill shows, and hides on when zero. */
+  count: number;
+  hasMoreFiles: boolean;
+  hasMoreFrames: boolean;
+  loadMoreFiles: () => void;
+  loadMoreFrames: () => void;
+}
+
+/**
+ * Ids are prefixed per kind so a document, an attachment, and a frame that
+ * happen to share an underlying id can never collide as React keys.
+ */
+export function toConversationFileAssets(
+  docs: DocumentSummary[],
+  entries: ConversationAttachmentEntry[],
+): { files: ConversationFileAsset[]; frames: ConversationFileAsset[] } {
+  const files: ConversationFileAsset[] = [...docs]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .map((doc) => ({
+      kind: "document" as const,
+      id: `doc-${doc.surfaceId}`,
+      title: doc.title,
+      doc,
+    }));
+  const frames: ConversationFileAsset[] = [];
+
+  for (const entry of entries) {
+    if (entry.sightFrame) {
+      frames.push({
+        kind: "frame",
+        id: `frame-${entry.attachment.id}`,
+        title: entry.attachment.filename,
+        attachment: entry.attachment,
+        capturedAt: entry.capturedAt,
+      });
+    } else {
+      files.push({
+        kind: "attachment",
+        id: `att-${entry.attachment.id}`,
+        title: entry.attachment.filename,
+        attachment: entry.attachment,
+      });
+    }
+  }
+
+  return { files, frames };
+}
+
+export function useConversationAssets({
+  assistantId,
+  conversationId,
+  refreshKey,
+}: {
+  assistantId: string;
+  conversationId: string;
+  /** Bumped externally to trigger a refetch (e.g. on ui_surface_show). Only one mounted caller should pass it. */
+  refreshKey?: number;
+}): ConversationAssets {
+  const queryClient = useQueryClient();
+  const appsQueryOpts = appsGetOptions({
+    path: { assistant_id: assistantId },
+    query: { conversationId },
+  });
+  const docsQueryOpts = documentsGetOptions({
+    path: { assistant_id: assistantId },
+    query: { conversationId },
+  });
+
+  const { data: apps = [] } = useQuery({
+    ...appsQueryOpts,
+    select: (data) => data.apps,
+  });
+  const { data: docs = [] } = useQuery({
+    ...docsQueryOpts,
+    select: (data) => data.documents,
+  });
+
+  useEffect(() => {
+    if (refreshKey === undefined) {
+      return;
+    }
+    void queryClient.invalidateQueries({
+      queryKey: appsGetQueryKey({
+        path: { assistant_id: assistantId },
+        query: { conversationId },
+      }),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: documentsGetQueryKey({
+        path: { assistant_id: assistantId },
+        query: { conversationId },
+      }),
+    });
+  }, [refreshKey, queryClient, assistantId, conversationId]);
+
+  const attachments = useConversationAttachments({
+    assistantId,
+    conversationId,
+  });
+
+  const sortedApps = useMemo(
+    () => [...apps].sort((a, b) => b.updatedAt - a.updatedAt),
+    [apps],
+  );
+
+  const { files, frames } = useMemo(
+    () => toConversationFileAssets(docs, attachments.entries),
+    [docs, attachments.entries],
+  );
+
+  return useMemo(() => {
+    const counts = {
+      apps: sortedApps.length,
+      files: docs.length + attachments.totalFiles,
+      frames: attachments.totalFrames,
+    };
+    return {
+      apps: sortedApps,
+      files,
+      frames,
+      counts,
+      count: counts.apps + counts.files + counts.frames,
+      hasMoreFiles: attachments.hasMoreFiles,
+      hasMoreFrames: attachments.hasMoreFrames,
+      loadMoreFiles: attachments.loadMoreFiles,
+      loadMoreFrames: attachments.loadMoreFrames,
+    };
+  }, [sortedApps, files, frames, docs.length, attachments]);
+}

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
@@ -17,7 +17,6 @@ import {
 import {
   type ConversationAttachmentEntry,
   useConversationAttachments,
-  conversationAttachmentKey,
 } from "@/domains/chat/hooks/use-conversation-attachments";
 import type { AppSummary } from "@/types/app-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
@@ -75,7 +74,7 @@ export function toConversationFileAssets(
     if (entry.sightFrame) {
       frames.push({
         kind: "frame",
-        id: `frame-${conversationAttachmentKey(entry.messageId, entry.attachment.id)}`,
+        id: `frame-${entry.key}`,
         title: entry.attachment.filename,
         attachment: entry.attachment,
         capturedAt: entry.capturedAt,
@@ -83,7 +82,7 @@ export function toConversationFileAssets(
     } else {
       files.push({
         kind: "attachment",
-        id: `att-${conversationAttachmentKey(entry.messageId, entry.attachment.id)}`,
+        id: `att-${entry.key}`,
         title: entry.attachment.filename,
         attachment: entry.attachment,
       });

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
@@ -17,6 +17,7 @@ import {
 import {
   type ConversationAttachmentEntry,
   useConversationAttachments,
+  conversationAttachmentKey,
 } from "@/domains/chat/hooks/use-conversation-attachments";
 import type { AppSummary } from "@/types/app-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
@@ -74,7 +75,7 @@ export function toConversationFileAssets(
     if (entry.sightFrame) {
       frames.push({
         kind: "frame",
-        id: `frame-${entry.attachment.id}`,
+        id: `frame-${conversationAttachmentKey(entry.messageId, entry.attachment.id)}`,
         title: entry.attachment.filename,
         attachment: entry.attachment,
         capturedAt: entry.capturedAt,
@@ -82,7 +83,7 @@ export function toConversationFileAssets(
     } else {
       files.push({
         kind: "attachment",
-        id: `att-${entry.attachment.id}`,
+        id: `att-${conversationAttachmentKey(entry.messageId, entry.attachment.id)}`,
         title: entry.attachment.filename,
         attachment: entry.attachment,
       });

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for `useConversationAttachments` on its transcript path.
+ *
+ * The transcript hook is mocked so a test states the rendered rows directly;
+ * everything asserted here is the walk over those rows.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import type * as TranscriptMessages from "@/domains/chat/transcript/use-transcript-messages";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+const messagesRef: { value: DisplayMessage[] } = { value: [] };
+
+mock.module(
+  "@/domains/chat/transcript/use-transcript-messages",
+  (): Partial<typeof TranscriptMessages> => ({
+    useTranscriptMessages: () => messagesRef.value,
+  }),
+);
+
+const { useConversationAttachments } =
+  await import("@/domains/chat/hooks/use-conversation-attachments");
+const { makeDisplayAttachment } =
+  await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
+
+const TARGET = { assistantId: "asst-1", conversationId: "conv-1" };
+
+function makeMessage(overrides: Partial<DisplayMessage>): DisplayMessage {
+  return { id: "msg-1", role: "user", ...overrides };
+}
+
+afterEach(() => {
+  cleanup();
+  messagesRef.value = [];
+});
+
+describe("useConversationAttachments", () => {
+  test("walks the transcript newest first", () => {
+    messagesRef.value = [
+      makeMessage({
+        id: "msg-1",
+        timestamp: 1_000,
+        attachments: [makeDisplayAttachment({ id: "old" })],
+      }),
+      makeMessage({
+        id: "msg-2",
+        timestamp: 2_000,
+        attachments: [makeDisplayAttachment({ id: "new" })],
+      }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
+      "new",
+      "old",
+    ]);
+    expect(result.current.entries[0]).toMatchObject({
+      messageId: "msg-2",
+      capturedAt: 2_000,
+      sightFrame: false,
+    });
+    expect(result.current.source).toBe("transcript");
+    expect(result.current.totalFiles).toBe(2);
+    expect(result.current.totalFrames).toBe(0);
+    expect(result.current.hasMoreFiles).toBe(false);
+    expect(result.current.hasMoreFrames).toBe(false);
+  });
+
+  test("collapses an attachment carried by two rows", () => {
+    // An optimistic send and its confirmed echo carry the same attachment.
+    const attachment = makeDisplayAttachment({ id: "shared" });
+    messagesRef.value = [
+      makeMessage({
+        id: "msg-echo",
+        timestamp: 1_000,
+        attachments: [attachment],
+      }),
+      makeMessage({
+        id: "msg-optimistic",
+        timestamp: 2_000,
+        attachments: [attachment],
+      }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0]!.messageId).toBe("msg-optimistic");
+    expect(result.current.totalFiles).toBe(1);
+  });
+
+  test("reports a null capture time for a row with no timestamp", () => {
+    messagesRef.value = [
+      makeMessage({ attachments: [makeDisplayAttachment({ id: "att-1" })] }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries[0]!.capturedAt).toBeNull();
+  });
+
+  test("hands back the same empty array across renders", () => {
+    messagesRef.value = [makeMessage({})];
+
+    const { result, rerender } = renderHook(() =>
+      useConversationAttachments(TARGET),
+    );
+    const first = result.current.entries;
+    rerender();
+
+    expect(result.current.entries).toHaveLength(0);
+    expect(result.current.entries).toBe(first);
+  });
+
+  test("keeps the load-more callbacks stable", () => {
+    const { result, rerender } = renderHook(() =>
+      useConversationAttachments(TARGET),
+    );
+    const { loadMoreFiles, loadMoreFrames } = result.current;
+    rerender();
+
+    expect(result.current.loadMoreFiles).toBe(loadMoreFiles);
+    expect(result.current.loadMoreFrames).toBe(loadMoreFrames);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -120,6 +120,28 @@ describe("useConversationAttachments", () => {
     expect(result.current.totalFiles).toBe(2);
   });
 
+  test("keeps two rehydrated ids inside one folded row apart", () => {
+    // Adjacent assistant rows fold across a page boundary and concatenate
+    // their attachments under one message id.
+    messagesRef.value = [
+      makeMessage({
+        id: "msg-folded",
+        role: "assistant",
+        attachments: [
+          makeDisplayAttachment({ id: "rehydrated:0", filename: "a.pdf" }),
+          makeDisplayAttachment({ id: "rehydrated:0", filename: "b.pdf" }),
+        ],
+      }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries).toHaveLength(2);
+    expect(new Set(result.current.entries.map((entry) => entry.key)).size).toBe(
+      2,
+    );
+  });
+
   test("reports a null capture time for a row with no timestamp", () => {
     messagesRef.value = [
       makeMessage({ attachments: [makeDisplayAttachment({ id: "att-1" })] }),

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -92,6 +92,34 @@ describe("useConversationAttachments", () => {
     expect(result.current.totalFiles).toBe(1);
   });
 
+  test("keeps legacy rehydrated ids from different rows apart", () => {
+    // Rows reloaded without structured metadata synthesize ids per message.
+    messagesRef.value = [
+      makeMessage({
+        id: "msg-old",
+        timestamp: 1_000,
+        attachments: [
+          makeDisplayAttachment({ id: "rehydrated:0", filename: "old.pdf" }),
+        ],
+      }),
+      makeMessage({
+        id: "msg-new",
+        timestamp: 2_000,
+        attachments: [
+          makeDisplayAttachment({ id: "rehydrated:0", filename: "new.pdf" }),
+        ],
+      }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries.map((entry) => entry.messageId)).toEqual([
+      "msg-new",
+      "msg-old",
+    ]);
+    expect(result.current.totalFiles).toBe(2);
+  });
+
   test("reports a null capture time for a row with no timestamp", () => {
     messagesRef.value = [
       makeMessage({ attachments: [makeDisplayAttachment({ id: "att-1" })] }),

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -140,6 +140,34 @@ describe("useConversationAttachments", () => {
     expect(new Set(result.current.entries.map((entry) => entry.key)).size).toBe(
       2,
     );
+    // The donor's file was appended last, so it is the newer of the two.
+    expect(
+      result.current.entries.map((entry) => entry.attachment.filename),
+    ).toEqual(["b.pdf", "a.pdf"]);
+  });
+
+  test("skips a channel-deleted row's files", () => {
+    messagesRef.value = [
+      makeMessage({
+        id: "msg-gone",
+        deletedAt: 3_000,
+        attachments: [
+          makeDisplayAttachment({ id: "gone", filename: "gone.pdf" }),
+        ],
+      }),
+      makeMessage({
+        id: "msg-kept",
+        attachments: [
+          makeDisplayAttachment({ id: "kept", filename: "kept.pdf" }),
+        ],
+      }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
+      "kept",
+    ]);
   });
 
   test("reports a null capture time for a row with no timestamp", () => {

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -43,6 +43,21 @@ const NO_ENTRIES: ConversationAttachmentEntry[] = [];
 
 const NOOP = () => {};
 
+/**
+ * The identity an attachment has across the whole conversation. A legacy row
+ * without structured metadata gets `rehydrated:N` ids that restart per
+ * message, so those are only unique within their own row; real attachment ids
+ * are unique on their own.
+ */
+export function conversationAttachmentKey(
+  messageId: string,
+  attachmentId: string,
+): string {
+  return attachmentId.startsWith("rehydrated:")
+    ? `${messageId}:${attachmentId}`
+    : attachmentId;
+}
+
 export function useConversationAttachments(target: {
   assistantId: string;
   conversationId: string;
@@ -61,12 +76,7 @@ export function useConversationAttachments(target: {
     for (let index = messages.length - 1; index >= 0; index -= 1) {
       const message = messages[index]!;
       for (const attachment of message.attachments ?? []) {
-        // A legacy row without structured metadata gets `rehydrated:N` ids
-        // that restart per message, so those are only duplicates within their
-        // own row; real attachment ids are unique across the conversation.
-        const key = attachment.id.startsWith("rehydrated:")
-          ? `${message.id}:${attachment.id}`
-          : attachment.id;
+        const key = conversationAttachmentKey(message.id, attachment.id);
         if (seen.has(key)) {
           continue;
         }

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -1,0 +1,95 @@
+/**
+ * Every attachment a conversation carries, newest first.
+ *
+ * This path reads the rendered transcript, which is the loaded pages only, so
+ * `totalFiles` counts what is loaded rather than what the conversation holds.
+ * It also cannot see the camera-frame tag: that lives in daemon message
+ * metadata which never crosses the message wire, so `sightFrame` is always
+ * false and `totalFrames` is always 0 here. A later PR puts a daemon list
+ * route in front of this path with exact counts and a real frame flag; the
+ * `assistantId` and `conversationId` arguments are unused today and exist for
+ * that route to scope its query by.
+ */
+
+import { useMemo } from "react";
+
+import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+/** Frames per page on the daemon path. */
+export const ATTACHMENT_PAGE_SIZE = 200;
+
+export interface ConversationAttachmentEntry {
+  attachment: DisplayAttachment;
+  /** Carrying transcript row. */
+  messageId: string;
+  /** The carrying row's timestamp, epoch ms; null when the row carries none. */
+  capturedAt: number | null;
+  /** Captured by the live-vision camera gate. Always false on the transcript path. */
+  sightFrame: boolean;
+}
+
+export interface ConversationAttachments {
+  entries: ConversationAttachmentEntry[];
+  /** Exact on the daemon path; the entry counts on the transcript path. */
+  totalFiles: number;
+  totalFrames: number;
+  hasMoreFiles: boolean;
+  hasMoreFrames: boolean;
+  loadMoreFiles: () => void;
+  loadMoreFrames: () => void;
+  source: "daemon" | "transcript";
+}
+
+/** Stable empty result, so a conversation with nothing stays referentially stable. */
+const NO_ENTRIES: ConversationAttachmentEntry[] = [];
+
+const NOOP = () => {};
+
+export function useConversationAttachments(target: {
+  assistantId: string;
+  conversationId: string;
+}): ConversationAttachments {
+  // The transcript is already the open conversation's, so nothing here reads
+  // `target`; the daemon route that lands in front of this path scopes by it.
+  void target;
+
+  const messages = useTranscriptMessages();
+
+  const entries = useMemo(() => {
+    const collected: ConversationAttachmentEntry[] = [];
+    const seen = new Set<string>();
+    // Newest first, and an optimistic row plus its confirmed echo carry the
+    // same attachment ids, so the first sighting wins.
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index]!;
+      for (const attachment of message.attachments ?? []) {
+        if (seen.has(attachment.id)) {
+          continue;
+        }
+        seen.add(attachment.id);
+        collected.push({
+          attachment,
+          messageId: message.id,
+          capturedAt: message.timestamp ?? null,
+          sightFrame: false,
+        });
+      }
+    }
+    return collected.length === 0 ? NO_ENTRIES : collected;
+  }, [messages]);
+
+  return useMemo(
+    () => ({
+      entries,
+      totalFiles: entries.length,
+      totalFrames: 0,
+      hasMoreFiles: false,
+      hasMoreFrames: false,
+      loadMoreFiles: NOOP,
+      loadMoreFrames: NOOP,
+      source: "transcript",
+    }),
+    [entries],
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -1,14 +1,11 @@
 /**
  * Every attachment a conversation carries, newest first.
  *
- * This path reads the rendered transcript, which is the loaded pages only, so
+ * Read from the rendered transcript, which is the loaded pages only, so
  * `totalFiles` counts what is loaded rather than what the conversation holds.
- * It also cannot see the camera-frame tag: that lives in daemon message
- * metadata which never crosses the message wire, so `sightFrame` is always
- * false and `totalFrames` is always 0 here. A later PR puts a daemon list
- * route in front of this path with exact counts and a real frame flag; the
- * `assistantId` and `conversationId` arguments are unused today and exist for
- * that route to scope its query by.
+ * The transcript also cannot see the camera-frame tag: that lives in daemon
+ * message metadata which never crosses the message wire, so `sightFrame` is
+ * always false and `totalFrames` is always 0 on this source.
  */
 
 import { useMemo } from "react";
@@ -16,7 +13,7 @@ import { useMemo } from "react";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
 import type { DisplayAttachment } from "@/types/attachment-types";
 
-/** Frames per page on the daemon path. */
+/** Page size for a paged attachment listing. */
 export const ATTACHMENT_PAGE_SIZE = 200;
 
 export interface ConversationAttachmentEntry {
@@ -50,8 +47,8 @@ export function useConversationAttachments(target: {
   assistantId: string;
   conversationId: string;
 }): ConversationAttachments {
-  // The transcript is already the open conversation's, so nothing here reads
-  // `target`; the daemon route that lands in front of this path scopes by it.
+  // The transcript is already the open conversation's, so this source has
+  // nothing to scope by; `target` names the conversation the entries belong to.
   void target;
 
   const messages = useTranscriptMessages();
@@ -64,10 +61,16 @@ export function useConversationAttachments(target: {
     for (let index = messages.length - 1; index >= 0; index -= 1) {
       const message = messages[index]!;
       for (const attachment of message.attachments ?? []) {
-        if (seen.has(attachment.id)) {
+        // A legacy row without structured metadata gets `rehydrated:N` ids
+        // that restart per message, so those are only duplicates within their
+        // own row; real attachment ids are unique across the conversation.
+        const key = attachment.id.startsWith("rehydrated:")
+          ? `${message.id}:${attachment.id}`
+          : attachment.id;
+        if (seen.has(key)) {
           continue;
         }
-        seen.add(attachment.id);
+        seen.add(key);
         collected.push({
           attachment,
           messageId: message.id,

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -77,9 +77,20 @@ export function useConversationAttachments(target: {
     // same attachment ids, so the first sighting wins.
     for (let index = messages.length - 1; index >= 0; index -= 1) {
       const message = messages[index]!;
-      for (const [position, attachment] of (
-        message.attachments ?? []
-      ).entries()) {
+      // A channel-deleted row keeps its content but renders as a tombstone,
+      // so its files are not on show either.
+      if (message.deletedAt) {
+        continue;
+      }
+      const attachments = message.attachments ?? [];
+      // Folded assistant rows append the newer donor's files after the
+      // survivor's, so a row is walked from its end as well.
+      for (
+        let position = attachments.length - 1;
+        position >= 0;
+        position -= 1
+      ) {
+        const attachment = attachments[position]!;
         const key = entryKey(message.id, attachment.id, position);
         if (seen.has(key)) {
           continue;

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -17,6 +17,13 @@ import type { DisplayAttachment } from "@/types/attachment-types";
 export const ATTACHMENT_PAGE_SIZE = 200;
 
 export interface ConversationAttachmentEntry {
+  /**
+   * Unique within the conversation. The attachment id, except for a legacy row
+   * without structured metadata, whose `rehydrated:N` ids restart per row and
+   * can repeat inside one row once adjacent assistant rows are folded, so
+   * those are keyed by row and position instead.
+   */
+  key: string;
   attachment: DisplayAttachment;
   /** Carrying transcript row. */
   messageId: string;
@@ -43,18 +50,13 @@ const NO_ENTRIES: ConversationAttachmentEntry[] = [];
 
 const NOOP = () => {};
 
-/**
- * The identity an attachment has across the whole conversation. A legacy row
- * without structured metadata gets `rehydrated:N` ids that restart per
- * message, so those are only unique within their own row; real attachment ids
- * are unique on their own.
- */
-export function conversationAttachmentKey(
+function entryKey(
   messageId: string,
   attachmentId: string,
+  position: number,
 ): string {
   return attachmentId.startsWith("rehydrated:")
-    ? `${messageId}:${attachmentId}`
+    ? `${messageId}:${position}`
     : attachmentId;
 }
 
@@ -75,13 +77,16 @@ export function useConversationAttachments(target: {
     // same attachment ids, so the first sighting wins.
     for (let index = messages.length - 1; index >= 0; index -= 1) {
       const message = messages[index]!;
-      for (const attachment of message.attachments ?? []) {
-        const key = conversationAttachmentKey(message.id, attachment.id);
+      for (const [position, attachment] of (
+        message.attachments ?? []
+      ).entries()) {
+        const key = entryKey(message.id, attachment.id, position);
         if (seen.has(key)) {
           continue;
         }
         seen.add(key);
         collected.push({
+          key,
           attachment,
           messageId: message.id,
           capturedAt: message.timestamp ?? null,


### PR DESCRIPTION
## Summary
- `useConversationAttachments` collects the loaded transcript's attachments newest first, deduplicated by id
- `useConversationAssets` merges apps, documents, attachments, and (later) camera frames with exact-count plumbing
- No consumer yet; the header pill is unchanged

Part of plan: chat-info-assets-panel.md (PR 2 of 12)