### PR TITLE
chore(skills): regenerate catalog.json to unblock CI on main

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -950,7 +950,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T19:30:15.000Z"
+      "updatedAt": "2026-09-08T20:44:30.000Z"
     },
     {
       "id": "stripe-link-wallet",
@@ -970,7 +970,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T19:30:15.000Z"
+      "updatedAt": "2026-09-08T20:44:30.000Z"
     },
     {
       "id": "telegram-setup",
@@ -1127,7 +1127,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T13:22:55.000Z"
+      "updatedAt": "2026-09-08T20:16:38.000Z"
     },
     {
       "id": "vellum-memory-v2-migration",
@@ -1213,7 +1213,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T14:44:21.000Z"
+      "updatedAt": "2026-09-08T20:03:58.000Z"
     },
     {
       "id": "vellum-skills-catalog",


### PR DESCRIPTION
`main` is currently failing `Check catalog.json is up to date`. The workflow is path-filtered to `skills/**`, `scripts/skills/**`, and its own file, so this blocks any PR touching those paths, not every open PR. This regenerates the catalog to unblock them.

## Why it drifted

`generate-catalog.mjs` derives each entry's `updatedAt` from `git log -1 --format=%aI` over that skill's directory. A squash-merge writes a **new author date** for the directories it touches, which invalidates whatever catalog the merged branch committed. So the check cannot stay green across a merge no matter what the contributor does: regenerate before committing and you capture the pre-commit date, regenerate after and the merge rewrites it again.

Four entries are stale on `main` today:

| skill | committed | actual |
|---|---|---|
| `stripe-app-setup` | 2026-09-08T19:30:15Z | 2026-09-08T20:44:30Z |
| `stripe-link-wallet` | 2026-09-08T19:30:15Z | 2026-09-08T20:44:30Z |
| `vellum-heartbeat` | 2026-09-08T13:22:55Z | 2026-09-08T20:16:38Z |
| `vellum-self-knowledge` | 2026-09-03T14:44:21Z | 2026-09-08T20:03:58Z |

This is the fourth time this week the same mechanism has broken the check: `outlook` and `plugin-builder` on `main` (fixed in #42280), `vellum-memory-v3-migration` on `release/v0.11.10` (fixed in #42298), and now these four.

## Why this commit is stable

It touches only `skills/catalog.json` and no skill directory, so merging it does not change any `git log` value the generator reads, and it therefore does not invalidate itself.

It is still a band-aid. The next PR that changes a SKILL.md re-breaks the check on merge.

## The durable fix

Stop deriving `updatedAt` from history that the merge rewrites. Options, roughly in order of preference:

1. Drop `updatedAt` from the freshness comparison. `check-catalog.mjs` would compare only generator-deterministic fields, and the timestamp becomes advisory.
2. Compute `updatedAt` at publish time rather than committing it, so the catalog in git carries no history-derived field at all.
3. Carry it explicitly in SKILL.md frontmatter, making it author-controlled and merge-stable.

Happy to take whichever you prefer as a follow-up; that decision felt like yours rather than something to pick unilaterally inside an unblock PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016B4QFL62YsTH1hn1dtzgQi
