### PR TITLE
feat(web): app, file, and camera-frame tiles for the chat-info panel

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -1,14 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import type { FC, MouseEvent } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 
 import { AttachmentDownloadOverlay } from "@/domains/chat/components/chat-attachments/attachment-download-overlay";
-import {
-  downloadAttachment,
-  fetchAttachmentContentBlob,
-} from "@/domains/chat/components/chat-attachments/download-attachment";
+import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { estimateBase64Bytes } from "@/domains/chat/components/chat-attachments/utils";
+import { useAttachmentObjectUrl } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
 import { sniffMimeType } from "@/domains/chat/utils/mime-sniff";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -331,50 +328,22 @@ const ToolResultImageThumb: FC<{
 };
 
 /**
- * Lazily fetches a workspace-referenced tool-result image by attachment id and
- * renders it from an object URL, revoked on unmount. Uses the same fetch/cache
- * key as the preview modal, so opening the modal reuses the already-fetched
- * blob. Until the fetch resolves (or when no assistant id is available to fetch
- * with), a spinner placeholder holds the slot.
+ * Renders a workspace-referenced tool-result image from the object URL
+ * {@link useAttachmentObjectUrl} fetches for it, which shares its cache entry
+ * with the preview modal. Until that resolves (or when no assistant id is
+ * available to fetch with), a spinner placeholder holds the slot.
  */
 const ReferencedToolResultImage: FC<{
   attachment: DisplayAttachment;
   assistantId?: string | null;
 }> = ({ attachment, assistantId }) => {
-  const shouldFetch = !!assistantId && !!attachment.id;
+  const { url, isError } = useAttachmentObjectUrl(
+    assistantId,
+    attachment,
+    true,
+  );
 
-  const { data: blob, isError } = useQuery({
-    queryKey: ["attachmentContent", assistantId, attachment.id],
-    queryFn: async () => {
-      const data = await fetchAttachmentContentBlob(
-        assistantId!,
-        attachment.id,
-      );
-      if (!data) {
-        throw new Error("Failed to load image");
-      }
-      return data;
-    },
-    enabled: shouldFetch,
-    staleTime: Infinity,
-    retry: false,
-  });
-
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  useEffect(() => {
-    if (!blob) {
-      setObjectUrl(null);
-      return;
-    }
-    const url = URL.createObjectURL(blob);
-    setObjectUrl(url);
-    return () => {
-      URL.revokeObjectURL(url);
-      setObjectUrl(null);
-    };
-  }, [blob]);
-
-  if (!objectUrl) {
+  if (!url) {
     return (
       <div
         data-testid="tool-result-image-placeholder"
@@ -390,7 +359,7 @@ const ReferencedToolResultImage: FC<{
   return (
     <img
       data-testid="tool-result-image"
-      src={objectUrl}
+      src={url}
       alt={attachment.filename}
       className={IMAGE_CLASS}
     />

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
@@ -19,6 +19,7 @@ import type { DisplayAttachment } from "@/types/attachment-types";
 export interface AttachmentObjectUrl {
   /** The inline preview URL, the fetched object URL, or null until one exists. */
   url: string | null;
+  /** The bytes failed to load, or can never be fetched (no assistant, no resolvable id). */
   isError: boolean;
 }
 
@@ -31,12 +32,11 @@ export function useAttachmentObjectUrl(
   const { id, previewUrl } = attachment;
   // Synthetic `rehydrated:` ids from the text-parsing history fallback can
   // never resolve against the content endpoint, so they are never fetched.
-  const shouldFetch =
-    enabled &&
-    !previewUrl &&
-    !!assistantId &&
-    !!id &&
-    !id.startsWith("rehydrated:");
+  const canFetch = !!assistantId && !!id && !id.startsWith("rehydrated:");
+  const shouldFetch = enabled && !previewUrl && canFetch;
+  // No inline bytes and no way to fetch them is a settled answer, not a
+  // pending one, so callers can fall back instead of waiting.
+  const unavailable = !previewUrl && !canFetch;
 
   const { data: blob, isError } = useQuery({
     queryKey: ["attachmentContent", assistantId, id],
@@ -66,5 +66,5 @@ export function useAttachmentObjectUrl(
     };
   }, [blob]);
 
-  return { url: previewUrl ?? objectUrl, isError };
+  return { url: previewUrl ?? objectUrl, isError: isError || unavailable };
 }

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
@@ -1,0 +1,70 @@
+/**
+ * A displayable URL for one attachment's bytes.
+ *
+ * An attachment that already carries its content inline resolves to that URL
+ * with no daemon round trip. A metadata-only attachment (a real id and a null
+ * `previewUrl`) fetches its bytes once and holds them as an object URL, revoked
+ * when the blob changes or the caller unmounts.
+ *
+ * The cache key is the one `AttachmentPreviewModal` reads, so a thumbnail that
+ * has already loaded hands the modal a cache hit instead of a second request.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+
+import { fetchAttachmentContentBlob } from "@/domains/chat/components/chat-attachments/download-attachment";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+export interface AttachmentObjectUrl {
+  /** The inline preview URL, the fetched object URL, or null until one exists. */
+  url: string | null;
+  isError: boolean;
+}
+
+export function useAttachmentObjectUrl(
+  assistantId: string | null | undefined,
+  attachment: Pick<DisplayAttachment, "id" | "previewUrl">,
+  /** Fetch only while true (the tile is on screen). */
+  enabled: boolean,
+): AttachmentObjectUrl {
+  const { id, previewUrl } = attachment;
+  // Synthetic `rehydrated:` ids from the text-parsing history fallback can
+  // never resolve against the content endpoint, so they are never fetched.
+  const shouldFetch =
+    enabled &&
+    !previewUrl &&
+    !!assistantId &&
+    !!id &&
+    !id.startsWith("rehydrated:");
+
+  const { data: blob, isError } = useQuery({
+    queryKey: ["attachmentContent", assistantId, id],
+    queryFn: async () => {
+      const data = await fetchAttachmentContentBlob(assistantId!, id);
+      if (!data) {
+        throw new Error("Failed to load attachment content");
+      }
+      return data;
+    },
+    enabled: shouldFetch,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (!blob) {
+      setObjectUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(blob);
+    setObjectUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+      setObjectUrl(null);
+    };
+  }, [blob]);
+
+  return { url: previewUrl ?? objectUrl, isError };
+}

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
@@ -1,0 +1,122 @@
+/**
+ * The Chat Info panel's app tile: a live preview of the app, its options menu
+ * revealed over the preview, and the app's name beneath.
+ *
+ * The previews are real: each story primes the app-html cache the tile reads,
+ * so the iframe renders a small page instead of the icon placeholder. Hover a
+ * tile to see the options menu appear; on a touch device it is always visible.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { appsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { AppSummary } from "@/types/app-types";
+import { primeAppHtmlCache } from "@/utils/app-html-cache";
+
+import { ChatInfoAppTile } from "./chat-info-app-tile";
+
+const ASSISTANT_ID = "story-assistant";
+
+function makeApp(id: string, name: string, icon: string): AppSummary {
+  return {
+    id,
+    name,
+    icon,
+    createdAt: 1_760_000_000_000,
+    updatedAt: 1_760_000_100_000,
+    version: "1.0.0",
+    contentId: `${id}-content`,
+    origin: "workspace",
+  };
+}
+
+const TRIP_PLANNER = makeApp("app-trip-planner", "Trip Planner", "🧭");
+const PACKING_LIST = makeApp("app-packing-list", "Packing List", "🧳");
+const FERRY_TIMES = makeApp("app-ferry-times", "Ferry Times", "⛴️");
+const LONG_NAME = makeApp(
+  "app-itinerary",
+  "Coastal Itinerary and Harbour Tour Booking Planner",
+  "🗺️",
+);
+/** Never primed, so its preview never resolves and the tile keeps the icon. */
+const NO_PREVIEW = makeApp("app-field-notes", "Field Notes", "📓");
+
+/** A small page for the preview iframe, using system colours so it reads in either theme. */
+function previewHtml(title: string, items: string[]): string {
+  const list = items.map((item) => `<li>${item}</li>`).join("");
+  return `<!doctype html><meta charset="utf-8"><title>${title}</title><style>body{margin:0;padding:24px;font-family:system-ui,sans-serif;background:Canvas;color:CanvasText}h1{margin:0 0 12px;font-size:28px}ul{margin:0;padding-left:22px;font-size:18px;line-height:1.7}</style><h1>${title}</h1><ul>${list}</ul>`;
+}
+
+const PRIMED: Array<[AppSummary, string[]]> = [
+  [TRIP_PLANNER, ["Book the ferry", "Pack a rain shell", "Confirm the tour"]],
+  [PACKING_LIST, ["Rain shell", "Walking boots", "Ferry tickets"]],
+  [FERRY_TIMES, ["07:40 harbour", "11:15 harbour", "16:50 harbour"]],
+  [LONG_NAME, ["Day 1 coast road", "Day 2 harbour", "Day 3 return"]],
+];
+
+for (const [app, items] of PRIMED) {
+  primeAppHtmlCache(ASSISTANT_ID, app.id, previewHtml(app.name, items));
+}
+
+const storyClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+});
+// The options menu reads the app list to know whether the app is pinned.
+storyClient.setQueryData(
+  appsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+  {
+    apps: [TRIP_PLANNER, PACKING_LIST, FERRY_TIMES, LONG_NAME, NO_PREVIEW],
+  },
+);
+
+const withPrimedPreviews: Decorator = (Story) => (
+  <QueryClientProvider client={storyClient}>
+    <Story />
+  </QueryClientProvider>
+);
+
+const meta: Meta<typeof ChatInfoAppTile> = {
+  title: "Chat/ChatInfoAppTile",
+  component: ChatInfoAppTile,
+  parameters: { layout: "centered" },
+  decorators: [withPrimedPreviews],
+  args: {
+    app: TRIP_PLANNER,
+    assistantId: ASSISTANT_ID,
+    onOpen: fn(),
+    onRequestDelete: fn(),
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChatInfoAppTile>;
+
+/** One tile at its fixed 184px width, the size it keeps in a strip or a grid. */
+export const Default: Story = {};
+
+/**
+ * Three stretched tiles sharing the 569px panel body, which is what the fitted
+ * row does: each tile takes an equal share rather than its fixed width.
+ */
+export const Stretched: Story = {
+  args: { stretch: true },
+  render: (args) => (
+    <div className="flex w-[569px] gap-2">
+      <ChatInfoAppTile {...args} app={TRIP_PLANNER} />
+      <ChatInfoAppTile {...args} app={PACKING_LIST} />
+      <ChatInfoAppTile {...args} app={FERRY_TIMES} />
+    </div>
+  ),
+};
+
+/** An app whose preview has not resolved: the icon holds the box instead. */
+export const NoPreview: Story = {
+  args: { app: NO_PREVIEW },
+};
+
+/** A name wider than the tile, truncated with the full name in the tooltip. */
+export const LongName: Story = {
+  args: { app: LONG_NAME },
+};

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
@@ -1,0 +1,85 @@
+/**
+ * One app in the Chat Info panel's Apps row: a live preview of the app, an
+ * options menu revealed over it, and the app's name underneath.
+ */
+
+import { useCallback } from "react";
+
+import { cn, Typography } from "@vellumai/design-library";
+
+import { AppPreviewThumbnail } from "@/components/app-card";
+import { AppAssetActions } from "@/domains/chat/components/conversation-asset-actions";
+import { useTranslation } from "@/i18n";
+import type { AppSummary } from "@/types/app-types";
+import { getCachedAppHtml } from "@/utils/app-html-cache";
+
+/** Fixed tile width, and the minimum the section fits a row of them to. Kept in step with `w-[184px]` below. */
+export const CHAT_INFO_APP_TILE_WIDTH_PX = 184;
+
+export interface ChatInfoAppTileProps {
+  app: AppSummary;
+  assistantId: string;
+  onOpen: (appId: string) => void;
+  /** Forwarded to `AppAssetActions`; the dialog is rendered by the panel. */
+  onRequestDelete: (app: AppSummary) => void;
+  /** In a fitted row the tile shares the row width with its siblings; in a strip or a wrapping grid it keeps its fixed width. */
+  stretch?: boolean;
+}
+
+export function ChatInfoAppTile({
+  app,
+  assistantId,
+  onOpen,
+  onRequestDelete,
+  stretch = false,
+}: ChatInfoAppTileProps) {
+  const { t } = useTranslation("chat");
+
+  const loadHtml = useCallback(
+    () => getCachedAppHtml(assistantId, app.id),
+    [assistantId, app.id],
+  );
+
+  return (
+    <div
+      data-reveal-row=""
+      className={cn(
+        "relative flex flex-col gap-1",
+        stretch ? "min-w-0 flex-1" : "w-[184px] shrink-0",
+      )}
+    >
+      {/* The preview iframe is `pointer-events: none`, so this button takes the click. */}
+      <button
+        type="button"
+        aria-label={t("chatInfoPanel.openAppAria", { name: app.name })}
+        onClick={() => onOpen(app.id)}
+        className="block w-full cursor-pointer rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+      >
+        <AppPreviewThumbnail
+          name={app.name}
+          icon={app.icon}
+          loadHtml={loadHtml}
+        />
+      </button>
+
+      <span
+        data-reveal=""
+        className="absolute right-1 top-1 rounded-md bg-[var(--surface-lift)]"
+      >
+        <AppAssetActions
+          assistantId={assistantId}
+          app={app}
+          onRequestDelete={onRequestDelete}
+        />
+      </span>
+
+      <Typography
+        variant="body-small-default"
+        title={app.name}
+        className="truncate text-[var(--content-tertiary)]"
+      >
+        {app.name}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
@@ -1,0 +1,199 @@
+/**
+ * The Chat Info panel's file tile, in each of the states it settles into: a
+ * document, an image it already holds, an image it has to fetch, an image it
+ * cannot get, a non-image glyph, a video poster, and a camera frame labelled
+ * with when it was captured.
+ *
+ * `LazyImage` seeds the shared `attachmentContent` cache entry the tile reads,
+ * which is the same entry the preview modal uses, so the story shows the
+ * fetched path without a daemon behind it.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import {
+  makeDisplayAttachment,
+  makeSamplePreview,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
+import type { DocumentSummary } from "@/types/document-types";
+
+import { ChatInfoFileTile } from "./chat-info-file-tile";
+
+const ASSISTANT_ID = "story-assistant";
+
+const DOC: DocumentSummary = {
+  surfaceId: "surface-trip-notes",
+  conversationId: "conv-1",
+  title: "Trip Notes",
+  wordCount: 842,
+  createdAt: 1_760_000_000_000,
+  updatedAt: 1_760_000_100_000,
+};
+
+const DOCUMENT_FILE: ConversationFileAsset = {
+  kind: "document",
+  id: `doc-${DOC.surfaceId}`,
+  title: DOC.title,
+  doc: DOC,
+};
+
+function attachmentFile(
+  attachment: ReturnType<typeof makeDisplayAttachment>,
+): ConversationFileAsset {
+  return {
+    kind: "attachment",
+    id: `att-${attachment.id}`,
+    title: attachment.filename,
+    attachment,
+  };
+}
+
+const INLINE_IMAGE = attachmentFile(
+  makeDisplayAttachment({
+    id: "harbour-at-dawn",
+    filename: "harbour-at-dawn.png",
+    sizeBytes: 184_320,
+    previewUrl: makeSamplePreview(240, 150),
+  }),
+);
+
+/** Metadata only: the tile has to fetch these bytes before it can draw them. */
+const LAZY_IMAGE_ATTACHMENT = makeDisplayAttachment({
+  id: "ferry-deck",
+  filename: "ferry-deck.png",
+  sizeBytes: 190_464,
+});
+const LAZY_IMAGE = attachmentFile(LAZY_IMAGE_ATTACHMENT);
+
+const LAZY_IMAGE_UNAVAILABLE = attachmentFile(
+  makeDisplayAttachment({
+    id: "gulls-at-dusk",
+    filename: "gulls-at-dusk.png",
+    sizeBytes: 176_128,
+  }),
+);
+
+const PDF_FILE = attachmentFile(
+  makeDisplayAttachment({
+    id: "coast-guide",
+    filename: "coast-guide.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_097_152,
+  }),
+);
+
+const VIDEO_FILE = attachmentFile(
+  makeDisplayAttachment({
+    id: "harbour-tour",
+    filename: "harbour-tour.mp4",
+    mimeType: "video/mp4",
+    sizeBytes: 8_388_608,
+    thumbnailUrl: makeSamplePreview(240, 150),
+  }),
+);
+
+const FRAME_FILE: ConversationFileAsset = {
+  kind: "frame",
+  id: "frame-capture-1",
+  title: "camera-frame-01.jpg",
+  attachment: makeDisplayAttachment({
+    id: "camera-frame-01",
+    filename: "camera-frame-01.jpg",
+    mimeType: "image/jpeg",
+    sizeBytes: 98_304,
+    previewUrl: SAMPLE_PREVIEWS[3]!,
+  }),
+  capturedAt: Date.UTC(2026, 4, 27, 9, 41),
+};
+
+/** The bytes the daemon would return, decoded from a sample preview data URL. */
+function blobFromDataUrl(dataUrl: string): Blob {
+  const [prefix, payload] = dataUrl.split(",");
+  const binary = atob(payload!);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return new Blob([bytes], {
+    type: prefix!.slice("data:".length).replace(";base64", ""),
+  });
+}
+
+const storyClient = new QueryClient({
+  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+});
+storyClient.setQueryData(
+  ["attachmentContent", ASSISTANT_ID, LAZY_IMAGE_ATTACHMENT.id],
+  blobFromDataUrl(SAMPLE_PREVIEWS[2]!),
+);
+
+const withSeededBytes: Decorator = (Story) => (
+  <QueryClientProvider client={storyClient}>
+    <Story />
+  </QueryClientProvider>
+);
+
+const meta: Meta<typeof ChatInfoFileTile> = {
+  title: "Chat/ChatInfoFileTile",
+  component: ChatInfoFileTile,
+  parameters: { layout: "centered" },
+  decorators: [withSeededBytes],
+  args: {
+    file: DOCUMENT_FILE,
+    assistantId: ASSISTANT_ID,
+    onOpen: fn(),
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChatInfoFileTile>;
+
+/** A daemon document: the text glyph, and the only tile kind with a menu. */
+export const Document: Story = {};
+
+/** An image the transcript already carries, drawn straight from its data URL. */
+export const InlineImage: Story = {
+  args: { file: INLINE_IMAGE },
+};
+
+/** An image whose bytes the tile fetches once it is on screen. */
+export const LazyImage: Story = {
+  args: { file: LAZY_IMAGE },
+};
+
+/** The same path with nothing to fetch: the tile settles on the image glyph. */
+export const LazyImageUnavailable: Story = {
+  args: { file: LAZY_IMAGE_UNAVAILABLE },
+};
+
+/** A non-image attachment, which is always its kind's glyph. */
+export const Pdf: Story = {
+  args: { file: PDF_FILE },
+};
+
+/** A video, painted from its poster frame rather than an image element. */
+export const VideoPoster: Story = {
+  args: { file: VIDEO_FILE },
+};
+
+/** A camera frame, labelled with when it was captured rather than its filename. */
+export const Frame: Story = {
+  args: { file: FRAME_FILE },
+};
+
+/** Four tiles at the panel's 8px gutter, the way a row of them reads together. */
+export const Row: Story = {
+  parameters: { controls: { disable: true } },
+  render: (args) => (
+    <div className="flex gap-2">
+      <ChatInfoFileTile {...args} file={DOCUMENT_FILE} />
+      <ChatInfoFileTile {...args} file={INLINE_IMAGE} />
+      <ChatInfoFileTile {...args} file={PDF_FILE} />
+      <ChatInfoFileTile {...args} file={FRAME_FILE} />
+    </div>
+  ),
+};

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
@@ -1,0 +1,168 @@
+/**
+ * One file in the Chat Info panel: a daemon document, a message attachment, or
+ * a camera frame. Documents and non-image attachments show their kind's glyph;
+ * an image shows its picture, fetched only once the tile is on screen.
+ */
+
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+import { DocumentAssetActions } from "@/domains/chat/components/conversation-asset-actions";
+import { useAttachmentObjectUrl } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
+import {
+  ATTACHMENT_ICON_BY_KIND,
+  classifyAttachment,
+} from "@/domains/chat/components/chat-attachments/utils";
+import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
+import { useTranslation } from "@/i18n";
+import { formatFriendlyDate } from "@/utils/format-date";
+
+/** Fixed tile width, and what the section fits a row of them to. Kept in step with `w-[135px]` below. */
+export const CHAT_INFO_FILE_TILE_WIDTH_PX = 135;
+
+/** Stands in for a document's absent attachment so the bytes hook stays unconditional. */
+const NO_ATTACHMENT = { id: "", previewUrl: null };
+
+export interface ChatInfoFileTileProps {
+  file: ConversationFileAsset;
+  assistantId: string;
+  onOpen: (file: ConversationFileAsset) => void;
+}
+
+export function ChatInfoFileTile({
+  file,
+  assistantId,
+  onOpen,
+}: ChatInfoFileTileProps) {
+  const { t } = useTranslation("chat");
+  const boxRef = useRef<HTMLButtonElement>(null);
+
+  // A browser without IntersectionObserver loads every tile rather than none:
+  // the picture is the tile's content here, not an enhancement of it.
+  const [isVisible, setIsVisible] = useState(
+    () => typeof IntersectionObserver === "undefined",
+  );
+  useEffect(() => {
+    const el = boxRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const attachment = file.kind === "document" ? null : file.attachment;
+  // A document's own glyph is the `document` kind's, so the three kinds of tile
+  // share one lookup rather than branching on which one this is.
+  const kind = attachment
+    ? classifyAttachment(attachment.mimeType, attachment.filename)
+    : "document";
+
+  const [previewFailed, setPreviewFailed] = useState(false);
+  const { url, isError } = useAttachmentObjectUrl(
+    assistantId,
+    attachment ?? NO_ATTACHMENT,
+    isVisible && kind === "image",
+  );
+
+  // Video posters stay a CSS background: there is no fallback to swap to when
+  // a poster fails, so an <img> would surface the browser's broken glyph.
+  const posterUrl =
+    kind === "video" && attachment?.thumbnailUrl != null
+      ? attachment.thumbnailUrl
+      : null;
+
+  let ariaLabel: string;
+  if (file.kind === "document") {
+    ariaLabel = t("chatInfoPanel.openDocumentAria", { name: file.title });
+  } else if (file.kind === "frame") {
+    ariaLabel = t("chatInfoPanel.previewFrameAria");
+  } else {
+    ariaLabel = t("chatInfoPanel.previewAttachmentAria", {
+      filename: file.attachment.filename,
+    });
+  }
+
+  const label =
+    file.kind === "frame" && file.capturedAt !== null
+      ? formatFriendlyDate(new Date(file.capturedAt))
+      : file.title;
+
+  const renderBoxContent = () => {
+    if (kind === "image" && !previewFailed) {
+      if (url) {
+        return (
+          <img
+            src={url}
+            alt=""
+            aria-hidden
+            className="h-full w-full object-cover"
+            onError={() => setPreviewFailed(true)}
+          />
+        );
+      }
+      if (!isError) {
+        return (
+          <Loader2 className="size-8 animate-spin text-[var(--content-tertiary)]" />
+        );
+      }
+    }
+    if (posterUrl) {
+      return null;
+    }
+    const Icon = ATTACHMENT_ICON_BY_KIND[kind];
+    return <Icon className="size-8" />;
+  };
+
+  return (
+    <div
+      data-reveal-row=""
+      className="relative flex w-[135px] shrink-0 flex-col gap-1"
+    >
+      <button
+        ref={boxRef}
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => onOpen(file)}
+        style={
+          posterUrl
+            ? { backgroundImage: `url(${JSON.stringify(posterUrl)})` }
+            : undefined
+        }
+        className="relative flex h-[84px] w-full cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-base)] bg-cover bg-center text-[var(--content-secondary)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+      >
+        {renderBoxContent()}
+      </button>
+
+      {/* Attachments and frames carry no menu: the preview modal already offers Download. */}
+      {file.kind === "document" ? (
+        <span data-reveal="" className="absolute right-1 top-1">
+          <DocumentAssetActions
+            assistantId={assistantId}
+            doc={file.doc}
+            onOpen={() => onOpen(file)}
+          />
+        </span>
+      ) : null}
+
+      <Typography
+        variant="body-small-default"
+        title={label}
+        className="truncate text-[var(--content-tertiary)]"
+      >
+        {label}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
@@ -278,6 +278,24 @@ describe("ChatInfoFileTile attachments", () => {
     expect(container.querySelector("img")).toBeNull();
   });
 
+  test("falls back to the image glyph for a legacy image it can never fetch", () => {
+    // A row reloaded from a summary line carries a synthetic id and no bytes.
+    const file = attachmentAsset(
+      makeDisplayAttachment({ id: "rehydrated:0", filename: "legacy.png" }),
+    );
+    const { container } = renderTile(
+      <ChatInfoFileTile
+        file={file}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(container.querySelector(".lucide-file-image")).toBeTruthy();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(fetchAttachmentContentBlob).not.toHaveBeenCalled();
+  });
+
   test("renders the PDF glyph without fetching", () => {
     const file = attachmentAsset(
       makeDisplayAttachment({

--- a/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
@@ -1,0 +1,330 @@
+/**
+ * The Chat Info tiles: what each kind draws, and which of them fetch bytes.
+ *
+ * Glyphs are located by their lucide class because the tile draws them
+ * decoratively, with no accessible name of their own; everything else is
+ * asserted through accessible names and the rendered image source.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactElement } from "react";
+
+import * as appHtmlCache from "@/utils/app-html-cache";
+import * as downloadAttachmentModule from "@/domains/chat/components/chat-attachments/download-attachment";
+import type { AppSummary } from "@/types/app-types";
+import type { DocumentSummary } from "@/types/document-types";
+
+const OBJECT_URL = "blob:chat-info-tile";
+
+// happy-dom implements neither object URLs nor IntersectionObserver.
+globalThis.URL.createObjectURL = mock(
+  (_obj: Blob | MediaSource): string => OBJECT_URL,
+);
+globalThis.URL.revokeObjectURL = mock((_url: string): void => undefined);
+
+class ImmediateIntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds: number[] = [];
+  constructor(private readonly callback: IntersectionObserverCallback) {}
+  observe(target: Element): void {
+    this.callback(
+      [{ isIntersecting: true, target } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+globalThis.IntersectionObserver =
+  ImmediateIntersectionObserver as unknown as typeof IntersectionObserver;
+
+const fetchAttachmentContentBlob = mock(
+  async (_assistantId: string, _attachmentId: string): Promise<Blob | null> =>
+    new Blob(["image-bytes"], { type: "image/png" }),
+);
+// Both factories keep the rest of their module real, so a file that imports
+// another of its exports is unaffected by these process-global replacements.
+mock.module(
+  "@/domains/chat/components/chat-attachments/download-attachment",
+  (): Partial<typeof downloadAttachmentModule> => ({
+    ...downloadAttachmentModule,
+    fetchAttachmentContentBlob,
+  }),
+);
+
+// The app tile's live preview would otherwise call the daemon's open endpoint.
+mock.module(
+  "@/utils/app-html-cache",
+  (): Partial<typeof appHtmlCache> => ({
+    ...appHtmlCache,
+    getCachedAppHtml: async () => "<!doctype html><title>App</title>",
+  }),
+);
+
+const { ChatInfoAppTile } =
+  await import("@/domains/chat/components/chat-info-app-tile");
+const { ChatInfoFileTile } =
+  await import("@/domains/chat/components/chat-info-file-tile");
+const { makeDisplayAttachment, SAMPLE_PREVIEWS } =
+  await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
+const { appsGetQueryKey } =
+  await import("@/generated/daemon/@tanstack/react-query.gen");
+const { formatFriendlyDate } = await import("@/utils/format-date");
+type ConversationFileAsset =
+  import("@/domains/chat/hooks/use-conversation-assets").ConversationFileAsset;
+
+const ASSISTANT_ID = "asst-1";
+
+const APP: AppSummary = {
+  id: "app-1",
+  name: "Trip Planner",
+  icon: "🧭",
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_001,
+  version: "1.0.0",
+  contentId: "content-1",
+  origin: "workspace",
+};
+
+const DOC: DocumentSummary = {
+  surfaceId: "surface-1",
+  conversationId: "conv-1",
+  title: "Trip Notes",
+  wordCount: 120,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_001,
+};
+
+const DOCUMENT_ASSET: ConversationFileAsset = {
+  kind: "document",
+  id: "doc-surface-1",
+  title: DOC.title,
+  doc: DOC,
+};
+
+function attachmentAsset(
+  attachment: ReturnType<typeof makeDisplayAttachment>,
+): ConversationFileAsset {
+  return {
+    kind: "attachment",
+    id: `att-${attachment.id}`,
+    title: attachment.filename,
+    attachment,
+  };
+}
+
+function renderTile(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  // Seeded so the options menu's pin lookup never reaches the daemon.
+  client.setQueryData(
+    appsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+    {
+      apps: [APP],
+    },
+  );
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  fetchAttachmentContentBlob.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ChatInfoAppTile", () => {
+  test("opens the app by id and offers its options menu", async () => {
+    const onOpen = mock((_appId: string): void => undefined);
+    const { container } = renderTile(
+      <ChatInfoAppTile
+        app={APP}
+        assistantId={ASSISTANT_ID}
+        onOpen={onOpen}
+        onRequestDelete={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Open Trip Planner"));
+
+    expect(onOpen).toHaveBeenCalledWith("app-1");
+    expect(screen.getByLabelText("Options for Trip Planner")).toBeDefined();
+    // The preview loads its html asynchronously; settle it inside the test.
+    await waitFor(() => {
+      expect(container.querySelector("iframe")).toBeTruthy();
+    });
+  });
+});
+
+describe("ChatInfoFileTile documents", () => {
+  test("draws the document glyph and offers its options menu", () => {
+    const onOpen = mock((_file: ConversationFileAsset): void => undefined);
+    const { container } = renderTile(
+      <ChatInfoFileTile
+        file={DOCUMENT_ASSET}
+        assistantId={ASSISTANT_ID}
+        onOpen={onOpen}
+      />,
+    );
+
+    expect(container.querySelector(".lucide-file-text")).toBeTruthy();
+    expect(screen.getByLabelText("Options for Trip Notes")).toBeDefined();
+
+    fireEvent.click(screen.getByLabelText("Open Trip Notes"));
+    expect(onOpen).toHaveBeenCalledWith(DOCUMENT_ASSET);
+  });
+});
+
+describe("ChatInfoFileTile attachments", () => {
+  test("renders an inline preview without fetching", () => {
+    const file = attachmentAsset(
+      makeDisplayAttachment({
+        id: "inline-1",
+        filename: "harbour.png",
+        previewUrl: SAMPLE_PREVIEWS[0]!,
+      }),
+    );
+    const { container } = renderTile(
+      <ChatInfoFileTile
+        file={file}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      SAMPLE_PREVIEWS[0]!,
+    );
+    expect(fetchAttachmentContentBlob).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Preview harbour.png")).toBeDefined();
+  });
+
+  test("spins while it fetches, then renders the object URL", async () => {
+    const file = attachmentAsset(
+      makeDisplayAttachment({ id: "lazy-1", filename: "photo.png" }),
+    );
+    const { container } = renderTile(
+      <ChatInfoFileTile
+        file={file}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(container.querySelector(".lucide-loader-circle")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(container.querySelector("img")).toBeTruthy();
+    });
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      OBJECT_URL,
+    );
+    expect(fetchAttachmentContentBlob).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to the image glyph when the bytes will not decode", async () => {
+    const file = attachmentAsset(
+      makeDisplayAttachment({ id: "broken-1", filename: "broken.png" }),
+    );
+    const { container } = renderTile(
+      <ChatInfoFileTile
+        file={file}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("img")).toBeTruthy();
+    });
+    fireEvent.error(container.querySelector("img")!);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector(".lucide-file-image")).toBeTruthy();
+  });
+
+  test("falls back to the image glyph when the fetch resolves nothing", async () => {
+    fetchAttachmentContentBlob.mockImplementationOnce(async () => null);
+    const file = attachmentAsset(
+      makeDisplayAttachment({ id: "missing-1", filename: "missing.png" }),
+    );
+    const { container } = renderTile(
+      <ChatInfoFileTile
+        file={file}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector(".lucide-file-image")).toBeTruthy();
+    });
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  test("renders the PDF glyph without fetching", () => {
+    const file = attachmentAsset(
+      makeDisplayAttachment({
+        id: "pdf-1",
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+      }),
+    );
+    const { container } = renderTile(
+      <ChatInfoFileTile
+        file={file}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(container.querySelector(".lucide-file-type-corner")).toBeTruthy();
+    expect(fetchAttachmentContentBlob).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChatInfoFileTile camera frames", () => {
+  test("labels itself with the capture time and names itself a frame", () => {
+    const capturedAt = new Date(2026, 4, 27, 10, 30).getTime();
+    const file: ConversationFileAsset = {
+      kind: "frame",
+      id: "frame-1",
+      title: "frame-01.jpg",
+      attachment: makeDisplayAttachment({
+        id: "frame-1",
+        filename: "frame-01.jpg",
+        mimeType: "image/jpeg",
+        previewUrl: SAMPLE_PREVIEWS[1]!,
+      }),
+      capturedAt,
+    };
+    renderTile(
+      <ChatInfoFileTile
+        file={file}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Preview camera frame")).toBeDefined();
+    expect(
+      screen.getByText(formatFriendlyDate(new Date(capturedAt))),
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `ChatInfoAppTile` (live app preview, options menu, name) and `ChatInfoFileTile` (document, attachment, or camera frame; glyph or image; capture-time label for frames)
- `useAttachmentObjectUrl` lifts the lazy attachment-bytes fetch out of the tool-result image so tiles and the preview modal share one cached request
- Stories for every tile state, including a lazily fetched image seeded from the query cache

Part of plan: chat-info-assets-panel.md (PR 5 of 12)