### PR TITLE
fix: desktop sender provenance, hash schema, canvas clip, Linux sender

### DIFF
--- a/clients/linux/src/main/features/notifications.ts
+++ b/clients/linux/src/main/features/notifications.ts
@@ -8,6 +8,7 @@ import type {
   CapabilityModule,
   DesktopCapabilityRegistry,
 } from "@vellumai/electron-desktop/capability-registry";
+import { ensureNotificationAvatarFile } from "@vellumai/electron-desktop/notification-avatar-file";
 import {
   configureNotifications,
   installNotifications,
@@ -24,6 +25,11 @@ import { ensureVisible } from "../main-window";
  * Linux notifications feature. Delivery prefers a native helper toast module
  * when one exists. Until a Linux sidecar ships, the shared module's default
  * `electron.Notification` path delivers click-only toasts.
+ *
+ * A toast from a sender puts the assistant's avatar in the toast's image slot,
+ * which the helper reads from a file, so the assistant's name is the title and
+ * the conversation title becomes the subtitle. The default path draws the same
+ * avatar through `electron.Notification`'s `icon`.
  */
 
 const HELPER_EXECUTABLE = "vellum-linux-helper";
@@ -99,6 +105,32 @@ export const createHelperToastFactory = (
     return client;
   };
 
+  /**
+   * The toast's image, or null when there is no sender or the file could not
+   * be written. A cache failure must not cost the user the notification, so it
+   * falls back to the app-icon toast.
+   */
+  const resolveAvatarPath = (
+    options: NotificationCreateOptions,
+  ): string | null => {
+    if (!options.sender) {
+      return null;
+    }
+    try {
+      return ensureNotificationAvatarFile(
+        app.getPath("userData"),
+        options.sender.avatarPng,
+        options.sender.avatarHash,
+      );
+    } catch (error) {
+      log.warn(
+        "[notifications] Could not store the notification avatar:",
+        error,
+      );
+      return null;
+    }
+  };
+
   return (options) => {
     const token = `toast-${nextToken++}`;
     const listeners: Record<string, ToastListener> = {};
@@ -117,14 +149,27 @@ export const createHelperToastFactory = (
       // (helper unavailable, circuit open) still acks as a failed delivery
       // instead of rejecting the renderer's invoke.
       Promise.resolve()
-        .then(() =>
-          ensureClient().call("notifications/show", {
-            token,
-            title: options.title,
-            body: options.body,
-            actions: options.actions.map((action) => ({ text: action.text })),
-          }),
-        )
+        .then(() => {
+          const actions = options.actions.map((action) => ({
+            text: action.text,
+          }));
+          const avatarPath = resolveAvatarPath(options);
+          // With an avatar in the image slot the assistant is the sender, so
+          // its name is the toast title and the conversation title drops to
+          // the subtitle.
+          const params =
+            options.sender && avatarPath
+              ? {
+                  token,
+                  title: options.sender.name,
+                  subtitle: options.title,
+                  body: options.body,
+                  actions,
+                  avatarPath,
+                }
+              : { token, title: options.title, body: options.body, actions };
+          return ensureClient().call("notifications/show", params);
+        })
         .then((result) => {
           const parsed = SHOW_RESULT_SCHEMA.safeParse(result);
           if (parsed.success && parsed.data.success) {

--- a/clients/linux/src/main/notifications-feature.test.ts
+++ b/clients/linux/src/main/notifications-feature.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The Linux helper toast factory, whose whole job beyond delivery is the
+ * sender: when the renderer sends an assistant's avatar, the toast is from
+ * that assistant, so its name is the title, the conversation title drops to
+ * the subtitle, and the picture travels as a file path the helper reads.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("electron", () => ({
+  app: {
+    getAppPath: () => "/app",
+    getPath: () => "/userData",
+    once: () => undefined,
+  },
+  // The shared notifications module reaches these at import time; only the
+  // helper factory is under test here.
+  BrowserWindow: { getAllWindows: () => [] },
+  nativeImage: { createFromBuffer: () => ({}) },
+  Notification: class {
+    static isSupported = () => true;
+    on(): void {}
+    show(): void {}
+  },
+}));
+
+interface HelperCall {
+  method: string;
+  params: Record<string, unknown>;
+}
+const calls: HelperCall[] = [];
+mock.module("@vellumai/native-sidecar/supervisor", () => ({
+  NativeSidecarClient: class {
+    onNotification(): void {}
+    call(method: string, params: Record<string, unknown>): Promise<unknown> {
+      calls.push({ method, params });
+      return Promise.resolve({ success: true });
+    }
+    shutdown(): void {}
+  },
+}));
+
+let avatarFileError: Error | null = null;
+const ensureNotificationAvatarFile = mock(() => {
+  if (avatarFileError) {
+    throw avatarFileError;
+  }
+  return "/userData/notification-avatars/abc.png";
+});
+mock.module("@vellumai/electron-desktop/notification-avatar-file", () => ({
+  ensureNotificationAvatarFile,
+}));
+
+mock.module("./ipc.client", () => ({ handle: () => undefined }));
+mock.module("./main-window", () => ({ ensureVisible: () => undefined }));
+const warn = mock(() => undefined);
+mock.module("./logger", () => ({ default: { warn, info: () => undefined } }));
+
+const { createHelperToastFactory } = await import("./features/notifications");
+
+const AVATAR_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+const AVATAR_HASH = "a".repeat(64);
+
+const sender = {
+  id: "assistant-1",
+  name: "Aria",
+  avatarPng: AVATAR_PNG,
+  avatarHash: AVATAR_HASH,
+};
+
+const baseOptions = {
+  title: "Weekly review",
+  body: "Three items need you",
+  silent: false,
+  actions: [{ type: "button" as const, text: "View" }],
+};
+
+const showToast = async (
+  options: Parameters<ReturnType<typeof createHelperToastFactory>>[0],
+): Promise<void> => {
+  const toast = createHelperToastFactory("/helper")(options);
+  toast.show();
+  // `show()` defers the call so a synchronous throw still acks as a failed
+  // delivery, so the params land a couple of microtasks later.
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+beforeEach(() => {
+  calls.length = 0;
+  avatarFileError = null;
+  ensureNotificationAvatarFile.mockClear();
+  warn.mockClear();
+});
+
+describe("Linux helper toast factory", () => {
+  test("posts a sender's toast under the assistant's name with the avatar file", async () => {
+    await showToast({ ...baseOptions, sender });
+
+    expect(ensureNotificationAvatarFile).toHaveBeenCalledWith(
+      "/userData",
+      AVATAR_PNG,
+      AVATAR_HASH,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.method).toBe("notifications/show");
+    expect(calls[0]!.params).toMatchObject({
+      title: "Aria",
+      subtitle: "Weekly review",
+      body: "Three items need you",
+      avatarPath: "/userData/notification-avatars/abc.png",
+      actions: [{ text: "View" }],
+    });
+  });
+
+  test("keeps the conversation title and sends no avatar without a sender", async () => {
+    await showToast(baseOptions);
+
+    expect(ensureNotificationAvatarFile).not.toHaveBeenCalled();
+    expect(calls[0]!.params).toMatchObject({
+      title: "Weekly review",
+      body: "Three items need you",
+    });
+    expect(calls[0]!.params).not.toHaveProperty("subtitle");
+    expect(calls[0]!.params).not.toHaveProperty("avatarPath");
+  });
+
+  test("falls back to the plain toast when the avatar file cannot be written", async () => {
+    avatarFileError = new Error("read-only volume");
+
+    await showToast({ ...baseOptions, sender });
+
+    expect(warn).toHaveBeenCalled();
+    expect(calls[0]!.params).toMatchObject({ title: "Weekly review" });
+    expect(calls[0]!.params).not.toHaveProperty("avatarPath");
+  });
+});

--- a/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
@@ -2,9 +2,10 @@
  * The gate this hook exists to hold: the notification avatar is composited and
  * held only on Electron with `push-avatar-sender` on. Every other host, and the
  * flag off, must leave the holder empty so the IPC payload carries no `sender`
- * field, and a flag that turns off has to take back what an earlier run stored.
- * What is held is stamped with the assistant it was drawn for, and a
- * replacement render empties the holder before it starts drawing.
+ * field, and a flag that turns off, or a hook that goes away, has to take back
+ * what an earlier run stored. What is held is stamped with the assistant it was
+ * drawn for, and a replacement render empties the holder before it starts
+ * drawing.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
@@ -111,6 +112,17 @@ describe("useNotificationAvatarSync", () => {
     await waitFor(() => {
       expect(getNotificationAvatar()).toBeNull();
     });
+  });
+
+  test("empties the holder when the hook goes away", async () => {
+    const { unmount } = render();
+    await waitFor(() => {
+      expect(getNotificationAvatar()).not.toBeNull();
+    });
+
+    unmount();
+
+    expect(getNotificationAvatar()).toBeNull();
   });
 
   test("holds nothing for an assistant with no avatar to draw", async () => {

--- a/clients/web/src/hooks/use-notification-avatar-sync.ts
+++ b/clients/web/src/hooks/use-notification-avatar-sync.ts
@@ -22,12 +22,13 @@ import { NOTIFICATION_AVATAR_SIZE } from "@vellumai/avatar-manifest/notification
  * `push-avatar-sender`: no other host reads the holder, and while the flag is
  * off the holder stays empty so the IPC payload carries no `sender` field.
  *
- * Every run starts by emptying the holder, and what it stores is stamped with
- * the assistant it was drawn for. The holder outlives this effect, so a flag
- * turned off, an assistant with no avatar, or a failed rasterization all have
- * to take back what an earlier run put there; and a replacement render must not
- * keep serving the old picture across the rasterize-and-hash gap, which is the
- * window an assistant switch lands in.
+ * Every run starts by emptying the holder and cleanup empties it again, and
+ * what a run stores is stamped with the assistant it was drawn for. The holder
+ * outlives this effect, so a flag turned off, an assistant with no avatar, a
+ * failed rasterization and an unmount all have to take back what an earlier run
+ * put there; and a replacement render must not keep serving the old picture
+ * across the rasterize-and-hash gap, which is the window an assistant switch
+ * lands in.
  */
 export function useNotificationAvatarSync(
   assistantId: string | null,
@@ -75,6 +76,7 @@ export function useNotificationAvatarSync(
 
     return () => {
       cancelled = true;
+      clearNotificationAvatar();
     };
   }, [enabled, assistantId, customImageUrl, components, traits, accentHex]);
 }

--- a/clients/web/src/runtime/notification-avatar.ts
+++ b/clients/web/src/runtime/notification-avatar.ts
@@ -16,10 +16,9 @@ import { encodeBase64Bytes } from "@/utils/base64";
  */
 export interface NotificationAvatar {
   /**
-   * The assistant this picture was drawn for. `senderPayload()` reads the
-   * active assistant itself, so a held avatar is usable only while the two
-   * agree: after a switch the new assistant's name would otherwise be sent
-   * with the old one's face.
+   * The assistant this picture was drawn for. `senderPayload()` refuses a face
+   * that was not drawn for the notification's own assistant, so after a switch
+   * the new assistant's name cannot be sent with the old one's face.
    */
   assistantId: string;
   /** The disc PNG as base64, with no data-URI prefix. */

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -110,8 +110,8 @@ const { clearNotificationAvatar, setNotificationAvatar } =
   await import("@/runtime/notification-avatar");
 const { useAssistantIdentityStore } =
   await import("@/stores/assistant-identity-store");
-const { useResolvedAssistantsStore } =
-  await import("@/stores/resolved-assistants-store");
+const { useClientFeatureFlagStore } =
+  await import("@/stores/client-feature-flag-store");
 
 const setVisibility = (state: "visible" | "hidden") => {
   Object.defineProperty(document, "visibilityState", {
@@ -376,6 +376,7 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
 
 describe("postLocalNotification sender (Electron branch)", () => {
   const AVATAR = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+  const AVATAR_HASH = "b".repeat(64);
   const showMock = mock(async (_payload: ShowNotificationPayload) => ({
     success: true,
   }));
@@ -384,8 +385,10 @@ describe("postLocalNotification sender (Electron branch)", () => {
     electronHost = true;
     showMock.mockClear();
     clearNotificationAvatar();
-    useAssistantIdentityStore.getState().setIdentity("Aria", "1.0.0");
-    useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("Aria", "1.0.0", "assistant-1");
+    useClientFeatureFlagStore.setState({ pushAvatarSender: true });
     (window as unknown as { vellum?: unknown }).vellum = {
       notifications: { show: showMock },
     };
@@ -394,11 +397,12 @@ describe("postLocalNotification sender (Electron branch)", () => {
   afterEach(() => {
     clearNotificationAvatar();
     useAssistantIdentityStore.getState().clearIdentity();
+    useClientFeatureFlagStore.setState({ pushAvatarSender: false });
     delete (window as unknown as { vellum?: unknown }).vellum;
   });
 
   test("attaches the held avatar, the assistant's name and its id", async () => {
-    setNotificationAvatar("assistant-1", AVATAR, "sha256-abc");
+    setNotificationAvatar("assistant-1", AVATAR, AVATAR_HASH);
 
     await postLocalNotification(baseArgs);
 
@@ -407,7 +411,7 @@ describe("postLocalNotification sender (Electron branch)", () => {
       id: "assistant-1",
       name: "Aria",
       avatarBase64: "iVBORw==",
-      avatarHash: "sha256-abc",
+      avatarHash: AVATAR_HASH,
     });
   });
 
@@ -419,7 +423,7 @@ describe("postLocalNotification sender (Electron branch)", () => {
   });
 
   test("sends no sender when the assistant has no name yet", async () => {
-    setNotificationAvatar("assistant-1", AVATAR, "sha256-abc");
+    setNotificationAvatar("assistant-1", AVATAR, AVATAR_HASH);
     useAssistantIdentityStore.getState().clearIdentity();
 
     await postLocalNotification(baseArgs);
@@ -428,7 +432,40 @@ describe("postLocalNotification sender (Electron branch)", () => {
   });
 
   test("sends no sender when the held avatar belongs to another assistant", async () => {
-    setNotificationAvatar("assistant-2", AVATAR, "sha256-abc");
+    setNotificationAvatar("assistant-2", AVATAR, AVATAR_HASH);
+
+    await postLocalNotification(baseArgs);
+
+    expect(showMock.mock.calls[0]?.[0].sender).toBeUndefined();
+  });
+
+  test("sends no sender when the hydrated identity belongs to another assistant", async () => {
+    // The name and the face come from stores written at different moments in
+    // an assistant switch, so a name that is not this assistant's is refused
+    // rather than paired with a face that is.
+    setNotificationAvatar("assistant-1", AVATAR, AVATAR_HASH);
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("Nova", "1.0.0", "assistant-2");
+
+    await postLocalNotification(baseArgs);
+
+    expect(showMock.mock.calls[0]?.[0].sender).toBeUndefined();
+  });
+
+  test("sends no sender when the notification is for a different assistant", async () => {
+    setNotificationAvatar("assistant-1", AVATAR, AVATAR_HASH);
+
+    await postLocalNotification({ ...baseArgs, assistantId: "assistant-9" });
+
+    expect(showMock.mock.calls[0]?.[0].sender).toBeUndefined();
+  });
+
+  test("sends no sender while push-avatar-sender is off", async () => {
+    // The holder outlives the flag, so the send path checks it again rather
+    // than trusting that the hook has emptied it.
+    setNotificationAvatar("assistant-1", AVATAR, AVATAR_HASH);
+    useClientFeatureFlagStore.setState({ pushAvatarSender: false });
 
     await postLocalNotification(baseArgs);
 

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -46,7 +46,7 @@ import {
   hasSessionConfirmedRemotePushRegistration,
 } from "@/runtime/push-registration";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 /**
  * Payload stored alongside each native notification so the tap handler can
@@ -454,26 +454,36 @@ export async function sendNotificationIntentAck(
  * The assistant to post the Electron notification as, when there is one to
  * post as: `useNotificationAvatarSync` holds an avatar only on Electron with
  * `push-avatar-sender` on, so an empty holder is what keeps the payload
- * unchanged everywhere else.
+ * unchanged everywhere else. The flag is read again here because the holder
+ * outlives the moment it is turned off.
  *
- * The name, the id and the avatar all describe the active assistant, and all
- * three are read from the stores that own it rather than from the caller, so
- * the sender cannot name one assistant while wearing another's face. The
- * avatar carries the assistant it was drawn for and is refused when that is
- * not the active one, which is what closes the window between an assistant
- * switch and the replacement avatar finishing.
+ * `assistantId` is the assistant this notification is for, and it is the only
+ * id the payload carries. The name and the face are attached only when the
+ * hydrated identity and the held avatar both say they belong to that
+ * assistant: the identity store and the avatar holder are written at
+ * different moments during a switch, so anything looser lets the sender wear
+ * one assistant's name over another's face.
  */
-function senderPayload(): { sender?: NotificationSender } {
+function senderPayload(assistantId: string | undefined): {
+  sender?: NotificationSender;
+} {
+  if (!assistantId || !useClientFeatureFlagStore.getState().pushAvatarSender) {
+    return {};
+  }
   const avatar = getNotificationAvatar();
-  const name = useAssistantIdentityStore.getState().name;
-  const id = useResolvedAssistantsStore.getState().activeAssistantId;
-  if (!avatar || !name || !id || avatar.assistantId !== id) {
+  const identity = useAssistantIdentityStore.getState();
+  if (
+    !avatar ||
+    !identity.name ||
+    avatar.assistantId !== assistantId ||
+    identity.assistantId !== assistantId
+  ) {
     return {};
   }
   return {
     sender: {
-      id,
-      name,
+      id: assistantId,
+      name: identity.name,
       avatarBase64: avatar.avatarBase64,
       avatarHash: avatar.avatarHash,
     },
@@ -516,7 +526,7 @@ export async function postLocalNotification(
         deliveryId: args.deliveryId,
         conversationId: extractConversationId(args.deepLinkMetadata),
         deepLinkMetadata: args.deepLinkMetadata,
-        ...senderPayload(),
+        ...senderPayload(args.assistantId),
       });
       success = result.success;
       errorMessage = result.errorMessage;

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -45,6 +45,7 @@ import {
   assistantsPushTokensDelete,
   assistantsPushTokensUpsert,
 } from "@/generated/api/sdk.gen";
+import type { AssistantsPushTokensUpsertData } from "@/generated/api/types.gen";
 import { publish } from "@/lib/event-bus";
 import { resolvePlatformAssistantId } from "@/lib/platform-assistant-id";
 import { captureError } from "@/lib/sentry/capture-error";
@@ -164,7 +165,8 @@ export function isRemotePushSupported(): boolean {
 }
 
 /**
- * What this Android build can do with a push, advertised on the token row.
+ * What this Android build can do with a push, advertised on the token row as
+ * `DevicePushToken.capabilities`, which the Android upsert serializer accepts.
  *
  * The platform sends data-only FCM messages only to tokens claiming
  * `native-notification-render`, so an older shell whose plugin lacks the
@@ -184,6 +186,12 @@ async function readAndroidCapabilities(): Promise<string[]> {
   }
 }
 
+/** The Android arm of the generated upsert body. */
+type AndroidUpsertBody = Extract<
+  AssistantsPushTokensUpsertData["body"],
+  { platform: "android" }
+>;
+
 /**
  * Upsert a freshly-minted native token to the platform for the given assistant.
  * Best-effort: a non-2xx response or thrown error is reported and swallowed.
@@ -198,17 +206,20 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
     const { App } = await import("@capacitor/app");
     const { id: bundleId } = await App.getInfo();
     const platform = Capacitor.getPlatform();
-    const body =
+    // Annotated so a change to the generated contract is a compile error here.
+    // `capabilities` is not in it yet, and the assertion is what admits that
+    // one field without loosening the rest of the row.
+    const body: AssistantsPushTokensUpsertData["body"] =
       platform === "android"
-        ? {
+        ? ({
             token,
-            platform: "android" as const,
+            platform: "android",
             bundle_id: bundleId,
             capabilities: await readAndroidCapabilities(),
-          }
+          } as AndroidUpsertBody)
         : {
             token,
-            platform: "ios" as const,
+            platform: "ios",
             bundle_id: bundleId,
             apns_environment: await resolveSignedApnsEnvironment(bundleId),
           };

--- a/clients/web/src/utils/avatar-raster.test.ts
+++ b/clients/web/src/utils/avatar-raster.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { coverCropSquare } from "@/utils/avatar-raster";
+import {
+  coverCropSquare,
+  rasterizeNotificationAvatar,
+} from "@/utils/avatar-raster";
+import {
+  NOTIFICATION_AVATAR_INSET,
+  NOTIFICATION_AVATAR_SIZE,
+  notificationAvatarDiscHex,
+} from "@vellumai/avatar-manifest/notification-avatar";
 
 // Locks `object-cover` parity for every rasterized avatar surface
 // (Dock/menu-bar icons, the iOS Live Activity): a non-square avatar
@@ -26,5 +34,135 @@ describe("coverCropSquare", () => {
     expect(coverCropSquare(0, 100)).toBeNull();
     expect(coverCropSquare(100, 0)).toBeNull();
     expect(coverCropSquare(0, 0)).toBeNull();
+  });
+});
+
+/**
+ * The notification avatar's disc, drawn through a stand-in canvas.
+ *
+ * happy-dom hands back no 2D context, so there are no pixels to sample here:
+ * the corner cannot be read as transparent directly, and the circular clip the
+ * drawing passes through is what stands in for it. The clip has to match the
+ * disc the SVG in `@vellumai/avatar-manifest` is clipped to, so an avatar whose
+ * subject runs to its own edges keeps the round silhouette on every platform.
+ */
+describe("rasterizeNotificationAvatar", () => {
+  const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+  const SOURCE = "data:image/svg+xml;base64,PHN2Zy8+";
+
+  interface Arc {
+    x: number;
+    y: number;
+    radius: number;
+  }
+
+  let ops: string[] = [];
+  let arcs: Arc[] = [];
+  let drawn: number[][] = [];
+  let fills: string[] = [];
+  let canvas: { width: number; height: number };
+  let realCreateElement: typeof document.createElement;
+  let realImage: typeof Image;
+
+  beforeEach(() => {
+    ops = [];
+    arcs = [];
+    drawn = [];
+    fills = [];
+    let fillStyle = "";
+    const ctx = {
+      clearRect: () => ops.push("clearRect"),
+      beginPath: () => ops.push("beginPath"),
+      arc: (x: number, y: number, radius: number) => {
+        ops.push("arc");
+        arcs.push({ x, y, radius });
+      },
+      fill: () => {
+        ops.push("fill");
+        fills.push(fillStyle);
+      },
+      save: () => ops.push("save"),
+      clip: () => ops.push("clip"),
+      restore: () => ops.push("restore"),
+      drawImage: (_image: unknown, ...args: number[]) => {
+        ops.push("drawImage");
+        drawn.push(args);
+      },
+      get fillStyle(): string {
+        return fillStyle;
+      },
+      set fillStyle(value: string) {
+        fillStyle = value;
+      },
+    };
+    canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ctx,
+      toBlob: (callback: (blob: Blob) => void) => {
+        callback(new Blob([PNG_BYTES], { type: "image/png" }));
+      },
+    } as unknown as { width: number; height: number };
+
+    realCreateElement = document.createElement;
+    document.createElement = ((tag: string) =>
+      tag === "canvas"
+        ? canvas
+        : realCreateElement.call(
+            document,
+            tag,
+          )) as unknown as typeof document.createElement;
+
+    realImage = globalThis.Image;
+    globalThis.Image = class {
+      naturalWidth = 512;
+      naturalHeight = 512;
+      onload: (() => void) | null = null;
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    } as unknown as typeof Image;
+  });
+
+  afterEach(() => {
+    document.createElement = realCreateElement;
+    globalThis.Image = realImage;
+  });
+
+  test("draws the accent disc and the inset avatar through a full-circle clip", async () => {
+    const bytes = await rasterizeNotificationAvatar(SOURCE, "#E9642F");
+
+    expect(canvas.width).toBe(NOTIFICATION_AVATAR_SIZE);
+    expect(canvas.height).toBe(NOTIFICATION_AVATAR_SIZE);
+    expect(ops).toEqual([
+      "clearRect",
+      "beginPath",
+      "arc",
+      "fill",
+      "save",
+      "beginPath",
+      "arc",
+      "clip",
+      "drawImage",
+      "restore",
+    ]);
+    expect(fills).toEqual([notificationAvatarDiscHex("#E9642F")]);
+
+    const radius = NOTIFICATION_AVATAR_SIZE / 2;
+    const disc = { x: radius, y: radius, radius };
+    // The clipped circle is the disc itself, so nothing lands outside it and
+    // the square corners of the output stay untouched.
+    expect(arcs).toEqual([disc, disc]);
+
+    const inset = NOTIFICATION_AVATAR_SIZE * NOTIFICATION_AVATAR_INSET;
+    const inner = NOTIFICATION_AVATAR_SIZE - 2 * inset;
+    expect(drawn[0]?.slice(4)).toEqual([inset, inset, inner, inner]);
+    expect(bytes && Array.from(bytes)).toEqual(Array.from(PNG_BYTES));
+  });
+
+  test("falls back to the neutral disc for an assistant with no accent", async () => {
+    await rasterizeNotificationAvatar(SOURCE, null);
+
+    expect(fills).toEqual([notificationAvatarDiscHex(null)]);
   });
 });

--- a/clients/web/src/utils/avatar-raster.ts
+++ b/clients/web/src/utils/avatar-raster.ts
@@ -190,13 +190,24 @@ export async function rasterizeNotificationAvatar(
   const { canvas, ctx } = surface;
 
   const radius = size / 2;
+  const discPath = (): void => {
+    ctx.beginPath();
+    ctx.arc(radius, radius, radius, 0, Math.PI * 2);
+  };
+
+  discPath();
   ctx.fillStyle = notificationAvatarDiscHex(accentHex);
-  ctx.beginPath();
-  ctx.arc(radius, radius, radius, 0, Math.PI * 2);
   ctx.fill();
 
+  // The avatar goes through the same disc, the one the SVG is clipped to, so a
+  // source whose subject runs to its own edges keeps the round silhouette
+  // instead of painting square corners over the fill.
+  ctx.save();
+  discPath();
+  ctx.clip();
   const inset = size * NOTIFICATION_AVATAR_INSET;
   drawCoverSquare(ctx, image, inset, inset, size - 2 * inset);
+  ctx.restore();
 
   return encodeCanvas(canvas, "image/png");
 }

--- a/clients/web/src/utils/base64.test.ts
+++ b/clients/web/src/utils/base64.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { decodeBase64Payload } from "./base64";
+import { decodeBase64Payload, encodeBase64Bytes } from "./base64";
 
 describe("decodeBase64Payload", () => {
   test("decodes bare base64, which is what the native bridge answers with", () => {
@@ -61,5 +61,30 @@ describe("decodeBase64Payload", () => {
     expect(() =>
       decodeBase64Payload("data:image/jpeg;base64,!!!not base64!!!"),
     ).toThrow();
+  });
+});
+
+/**
+ * The encoder chunks its input because `String.fromCharCode` is spread over a
+ * whole chunk at once, so the case worth pinning is a buffer larger than one
+ * chunk: a notification avatar is a few tens of kilobytes of PNG, which is
+ * exactly where a chunking bug would first show.
+ */
+describe("encodeBase64Bytes", () => {
+  test("encodes a short buffer", () => {
+    const bytes = new Uint8Array([0, 255, 16, 128, 7]);
+    expect(encodeBase64Bytes(bytes)).toBe(
+      Buffer.from(bytes).toString("base64"),
+    );
+  });
+
+  test("encodes a buffer larger than one chunk", () => {
+    const bytes = new Uint8Array(0x8000 + 517);
+    for (let index = 0; index < bytes.length; index++) {
+      bytes[index] = (index * 31) % 256;
+    }
+    expect(encodeBase64Bytes(bytes)).toBe(
+      Buffer.from(bytes).toString("base64"),
+    );
   });
 });

--- a/packages/electron-desktop/src/notifications.test.ts
+++ b/packages/electron-desktop/src/notifications.test.ts
@@ -413,11 +413,13 @@ describe("interaction broadcast", () => {
 
 describe("sender", () => {
   const AVATAR_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+  const AVATAR_HASH =
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
   const sender = {
     id: "assistant-1",
     name: "Aria",
     avatarBase64: AVATAR_PNG.toString("base64"),
-    avatarHash: "sha256-abc",
+    avatarHash: AVATAR_HASH,
   };
 
   const realPlatform = process.platform;
@@ -451,6 +453,29 @@ describe("sender", () => {
     ).toThrow();
   });
 
+  test("the captured schema rejects a hash that is not a SHA-256", () => {
+    // The hash names the avatar's cache file, so a value that is not 64
+    // lowercase hex characters has to be refused here rather than reaching the
+    // file the host writes.
+    const { schema } = showHandler();
+    for (const avatarHash of [
+      "sha256-abc",
+      "../escape",
+      AVATAR_HASH.toUpperCase(),
+    ]) {
+      expect(() =>
+        schema.parse([
+          {
+            category: "notificationIntent",
+            title: "t",
+            body: "b",
+            sender: { ...sender, avatarHash },
+          },
+        ]),
+      ).toThrow();
+    }
+  });
+
   test("hands the factory the decoded avatar bytes", async () => {
     const created: NotificationCreateOptions[] = [];
     configureNotifications({
@@ -476,7 +501,7 @@ describe("sender", () => {
       id: "assistant-1",
       name: "Aria",
       avatarPng: AVATAR_PNG,
-      avatarHash: "sha256-abc",
+      avatarHash: AVATAR_HASH,
     });
   });
 

--- a/packages/electron-desktop/src/notifications.ts
+++ b/packages/electron-desktop/src/notifications.ts
@@ -226,12 +226,14 @@ const pruneStaleEntries = (): void => {
  * Swift client, which acks only after `UNUserNotificationCenter.add(...)`'s
  * completion handler resolves.
  *
- * Unlike the Swift client, Electron cannot request authorization up front, so
- * the very first notification races the macOS permission prompt — neither
- * event fires until the user answers. The timeout is deliberately generous so
- * a user who takes a few seconds to click "Allow" still acks as delivered;
- * only a genuinely unanswered or dropped notification falls through to the
- * conservative "not confirmed" failure ack.
+ * On the default `electron.Notification` path the very first notification
+ * races the macOS permission prompt: neither event fires until the user
+ * answers. A client whose `create` factory owns the notification center (the
+ * macOS native addon) prompts for authorization up front instead, so its first
+ * notification is posted against an answered prompt. The timeout is
+ * deliberately generous so a user who takes a few seconds to click "Allow"
+ * still acks as delivered; only a genuinely unanswered or dropped notification
+ * falls through to the conservative "not confirmed" failure ack.
  */
 const DELIVERY_TIMEOUT_MS = 30_000;
 

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -38,11 +38,16 @@ export const assistantStatusSchema = z.enum(ASSISTANT_STATUSES);
 
 export const notificationCategorySchema = z.enum(NOTIFICATION_CATEGORIES);
 
-export const notificationSenderSchema = z.object({
+/**
+ * The hash names the file a host writes the avatar to, so the boundary that
+ * accepts it is where "64 lowercase hex characters" has to be true: anything
+ * else could escape the cache directory.
+ */
+const notificationSenderSchema = z.object({
   id: z.string(),
   name: z.string(),
   avatarBase64: z.string(),
-  avatarHash: z.string(),
+  avatarHash: z.string().regex(/^[0-9a-f]{64}$/),
 });
 
 export const showNotificationPayloadSchema = z.object({

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -690,7 +690,11 @@ export interface NotificationSender {
    * canvas.
    */
   avatarBase64: string;
-  /** Content hash of the PNG, so a host can name a cache file by it. */
+  /**
+   * SHA-256 of the PNG, 64 lowercase hex characters, so a host can name a
+   * cache file by it. The schema enforces the shape, because the file name is
+   * what it becomes.
+   */
   avatarHash: string;
 }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for avatar-notification-icon.md.

- **Sender provenance**: `senderPayload()` now takes the notification's own `assistantId` and attaches a sender only when the hydrated identity and the held avatar both belong to that assistant. The active-assistant read from `useResolvedAssistantsStore` is gone, so the sender can no longer pair one assistant's name with another's face.
- **Flag re-checked at send time**: `senderPayload()` also requires `pushAvatarSender`, because the holder outlives the moment the flag turns off. `useNotificationAvatarSync` now empties the holder in its effect cleanup, not only at the start of the next run.
- **Hash validated at the IPC boundary**: `avatarHash` is `/^[0-9a-f]{64}$/` in `notificationSenderSchema`, which is no longer exported (nothing imported it). The hash names the avatar's cache file, so the shape is enforced where the payload arrives.
- **Canvas mirrors the disc clip**: `rasterizeNotificationAvatar` draws the avatar through the same circular path it fills, matching the SVG's clip.
- **`capabilities` typechecks deliberately**: the Android upsert body is annotated with the generated request type, with an explicit assertion for the pending `DevicePushToken.capabilities` field.
- **Linux sender**: the Linux helper toast factory threads `sender` into its `notifications/show` params the way Windows does (assistant name as title, conversation title as subtitle, avatar written through `ensureNotificationAvatarFile`).
- **Stale comment**: the delivery-timeout docblock no longer claims Electron cannot request authorization up front.

## Tests
- `clients/web`: sender provenance (identity for another assistant, a different notification assistant, flag off), holder emptied on unmount, `rasterizeNotificationAvatar` disc/clip geometry, `encodeBase64Bytes` for a short buffer and one larger than a chunk.
- `packages/electron-desktop`: the captured schema rejects a hash that is not a SHA-256; fixtures are real 64-hex strings.
- `clients/linux`: new `notifications-feature.test.ts` covering the sender toast, the plain toast, and the avatar-file failure fallback.

Note: `rasterizeNotificationAvatar` is exercised through a stand-in canvas because happy-dom hands back no 2D context, so the circular clip stands in for reading a transparent corner.