### PR TITLE
fix: iOS notification extension hardening

### DIFF
--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -224,6 +224,17 @@ jobs:
             exit 1
           fi
 
+          # The app entitlements declare
+          # com.apple.developer.usernotifications.communication, and a profile
+          # issued before Communication Notifications was enabled on the App ID
+          # does not grant it. Xcode only notices at Archive, long after the
+          # build has started, with an error that names neither the entitlement
+          # nor the fix, so the profile is decoded and checked here instead.
+          if ! security cms -D -i "$PROFILE_DIR/ios_distribution.mobileprovision" | grep -q usernotifications.communication; then
+            echo "::error::Provisioning profile $APP_PROFILE_KEY does not grant com.apple.developer.usernotifications.communication, which App.entitlements and App-Dev.entitlements declare. Archive would fail while signing the app target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md, steps 2 and 4 for this environment's app row: tick Communication Notifications on the app App ID, reissue its distribution profile under the identical name, then replace $APP_PROFILE_KEY."
+            exit 1
+          fi
+
           # A missing extension profile is tolerated: the App IDs and profiles
           # behind IOS_PROVISIONING_PROFILE_EXT* do not exist in the Apple
           # Developer portal yet. The archive fails either way, so exiting here

--- a/clients/ios/App/App/Shared/AppGroupID.swift
+++ b/clients/ios/App/App/Shared/AppGroupID.swift
@@ -8,8 +8,9 @@ import Foundation
 /// `...-ios.dev`), so a hardcoded literal would point a Dev or Staging build
 /// at the production container and let one environment read another's data.
 ///
-/// Shared by the app target, the VoiceActivity widget extension, and the
-/// share extension so there is one implementation. Each reads the same
+/// Shared by the app target, the VoiceActivity widget extension, the share
+/// extension, and the NotificationService extension so there is one
+/// implementation. Each reads the same
 /// ``infoPlistKey`` string, populated from the very same `$(APP_GROUP_ID)`
 /// variable that reaches their entitlements plists: the entitlement is what
 /// actually grants access, but it is not readable from Swift, so the value
@@ -20,8 +21,9 @@ import Foundation
 /// container, and naming another environment's group would only trade a no-op
 /// for cross-environment data mixing. Each caller decides explicitly.
 /// ``WidgetSnapshotStore`` and ``ShareInbox`` degrade to doing nothing;
-/// ``RecentChatsStore`` falls back to `UserDefaults.standard` so in-process
-/// Shortcuts still have a picker.
+/// ``AvatarCache`` degrades to no cache, so the notification extension
+/// delivers the push unrewritten; ``RecentChatsStore`` falls back to
+/// `UserDefaults.standard` so in-process Shortcuts still have a picker.
 enum AppGroupID {
     /// Info.plist key carrying the group id, restated from the entitlement.
     static let infoPlistKey = "VellumAppGroupId"

--- a/clients/ios/App/AppTests/AvatarCacheTests.swift
+++ b/clients/ios/App/AppTests/AvatarCacheTests.swift
@@ -9,9 +9,12 @@ final class AvatarCacheTests: XCTestCase {
         root = FileManager.default.temporaryDirectory
             .appendingPathComponent("AvatarCache-\(UUID().uuidString)", isDirectory: true)
         cache = AvatarCache(rootURL: root)
+        URLProtocol.registerClass(CountingURLProtocol.self)
+        loadCounter.reset()
     }
 
     override func tearDown() {
+        URLProtocol.unregisterClass(CountingURLProtocol.self)
         try? FileManager.default.removeItem(at: root)
         super.tearDown()
     }
@@ -100,6 +103,16 @@ final class AvatarCacheTests: XCTestCase {
         XCTAssertEqual(cache.data(forHash: hashes[0]), avatar(0))
     }
 
+    func testDropsACachedFileWhoseBytesNoLongerMatchItsName() throws {
+        let hash = AvatarCache.sha256Hex(avatar(1))
+        let url = try XCTUnwrap(cache.fileURL(forHash: hash))
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try avatar(2).write(to: url)
+
+        XCTAssertNil(cache.data(forHash: hash))
+        XCTAssertEqual(storedFileCount(), 0)
+    }
+
     func testReadsUpToTheByteCap() async throws {
         let atCap = ByteFeed(count: 16)
         let atCapBytes = try await AvatarCache.readAtMost(16, from: atCap.stream())
@@ -111,13 +124,85 @@ final class AvatarCacheTests: XCTestCase {
         XCTAssertEqual(underCapBytes?.count, 4)
     }
 
+    func testReadsABodyThatSpansSeveralBufferedChunks() async throws {
+        let count = AvatarCache.readChunkSize * 2 + 7
+        let feed = ByteFeed(count: count)
+        let bytes = try await AvatarCache.readAtMost(AvatarCache.maxBytes, from: feed.stream())
+        XCTAssertEqual(bytes?.count, count)
+        XCTAssertEqual(feed.produced, count)
+    }
+
     func testStopsReadingPastTheByteCap() async throws {
         let feed = ByteFeed(count: 4_096)
         let bytes = try await AvatarCache.readAtMost(16, from: feed.stream())
         XCTAssertNil(bytes)
         // One byte past the cap is enough to know the body is too large, so the
-        // rest of the response is never pulled into memory.
+        // rest of the response is never pulled into memory, buffered chunk or
+        // not.
         XCTAssertEqual(feed.produced, 17)
+    }
+
+    func testFetchRefusesANonHttpsURL() async throws {
+        let url = try XCTUnwrap(URL(string: "http://storage.example.com/avatar.png"))
+        let bytes = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(avatar(1)))
+        XCTAssertNil(bytes)
+        XCTAssertEqual(loadCounter.count, 0)
+    }
+
+    func testFetchRefusesAMalformedHash() async throws {
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
+        let bytes = await cache.fetch(url: url, hash: "../etc/passwd")
+        XCTAssertNil(bytes)
+        XCTAssertEqual(loadCounter.count, 0)
+    }
+
+    /// Proves the two guards above are what stopped the request, rather than a
+    /// stub that never intercepts: the same call with both guards satisfied
+    /// does reach the URL loading system.
+    func testFetchReachesTheNetworkOnceTheGuardsPass() async throws {
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
+        let bytes = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(avatar(1)))
+        XCTAssertNil(bytes)
+        XCTAssertEqual(loadCounter.count, 1)
+    }
+}
+
+/// Counts the requests that reach the URL loading system and fails every one of
+/// them, so a test can tell a guard that returned early apart from a request
+/// that went out and came back empty.
+private final class CountingURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        loadCounter.increment()
+        client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+    }
+
+    override func stopLoading() {}
+}
+
+/// Shared because `URLProtocol` instances are created by the loading system,
+/// which hands the test no reference to them.
+private let loadCounter = LoadCounter()
+
+private final class LoadCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var count: Int { lock.withLock { value } }
+
+    func increment() {
+        lock.withLock { value += 1 }
+    }
+
+    func reset() {
+        lock.withLock { value = 0 }
     }
 }
 

--- a/clients/ios/App/AppTests/SenderPayloadTests.swift
+++ b/clients/ios/App/AppTests/SenderPayloadTests.swift
@@ -3,13 +3,10 @@ import XCTest
 final class SenderPayloadTests: XCTestCase {
     private let avatarHash = String(repeating: "a", count: 64)
 
-    private func userInfo(sender: [String: Any]?, deepLink: [String: Any]? = nil) -> [AnyHashable: Any] {
+    private func userInfo(sender: [String: Any]?) -> [AnyHashable: Any] {
         var info: [AnyHashable: Any] = ["aps": ["alert": ["title": "Gym", "body": "Ready"]]]
         if let sender {
             info["sender"] = sender
-        }
-        if let deepLink {
-            info["deep_link"] = deepLink
         }
         return info
     }
@@ -68,37 +65,6 @@ final class SenderPayloadTests: XCTestCase {
             SenderPayload.parse(
                 userInfo: userInfo(sender: ["id": "asst-123", "name": "Vellum", "avatar_hash": ""])
             )
-        )
-    }
-
-    func testConversationIdentifierPrefersTheDeepLink() {
-        XCTAssertEqual(
-            SenderPayload.conversationIdentifier(
-                userInfo: userInfo(sender: nil, deepLink: ["conversationId": "conv-xyz"]),
-                senderId: "asst-123"
-            ),
-            "conv-xyz"
-        )
-    }
-
-    func testConversationIdentifierFallsBackToTheSenderId() {
-        XCTAssertEqual(
-            SenderPayload.conversationIdentifier(userInfo: userInfo(sender: nil), senderId: "asst-123"),
-            "asst-123"
-        )
-        XCTAssertEqual(
-            SenderPayload.conversationIdentifier(
-                userInfo: userInfo(sender: nil, deepLink: ["conversationId": ""]),
-                senderId: "asst-123"
-            ),
-            "asst-123"
-        )
-        XCTAssertEqual(
-            SenderPayload.conversationIdentifier(
-                userInfo: userInfo(sender: nil, deepLink: ["other": "value"]),
-                senderId: "asst-123"
-            ),
-            "asst-123"
         )
     }
 }

--- a/clients/ios/App/NotificationService/AvatarCache.swift
+++ b/clients/ios/App/NotificationService/AvatarCache.swift
@@ -21,6 +21,7 @@ struct AvatarCache {
     static let maxEntries = 8
     static let maxBytes = 512 * 1024
     static let defaultTimeout: TimeInterval = 8
+    static let readChunkSize = 16 * 1024
 
     let rootURL: URL
 
@@ -42,10 +43,18 @@ struct AvatarCache {
 
     /// The cached bytes for `hash`, or `nil` when nothing is stored under it.
     ///
+    /// The bytes are re-hashed on the way out, not only on the way in: the
+    /// container is shared with the app, and a file that no longer matches its
+    /// own name is deleted rather than rendered.
+    ///
     /// A hit stamps the file with the current time so eviction, which ranks by
     /// modification date, treats a recently used avatar as recent.
     func data(forHash hash: String) -> Data? {
         guard let url = fileURL(forHash: hash), let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        guard Self.sha256Hex(data) == hash else {
+            try? FileManager.default.removeItem(at: url)
             return nil
         }
         try? FileManager.default.setAttributes(
@@ -78,10 +87,11 @@ struct AvatarCache {
     /// notification unchanged.
     ///
     /// The URL arrives in the push payload, so only `https` is followed and only
-    /// bytes that hash to `hash` are used. The body is streamed and abandoned
-    /// the moment it goes past ``maxBytes``, which keeps an oversized or
-    /// malformed response from filling the extension's memory budget, and
-    /// `timeout` bounds how long the read may take.
+    /// bytes that hash to `hash` are used. A response that declares no length or
+    /// one past ``maxBytes`` is dropped before its body is read, and the body
+    /// itself is abandoned the moment it goes past the same cap, which keeps an
+    /// oversized or malformed response from filling the extension's memory
+    /// budget. `timeout` bounds how long the read may take.
     func fetch(url: URL, hash: String, timeout: TimeInterval = defaultTimeout) async -> Data? {
         guard Self.isValidHash(hash), url.scheme == "https" else {
             return nil
@@ -96,6 +106,7 @@ struct AvatarCache {
         }
         guard let http = response as? HTTPURLResponse,
               http.statusCode == 200,
+              http.expectedContentLength >= 0,
               http.expectedContentLength <= Int64(Self.maxBytes)
         else {
             bytes.task.cancel()
@@ -113,18 +124,30 @@ struct AvatarCache {
 
     /// Collect `bytes` until the sequence ends, or return `nil` as soon as more
     /// than `limit` bytes arrive so an oversized body is never held whole.
+    ///
+    /// Bytes land in an array first and reach the `Data` a chunk at a time:
+    /// appending each byte to `Data` individually costs a bounds check and a
+    /// possible reallocation per byte, which is the whole of the extension's
+    /// CPU budget on a 512 KB avatar.
     static func readAtMost<Bytes: AsyncSequence>(
         _ limit: Int,
         from bytes: Bytes
     ) async throws -> Data? where Bytes.Element == UInt8 {
         var data = Data()
-        data.reserveCapacity(min(limit, 32 * 1024))
+        data.reserveCapacity(min(limit, readChunkSize))
+        var chunk = [UInt8]()
+        chunk.reserveCapacity(min(limit, readChunkSize))
         for try await byte in bytes {
-            if data.count >= limit {
+            if data.count + chunk.count >= limit {
                 return nil
             }
-            data.append(byte)
+            chunk.append(byte)
+            if chunk.count == readChunkSize {
+                data.append(contentsOf: chunk)
+                chunk.removeAll(keepingCapacity: true)
+            }
         }
+        data.append(contentsOf: chunk)
         return data
     }
 

--- a/clients/ios/App/NotificationService/CommunicationContent.swift
+++ b/clients/ios/App/NotificationService/CommunicationContent.swift
@@ -10,11 +10,15 @@ import UserNotifications
 /// is rewritten. `updating(from:)` copies the sender, image, and thread onto the
 /// content and leaves `userInfo`, `categoryIdentifier`, and the body alone, so
 /// tap routing is unaffected.
+///
+/// The intent is built the way `clients/macos/native/notifier/notifier.mm`
+/// builds its own, so one assistant looks and threads the same on both
+/// platforms: the sender id is the thread, "me" is a handle rather than an
+/// empty person, and `serviceName` is left off.
 func communicationContent(
     from content: UNNotificationContent,
     sender: SenderPayload,
-    avatar: Data,
-    conversationId: String
+    avatar: Data
 ) async throws -> UNNotificationContent {
     // INImage(url:) reads local files only, so the bytes travel inline.
     let image = INImage(imageData: avatar)
@@ -29,12 +33,12 @@ func communicationContent(
         suggestionType: .none
     )
     let mePerson = INPerson(
-        personHandle: INPersonHandle(value: nil, type: .unknown),
+        personHandle: INPersonHandle(value: "me", type: .unknown),
         nameComponents: nil,
         displayName: nil,
         image: nil,
         contactIdentifier: nil,
-        customIdentifier: nil,
+        customIdentifier: "me",
         isMe: true,
         suggestionType: .none
     )
@@ -51,8 +55,8 @@ func communicationContent(
         outgoingMessageType: .outgoingMessageText,
         content: content.body,
         speakableGroupName: groupName,
-        conversationIdentifier: conversationId,
-        serviceName: "Vellum",
+        conversationIdentifier: sender.id,
+        serviceName: nil,
         sender: senderPerson,
         attachments: nil
     )

--- a/clients/ios/App/NotificationService/Info.plist
+++ b/clients/ios/App/NotificationService/Info.plist
@@ -31,15 +31,6 @@
 		<string>com.apple.usernotifications.service</string>
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
-		<key>NSExtensionAttributes</key>
-		<dict>
-			<!-- Declares that this extension rewrites notifications into
-			     Communication Notifications via INSendMessageIntent. -->
-			<key>IntentsSupported</key>
-			<array>
-				<string>INSendMessageIntent</string>
-			</array>
-		</dict>
 	</dict>
 	<!-- The App Group this appex shares with its containing app, so code here
 	     can open the shared container. The entitlement grants access but is not

--- a/clients/ios/App/NotificationService/NotificationService.swift
+++ b/clients/ios/App/NotificationService/NotificationService.swift
@@ -8,9 +8,18 @@ import os
 /// Communication Notification so the assistant's avatar is the icon. Everything
 /// else, including every push sent while the `push-avatar-sender` flag is off,
 /// is delivered exactly as it arrived.
+///
+/// Every path that gives up on the rewrite logs one stable `nse.*` prefix
+/// before delivering the push unchanged, so a device that shows plain
+/// notifications can be diagnosed from Console with a single filter on `nse.`
+/// rather than by guessing which of the five it took.
 final class NotificationService: UNNotificationServiceExtension {
+    /// Falls back to the production appex bundle id so a build that somehow
+    /// reports no identifier still logs under a subsystem Console can filter,
+    /// rather than one that matches nothing.
     private static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier ?? "ai.vellum.assistant",
+        subsystem: Bundle.main.bundleIdentifier
+            ?? "ai.vocify-inc.vellum-assistant-ios.NotificationService",
         category: "NotificationService"
     )
 
@@ -29,17 +38,16 @@ final class NotificationService: UNNotificationServiceExtension {
         unchangedContent = request.content
         lock.unlock()
 
-        let userInfo = request.content.userInfo
-        guard let sender = SenderPayload.parse(userInfo: userInfo),
-              let cache = AvatarCache.inAppGroup()
-        else {
+        guard let sender = SenderPayload.parse(userInfo: request.content.userInfo) else {
+            Self.logger.info("nse.no_sender: push carries no complete sender block")
             deliver(request.content)
             return
         }
-        let conversationId = SenderPayload.conversationIdentifier(
-            userInfo: userInfo,
-            senderId: sender.id
-        )
+        guard let cache = AvatarCache.inAppGroup() else {
+            Self.logger.error("nse.no_app_group: the appex declares no App Group container")
+            deliver(request.content)
+            return
+        }
 
         Task {
             var avatar = cache.data(forHash: sender.avatarHash)
@@ -47,7 +55,7 @@ final class NotificationService: UNNotificationServiceExtension {
                 avatar = await cache.fetch(url: url, hash: sender.avatarHash)
             }
             guard let avatar else {
-                Self.logger.info("No avatar for the push sender, delivering unchanged")
+                Self.logger.info("nse.avatar_unavailable: cache miss and no usable download")
                 self.deliver(request.content)
                 return
             }
@@ -56,13 +64,12 @@ final class NotificationService: UNNotificationServiceExtension {
                     try await communicationContent(
                         from: request.content,
                         sender: sender,
-                        avatar: avatar,
-                        conversationId: conversationId
+                        avatar: avatar
                     )
                 )
             } catch {
                 Self.logger.error(
-                    "Communication notification rewrite failed: \(error.localizedDescription, privacy: .public)"
+                    "nse.intent_failed: \(error.localizedDescription, privacy: .public)"
                 )
                 self.deliver(request.content)
             }
@@ -76,6 +83,7 @@ final class NotificationService: UNNotificationServiceExtension {
         let content = unchangedContent
         lock.unlock()
         if let content {
+            Self.logger.info("nse.expired: budget ran out before the rewrite finished")
             deliver(content)
         }
     }

--- a/clients/ios/App/NotificationService/SenderPayload.swift
+++ b/clients/ios/App/NotificationService/SenderPayload.swift
@@ -30,25 +30,6 @@ struct SenderPayload: Equatable {
         )
     }
 
-    /// Thread the rewritten notification belongs to, read from the same
-    /// `deep_link.conversationId` a tap routes through
-    /// (`extractPushConversationId` in `clients/web/src/runtime/push-registration.ts`).
-    ///
-    /// The sender id is the fallback so notifications from one assistant still
-    /// group together when the platform dropped the deep link to fit the
-    /// payload budget.
-    static func conversationIdentifier(
-        userInfo: [AnyHashable: Any],
-        senderId: String
-    ) -> String {
-        guard let deepLink = userInfo["deep_link"] as? [AnyHashable: Any],
-              let conversationId = nonEmptyString(deepLink["conversationId"])
-        else {
-            return senderId
-        }
-        return conversationId
-    }
-
     private static func nonEmptyString(_ value: Any?) -> String? {
         guard let text = value as? String, !text.isEmpty else {
             return nil

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -755,6 +755,18 @@ build of the affected environment fails while signing or exporting.
 > help either; manual signing then fails with `"VoiceActivity …" requires a
 > provisioning profile` instead. The fix is the portal work below, not a
 > workflow change.
+>
+> **The app's own profiles are equally stale.** `App.entitlements` and
+> `App-Dev.entitlements` now declare
+> `com.apple.developer.usernotifications.communication`, and a profile issued
+> before Communication Notifications was ticked on its App ID does not grant
+> it, so the archive fails on the **app** target even once every extension row
+> is complete. Unlike the extension case this one is caught early:
+> "Install provisioning profiles" decodes the installed app profile with
+> `security cms -D` and hard-fails the run with an `::error::` when the
+> entitlement is absent, rather than letting the run reach Archive. Clearing
+> it means doing step 2 and step 4 below for the app App ID of the environment
+> being released and replacing its `IOS_PROVISIONING_PROFILE*` secret.
 
 | Environment | Extension bundle ID | Profile name (exact) | GitHub secret |
 |-------------|---------------------|----------------------|---------------|
@@ -836,8 +848,10 @@ track that releases hourly, so it is the fastest way to prove the setup):
    ```
 
 6. **Add or replace the GitHub secrets.** Repo **Settings → Secrets and
-   variables → Actions**. This row's `IOS_PROVISIONING_PROFILE_EXT*` is
-   a **New repository secret** named exactly as in the first table; its
+   variables → Actions**. This row's extension secret
+   (`IOS_PROVISIONING_PROFILE_EXT*`, `IOS_PROVISIONING_PROFILE_SHARE*`, or
+   `IOS_PROVISIONING_PROFILE_NSE*`, whichever the first table names) is a
+   **New repository secret** named exactly as in that table; its
    `IOS_PROVISIONING_PROFILE*` already exists, so **Update** it with the
    step 4 profile. Use the same scope as the existing
    `IOS_PROVISIONING_PROFILE*` secrets.
@@ -855,7 +869,29 @@ unzip -q ios-ipa-dev.zip && unzip -q *.ipa
 codesign -dvvv "Payload/App Dev.app/PlugIns/VoiceActivity Dev.appex" 2>&1 | grep -i profile
 codesign -d --entitlements - "Payload/App Dev.app" 2>&1 | grep -A2 application-groups
 codesign -d --entitlements - "Payload/App Dev.app/PlugIns/VoiceActivity Dev.appex" 2>&1 | grep -A2 application-groups
+# Communication Notifications reached the signed app, not just its entitlements
+# file. An empty result means the profile predates the capability.
+codesign -d --entitlements - "Payload/App Dev.app" 2>&1 | grep usernotifications.communication
 ```
+
+Then check the notification avatar itself on a device: send a push while the
+app is killed, backgrounded, and foregrounded; send a second push for the same
+avatar and confirm Console shows no network fetch; change the avatar on the
+daemon and confirm the next push picks it up; tap through to the conversation.
+Every path that gives up logs one `nse.` prefix
+(`nse.no_sender`, `nse.no_app_group`, `nse.avatar_unavailable`,
+`nse.intent_failed`, `nse.expired`), so filter Console on `nse.` before
+guessing.
+
+If the avatar never appears, the first thing to **check** is whether the appex
+needs `com.apple.developer.usernotifications.communication` too. It is on the
+app alone today, following Apple's Notification Service Extension guide, and
+`updating(from:)` fails closed when the entitlement is missing from whichever
+bundle iOS looks at, which lands in `nse.intent_failed`. The first thing to
+**restore** is the `NSExtensionAttributes` / `IntentsSupported` dict in
+`App/NotificationService/Info.plist`: it was removed because `IntentsSupported`
+belongs to the Intents extension point rather than the notification-service
+one, and it is the cheapest change to undo.
 
 > **Profiles expire after one year.** Renewal is the same loop:
 > regenerate in the portal under the identical name, re-encode, update
@@ -926,6 +962,9 @@ clients/
     │   │   └── Info.plist
     │   ├── AppTests/                 # XCTest bundle for the framework-free
     │   │                             # helpers under App/ (no host app)
+    │   ├── NotificationService/      # Notification Service Extension: rewrite
+    │   │                             # a push into a Communication Notification
+    │   │                             # so the assistant avatar is the icon
     │   ├── ShareExtension/           # Share Sheet: write inbox + open host
     │   ├── VoiceActivity/            # WidgetKit extension: Live Activity
     │   │   │                         # presentations + Control Center controls

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -814,7 +814,7 @@ agree character for character across the portal, the xcconfigs, and
 | `App/VoiceActivity/` | Widget extension: bundle, Live Activity, island views, Control Center controls |
 | `App/VoiceActivity/Widgets/` | The three Home Screen widgets, their shared snapshot timeline, and the widget palette; snapshot-driven and unrelated to voice apart from a shared voice button |
 | `App/App/Config/Extension*.xcconfig` | Extension build settings; bundle IDs, schemes, profile specifiers |
-| `App/project.yml` | Six targets, `VOICE_ACTIVITY_EXTENSION`, embed relationships |
+| `App/project.yml` | Thirteen targets, `VOICE_ACTIVITY_EXTENSION`, embed relationships |
 
 Web-side counterparts:
 

--- a/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
+++ b/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
@@ -47,3 +47,33 @@ describe("Communication Notifications is declared on both sides", () => {
     expect(plist).toContain("<string>INSendMessageIntent</string>");
   });
 });
+
+describe("NSE profile names agree with release-ios.yaml", () => {
+  // Three places have to hold the same string character for character: the
+  // Apple Developer portal, the xcconfig, and the workflow. The portal cannot
+  // be checked from here, but a drift between the other two fails the archive
+  // with "No profile for team ... matching '<name>' found", which names
+  // neither file.
+  const workflow = readFileSync(
+    join(import.meta.dir, "../../../../.github/workflows/release-ios.yaml"),
+    "utf8",
+  );
+  const workflowNames = workflow
+    .split("\n")
+    .flatMap((line) => {
+      const match = line.match(/nse_profile_name=(.+?)"/);
+      return match ? [match[1]] : [];
+    })
+    .sort();
+
+  test("the workflow names one profile per environment", () => {
+    expect(workflowNames).toHaveLength(PAIRS.length);
+  });
+
+  test("every xcconfig specifier appears in the workflow", () => {
+    const configNames = PAIRS.map(({ nse }) =>
+      readSetting(nse, "PROVISIONING_PROFILE_SPECIFIER_Manual"),
+    ).sort();
+    expect(configNames).toEqual(workflowNames);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for avatar-notification-icon.md.

- **Release preflight for the app entitlement.** `release-ios.yaml` now decodes the installed app provisioning profile with `security cms -D` and hard-fails with an `::error::` when it does not grant `com.apple.developer.usernotifications.communication`, so a stale profile is caught at the install step instead of at Archive. The README warning box covers the app-profile reissue, and portal step 6 names the Share and NSE secrets alongside the EXT ones.
- **Stable thread identifier.** `SenderPayload.conversationIdentifier` is gone; the intent always threads on `sender.id`, matching macOS. The platform drops `deep_link` under payload pressure, which let one conversation thread two ways.
- **Match the shipped macOS intent construction.** The "me" person is built with `INPersonHandle(value: "me")` and `customIdentifier: "me"`, and `serviceName` is `nil`, both as `notifier.mm` does. Group mode is unchanged.
- **Diagnosable fallbacks.** Every no-op path logs a distinct stable prefix (`nse.no_sender`, `nse.no_app_group`, `nse.avatar_unavailable`, `nse.intent_failed`, `nse.expired`), and the logger subsystem falls back to a real bundle-id shape. The README verification block gains a `codesign -d --entitlements -` check for the app plus what to check first when no avatar renders.
- **Avatar cache.** Cache hits are re-hashed and a mismatching file is deleted; `fetch` rejects a negative or over-cap `expectedContentLength` before reading a body; the body accumulates in 16 KB buffered chunks instead of one byte at a time. The 512 KB cap and 8 s timeout are unchanged. New tests cover the https-only guard and an invalid hash returning nil before any network call, a cached file whose bytes no longer match its name, and a body spanning several chunks.
- **Info.plist.** The `NSExtensionAttributes` / `IntentsSupported` dict is removed; it belongs to the Intents extension point. The README says it is the first thing to restore if avatars do not render on device.
- **Docs and guards.** `AppGroupID` names the NotificationService extension as a consumer; a new guard test pins the three NSE `PROVISIONING_PROFILE_SPECIFIER_Manual` values against the `nse_profile_name=` lines in `release-ios.yaml`; the README source layout lists `NotificationService/`; `NATIVE_VOICE.md` says thirteen targets.

## Test plan
- `xcodegen generate` and unsigned `xcodebuild build -scheme "App Dev"`: BUILD SUCCEEDED
- `xcodebuild test -scheme AppTests` on iPhone 17 simulator: 40 tests, 0 failures
- `bun test scripts/__tests__/` from `clients/ios`: 112 pass, 0 fail
- `release-ios.yaml` parses and the preflight is present in the install step