### PR TITLE
fix: Windows toast avatar URI escaping

### DIFF
--- a/clients/windows/native/Vellum.WindowsHelper.Tests/NotificationServiceTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/NotificationServiceTests.cs
@@ -47,6 +47,15 @@ public static class NotificationServiceTests
         Assert(blankXml.Contains("<text>T</text><text>B</text>", StringComparison.Ordinal));
         Assert(!blankXml.Contains("<image", StringComparison.Ordinal));
 
+        // The src is built from the path's own segments, so a literal percent
+        // sequence in a folder name stays encoded instead of decoding to a
+        // different file.
+        Assert(AvatarImageSrc(@"C:\Users\%20\a.png") == "file:///C:/Users/%2520/a.png");
+        // Spaces and reserved characters are percent-encoded, not passed through.
+        Assert(AvatarImageSrc(@"C:\Vellum Data\a&b.png") == "file:///C:/Vellum%20Data/a%26b.png");
+        // A path with no drive root is not something a toast can load.
+        Assert(AvatarImageSrc(@"notification-avatars\a.png") is null);
+
         Assert(NotificationService.ParseActivationArguments("kind=action;index=1") == ("action", 1));
         // Unreadable arguments still route as a body click.
         Assert(NotificationService.ParseActivationArguments("garbage") == ("click", -1));
@@ -77,6 +86,23 @@ public static class NotificationServiceTests
         Assert(okResult is NotificationService.ShowResponse { Success: true } && delivered == 1);
 
         Console.WriteLine("NotificationService tests passed");
+    }
+
+    /// <summary>The app-logo image src the toast carries for an avatar path,
+    /// or null when the toast drops the image.</summary>
+    private static string? AvatarImageSrc(string avatarPath)
+    {
+        const string prefix =
+            "<image placement=\"appLogoOverride\" hint-crop=\"circle\" src=\"";
+        var xml = NotificationService.BuildToastXml(
+            new NotificationService.ShowRequest("t-src", "T", null, "B", [], avatarPath));
+        var start = xml.IndexOf(prefix, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return null;
+        }
+        var value = xml[(start + prefix.Length)..];
+        return value[..value.IndexOf('"')];
     }
 
     private static void Assert(bool condition)

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/NotificationService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/NotificationService.cs
@@ -176,13 +176,40 @@ public sealed class NotificationService : IRpcModule, INotificationAdapter
         return builder.Append("</toast>").ToString();
     }
 
-    /// <summary>The `file:///` form of an absolute local path, with separators
-    /// flipped and reserved characters percent-encoded, or null for anything a
-    /// toast image cannot load.</summary>
-    private static string? ToFileUri(string? avatarPath) =>
-        Uri.TryCreate(avatarPath, UriKind.Absolute, out var uri) && uri.IsFile
-            ? uri.AbsoluteUri
-            : null;
+    private static readonly char[] PathSeparators = ['\\', '/'];
+
+    /// <summary>The `file:///` form of a drive-rooted local path: the drive
+    /// kept verbatim, every following segment percent-encoded, separators
+    /// flipped to forward slashes. Null for anything a toast image cannot
+    /// load, including relative paths and UNC shares. The URI is assembled
+    /// from the path's own segments rather than parsed out of it, so a literal
+    /// `%` in a folder name stays encoded and keeps naming the file the avatar
+    /// was written to.</summary>
+    private static string? ToFileUri(string? avatarPath)
+    {
+        if (avatarPath is null)
+        {
+            return null;
+        }
+        var segments = avatarPath.Split(PathSeparators);
+        if (segments.Length < 2 ||
+            segments[0].Length != 2 ||
+            !char.IsAsciiLetter(segments[0][0]) ||
+            segments[0][1] != ':')
+        {
+            return null;
+        }
+        var builder = new StringBuilder("file:///").Append(segments[0]);
+        for (var index = 1; index < segments.Length; index++)
+        {
+            if (segments[index].Length == 0)
+            {
+                return null;
+            }
+            builder.Append('/').Append(Uri.EscapeDataString(segments[index]));
+        }
+        return builder.ToString();
+    }
 
     public static (string Kind, int Index) ParseActivationArguments(string arguments)
     {


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for avatar-notification-icon.md.

**Gap:** ToFileUri decoded percent sequences in the avatar path.
**Fix:** the URI is built from escaped path segments; tests cover literal percent, spaces and ampersands, and relative paths.