### PR TITLE
Fix false conversation load errors after mobile resume

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-history-resume-grace.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-resume-grace.test.tsx
@@ -3,45 +3,30 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
-import { __setResumeGraceMsForTesting } from "@/hooks/use-resume-grace";
+import {
+  __setResumeGraceMsForTesting,
+  useResumeGrace,
+} from "@/hooks/use-resume-grace";
 import { __resetForTesting, publish } from "@/lib/event-bus";
-import type { HistoryPaginationResult } from "@/domains/chat/transcript/use-history-pagination";
+import type { PaginatedHistoryResult } from "@/domains/chat/transcript/types";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 
-// Stub the TanStack Query layer so the test drives the initial-page error
-// state directly. `isSuccess: false` marks it as an initial-page (not
-// older-page) failure and keeps the data-apply effect dormant.
-const realPaginationModule = await import(
-  "@/domains/chat/transcript/use-history-pagination"
+const realHistoryApi = await import("@/domains/chat/api/history");
+const fetchLatestHistoryPage = mock(
+  async (): Promise<PaginatedHistoryResult> => page(),
+);
+const fetchOlderHistoryPage = mock(
+  async (): Promise<PaginatedHistoryResult> => page(),
 );
 
-let paginationIsError = false;
+mock.module("@/domains/chat/api/history", () => ({
+  ...realHistoryApi,
+  fetchLatestHistoryPage,
+  fetchOlderHistoryPage,
+}));
 
-function paginationStub(): HistoryPaginationResult {
-  return {
-    messages: [],
-    latestPage: undefined,
-    subagentNotifications: undefined,
-    backgroundToolCompletions: undefined,
-    isLoading: false,
-    isSuccess: false,
-    isError: paginationIsError,
-    error: paginationIsError ? new Error("probe failed") : null,
-    hasMore: false,
-    isFetchingOlderPages: false,
-    isFetching: false,
-    fetchOlderPage: () => {},
-    invalidate: async () => {},
-    removeCache: () => {},
-    latestPageOldestTimestamp: null,
-    oldestLoadedTimestamp: null,
-    dataUpdatedAt: 0,
-  };
-}
-
-mock.module("@/domains/chat/transcript/use-history-pagination", () => ({
-  ...realPaginationModule,
-  useHistoryPagination: () => paginationStub(),
+mock.module("@/domains/chat/api/interactions", () => ({
+  getPendingInteractions: async () => ({}),
 }));
 
 mock.module("@/lib/sentry/capture-error", () => ({
@@ -53,7 +38,17 @@ const { useConversationHistory } = await import(
 );
 
 const DEFAULT_RESUME_GRACE_MS = 15_000;
-const queryClient = new QueryClient();
+const HISTORY_ERROR = "Failed to load conversation history. Please try again.";
+let queryClient: QueryClient;
+
+function page(empty = false): PaginatedHistoryResult {
+  return {
+    messages: empty ? [] : [{ id: "msg-1", role: "user", textSegments: ["Hello"] }],
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+  };
+}
 
 function Wrapper({ children }: { children: ReactNode }) {
   return (
@@ -63,12 +58,14 @@ function Wrapper({ children }: { children: ReactNode }) {
 
 function renderHistory() {
   return renderHook(
-    () =>
-      useConversationHistory({
+    () => ({
+      ...useConversationHistory({
         assistantId: "asst-1",
         assistantStateKind: "active",
         activeConversationId: "conv-A",
       }),
+      isResumeGraceActive: useResumeGrace(),
+    }),
     { wrapper: Wrapper },
   );
 }
@@ -77,71 +74,152 @@ function currentError() {
   return useChatSessionStore.getState().error;
 }
 
+function failLatestFetch() {
+  fetchLatestHistoryPage.mockImplementation(async () => {
+    throw new TypeError("Failed to fetch");
+  });
+}
+
+function resume() {
+  act(() => {
+    publish("app.hidden", { signal: "app_state" });
+    publish("app.resume", { signal: "app_state" });
+    publish("sse.opened", { assistantId: "asst-1", cause: "resume" });
+  });
+}
+
 beforeEach(() => {
   __resetForTesting();
   __setResumeGraceMsForTesting(DEFAULT_RESUME_GRACE_MS);
-  paginationIsError = false;
-  useChatSessionStore.getState().setError(null);
+  queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } });
+  fetchLatestHistoryPage.mockReset();
+  fetchLatestHistoryPage.mockImplementation(async () => page());
+  fetchOlderHistoryPage.mockReset();
+  fetchOlderHistoryPage.mockImplementation(async () => page());
+  useChatSessionStore.setState({ error: null, snapshot: null, optimisticSends: [] });
 });
 
 afterEach(() => {
   cleanup();
+  queryClient.clear();
   __resetForTesting();
   __setResumeGraceMsForTesting(DEFAULT_RESUME_GRACE_MS);
-  useChatSessionStore.getState().setError(null);
+  useChatSessionStore.setState({ error: null, snapshot: null, optimisticSends: [] });
 });
 
-describe("useConversationHistory resume grace on history errors", () => {
-  test("holds back the initial-page error within the resume grace window", () => {
-    // GIVEN a mounted history hook for an active conversation
-    const { rerender } = renderHistory();
+describe("useConversationHistory resume and fetch errors", () => {
+  test("holds back an initial-page error within the resume grace window", async () => {
+    failLatestFetch();
+    const { result } = renderHistory();
+    resume();
 
-    // AND the app has just resumed from the background
-    act(() => {
-      publish("app.resume", { signal: "visibility" });
-    });
-
-    // WHEN the initial history page errors transiently
-    paginationIsError = true;
-    rerender();
-
-    // THEN no blocking history error is surfaced
+    await waitFor(() => expect(result.current.pagination.isError).toBe(true));
+    expect(result.current.isResumeGraceActive).toBe(true);
     expect(currentError()).toBeNull();
   });
 
-  test("surfaces the initial-page error once the resume grace window expires", async () => {
-    // GIVEN a very short resume grace window
+  test("surfaces an initial-page error once the resume grace window expires", async () => {
     __setResumeGraceMsForTesting(20);
+    failLatestFetch();
+    renderHistory();
+    resume();
 
-    // AND a mounted history hook that just resumed from the background
-    const { rerender } = renderHistory();
-    act(() => {
-      publish("app.resume", { signal: "visibility" });
-    });
-
-    // WHEN the initial history page error persists past the window
-    paginationIsError = true;
-    rerender();
-
-    // THEN the blocking history error surfaces
-    await waitFor(() => {
-      expect(currentError()?.message).toBe(
-        "Failed to load conversation history. Please try again.",
-      );
-    });
+    await waitFor(() => expect(currentError()?.message).toBe(HISTORY_ERROR));
   });
 
-  test("surfaces the initial-page error immediately without a resume", () => {
-    // GIVEN a mounted history hook with no resume signal
-    const { rerender } = renderHistory();
+  test("surfaces an initial-page error without a resume", async () => {
+    failLatestFetch();
+    renderHistory();
 
-    // WHEN the initial history page errors
-    paginationIsError = true;
-    rerender();
+    await waitFor(() => expect(currentError()?.message).toBe(HISTORY_ERROR));
+  });
 
-    // THEN the blocking history error surfaces right away
-    expect(currentError()?.message).toBe(
-      "Failed to load conversation history. Please try again.",
-    );
+  test.each([false, true])(
+    "keeps cached history usable after resume grace expires (empty: %s)",
+    async (empty) => {
+      __setResumeGraceMsForTesting(20);
+      fetchLatestHistoryPage.mockImplementation(async () => page(empty));
+      const { result } = renderHistory();
+      await waitFor(() => expect(result.current.pagination.isSuccess).toBe(true));
+      const snapshot = useChatSessionStore.getState().snapshot;
+      expect(snapshot?.messages).toEqual(page(empty).messages);
+
+      failLatestFetch();
+      resume();
+
+      await waitFor(() => {
+        expect(result.current.pagination.isError).toBe(true);
+        expect(result.current.isResumeGraceActive).toBe(false);
+      });
+      expect(result.current.pagination.isSuccess).toBe(false);
+      expect(useChatSessionStore.getState().snapshot).toBe(snapshot);
+      expect(currentError()).toBeNull();
+
+      fetchLatestHistoryPage.mockImplementation(async () => ({
+        ...page(),
+        messages: [{ id: "msg-2", role: "user", textSegments: ["New message"] }],
+      }));
+      act(() => publish("sse.opened", { assistantId: "asst-1", cause: "error" }));
+      await waitFor(() => {
+        expect(useChatSessionStore.getState().snapshot?.messages[0]?.id).toBe("msg-2");
+      });
+      expect(currentError()).toBeNull();
+    },
+  );
+
+  test("keeps cached history usable when an older-page fetch fails", async () => {
+    fetchLatestHistoryPage.mockImplementation(async () => ({
+      ...page(),
+      hasMore: true,
+      oldestTimestamp: 100,
+    }));
+    fetchOlderHistoryPage.mockImplementation(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    const { result } = renderHistory();
+    await waitFor(() => expect(result.current.pagination.isSuccess).toBe(true));
+    const snapshot = useChatSessionStore.getState().snapshot;
+
+    act(() => result.current.pagination.fetchOlderPage());
+    await waitFor(() => expect(result.current.pagination.isError).toBe(true));
+
+    expect(useChatSessionStore.getState().snapshot).toBe(snapshot);
+    expect(currentError()).toBeNull();
+  });
+
+  test("clears a history error after a successful retry", async () => {
+    failLatestFetch();
+    const { result } = renderHistory();
+    await waitFor(() => expect(currentError()?.message).toBe(HISTORY_ERROR));
+
+    fetchLatestHistoryPage.mockImplementation(async () => page());
+    await act(() => result.current.pagination.invalidate());
+    await waitFor(() => expect(result.current.pagination.isSuccess).toBe(true));
+
+    expect(currentError()).toBeNull();
+  });
+
+  test("holds back a pre-resume history error while reconnecting", async () => {
+    failLatestFetch();
+    renderHistory();
+    await waitFor(() => expect(currentError()?.message).toBe(HISTORY_ERROR));
+
+    resume();
+
+    expect(currentError()).toBeNull();
+  });
+
+  test("preserves a newer send error when history recovers", async () => {
+    failLatestFetch();
+    const { result } = renderHistory();
+    await waitFor(() => expect(currentError()?.message).toBe(HISTORY_ERROR));
+    const sendError = { message: "Message could not be sent" };
+    act(() => useChatSessionStore.getState().setError(sendError));
+
+    fetchLatestHistoryPage.mockImplementation(async () => page());
+    await act(() => result.current.pagination.invalidate());
+    await waitFor(() => expect(result.current.pagination.isSuccess).toBe(true));
+
+    expect(currentError()).toBe(sendError);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -64,7 +64,7 @@ import {
   parsePendingSecretState,
   parsePendingConfirmationData,
 } from "@/domains/chat/utils/send-message-utils";
-import type { AssistantStateKind } from "@/domains/chat/types";
+import type { AssistantStateKind, ChatError } from "@/domains/chat/types";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import {
   getPendingInteractions,
@@ -761,38 +761,45 @@ export function useConversationHistory({
   }, [pagination.isFetchingOlderPages, setTranscriptPagination]);
 
   // -------------------------------------------------------------------------
-  // Surface TanStack Query errors.
-  //
-  // An initial-page failure inside the resume grace window is held back: the
-  // refetch that fires when the client returns from the background often
-  // fails transiently against a still-waking pod. It is still reported, and
-  // the blocking error surfaces once the window expires.
+  // Cached history stays usable when a refresh or older-page fetch fails.
+  // Only an initial load can surface an error, after the resume grace window.
   // -------------------------------------------------------------------------
   const isResumeGraceActive = useResumeGrace();
+  const historyErrorRef = useRef<ChatError | null>(null);
   useEffect(() => {
+    if (historyErrorRef.current && (pagination.isSuccess || isResumeGraceActive)) {
+      const historyError = historyErrorRef.current;
+      setError((current) => (current === historyError ? null : current));
+      historyErrorRef.current = null;
+    }
+
     if (!pagination.isError || !pagination.error) {
       return;
     }
 
-    const isOlderPageError = pagination.isSuccess;
+    const hasLoadedHistory = pagination.latestPage !== undefined;
     captureError(pagination.error, {
-      context: isOlderPageError
-        ? "conversation_history_older_page"
+      context: hasLoadedHistory
+        ? "conversation_history_refresh"
         : "conversation_history_initial",
+      bestEffort: hasLoadedHistory,
     });
 
-    if (!isOlderPageError) {
+    if (!hasLoadedHistory) {
       setIsLoadingHistory(false);
       if (!isResumeGraceActive) {
-        setError({
+        const historyError: ChatError = {
           message: "Failed to load conversation history. Please try again.",
-        });
+        };
+        historyErrorRef.current = historyError;
+        setError(historyError);
       }
     }
   }, [
     pagination.isError,
     pagination.isSuccess,
     pagination.error,
+    pagination.latestPage,
     isResumeGraceActive,
     setIsLoadingHistory,
     setError,

--- a/clients/web/src/domains/chat/transcript/use-history-pagination.ts
+++ b/clients/web/src/domains/chat/transcript/use-history-pagination.ts
@@ -117,7 +117,7 @@ export interface HistoryPaginationResult {
   backgroundToolCompletions: BackgroundTaskEntry[] | undefined;
   /** First-time load with no cached data available. */
   isLoading: boolean;
-  /** At least one successful fetch has completed. */
+  /** Whether the current query status is successful. */
   isSuccess: boolean;
   /** The query errored. */
   isError: boolean;


### PR DESCRIPTION
## Summary
- Keep loaded conversations visible without a load-error notice when a resume refresh or older-message fetch fails, including empty conversations. Query error status does not mean cached history is missing.
- Clear history notices on successful recovery or resume while preserving unrelated chat errors. Continue showing genuine initial-load failures after the existing grace period.
- Exercise the real history query in regression coverage for Android app-state resume, failed refreshes, pagination failures, and recovery.

## Original prompt
Returning to the Android app after spending time in another app can display an incorrect "failed to load conversation" error. The requested fix prevents those misleading errors while the conversation reconnects and refreshes.

## Validation
- All 12 PR checks passed, including the web test suite, lint, type check, production build, and Windows checks.
- Regression tests use the real history query to cover resume failures after grace expires, empty cached history, older-page failures, and error recovery.
- Physical Android background/resume testing remains a manual check.
