### PR TITLE
fix: Android native push hardening

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -393,8 +393,65 @@ voice launches.
 
 ## Native notifications
 
-Android registers FCM on `vellum-alerts`, renders foreground pushes once, and handles background pushes and taps.
-FCM needs Play services and untracked `google-services.json`; failures retry on resume.
+Android registers FCM on the `vellum-alerts` channel and handles pushes and
+taps. FCM needs Play services and an untracked `google-services.json`;
+failures retry on resume.
+
+`AndroidPushRegistration.getCapabilities` advertises
+`native-notification-render` on token registration. The platform sends
+data-only pushes only to tokens that claim it, so a build that cannot render
+one natively must never claim it.
+
+`SafeMessagingService` routes each push to exactly one renderer. A push whose
+payload carries a Firebase notification block, or a data-only push the web
+layer can render right now, goes to `PushNotificationsPlugin`. Everything else
+is rendered natively, including a data-only push that arrives while the app is
+on screen but the bridge is not up yet, so a cold start never drops one. The
+two paths never both run: the web handler posts its own banner from either a
+live `pushNotificationReceived` or the message it stashes for the next load.
+
+`NativePushRenderer` posts the native notification. With a sender it is a
+`MessagingStyle` conversation: the avatar is the large icon, the assistant's
+name is the message line, and the conversation title is the header. Without a
+sender it matches what Firebase would have rendered. The channel the payload
+names is created if it is missing and falls back to `vellum-alerts` if it is
+not one of ours, because from API 26 posting to a channel that does not exist
+is a silent no-op. The notification id is the same hash of the delivery id the
+web layer derives, so a delivery both paths see collapses onto one entry.
+
+Each conversation notification also publishes a long-lived dynamic shortcut,
+which is what gives Android the conversation treatment. The shortcut intent
+carries only the conversation id, never the push's identifiers, so a tap on a
+week-old shortcut cannot replay a stale delivery. At most two of our shortcuts
+are kept; the oldest is removed before a new one is pushed, so the static New
+chat and Start voice entries keep their places.
+
+`AvatarCache` keeps the sender avatars on disk under the cache directory, eight
+at a time, evicted least-recently-used. The avatar is resolved before the
+notification is posted: the cache first, then an HTTPS download verified
+against the pushed sha256. The download runs inside `onMessageReceived` with
+3 s connect and read timeouts, deliberately shorter than the 8 s an iOS
+notification-service extension gets, because the Firebase callback window is
+much tighter. A miss just posts without an avatar.
+
+### Device QA checklist
+
+Native rendering needs a physical device with Play services and a data-only
+push from a lower environment. Verify:
+
+- Killed, background, and foreground delivery each post exactly one banner,
+  never two.
+- Foreground delivery during a cold start, before the web layer has loaded,
+  still posts.
+- The first push for a new avatar hash downloads and shows the avatar; the
+  next push for the same hash shows it from the cache with no visible delay.
+- A push whose `sender_avatar_url` is missing posts without an avatar.
+- Tapping a notification opens the conversation it came from.
+- The conversation appears as a launcher shortcut, tapping it opens that
+  conversation rather than replaying the push, and a third conversation
+  evicts the oldest of ours without disturbing New chat or Start voice.
+- On API 24 or 25 the notification plays the default sound.
+- A push naming an unknown channel still arrives, on `vellum-alerts`.
 
 ## Structure
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
@@ -4,6 +4,8 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -11,7 +13,9 @@ import com.getcapacitor.annotation.CapacitorPlugin;
 
 @CapacitorPlugin(name = "AndroidNotificationChannels")
 public class AndroidNotificationChannelsPlugin extends Plugin {
-    private static final String ALERTS_CHANNEL_ID = "vellum-alerts";
+    public static final String ALERTS_CHANNEL_ID = "vellum-alerts";
+
+    private static final String ALERTS_CHANNEL_NAME = "Alerts";
     private static final String FAILURE_CODE = "NOTIFICATION_CHANNEL_FAILED";
     private static final String FAILURE_MESSAGE = "Android notification channels are unavailable";
 
@@ -22,19 +26,63 @@ public class AndroidNotificationChannelsPlugin extends Plugin {
                 call.resolve();
                 return;
             }
-            NotificationManager manager = (NotificationManager) getContext()
-                .getSystemService(Context.NOTIFICATION_SERVICE);
-            if (manager == null) {
+            if (!createAlertsChannel(getContext())) {
                 call.reject(FAILURE_MESSAGE, FAILURE_CODE);
                 return;
             }
-            NotificationChannel channel = new NotificationChannel(
-                ALERTS_CHANNEL_ID,
-                "Alerts",
-                NotificationManager.IMPORTANCE_DEFAULT
-            );
-            manager.createNotificationChannel(channel);
             call.resolve();
         });
+    }
+
+    /**
+     * The channel a natively rendered push posts on. A push can arrive before
+     * the web runtime has ever asked for the alerts channel, and from API 26
+     * posting to a channel that does not exist is a silent no-op, so the
+     * channel is created here and stands in for any other channel a payload
+     * names.
+     */
+    public static String resolveChannelId(Context context, String requestedChannelId) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return requestedChannelId;
+        }
+        createAlertsChannel(context);
+        if (
+            ALERTS_CHANNEL_ID.equals(requestedChannelId)
+                || channelExists(context, requestedChannelId)
+        ) {
+            return requestedChannelId;
+        }
+        NativeFailureGuard.record(
+            "Android push named a notification channel that does not exist",
+            new IllegalStateException(requestedChannelId)
+        );
+        return ALERTS_CHANNEL_ID;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private static boolean createAlertsChannel(Context context) {
+        NotificationManager manager = manager(context);
+        if (manager == null) {
+            return false;
+        }
+        manager.createNotificationChannel(
+            new NotificationChannel(
+                ALERTS_CHANNEL_ID,
+                ALERTS_CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+        );
+        return true;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    private static boolean channelExists(Context context, String channelId) {
+        NotificationManager manager = manager(context);
+        return manager != null && manager.getNotificationChannel(channelId) != null;
+    }
+
+    @Nullable
+    private static NotificationManager manager(Context context) {
+        return (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
@@ -35,7 +35,7 @@ public final class NativeFailureGuard {
         }
     }
 
-    static <T> T get(String logMessage, Supplier<T> operation, T fallback) {
+    public static <T> T get(String logMessage, Supplier<T> operation, T fallback) {
         try {
             return operation.get();
         } catch (RuntimeException exception) {
@@ -44,7 +44,7 @@ public final class NativeFailureGuard {
         }
     }
 
-    static void record(String logMessage, Throwable exception) {
+    public static void record(String logMessage, Throwable exception) {
         Logger.error(logMessage, exception);
         Context context = applicationContext;
         if (context == null) {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
@@ -4,18 +4,15 @@ import ai.vellum.assistant.push.AvatarCache;
 import ai.vellum.assistant.push.NativePushRenderer;
 import ai.vellum.assistant.push.PushDataMessage;
 import android.app.ActivityManager;
-import android.app.NotificationManager;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Process;
-import android.service.notification.StatusBarNotification;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.List;
-import java.util.function.Function;
 
 public class SafeMessagingService extends FirebaseMessagingService {
     @Override
@@ -31,7 +28,7 @@ public class SafeMessagingService extends FirebaseMessagingService {
                 // pushNotificationReceived at a live bridge or stash the
                 // message for replay on the next load, and the web handler
                 // posts its own banner from either.
-                if (message.rendersNatively(isAppForeground())) {
+                if (message.rendersNatively(webWillRender())) {
                     render(remoteMessage, message);
                     return;
                 }
@@ -50,58 +47,45 @@ public class SafeMessagingService extends FirebaseMessagingService {
     }
 
     /**
-     * Posts with whatever the cache already holds, then re-posts the same
-     * notification id once a download lands, as long as the user has not
-     * tapped or cleared it in the meantime. onMessageReceived runs in a short
-     * execution window, so nothing waits on the network before the first post.
+     * Resolves the avatar before posting rather than posting twice: a second
+     * post on the same id flickers the banner and can land after the user has
+     * already dismissed the first. The download runs on the Firebase message
+     * thread inside onMessageReceived, so {@link AvatarCache}'s timeouts are
+     * the whole budget it gets.
      */
     private void render(RemoteMessage remoteMessage, PushDataMessage message) {
         AvatarCache cache = new AvatarCache(this);
-        Bitmap cached = avatar(message, sender -> cache.load(sender.avatarHash));
-        NativePushRenderer.show(this, remoteMessage, message, cached);
-        if (cached != null) {
-            return;
-        }
-        Bitmap fetched = avatar(message, sender ->
-            cache.fetch(sender.avatarUrl, sender.avatarHash)
-        );
-        if (fetched != null && isNotificationActive(message.notificationId())) {
-            NativePushRenderer.show(this, remoteMessage, message, fetched);
-        }
-    }
-
-    private boolean isNotificationActive(int notificationId) {
-        NotificationManager manager =
-            (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        if (manager == null) {
-            return false;
-        }
-        for (StatusBarNotification active : manager.getActiveNotifications()) {
-            if (active.getId() == notificationId) {
-                return true;
-            }
-        }
-        return false;
+        NativePushRenderer.show(this, remoteMessage, message, avatar(message, cache));
     }
 
     /** Runs on the Firebase message thread, so the cache read and fetch may block. */
     @Nullable
-    private Bitmap avatar(
-        PushDataMessage message,
-        Function<PushDataMessage.Sender, Bitmap> load
-    ) {
+    private Bitmap avatar(PushDataMessage message, AvatarCache cache) {
         PushDataMessage.Sender sender = message.sender;
         if (sender == null) {
             return null;
         }
         return NativeFailureGuard.get(
             "Unable to load the Android push notification avatar",
-            () -> load.apply(sender),
+            () -> {
+                Bitmap cached = cache.load(sender.avatarHash);
+                return cached == null ? cache.fetch(sender.avatarUrl, sender.avatarHash) : cached;
+            },
             null
         );
     }
 
-    private boolean isAppForeground() {
+    /**
+     * The web layer renders only a push it can actually receive, which takes a
+     * screen in front of the user and a bridge that is already up. A push
+     * arriving during a cold start, or while the app sits on a route that has
+     * not registered the handler, is rendered natively instead of lost.
+     */
+    private boolean webWillRender() {
+        return isOnScreen() && PushNotificationsPlugin.getPushNotificationsInstance() != null;
+    }
+
+    private boolean isOnScreen() {
         ActivityManager manager = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
         if (manager == null) {
             return false;
@@ -112,10 +96,14 @@ public class SafeMessagingService extends FirebaseMessagingService {
         }
         int pid = Process.myPid();
         for (ActivityManager.RunningAppProcessInfo process : processes) {
-            if (process.pid == pid) {
-                return process.importance
-                    == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+            if (process.pid != pid) {
+                continue;
             }
+            // A partly covered activity still shows the web layer's own banner.
+            return process.importance
+                == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+                || process.importance
+                    == ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE;
         }
         return false;
     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
@@ -15,24 +15,29 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Locale;
+import java.util.function.Function;
 import javax.net.ssl.HttpsURLConnection;
 
 /**
  * Disk cache for the sender avatars drawn into conversation notifications.
  * Every method blocks on the calling thread, which is the Firebase message
  * thread rather than the main thread. {@link #load} is a disk read; only
- * {@link #fetch} touches the network, and callers post their notification
- * before reaching it.
+ * {@link #fetch} touches the network.
  */
 public final class AvatarCache {
     private static final String DIRECTORY = "notification-avatars";
     private static final String EXTENSION = ".png";
     private static final int MAX_BYTES = 512 * 1024;
-    // A cached avatar is a handful of kilobytes, and onMessageReceived has a
-    // short execution window, so a stalled host has to give up quickly.
+    // The timeouts run inside onMessageReceived, whose window is far shorter
+    // than the 8 s an iOS notification-service extension gets, and a cached
+    // avatar is a handful of kilobytes, so a stalled host has to give up fast.
     private static final int CONNECT_TIMEOUT_MILLIS = 3_000;
     private static final int READ_TIMEOUT_MILLIS = 3_000;
     private static final int MAX_FILES = 8;
+    // A notification large icon is displayed at well under 512 px, and a
+    // decoded bitmap this size costs a megabyte of the Firebase callback's heap.
+    private static final int MAX_PIXELS = 512;
+    private static final int MAX_BITMAP_BYTES = 4 * 1024 * 1024;
 
     private final File directory;
 
@@ -46,7 +51,13 @@ public final class AvatarCache {
         if (normalized == null) {
             return null;
         }
-        return BitmapFactory.decodeFile(new File(directory, normalized + EXTENSION).getPath());
+        File file = new File(directory, normalized + EXTENSION);
+        Bitmap bitmap = decode(options -> BitmapFactory.decodeFile(file.getPath(), options));
+        if (bitmap != null) {
+            // Eviction reads the modified time, so a hit is also a touch.
+            file.setLastModified(System.currentTimeMillis());
+        }
+        return bitmap;
     }
 
     @Nullable
@@ -59,11 +70,50 @@ public final class AvatarCache {
         if (bytes == null || !normalized.equals(sha256Hex(bytes))) {
             return null;
         }
-        Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+        Bitmap bitmap = decode(options ->
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options)
+        );
         if (bitmap == null) {
             return null;
         }
         store(normalized, bytes);
+        return bitmap;
+    }
+
+    /**
+     * Reads the bounds first so the image is downsampled as it is decoded: a
+     * push claiming an enormous avatar must not allocate it in full.
+     */
+    @Nullable
+    private static Bitmap decode(Function<BitmapFactory.Options, Bitmap> decoder) {
+        BitmapFactory.Options bounds = new BitmapFactory.Options();
+        bounds.inJustDecodeBounds = true;
+        decoder.apply(bounds);
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inSampleSize = sampleSize(bounds.outWidth, bounds.outHeight);
+        return bounded(decoder.apply(options));
+    }
+
+    /** Halvings that bring the longest edge down to {@link #MAX_PIXELS}. */
+    static int sampleSize(int width, int height) {
+        int longest = Math.max(width, height);
+        int size = 1;
+        while (longest / size > MAX_PIXELS) {
+            size *= 2;
+        }
+        return size;
+    }
+
+    /** Downsampling alone still leaves room for an allocation the callback cannot afford. */
+    @Nullable
+    private static Bitmap bounded(@Nullable Bitmap bitmap) {
+        if (bitmap == null) {
+            return null;
+        }
+        if (bitmap.getByteCount() > MAX_BITMAP_BYTES) {
+            bitmap.recycle();
+            return null;
+        }
         return bitmap;
     }
 
@@ -83,8 +133,9 @@ public final class AvatarCache {
         prune();
     }
 
+    /** Keeps the {@link #MAX_FILES} most recently used avatars. */
     private void prune() {
-        File[] files = directory.listFiles();
+        File[] files = directory.listFiles((unused, name) -> name.endsWith(EXTENSION));
         if (files == null || files.length <= MAX_FILES) {
             return;
         }
@@ -121,7 +172,7 @@ public final class AvatarCache {
     }
 
     @Nullable
-    private static byte[] readCapped(InputStream stream) throws IOException {
+    static byte[] readCapped(InputStream stream) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         byte[] chunk = new byte[8192];
         int read = stream.read(chunk);
@@ -135,7 +186,7 @@ public final class AvatarCache {
         return buffer.toByteArray();
     }
 
-    private static String sha256Hex(byte[] bytes) {
+    static String sha256Hex(byte[] bytes) {
         final byte[] digest;
         try {
             digest = MessageDigest.getInstance("SHA-256").digest(bytes);
@@ -152,7 +203,7 @@ public final class AvatarCache {
 
     /** Lowercased sha256 hex, which is also a filename that cannot escape the cache. */
     @Nullable
-    private static String normalized(@Nullable String hash) {
+    static String normalized(@Nullable String hash) {
         if (hash == null || !hash.matches("[0-9a-fA-F]{64}")) {
             return null;
         }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/NativePushRenderer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/NativePushRenderer.java
@@ -1,5 +1,6 @@
 package ai.vellum.assistant.push;
 
+import ai.vellum.assistant.AndroidNotificationChannelsPlugin;
 import ai.vellum.assistant.NativeFailureGuard;
 import ai.vellum.assistant.R;
 import android.Manifest;
@@ -18,6 +19,9 @@ import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import com.google.firebase.messaging.RemoteMessage;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * Renders a data-only push. With a sender the notification is a
@@ -28,6 +32,13 @@ import com.google.firebase.messaging.RemoteMessage;
  * block.
  */
 public final class NativePushRenderer {
+    /**
+     * The launcher gives one app a small shortcut budget shared with the static
+     * New chat and Start voice entries, so only the two most recent
+     * conversations keep a shortcut.
+     */
+    private static final int MAX_CONVERSATION_SHORTCUTS = 2;
+
     private NativePushRenderer() {}
 
     public static void show(
@@ -55,13 +66,19 @@ public final class NativePushRenderer {
             : PushTapIntents.pendingIntent(context, launchIntent, notificationId);
         String body = message.body == null ? "" : message.body;
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, message.channelId)
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(
+            context,
+            AndroidNotificationChannelsPlugin.resolveChannelId(context, message.channelId)
+        )
             .setSmallIcon(R.drawable.ic_stat_notification)
             .setColor(ContextCompat.getColor(context, R.color.notification_icon_color))
-            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
             .setContentIntent(contentIntent)
-            .setOnlyAlertOnce(true)
             .setAutoCancel(true);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            // From API 26 the channel owns the sound. Before it, a notification
+            // that asks for nothing arrives silently.
+            builder.setDefaults(NotificationCompat.DEFAULT_SOUND);
+        }
         if (message.unreadCount != null && message.unreadCount > 0) {
             builder.setNumber(message.unreadCount);
         }
@@ -77,18 +94,18 @@ public final class NativePushRenderer {
         }
 
         // The avatar can be absent: the platform omits the signed url on an
-        // oversized payload, and the first push for a hash posts before the
-        // download lands. The conversation treatment does not depend on it.
+        // oversized payload, and a download that times out inside the Firebase
+        // callback window gives up. The conversation treatment does not depend
+        // on it.
         IconCompat icon = avatar == null ? null : IconCompat.createWithBitmap(avatar);
         Person.Builder personBuilder = new Person.Builder().setKey(sender.id).setName(sender.name);
         if (icon != null) {
             personBuilder.setIcon(icon);
         }
         Person person = personBuilder.build();
-        String shortcutId = PushDataMessage.shortcutId(sender.id, message.conversationId);
-        pushShortcut(context, shortcutId, sender, person, icon, launchIntent);
         builder
-            .setShortcutId(shortcutId)
+            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            .setOnlyAlertOnce(true)
             .setStyle(
                 new NotificationCompat.MessagingStyle(
                     new Person.Builder()
@@ -99,32 +116,66 @@ public final class NativePushRenderer {
                     .setConversationTitle(message.title)
                     .addMessage(body, System.currentTimeMillis(), person)
             );
+        String shortcutId = pushShortcut(context, message, sender, person, icon);
+        if (shortcutId != null) {
+            builder.setShortcutId(shortcutId);
+        }
 
         manager.notify(notificationId, builder.build());
     }
 
-    private static void pushShortcut(
+    /** The shortcut id once it is live, which is what lets the notification claim it. */
+    @Nullable
+    private static String pushShortcut(
         Context context,
-        String shortcutId,
+        PushDataMessage message,
         PushDataMessage.Sender sender,
         Person person,
-        @Nullable IconCompat icon,
-        @Nullable Intent launchIntent
+        @Nullable IconCompat icon
     ) {
-        if (launchIntent == null) {
+        Intent intent = PushTapIntents.shortcutIntent(context, message.conversationId);
+        if (intent == null) {
+            return null;
+        }
+        String shortcutId = PushDataMessage.shortcutId(sender.id, message.conversationId);
+        boolean pushed = NativeFailureGuard.get(
+            "Unable to publish the Android conversation shortcut",
+            () -> {
+                trimConversationShortcuts(context, shortcutId);
+                ShortcutInfoCompat.Builder shortcut =
+                    new ShortcutInfoCompat.Builder(context, shortcutId)
+                        .setLongLived(true)
+                        .setPerson(person)
+                        .setShortLabel(PushDataMessage.shortcutLabel(message.title, sender.name))
+                        .setIntent(intent);
+                if (icon != null) {
+                    shortcut.setIcon(icon);
+                }
+                return ShortcutManagerCompat.pushDynamicShortcut(context, shortcut.build());
+            },
+            false
+        );
+        return pushed ? shortcutId : null;
+    }
+
+    /** Drops our oldest conversation shortcuts so the new one fits within the cap. */
+    private static void trimConversationShortcuts(Context context, String keptId) {
+        List<ShortcutInfoCompat> ours = new ArrayList<>();
+        for (ShortcutInfoCompat shortcut : ShortcutManagerCompat.getDynamicShortcuts(context)) {
+            String id = shortcut.getId();
+            if (id.startsWith(PushDataMessage.SHORTCUT_ID_PREFIX) && !id.equals(keptId)) {
+                ours.add(shortcut);
+            }
+        }
+        int surplus = ours.size() - (MAX_CONVERSATION_SHORTCUTS - 1);
+        if (surplus <= 0) {
             return;
         }
-        NativeFailureGuard.run("Unable to publish the Android conversation shortcut", () -> {
-            ShortcutInfoCompat.Builder shortcut =
-                new ShortcutInfoCompat.Builder(context, shortcutId)
-                    .setLongLived(true)
-                    .setPerson(person)
-                    .setShortLabel(sender.name)
-                    .setIntent(launchIntent);
-            if (icon != null) {
-                shortcut.setIcon(icon);
-            }
-            ShortcutManagerCompat.pushDynamicShortcut(context, shortcut.build());
-        });
+        ours.sort(Comparator.comparingLong(ShortcutInfoCompat::getLastChangedTimestamp));
+        List<String> stale = new ArrayList<>();
+        for (ShortcutInfoCompat oldest : ours.subList(0, surplus)) {
+            stale.add(oldest.getId());
+        }
+        ShortcutManagerCompat.removeLongLivedShortcuts(context, stale);
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/PushDataMessage.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/PushDataMessage.java
@@ -1,20 +1,23 @@
 package ai.vellum.assistant.push;
 
+import ai.vellum.assistant.AndroidNotificationChannelsPlugin;
 import androidx.annotation.Nullable;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Objects;
 
 /** The Vellum fields of a push, read from the FCM {@code data} block. */
 public final class PushDataMessage {
-    static final String DEFAULT_CHANNEL_ID = "vellum-alerts";
+    static final String DEFAULT_CHANNEL_ID = AndroidNotificationChannelsPlugin.ALERTS_CHANNEL_ID;
+
+    /** Marks the shortcuts this renderer owns so pruning leaves the launcher's alone. */
+    static final String SHORTCUT_ID_PREFIX = "vellum-conversation:";
 
     private static final String KEY_TITLE = "title";
     private static final String KEY_BODY = "body";
     private static final String KEY_CHANNEL_ID = "channel_id";
     static final String KEY_DELIVERY_ID = "delivery_id";
-    private static final String KEY_CONVERSATION_ID = "conversationId";
+    static final String KEY_CONVERSATION_ID = "conversationId";
     private static final String KEY_UNREAD_COUNT = "unread_count";
     private static final String KEY_SENDER_ID = "sender_id";
     private static final String KEY_SENDER_NAME = "sender_name";
@@ -51,10 +54,17 @@ public final class PushDataMessage {
     @Nullable
     public final Sender sender;
 
+    @Nullable
+    private final String messageId;
     private final boolean hasNotificationBlock;
 
-    private PushDataMessage(Map<String, String> data, boolean hasNotificationBlock) {
+    private PushDataMessage(
+        Map<String, String> data,
+        boolean hasNotificationBlock,
+        @Nullable String messageId
+    ) {
         this.hasNotificationBlock = hasNotificationBlock;
+        this.messageId = trimmed(messageId);
         title = trimmed(data.get(KEY_TITLE));
         body = trimmed(data.get(KEY_BODY));
         String channel = trimmed(data.get(KEY_CHANNEL_ID));
@@ -66,13 +76,26 @@ public final class PushDataMessage {
     }
 
     public static PushDataMessage from(RemoteMessage remoteMessage) {
-        return of(remoteMessage.getData(), remoteMessage.getNotification() != null);
+        return of(
+            remoteMessage.getData(),
+            remoteMessage.getNotification() != null,
+            remoteMessage.getMessageId()
+        );
     }
 
     static PushDataMessage of(@Nullable Map<String, String> data, boolean hasNotificationBlock) {
+        return of(data, hasNotificationBlock, null);
+    }
+
+    static PushDataMessage of(
+        @Nullable Map<String, String> data,
+        boolean hasNotificationBlock,
+        @Nullable String messageId
+    ) {
         return new PushDataMessage(
             data == null ? Collections.emptyMap() : data,
-            hasNotificationBlock
+            hasNotificationBlock,
+            messageId
         );
     }
 
@@ -84,10 +107,12 @@ public final class PushDataMessage {
     /**
      * True when this process posts the notification itself. The web layer owns
      * every other push, and the two paths never both run: a second banner would
-     * otherwise land beside or on top of this one.
+     * otherwise land beside or on top of this one. A data-only push the web
+     * layer cannot render, because no screen is in front of the user or the
+     * bridge is not up yet, still belongs here.
      */
-    public boolean rendersNatively(boolean appIsForeground) {
-        return isDataOnly() && !appIsForeground;
+    public boolean rendersNatively(boolean webWillRender) {
+        return isDataOnly() && !webWillRender;
     }
 
     /**
@@ -96,12 +121,45 @@ public final class PushDataMessage {
      * and per-conversation settings apart.
      */
     static String shortcutId(String senderId, @Nullable String conversationId) {
-        return conversationId == null ? senderId : senderId + ":" + conversationId;
+        String suffix = conversationId == null ? senderId : senderId + ":" + conversationId;
+        return SHORTCUT_ID_PREFIX + suffix;
+    }
+
+    /** The conversation the shortcut opens, named by its title where there is one. */
+    static String shortcutLabel(@Nullable String title, String senderName) {
+        String trimmed = trimmed(title);
+        return trimmed == null ? senderName : trimmed;
     }
 
     /** Stable per-delivery id so a redelivery replaces its own notification. */
     public int notificationId() {
-        return Objects.hashCode(deliveryId == null ? conversationId : deliveryId);
+        return notificationId(seed());
+    }
+
+    /**
+     * The same id the web layer derives in {@code toNotificationId}
+     * (clients/web/src/runtime/notifications.ts) from the same seed, so a
+     * delivery rendered by both paths lands on one notification rather than
+     * two. {@code String.hashCode} is JavaScript's {@code (hash << 5) - hash +
+     * charCode | 0} loop, and the widening to {@code long} keeps
+     * {@code Integer.MIN_VALUE} positive the way {@code Math.abs} does there.
+     */
+    static int notificationId(String seed) {
+        return (int) (Math.abs((long) seed.hashCode()) % 0x7fffffffL);
+    }
+
+    /**
+     * Every push carries at least one of these. Hashing nothing would collapse
+     * unrelated deliveries onto a single notification id.
+     */
+    private String seed() {
+        if (deliveryId != null) {
+            return deliveryId;
+        }
+        if (conversationId != null) {
+            return conversationId;
+        }
+        return messageId == null ? "" : messageId;
     }
 
     @Nullable

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/PushTapIntents.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/PushTapIntents.java
@@ -21,18 +21,33 @@ public final class PushTapIntents {
 
     @Nullable
     public static Intent launchIntent(Context context, RemoteMessage remoteMessage) {
-        Intent intent = context
-            .getPackageManager()
-            .getLaunchIntentForPackage(context.getPackageName());
+        Intent intent = launcherIntent(context);
         if (intent == null) {
             return null;
         }
-        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         for (Map.Entry<String, String> extra : tapExtras(
             remoteMessage.getData(),
             remoteMessage.getMessageId()
         ).entrySet()) {
             intent.putExtra(extra.getKey(), extra.getValue());
+        }
+        return intent;
+    }
+
+    /**
+     * Tap target for a conversation shortcut, which outlives the push that
+     * created it. It names the conversation and nothing else: carrying the
+     * push's identifiers would make a shortcut tap replay a delivery the user
+     * has already read.
+     */
+    @Nullable
+    public static Intent shortcutIntent(Context context, @Nullable String conversationId) {
+        Intent intent = launcherIntent(context);
+        if (intent == null) {
+            return null;
+        }
+        if (conversationId != null) {
+            intent.putExtra(PushDataMessage.KEY_CONVERSATION_ID, conversationId);
         }
         return intent;
     }
@@ -44,6 +59,18 @@ public final class PushTapIntents {
             intent,
             PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT
         );
+    }
+
+    @Nullable
+    private static Intent launcherIntent(Context context) {
+        Intent intent = context
+            .getPackageManager()
+            .getLaunchIntentForPackage(context.getPackageName());
+        if (intent == null) {
+            return null;
+        }
+        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        return intent;
     }
 
     static Map<String, String> tapExtras(

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
@@ -1,0 +1,60 @@
+package ai.vellum.assistant.push;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class AvatarCacheTest {
+    private static final String VELLUM_SHA256 =
+        "2fc2a6dd013e7ab41c5a54ab8a254031ff329aa42c5815ac420f1facfe2542d1";
+
+    @Test
+    public void readsAPayloadUpToTheCap() throws IOException {
+        byte[] bytes = new byte[512 * 1024];
+        bytes[bytes.length - 1] = 7;
+
+        byte[] read = AvatarCache.readCapped(new ByteArrayInputStream(bytes));
+
+        assertEquals(bytes.length, read.length);
+        assertEquals(7, read[read.length - 1]);
+    }
+
+    @Test
+    public void rejectsAPayloadOverTheCap() throws IOException {
+        byte[] bytes = new byte[512 * 1024 + 1];
+
+        assertNull(AvatarCache.readCapped(new ByteArrayInputStream(bytes)));
+    }
+
+    @Test
+    public void lowercasesAHashAndRejectsAnythingThatIsNotSha256Hex() {
+        assertEquals(VELLUM_SHA256, AvatarCache.normalized(VELLUM_SHA256.toUpperCase()));
+        assertNull(AvatarCache.normalized(null));
+        assertNull("too short", AvatarCache.normalized(VELLUM_SHA256.substring(1)));
+        assertNull("not hex", AvatarCache.normalized(VELLUM_SHA256.replace('0', 'z')));
+        assertNull("path traversal", AvatarCache.normalized("../../etc/passwd"));
+    }
+
+    /** A payload whose digest does not match the pushed hash is never cached. */
+    @Test
+    public void digestsThePayloadTheWayThePushedHashIsWritten() {
+        byte[] bytes = "vellum".getBytes(StandardCharsets.UTF_8);
+
+        assertEquals(VELLUM_SHA256, AvatarCache.sha256Hex(bytes));
+        assertNotEquals(VELLUM_SHA256, AvatarCache.sha256Hex(new byte[0]));
+    }
+
+    @Test
+    public void downsamplesOnlyWhatIsBiggerThanTheLargeIcon() {
+        assertEquals(1, AvatarCache.sampleSize(512, 512));
+        assertEquals(1, AvatarCache.sampleSize(64, 64));
+        assertEquals(2, AvatarCache.sampleSize(1024, 512));
+        assertEquals(4, AvatarCache.sampleSize(512, 2048));
+        assertEquals("undecodable bounds", 1, AvatarCache.sampleSize(-1, -1));
+    }
+}

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/PushDataMessageTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/PushDataMessageTest.java
@@ -104,9 +104,12 @@ public class PushDataMessageTest {
     }
 
     @Test
-    public void onlyABackgroundedDataOnlyPushIsRenderedNatively() {
+    public void onlyADataOnlyPushTheWebLayerCannotRenderIsRenderedNatively() {
         assertTrue(PushDataMessage.of(alertData(), false).rendersNatively(false));
-        assertFalse("foreground", PushDataMessage.of(alertData(), false).rendersNatively(true));
+        assertFalse(
+            "web layer renders it",
+            PushDataMessage.of(alertData(), false).rendersNatively(true)
+        );
         assertFalse(
             "notification block",
             PushDataMessage.of(alertData(), true).rendersNatively(false)
@@ -120,7 +123,7 @@ public class PushDataMessageTest {
     @Test
     public void theShortcutIdSeparatesTwoConversationsWithOneAssistant() {
         assertEquals(
-            "assistant-1:conversation-1",
+            "vellum-conversation:assistant-1:conversation-1",
             PushDataMessage.shortcutId("assistant-1", "conversation-1")
         );
         assertNotEquals(
@@ -138,9 +141,25 @@ public class PushDataMessageTest {
 
         assertNull(message.conversationId);
         assertEquals(
-            "assistant-1",
+            "vellum-conversation:assistant-1",
             PushDataMessage.shortcutId("assistant-1", message.conversationId)
         );
+    }
+
+    /** Pruning has to tell our conversation shortcuts from the launcher's own. */
+    @Test
+    public void everyShortcutIdCarriesTheOwnershipPrefix() {
+        assertTrue(
+            PushDataMessage.shortcutId("assistant-1", "conversation-1")
+                .startsWith(PushDataMessage.SHORTCUT_ID_PREFIX)
+        );
+    }
+
+    @Test
+    public void theShortcutLabelPrefersTheConversationTitle() {
+        assertEquals("Weekly review", PushDataMessage.shortcutLabel("Weekly review", "Vellum"));
+        assertEquals("Vellum", PushDataMessage.shortcutLabel(null, "Vellum"));
+        assertEquals("Vellum", PushDataMessage.shortcutLabel("   ", "Vellum"));
     }
 
     @Test
@@ -151,5 +170,33 @@ public class PushDataMessageTest {
 
         assertEquals(first, PushDataMessage.of(alertData(), false).notificationId());
         assertNotEquals(first, PushDataMessage.of(other, false).notificationId());
+    }
+
+    /**
+     * The expected values come from running the web layer's toNotificationId
+     * (clients/web/src/runtime/notifications.ts) over the same seeds. A drift
+     * here shows both a native and a web notification for one delivery.
+     */
+    @Test
+    public void theNotificationIdMatchesTheWebFormula() {
+        assertEquals(1077802136, PushDataMessage.notificationId("delivery-1"));
+        assertEquals("negative hash", 1676096153, PushDataMessage.notificationId("conversation-1"));
+        assertEquals("Integer.MIN_VALUE", 1, PushDataMessage.notificationId("delivery-4b*42%$"));
+    }
+
+    @Test
+    public void theNotificationIdSeedFallsBackThroughConversationToMessageId() {
+        Map<String, String> data = alertData();
+        data.remove("delivery_id");
+        assertEquals(
+            PushDataMessage.notificationId("conversation-1"),
+            PushDataMessage.of(data, false, "message-1").notificationId()
+        );
+
+        data.remove("conversationId");
+        assertEquals(
+            PushDataMessage.notificationId("message-1"),
+            PushDataMessage.of(data, false, "message-1").notificationId()
+        );
     }
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for avatar-notification-icon.md.

- **The alerts channel is guaranteed before posting.** `AndroidNotificationChannelsPlugin` now owns one channel definition (id, name, importance) and exposes `resolveChannelId`, which creates the channel natively rather than waiting for the web runtime's first run. A payload naming a channel that does not exist falls back to alerts and records through `NativeFailureGuard`, so a push can no longer be a silent `notify` no-op on API 26+.
- **The notification id matches the web formula byte for byte.** `PushDataMessage.notificationId()` applies `Math.abs` over a widened `long` and `% 0x7fffffff`, so `Integer.MIN_VALUE` lands on 1 the way JS does instead of staying negative. The seed falls through delivery id, conversation id, then `RemoteMessage.getMessageId()` rather than hashing null. A JVM test pins three vectors computed from the web's `toNotificationId`.
- **Foreground routing no longer drops pushes.** `IMPORTANCE_VISIBLE` counts as on screen alongside `IMPORTANCE_FOREGROUND`, and the push goes to the JS path only when `PushNotificationsPlugin.getPushNotificationsInstance()` is live. A push during a cold start, or on a route without the handler, renders natively instead of vanishing.
- **Fetch first, post once.** The avatar is resolved from the cache, then the network, before the single `notify`. The post-then-repost flow, `isNotificationActive`, and the `getActiveNotifications` scan are gone. The 3 s connect and read timeouts stay, documented as deliberately shorter than the 8 s an iOS notification-service extension gets, because they run inside `onMessageReceived`.
- **Sound and category parity.** `setDefaults(DEFAULT_SOUND)` is applied below API 26, where channels do not yet govern sound, so an API 24-25 notification is not silent. `setCategory(CATEGORY_MESSAGE)` and `setOnlyAlertOnce(true)` now sit on the sender branch only.
- **Shortcuts cannot replay a stale push.** The shortcut intent is built separately and carries the launcher intent plus only `conversationId`, never `google.message_id` or `sender_avatar_url`. The short label is the conversation title, falling back to the assistant name. `pushDynamicShortcut`'s return value gates `setShortcutId`, and ids carry an ownership prefix so the two-shortcut cap prunes the oldest of ours through `removeLongLivedShortcuts` without touching New chat or Start voice.
- **Bitmaps are bounded.** Both `load()` and `fetch()` read bounds first and downsample to at most 512 px, and a decoded bitmap over 4 MB is rejected. A cache hit touches the file's modified time so eviction is genuinely LRU, and `prune()` counts only `.png` files.
- **Tests and docs.** New JVM tests cover `readCapped`, hash normalisation, the sha256 digest, sample-size derivation, and the shortcut id and label derivation. The README's Native notifications section now describes the native data-only path, MessagingStyle, the avatar cache, `getCapabilities`, and carries a device QA checklist.

Verified with `./gradlew :app:testDevDebugUnitTest` and `./gradlew :app:lintDevRelease`, both green.

Deviation worth a look: the brief scoped `setDefaults(DEFAULT_SOUND)` to the sender-less layout. It is applied to the shared builder instead, so a MessagingStyle notification is not silent on API 24-25 either.