### PR TITLE
feat(web): chat-info section row that fits one line of tiles and offers See All

### DIFF
--- a/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
@@ -1,0 +1,145 @@
+/**
+ * A Chat Info row: the category header with its exact total and a See All
+ * control, over one line of tiles.
+ *
+ * The row is tile-agnostic, so these stories feed it the shipped 64px
+ * `MessageAttachmentSquare` rather than the panel's own tiles. What they
+ * document is the fit rule: on a roomy window the line is truncated to the
+ * tiles its measured width holds, and on a phone the same width decides a
+ * horizontal strip that runs past the screen edge. See All appears whenever
+ * the category's total exceeds that line, which is why the paged story shows
+ * it under a row that looks complete.
+ *
+ * Read the phone stories at the Mobile viewports: the frame draws
+ * `DetailShell`'s 20px body inset, which the strip cancels.
+ */
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import {
+  makeMixedAttachments,
+  makePreviewableImages,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import {
+  ChatInfoSection,
+  type ChatInfoSectionProps,
+} from "./chat-info-section";
+
+/** `MessageAttachmentSquare`'s tile box, the width the fit rule is given. */
+const SQUARE_TILE_WIDTH_PX = 64;
+
+/**
+ * A category small enough for one line: two photos carrying a real preview,
+ * then a deck, a report, and an archive on their kind glyphs.
+ */
+const FITTING_SET: DisplayAttachment[] = [
+  ...makePreviewableImages(2),
+  ...makeMixedAttachments().filter((file) => file.previewUrl === null),
+];
+
+/** The drawer body's column on the desktop mock: 569px inside the shell's inset. */
+const inDrawerColumn: Decorator = (Story) => (
+  <div className="bg-[var(--surface-base)] p-5">
+    <div className="w-[569px]">
+      <Story />
+    </div>
+  </div>
+);
+
+/**
+ * A phone page at the shell's 20px body inset, which the strip's negative
+ * margin cancels so the tiles run to the screen edge and the last one is cut
+ * off, as in the mobile mock.
+ */
+const inPhonePage: Decorator = (Story) => (
+  <div className="max-w-[402px] bg-[var(--surface-base)] p-5">
+    <Story />
+  </div>
+);
+
+function renderSquare(attachment: DisplayAttachment) {
+  return (
+    <MessageAttachmentSquare key={attachment.id} attachment={attachment} />
+  );
+}
+
+const meta = {
+  title: "Chat/ChatInfoSection",
+  component: ChatInfoSection,
+  parameters: { layout: "fullscreen" },
+  argTypes: { renderTile: { control: false } },
+  args: {
+    title: "Documents & Images",
+    tileWidth: SQUARE_TILE_WIDTH_PX,
+    seeAllAriaLabel: "See all documents and images",
+    renderTile: renderSquare,
+    onSeeAll: fn(),
+  },
+} satisfies Meta<ChatInfoSectionProps<DisplayAttachment>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A category that fits on one line: every tile renders and the header carries
+ * no See All, because the count and the fitted line agree.
+ */
+export const Fit: Story = {
+  decorators: [inDrawerColumn],
+  args: {
+    items: FITTING_SET,
+    count: FITTING_SET.length,
+  },
+};
+
+/**
+ * More tiles than the row holds. The line is cut to what fits and See All
+ * takes the right edge of the header.
+ */
+export const Overflow: Story = {
+  decorators: [inDrawerColumn],
+  args: {
+    items: makePreviewableImages(12),
+    count: 12,
+  },
+};
+
+/**
+ * A paged category whose first page fits. The row looks complete, but the
+ * total is the number See All is decided from, so the drill-in is still
+ * offered.
+ */
+export const PagedCount: Story = {
+  decorators: [inDrawerColumn],
+  args: {
+    items: makePreviewableImages(4),
+    count: 240,
+  },
+};
+
+/**
+ * The phone treatment: the whole fetched set on one horizontally scrolling
+ * strip, bleeding past the body inset so the last visible tile is cut off at
+ * the screen edge.
+ */
+export const MobileStrip: Story = {
+  decorators: [inPhonePage],
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+  args: {
+    items: makePreviewableImages(8),
+    count: 12,
+  },
+};
+
+/** The same strip on the narrowest phone the app runs on. */
+export const NarrowPhoneStrip: Story = {
+  decorators: [inPhonePage],
+  globals: { viewport: { value: "sbNarrowPhone", isRotated: false } },
+  args: {
+    items: makePreviewableImages(8),
+    count: 12,
+  },
+};

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -164,6 +164,23 @@ describe("ChatInfoSection", () => {
     expect(seeAll()).not.toBeNull();
   });
 
+  test("counts the strip's reclaimed right inset toward the narrow-window fit", () => {
+    // A 402px phone leaves a 362px column; the strip shows 382px of tiles.
+    isMobileRef.value = true;
+    widthRef.value = 362;
+
+    const fitted = renderSection({
+      items: makeItems(2),
+      count: 2,
+      tileWidth: APP_TILE_WIDTH,
+    });
+    expect(seeAll()).toBeNull();
+    fitted.unmount();
+
+    renderSection({ items: makeItems(3), count: 3, tileWidth: APP_TILE_WIDTH });
+    expect(seeAll()).not.toBeNull();
+  });
+
   test("calls onSeeAll when the control is activated", () => {
     let seeAllCalls = 0;
     renderSection({

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -175,10 +175,19 @@ describe("ChatInfoSection", () => {
       tileWidth: APP_TILE_WIDTH,
     });
     expect(seeAll()).toBeNull();
+    // Nothing runs past the edge, so the strip claims no trailing inset.
+    expect(fitted.container.querySelector("[data-overflow]")).toBeNull();
     fitted.unmount();
 
-    renderSection({ items: makeItems(3), count: 3, tileWidth: APP_TILE_WIDTH });
+    const overflowing = renderSection({
+      items: makeItems(3),
+      count: 3,
+      tileWidth: APP_TILE_WIDTH,
+    });
     expect(seeAll()).not.toBeNull();
+    expect(
+      overflowing.container.querySelector("[data-overflow]"),
+    ).not.toBeNull();
   });
 
   test("calls onSeeAll when the control is activated", () => {

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * `ChatInfoSection` decides how many tiles a row shows from one number: the
+ * row's measured width. The suite drives that width and the window-size axis
+ * through module mocks rather than a layout engine, since happy-dom reports a
+ * zero box for everything.
+ *
+ * Tiles are plain elements here. The section is generic over its item type and
+ * never inspects a tile, so the real Chat Info tiles would only add mocks.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type * as ElementSizeModule from "@/hooks/use-element-size";
+import type * as IsMobileModule from "@/hooks/use-is-mobile";
+
+const widthRef = { value: 569 };
+const isMobileRef = { value: false };
+
+mock.module(
+  "@/hooks/use-element-size",
+  (): Partial<typeof ElementSizeModule> => ({
+    useElementSize: () => ({
+      ref: () => {},
+      size: { w: widthRef.value, h: 0 },
+    }),
+  }),
+);
+
+mock.module(
+  "@/hooks/use-is-mobile",
+  (): Partial<typeof IsMobileModule> => ({
+    useIsMobile: () => isMobileRef.value,
+    MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+  }),
+);
+
+const { ChatInfoSection, fitTileCount } =
+  await import("@/domains/chat/components/chat-info-section");
+
+/** The mock's tile widths: apps and files or camera frames. */
+const APP_TILE_WIDTH = 184;
+const FILE_TILE_WIDTH = 135;
+/** The drawer's body width on the desktop mock. */
+const DRAWER_WIDTH = 569;
+
+const SEE_ALL_ARIA = "See all apps";
+const TILE_TESTID = "section-tile";
+
+interface Item {
+  id: string;
+}
+
+function makeItems(count: number): Item[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `item-${index}`,
+  }));
+}
+
+function renderSection({
+  items,
+  count,
+  tileWidth,
+  onSeeAll = () => {},
+}: {
+  items: Item[];
+  count?: number;
+  tileWidth: number;
+  onSeeAll?: () => void;
+}) {
+  return render(
+    <ChatInfoSection
+      title="Apps"
+      count={count ?? items.length}
+      items={items}
+      tileWidth={tileWidth}
+      seeAllAriaLabel={SEE_ALL_ARIA}
+      onSeeAll={onSeeAll}
+      renderTile={(item, _index, layout) => (
+        <div key={item.id} data-testid={TILE_TESTID} data-layout={layout}>
+          {item.id}
+        </div>
+      )}
+    />,
+  );
+}
+
+function tiles(): HTMLElement[] {
+  return screen.queryAllByTestId(TILE_TESTID);
+}
+
+function seeAll(): HTMLElement | null {
+  return screen.queryByRole("button", { name: SEE_ALL_ARIA });
+}
+
+beforeEach(() => {
+  widthRef.value = DRAWER_WIDTH;
+  isMobileRef.value = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("fitTileCount", () => {
+  test.each([
+    [DRAWER_WIDTH, APP_TILE_WIDTH, 3],
+    [DRAWER_WIDTH, FILE_TILE_WIDTH, 4],
+    [378, APP_TILE_WIDTH, 2],
+    [378, FILE_TILE_WIDTH, 2],
+    [0, FILE_TILE_WIDTH, 1],
+    [100, FILE_TILE_WIDTH, 1],
+  ])("fits %p / %p tiles on one line", (rowWidth, tileWidth, expected) => {
+    expect(fitTileCount(rowWidth, tileWidth)).toBe(expected);
+  });
+
+  test("a wider gutter fits fewer tiles on the same row", () => {
+    expect(fitTileCount(DRAWER_WIDTH, APP_TILE_WIDTH, 40)).toBe(2);
+  });
+});
+
+describe("ChatInfoSection", () => {
+  test("truncates a roomy row to the tiles that fit and offers See All", () => {
+    renderSection({ items: makeItems(5), tileWidth: APP_TILE_WIDTH });
+
+    expect(tiles()).toHaveLength(3);
+    expect(tiles()[0]?.getAttribute("data-layout")).toBe("fitted");
+    expect(seeAll()).not.toBeNull();
+  });
+
+  test("shows every tile and no See All when the category fits", () => {
+    renderSection({ items: makeItems(4), tileWidth: FILE_TILE_WIDTH });
+
+    expect(tiles()).toHaveLength(4);
+    expect(seeAll()).toBeNull();
+  });
+
+  test("offers See All from the category total, not the loaded page", () => {
+    renderSection({
+      items: makeItems(4),
+      count: 12,
+      tileWidth: FILE_TILE_WIDTH,
+    });
+
+    expect(tiles()).toHaveLength(4);
+    expect(seeAll()).not.toBeNull();
+  });
+
+  test("scrolls the whole fetched set on a narrow window", () => {
+    isMobileRef.value = true;
+    const { container } = renderSection({
+      items: makeItems(5),
+      tileWidth: APP_TILE_WIDTH,
+    });
+
+    const strip = container.querySelector(
+      '[data-slot="scroll-shadow"][data-orientation="horizontal"]',
+    );
+    expect(strip).not.toBeNull();
+    expect(
+      strip?.querySelectorAll(`[data-testid="${TILE_TESTID}"]`),
+    ).toHaveLength(5);
+    expect(tiles()[0]?.getAttribute("data-layout")).toBe("strip");
+    expect(seeAll()).not.toBeNull();
+  });
+
+  test("calls onSeeAll when the control is activated", () => {
+    let seeAllCalls = 0;
+    renderSection({
+      items: makeItems(5),
+      tileWidth: APP_TILE_WIDTH,
+      onSeeAll: () => {
+        seeAllCalls += 1;
+      },
+    });
+
+    fireEvent.click(seeAll()!);
+
+    expect(seeAllCalls).toBe(1);
+  });
+
+  test("heads the row with the title, the count, and the catalog's See All copy", () => {
+    renderSection({
+      items: makeItems(4),
+      count: 12,
+      tileWidth: FILE_TILE_WIDTH,
+    });
+
+    expect(screen.getByText("Apps")).not.toBeNull();
+    expect(screen.getByText("12")).not.toBeNull();
+    expect(seeAll()?.textContent).toBe("See All");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-info-section.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.tsx
@@ -18,6 +18,12 @@ import { useTranslation } from "@/i18n";
 /** Gutter between tiles, the pixel value behind the rows' `gap-2`. */
 export const CHAT_INFO_TILE_GAP_PX = 8;
 
+/**
+ * How far the narrow-window strip runs past the measured column on the right:
+ * `DetailShell`'s 20px body inset, which the strip's `-mx-5 px-5` reclaims.
+ */
+const MOBILE_STRIP_BLEED_PX = 20;
+
 /** Whole tiles that fit on one line of `rowWidth`, never fewer than one. */
 export function fitTileCount(
   rowWidth: number,
@@ -59,7 +65,11 @@ export function ChatInfoSection<T>({
   const { t } = useTranslation("chat");
   const { ref, size } = useElementSize();
   const isMobile = useIsMobile();
-  const fit = fitTileCount(size.w, tileWidth);
+  // The strip runs through the body's right inset, so that width counts too.
+  const fit = fitTileCount(
+    isMobile ? size.w + MOBILE_STRIP_BLEED_PX : size.w,
+    tileWidth,
+  );
   const showSeeAll = count > fit;
 
   return (

--- a/clients/web/src/domains/chat/components/chat-info-section.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.tsx
@@ -14,6 +14,7 @@ import { Button, ScrollShadow, Typography } from "@vellumai/design-library";
 import { useElementSize } from "@/hooks/use-element-size";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTranslation } from "@/i18n";
+import { cn } from "@/utils/misc";
 
 /** Gutter between tiles, the pixel value behind the rows' `gap-2`. */
 export const CHAT_INFO_TILE_GAP_PX = 8;
@@ -71,6 +72,9 @@ export function ChatInfoSection<T>({
     tileWidth,
   );
   const showSeeAll = count > fit;
+  // Trailing padding only when tiles run past the edge: a strip that fits
+  // must not scroll into blank inset or fade an edge nothing hides behind.
+  const stripOverflows = items.length > fit;
 
   return (
     <section className="flex flex-col gap-3">
@@ -118,9 +122,12 @@ export function ChatInfoSection<T>({
           <ScrollShadow
             orientation="horizontal"
             hideScrollBar
-            className="-mx-5 px-5"
+            className={cn("-mx-5 pl-5", stripOverflows && "pr-5")}
           >
-            <div className="flex w-max gap-2">
+            <div
+              className="flex w-max gap-2"
+              data-overflow={stripOverflows || undefined}
+            >
               {items.map((item, index) => renderTile(item, index, "strip"))}
             </div>
           </ScrollShadow>

--- a/clients/web/src/domains/chat/components/chat-info-section.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.tsx
@@ -1,0 +1,127 @@
+/**
+ * One row of the Chat Info panel: a header carrying the category title, its
+ * exact total, and a See All control, over a single line of tiles.
+ *
+ * The row is tile-agnostic. Callers pass `renderTile` and the tile's width, so
+ * apps (184px) and files or camera frames (135px) share this component and one
+ * fit rule.
+ */
+
+import type { ReactNode } from "react";
+
+import { Button, ScrollShadow, Typography } from "@vellumai/design-library";
+
+import { useElementSize } from "@/hooks/use-element-size";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTranslation } from "@/i18n";
+
+/** Gutter between tiles, the pixel value behind the rows' `gap-2`. */
+export const CHAT_INFO_TILE_GAP_PX = 8;
+
+/** Whole tiles that fit on one line of `rowWidth`, never fewer than one. */
+export function fitTileCount(
+  rowWidth: number,
+  tileWidth: number,
+  gap = CHAT_INFO_TILE_GAP_PX,
+): number {
+  if (!(rowWidth > 0)) {
+    return 1;
+  }
+  return Math.max(1, Math.floor((rowWidth + gap) / (tileWidth + gap)));
+}
+
+export interface ChatInfoSectionProps<T> {
+  title: string;
+  /** The category's exact total, which may exceed `items.length` when the source is paged. */
+  count: number;
+  items: T[];
+  /** Fixed (strip) or minimum (fitted row) width of one tile, for the fit computation. */
+  tileWidth: number;
+  /** Returns the tile element with its own `key`: the caller owns tile identity. */
+  renderTile: (item: T, index: number, layout: "fitted" | "strip") => ReactNode;
+  seeAllAriaLabel: string;
+  onSeeAll: () => void;
+}
+
+/**
+ * See All reads `count`, not `items.length`, so a paged category whose first
+ * page already overflows one line still offers the drill-in.
+ */
+export function ChatInfoSection<T>({
+  title,
+  count,
+  items,
+  tileWidth,
+  renderTile,
+  seeAllAriaLabel,
+  onSeeAll,
+}: ChatInfoSectionProps<T>) {
+  const { t } = useTranslation("chat");
+  const { ref, size } = useElementSize();
+  const isMobile = useIsMobile();
+  const fit = fitTileCount(size.w, tileWidth);
+  const showSeeAll = count > fit;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="flex min-w-0 items-center gap-1">
+          <Typography
+            variant="title-small"
+            className="truncate text-[var(--content-emphasised)]"
+          >
+            {title}
+          </Typography>
+          <span
+            aria-hidden
+            className="size-[3px] shrink-0 rounded-full bg-[var(--content-disabled)]"
+          />
+          <Typography
+            variant="title-small"
+            className="shrink-0 text-[var(--content-disabled)]"
+          >
+            {count}
+          </Typography>
+        </span>
+        {showSeeAll && (
+          // The mock draws See All as plain title-small text at the right edge,
+          // so the compact ghost chrome gives up its box and keeps only the
+          // hover tint.
+          <Button
+            variant="ghost"
+            size="compact"
+            aria-label={seeAllAriaLabel}
+            onClick={onSeeAll}
+            className="h-auto shrink-0 px-0 text-title-small hover:bg-transparent [--vbtn-fg:var(--content-emphasised)]"
+          >
+            {t("chatInfoPanel.seeAll")}
+          </Button>
+        )}
+      </div>
+      {/* Both layouts are the same "one line" decision read at this one
+          measured width, so See All and the visible tiles can never disagree:
+          a roomy window truncates the line to what fits, a narrow one scrolls
+          the whole fetched set past the same edge. The strip cancels
+          `DetailShell`'s 20px body inset so tiles run to the viewport edge. */}
+      <div ref={ref} className="w-full">
+        {isMobile ? (
+          <ScrollShadow
+            orientation="horizontal"
+            hideScrollBar
+            className="-mx-5 px-5"
+          >
+            <div className="flex w-max gap-2">
+              {items.map((item, index) => renderTile(item, index, "strip"))}
+            </div>
+          </ScrollShadow>
+        ) : (
+          <div className="flex w-full gap-2">
+            {items
+              .slice(0, fit)
+              .map((item, index) => renderTile(item, index, "fitted"))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- `ChatInfoSection`: a titled row of tiles that measures its width, shows one fitted line on a roomy window and a horizontal strip on a narrow one, and offers See All when the category's total exceeds the line
- `fitTileCount` is the one fit rule, unit-tested against the mock's widths
- Stories cover fit, overflow, paged counts, and the mobile strip

Part of plan: chat-info-assets-panel.md (PR 6 of 12)