### PR TITLE
fix(skills): route Stripe Link setup to the wallet skill (#42281) [cherry-pick]

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -943,26 +943,34 @@
         "vellum": {
           "category": "commerce",
           "display-name": "Stripe App Setup",
-          "user-invocable": "true"
+          "user-invocable": "true",
+          "activation-hints": [
+            "the user wants the assistant to read or manage their Stripe merchant account: customers, subscriptions, refunds, invoices, payouts"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T21:17:09.000Z"
+      "updatedAt": "2026-09-08T20:44:30.000Z"
     },
     {
       "id": "stripe-link-wallet",
       "name": "stripe-link-wallet",
-      "description": "Use the Stripe Link CLI as an agent wallet to create spend requests, generate one-time-use payment credentials, and complete 402 / Machine Payment Protocol (MPP) payment flows on the user's behalf. Triggers on intents like \"buy\", \"purchase\", \"pay for\", \"spend up to <amount>\", \"complete this 402\", or any flow involving link-cli, spend-request, mpp pay, shared payment tokens, or @stripe/link-sdk. Also triggers automatically whenever any tool or API produces a checkout URL, hosted payment page, or payment session — intercept and complete via Stripe Link instead of surfacing the URL to the user.",
+      "description": "Agent wallet on the Stripe Link CLI (link-cli). Connect the wallet, then buy, purchase and pay for things on the user's behalf via approved spend requests, one-time-use cards, and 402 / Machine Payment Protocol (MPP) payments",
       "metadata": {
         "icon": "assets/icon.svg",
         "emoji": "💳",
         "vellum": {
           "category": "commerce",
-          "display-name": "Stripe Link Wallet"
+          "display-name": "Stripe Link Wallet",
+          "activation-hints": [
+            "the user wants to set up, connect, or log in to Stripe Link",
+            "the user asks to buy, purchase, pay for, or spend up to an amount",
+            "a tool returns a checkout URL or payment session"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T20:01:47.000Z"
+      "updatedAt": "2026-09-08T20:44:30.000Z"
     },
     {
       "id": "telegram-setup",
@@ -1165,7 +1173,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-06T03:18:24.000Z"
+      "updatedAt": "2026-09-06T10:00:02.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/stripe-app-setup/SKILL.md
+++ b/skills/stripe-app-setup/SKILL.md
@@ -9,6 +9,8 @@ metadata:
     category: "commerce"
     display-name: "Stripe App Setup"
     user-invocable: true
+    activation-hints:
+      - "the user wants the assistant to read or manage their Stripe merchant account: customers, subscriptions, refunds, invoices, payouts"
 ---
 
 ## Overview

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: "stripe-link-wallet"
-description: 'Use the Stripe Link CLI as an agent wallet to create spend requests, generate one-time-use payment credentials, and complete 402 / Machine Payment Protocol (MPP) payment flows on the user''s behalf. Triggers on intents like "buy", "purchase", "pay for", "spend up to <amount>", "complete this 402", or any flow involving link-cli, spend-request, mpp pay, shared payment tokens, or @stripe/link-sdk. Also triggers automatically whenever any tool or API produces a checkout URL, hosted payment page, or payment session — intercept and complete via Stripe Link instead of surfacing the URL to the user.'
+description: "Agent wallet on the Stripe Link CLI (link-cli). Connect the wallet, then buy, purchase and pay for things on the user's behalf via approved spend requests, one-time-use cards, and 402 / Machine Payment Protocol (MPP) payments"
 metadata:
   icon: assets/icon.svg
   emoji: "💳"
   vellum:
     category: "commerce"
     display-name: "Stripe Link Wallet"
+    activation-hints:
+      - "the user wants to set up, connect, or log in to Stripe Link"
+      - "the user asks to buy, purchase, pay for, or spend up to an amount"
+      - "a tool returns a checkout URL or payment session"
 compatibility: "Designed for Vellum personal assistants"
 ---
 


### PR DESCRIPTION
Cherry-picks `91fb352` (#42281) onto `release/v0.11.10`. The automated cherry-pick failed with conflicts; this resolves them.

## The conflict

Both hunks were `skills/catalog.json` `updatedAt` fields, nothing to do with the skill changes themselves. The generator derives each entry's timestamp from `git log -1 --format=%aI` over that skill's directory, so the value is a property of the branch's history rather than of the content. `main` and `release/v0.11.10` have different author dates for the same skills, so the field conflicts on every cherry-pick that touches a skill.

## Resolution

`catalog.json` is fully generated, so neither side of the conflict is authoritative. I took the release branch's copy, completed the cherry-pick, then regenerated the catalog against this branch's history and amended.

Verified:

- `skills/stripe-link-wallet/SKILL.md` and `skills/stripe-app-setup/SKILL.md` are byte-identical to `91fb352` on `main` (`git diff 91fb3520f1 HEAD -- <both files>` is empty), so the cherry-picked content is exactly what was reviewed and merged.
- `node scripts/skills/check-catalog.mjs` passes.
- `node scripts/skills/lint-skill-spec.mjs` passes, 75 skills.

## One extra line in the diff

The regeneration also corrects `vellum-memory-v3-migration`'s `updatedAt` (`2026-09-06T03:18:24Z` → `2026-09-06T10:00:02Z`). That was pre-existing drift on `release/v0.11.10` from the same mechanism: #42213 was cherry-picked here and its author date changed. It is unrelated to the Stripe change, but `check-catalog` fails on this branch until it is corrected, so it has to ride along.

Original PR: #42281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B4QFL62YsTH1hn1dtzgQi

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->