### PR TITLE
fix: macOS native notifier hardening

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -90,9 +90,54 @@ jobs:
       - name: Run tests
         run: bun run test:ci
 
+  native:
+    name: Native Notifier (macOS)
+    runs-on: macos-26
+    defaults:
+      run:
+        working-directory: clients/macos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --filter=@vellumai/macos
+
+      - name: Build the notifier addon
+        run: bash scripts/build-notifier.sh
+
+      # Installing does not download the Electron binary, and the smoke load
+      # below runs under Electron's ABI rather than plain Node's.
+      - name: Set up Electron binary
+        run: node node_modules/electron/install.js
+
+      - name: Smoke-load the addon under Electron
+        run: |
+          cat > "$RUNNER_TEMP/smoke-notifier.js" <<'JS'
+          const addon = { exports: {} };
+          process.dlopen(addon, process.argv[2]);
+          const exported = ["isSupported", "requestAuthorization", "registerCategories", "restoreDelegate", "show"];
+          for (const name of exported) {
+            if (typeof addon.exports[name] !== "function") {
+              console.error(`vellum-notifier: missing export ${name}`);
+              process.exit(1);
+            }
+          }
+          console.log("vellum-notifier loaded; isSupported =", addon.exports.isSupported());
+          process.exit(0);
+          JS
+          ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron \
+            "$RUNNER_TEMP/smoke-notifier.js" \
+            "resources/notifier/$(node -p 'process.arch')/vellum-notifier.node"
+
   checks:
     name: Type Check, Build & Test
-    needs: [typecheck, build, test]
+    needs: [typecheck, build, test, native]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -101,11 +146,13 @@ jobs:
           TYPECHECK: ${{ needs.typecheck.result }}
           BUILD: ${{ needs.build.result }}
           TEST: ${{ needs.test.result }}
+          NATIVE: ${{ needs.native.result }}
         run: |
           echo "Type Check: $TYPECHECK"
           echo "Build:      $BUILD"
           echo "Test:       $TEST"
-          for r in "$TYPECHECK" "$BUILD" "$TEST"; do
+          echo "Native:     $NATIVE"
+          for r in "$TYPECHECK" "$BUILD" "$TEST" "$NATIVE"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one macOS CI job failed."
               exit 1

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1754,6 +1754,9 @@ jobs:
           fi
           PROFILE_PATH="$RUNNER_TEMP/vellum-communication.provisionprofile"
           echo "$MAC_PROVISIONING_PROFILE" | base64 -D > "$PROFILE_PATH"
+          # A truncated or mis-encoded secret decodes to a file that codesign
+          # accepts and macOS then rejects at launch, so prove it parses here.
+          security cms -D -i "$PROFILE_PATH" > /dev/null
           echo "VELLUM_MAC_PROVISIONING_PROFILE=$PROFILE_PATH" >> "$GITHUB_ENV"
 
       - name: Build and package Electron app

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -121,7 +121,7 @@ jobs:
           cat > "$RUNNER_TEMP/smoke-notifier.js" <<'JS'
           const addon = { exports: {} };
           process.dlopen(addon, process.argv[2]);
-          const exported = ["isSupported", "requestAuthorization", "reassertDelegate", "show"];
+          const exported = ["isSupported", "requestAuthorization", "registerCategories", "restoreDelegate", "show"];
           for (const name of exported) {
             if (typeof addon.exports[name] !== "function") {
               console.error(`vellum-notifier: missing export ${name}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2139,6 +2139,9 @@ jobs:
           fi
           PROFILE_PATH="$RUNNER_TEMP/vellum-communication.provisionprofile"
           echo "$MAC_PROVISIONING_PROFILE" | base64 -D > "$PROFILE_PATH"
+          # A truncated or mis-encoded secret decodes to a file that codesign
+          # accepts and macOS then rejects at launch, so prove it parses here.
+          security cms -D -i "$PROFILE_PATH" > /dev/null
           echo "VELLUM_MAC_PROVISIONING_PROFILE=$PROFILE_PATH" >> "$GITHUB_ENV"
 
       - name: Build and package Electron app

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -202,7 +202,18 @@ exposes no intent API, so this is the only path to that layout.
 and `src/main/native-notifications.ts` adapts it to the `create` /
 `isSupported` seams of `@vellumai/electron-desktop/notifications`. A checkout
 with no built addon reports unavailable and the app falls back to Electron's
-own notifications.
+own notifications, and so does an addon that loads but answers
+`isSupported()` with false, which is what an unbundled run does because
+`UNUserNotificationCenter` raises there. Set
+`VELLUM_DISABLE_NATIVE_NOTIFIER=1` to force that fallback in a build that
+would otherwise use the addon.
+
+Notification categories carry the action buttons, and
+`setNotificationCategories:` applies asynchronously, so a category first
+registered in the runloop turn its notification is posted can miss it and the
+buttons never render. `src/main/index.ts` registers every action set through
+`registerCategories` at startup instead, and the addon unions its own set with
+whatever the notification center already holds rather than replacing it.
 
 **Delegate rule.** Electron's `NotificationPresenterMac` claims
 `UNUserNotificationCenter.currentNotificationCenter.delegate` the moment it is
@@ -217,11 +228,12 @@ renderer's Web Notification API all do. Three consequences:
   through the addon's `requestAuthorization()` whenever the addon is loaded.
   Constructing an `electron.Notification` there hands the presenter the
   delegate and strands clicks on notifications already on screen.
-- The addon installs its own delegate, remembers the previous one, forwards
-  every response it does not own to it, and re-asserts itself before each post
-  and each permission prompt. `reassertDelegate()` exposes the same reclaim to
-  JavaScript, and `startNotifierDelegateGuard()` calls it on a timer as
-  insurance against a presenter built by some path not listed here.
+- The addon installs its own delegate, holds a strong reference to the one it
+  displaced, forwards every response it does not own there, and re-asserts
+  itself on the way into `show` and `requestAuthorization`. Those two entry
+  points plus the permission probe above are every path in the app that
+  touches the notification center, which is why no periodic reclaim is needed.
+  `restoreDelegate()` hands the seat back at `before-quit`.
 
 **Rebuild:**
 
@@ -238,15 +250,22 @@ re-signs with `inherit.plist`.
 is a restricted entitlement: an app declaring it without an authorizing
 provisioning profile is killed at launch. `electron-builder.config.cjs` sets
 `mac.provisioningProfile` only when `VELLUM_MAC_PROVISIONING_PROFILE` names a
-profile on disk; the release workflows decode one there from the
-`MAC_PROVISIONING_PROFILE` secret. That build signs with an entitlements plist
-derived at pack time by `scripts/entitlements/derive-communication-entitlements.js`,
-which reads `scripts/entitlements/app.plist`, adds the one restricted key, and
-writes `build/entitlements/app-communication.plist` (gitignored, and rederived
-by `scripts/afterSign.js` for the outer re-sign), so `app.plist` stays the only
-place the entitlement set is edited. Every other build signs with `app.plist`
-itself, the intent path fails closed inside `contentByUpdatingWithProvider:`,
-and notifications post plainly.
+profile that exists on disk, and throws when the variable is set to a file that
+is not there rather than quietly signing the plain entitlements under a name
+that says otherwise. The release workflows decode one there from the
+`MAC_PROVISIONING_PROFILE` secret and prove it parses with `security cms -D`
+before exporting the variable.
+
+That build signs with an entitlements plist derived at pack time by
+`scripts/entitlements/derive-communication-entitlements.js`, which reads
+`scripts/entitlements/app.plist`, adds the one restricted key, and writes
+`build/entitlements/app-communication.plist` (gitignored), so `app.plist` stays
+the only place the entitlement set is edited. `scripts/afterSign.js` re-signs
+the outer app with whatever electron-builder was configured with, read back off
+`context.packager.platformSpecificBuildOptions`, so the two passes cannot
+disagree. Every other build signs with `app.plist` itself, the intent path
+fails closed inside `contentByUpdatingWithProvider:`, and notifications post
+plainly.
 
 ## Scripts
 

--- a/clients/macos/electron-builder.config.cjs
+++ b/clients/macos/electron-builder.config.cjs
@@ -1,4 +1,4 @@
-// @ts-check
+const fs = require("fs");
 
 const {
   deriveCommunicationEntitlements,
@@ -37,7 +37,16 @@ const helperBundleName =
 // build signs with the plain entitlements and posts plain notifications. The
 // profile build's plist is derived from app.plist at pack time, so app.plist
 // stays the single source of the entitlement set.
+//
+// A variable pointing at a file that is not there means the release job failed
+// to decode the profile, so the build stops rather than quietly shipping the
+// plain entitlements under a name that says otherwise.
 const provisioningProfile = process.env.VELLUM_MAC_PROVISIONING_PROFILE || "";
+if (provisioningProfile && !fs.existsSync(provisioningProfile)) {
+  throw new Error(
+    `VELLUM_MAC_PROVISIONING_PROFILE names ${provisioningProfile}, which does not exist`,
+  );
+}
 const entitlements = provisioningProfile
   ? deriveCommunicationEntitlements()
   : "./scripts/entitlements/app.plist";

--- a/clients/macos/native/notifier/notifier.mm
+++ b/clients/macos/native/notifier/notifier.mm
@@ -13,18 +13,21 @@
 // `UNUserNotificationCenter.currentNotificationCenter.delegate` the moment it
 // is constructed (by `new Notification()`, by `Notification.isSupported()`, or
 // by the renderer's Web Notification API). This addon installs its own
-// delegate, remembers whichever delegate was installed before it, and forwards
-// every response it does not own to that delegate. Every entry point that
-// touches the notification center re-asserts the delegate first, and
-// `reassertDelegate()` lets JavaScript do the same between posts, so a late
-// Electron presenter cannot keep the seat.
+// delegate, holds a strong reference to whichever delegate it displaced, and
+// forwards every response it does not own to that delegate. `Show` and
+// `RequestAuthorization` re-assert the delegate on the way in, and the JS side
+// routes its notification permission probe through `requestAuthorization`
+// rather than `electron.Notification`, so no path in the app can build the
+// presenter without the addon taking the seat straight back.
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 #import <Intents/Intents.h>
 #import <UserNotifications/UserNotifications.h>
+#import <os/log.h>
 
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -48,6 +51,9 @@ struct Event {
   // Negative when the event carries no action index.
   int actionIndex = -1;
   std::string error;
+  // Non-empty on `shown` when the Communication Notification treatment could
+  // not be applied, naming why the plain layout went out instead.
+  std::string degraded;
 };
 
 // Called with g_mutex held.
@@ -123,6 +129,9 @@ void EmitEvent(const std::string &id, Event event, bool final) {
         if (!value->error.empty()) {
           object.Set("error", Napi::String::New(env, value->error));
         }
+        if (!value->degraded.empty()) {
+          object.Set("degraded", Napi::String::New(env, value->degraded));
+        }
         jsCallback.Call({object});
         delete value;
       });
@@ -152,8 +161,12 @@ NSString *ToNSString(const std::string &value) {
 // ---------------------------------------------------------------------------
 
 @interface VellumNotifierDelegate : NSObject <UNUserNotificationCenterDelegate>
-// Weak so a torn-down Electron presenter zeroes out instead of dangling.
-@property(nonatomic, weak) id<UNUserNotificationCenterDelegate> previousDelegate;
+// Strong: every response this addon does not own is forwarded here, and the
+// notification center itself holds its delegate weakly, so a weak reference
+// would leave responses going nowhere the moment the displaced delegate lost
+// its last other owner. `restoreDelegate` hands the seat back and drops it.
+@property(nonatomic, strong)
+    id<UNUserNotificationCenterDelegate> previousDelegate;
 @end
 
 @implementation VellumNotifierDelegate
@@ -250,7 +263,41 @@ void EnsureDelegateInstalled() {
   center.delegate = g_delegate;
 }
 
-void RegisterCategory(NSString *categoryId, NSArray<NSString *> *actionTitles) {
+void RestoreDelegate() {
+  if (g_delegate == nil) {
+    return;
+  }
+  UNUserNotificationCenter *center =
+      [UNUserNotificationCenter currentNotificationCenter];
+  if (center.delegate == g_delegate) {
+    center.delegate = g_delegate.previousDelegate;
+  }
+  g_delegate.previousDelegate = nil;
+}
+
+// Hands the notification center the union of what it already holds and every
+// category this addon has registered. Replacing the set instead would drop
+// categories registered by anything else in the process.
+void ApplyCategories() {
+  UNUserNotificationCenter *center =
+      [UNUserNotificationCenter currentNotificationCenter];
+  NSDictionary<NSString *, UNNotificationCategory *> *ours =
+      [g_categories copy];
+  [center getNotificationCategoriesWithCompletionHandler:^(
+              NSSet<UNNotificationCategory *> *existing) {
+    NSMutableDictionary<NSString *, UNNotificationCategory *> *merged =
+        [NSMutableDictionary dictionary];
+    for (UNNotificationCategory *category in existing) {
+      merged[category.identifier] = category;
+    }
+    // Ours win on a shared identifier: the JS side mints one identifier per
+    // ordered action set, so a collision means the same buttons either way.
+    [merged addEntriesFromDictionary:ours];
+    [center setNotificationCategories:[NSSet setWithArray:merged.allValues]];
+  }];
+}
+
+void RememberCategory(NSString *categoryId, NSArray<NSString *> *actionTitles) {
   if (g_categories == nil) {
     g_categories = [NSMutableDictionary dictionary];
   }
@@ -271,9 +318,6 @@ void RegisterCategory(NSString *categoryId, NSArray<NSString *> *actionTitles) {
                      actions:actions
            intentIdentifiers:@[]
                      options:UNNotificationCategoryOptionCustomDismissAction];
-  [[UNUserNotificationCenter currentNotificationCenter]
-      setNotificationCategories:[NSSet
-                                    setWithArray:g_categories.allValues]];
 }
 
 struct SenderRequest {
@@ -309,17 +353,29 @@ INPerson *MakePerson(NSString *identifier, NSString *displayName, INImage *image
                                  suggestionType:INPersonSuggestionTypeNone];
 }
 
+struct SenderContent {
+  UNNotificationContent *content = nil;
+  // Empty when the intent was applied; otherwise why the plain layout is
+  // going out instead, which the `shown` event carries back to JavaScript.
+  std::string degraded;
+};
+
+SenderContent Degraded(UNNotificationContent *content, std::string reason) {
+  os_log_error(OS_LOG_DEFAULT, "vellum-notifier: %{public}s", reason.c_str());
+  return {content, std::move(reason)};
+}
+
 // Returns content updated with a donated Communication Notification intent, or
 // the plain content when anything on the intent path fails. The entitlement is
 // restricted: an unsigned build, a build without the provisioning profile, or a
 // missing avatar all land here and post an ordinary notification.
-UNNotificationContent *ContentWithSenderIntent(
-    UNMutableNotificationContent *content, const ShowRequest &request) {
+SenderContent ContentWithSenderIntent(UNMutableNotificationContent *content,
+                                      const ShowRequest &request) {
   @try {
     NSString *avatarPath = ToNSString(request.sender.avatarPngPath);
     NSData *avatarData = [NSData dataWithContentsOfFile:avatarPath];
     if (avatarData == nil) {
-      return content;
+      return Degraded(content, "the avatar file could not be read");
     }
     INImage *image = [INImage imageWithImageData:avatarData];
     NSString *senderId = ToNSString(request.sender.id);
@@ -358,21 +414,33 @@ UNNotificationContent *ContentWithSenderIntent(
     UNNotificationContent *updated =
         [content contentByUpdatingWithProvider:intent error:&updateError];
     if (updated != nil && updateError == nil) {
-      return updated;
+      return {updated, std::string()};
     }
+    return Degraded(content,
+                    updateError != nil
+                        ? "contentByUpdatingWithProvider: " +
+                              ToStdString(updateError.localizedDescription)
+                        : "contentByUpdatingWithProvider: returned no content");
   } @catch (NSException *exception) {
-    // Fall through to the plain content below.
+    return Degraded(content,
+                    "the intent path raised: " + ToStdString(exception.reason));
   }
-  return content;
 }
 
 void PostNotification(const ShowRequest &request) {
   NSString *categoryId = ToNSString(request.categoryId);
-  NSMutableArray<NSString *> *actionTitles = [NSMutableArray array];
-  for (const std::string &action : request.actions) {
-    [actionTitles addObject:ToNSString(action)];
+  // Every action set the app posts is registered at startup through
+  // `registerCategories`, because `setNotificationCategories:` applies
+  // asynchronously and a category minted in the runloop turn its notification
+  // is posted can miss it. This covers a set that was not registered there.
+  if (g_categories[categoryId] == nil) {
+    NSMutableArray<NSString *> *actionTitles = [NSMutableArray array];
+    for (const std::string &action : request.actions) {
+      [actionTitles addObject:ToNSString(action)];
+    }
+    RememberCategory(categoryId, actionTitles);
+    ApplyCategories();
   }
-  RegisterCategory(categoryId, actionTitles);
 
   UNMutableNotificationContent *content =
       [[UNMutableNotificationContent alloc] init];
@@ -384,8 +452,13 @@ void PostNotification(const ShowRequest &request) {
   content.sound = [UNNotificationSound defaultSound];
   content.categoryIdentifier = categoryId;
 
-  UNNotificationContent *finalContent =
-      request.hasSender ? ContentWithSenderIntent(content, request) : content;
+  UNNotificationContent *finalContent = content;
+  std::string degraded;
+  if (request.hasSender) {
+    SenderContent applied = ContentWithSenderIntent(content, request);
+    finalContent = applied.content;
+    degraded = applied.degraded;
+  }
 
   const std::string id = request.id;
   UNNotificationRequest *notificationRequest =
@@ -404,6 +477,7 @@ void PostNotification(const ShowRequest &request) {
          }
          Event event;
          event.kind = "shown";
+         event.degraded = degraded;
          EmitEvent(id, std::move(event), false);
        }];
 }
@@ -419,14 +493,12 @@ Napi::Value IsSupported(const Napi::CallbackInfo &info) {
   return Napi::Boolean::New(info.Env(), IsBundled());
 }
 
-// Reclaims the notification center's delegate. Idempotent, and cheap enough to
-// call on a timer: the addon remembers whichever delegate it displaces and
-// keeps forwarding to it.
-Napi::Value ReassertDelegate(const Napi::CallbackInfo &info) {
+// Returns the notification center's delegate to whoever held it before this
+// addon installed its own, and drops the addon's reference to them. Called at
+// quit.
+Napi::Value RestoreDelegateBinding(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-  if (IsBundled()) {
-    EnsureDelegateInstalled();
-  }
+  RestoreDelegate();
   return env.Undefined();
 }
 
@@ -463,14 +535,22 @@ Napi::Value RequestAuthorization(const Napi::CallbackInfo &info) {
 
   EnsureDelegateInstalled();
 
-  Napi::ThreadSafeFunction *tsfn = nullptr;
+  // Owned by the completion block: a prompt the user never answers destroys
+  // the block without calling it, and the deleter releases the function then
+  // rather than leaking it for the life of the process.
+  std::shared_ptr<Napi::ThreadSafeFunction> tsfn;
   if (hasCallback) {
     Napi::ThreadSafeFunction created =
         Napi::ThreadSafeFunction::New(env, info[0].As<Napi::Function>(),
                                       "vellum-notifier-authorization", 0, 1);
     // The prompt waits on the user, so it must not hold the process open.
     created.Unref(env);
-    tsfn = new Napi::ThreadSafeFunction(created);
+    tsfn = std::shared_ptr<Napi::ThreadSafeFunction>(
+        new Napi::ThreadSafeFunction(created),
+        [](Napi::ThreadSafeFunction *function) {
+          function->Release();
+          delete function;
+        });
   }
 
   [[UNUserNotificationCenter currentNotificationCenter]
@@ -478,7 +558,7 @@ Napi::Value RequestAuthorization(const Napi::CallbackInfo &info) {
                                       UNAuthorizationOptionSound |
                                       UNAuthorizationOptionBadge
                     completionHandler:^(BOOL granted, NSError *error) {
-                      if (tsfn == nullptr) {
+                      if (!tsfn) {
                         return;
                       }
                       auto *payload = new AuthorizationResult();
@@ -497,8 +577,6 @@ Napi::Value RequestAuthorization(const Napi::CallbackInfo &info) {
                       if (status != napi_ok) {
                         delete payload;
                       }
-                      tsfn->Release();
-                      delete tsfn;
                     }];
   return env.Undefined();
 }
@@ -519,6 +597,44 @@ std::string OptionalString(const Napi::Object &object, const char *key) {
     return std::string();
   }
   return value.As<Napi::String>().Utf8Value();
+}
+
+// Registers every category the app can post, so `setNotificationCategories:`
+// has applied long before the first notification carries one of them.
+Napi::Value RegisterCategories(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsArray()) {
+    throw Napi::TypeError::New(
+        env, "notifier.registerCategories(categories) requires an array");
+  }
+  if (!IsBundled()) {
+    return env.Undefined();
+  }
+
+  Napi::Array categories = info[0].As<Napi::Array>();
+  for (uint32_t index = 0; index < categories.Length(); index++) {
+    Napi::Value entry = categories.Get(index);
+    if (!entry.IsObject()) {
+      continue;
+    }
+    Napi::Object category = entry.As<Napi::Object>();
+    NSString *categoryId = ToNSString(RequiredString(category, "categoryId"));
+    NSMutableArray<NSString *> *actionTitles = [NSMutableArray array];
+    Napi::Value actionsValue = category.Get("actions");
+    if (actionsValue.IsArray()) {
+      Napi::Array actions = actionsValue.As<Napi::Array>();
+      for (uint32_t action = 0; action < actions.Length(); action++) {
+        Napi::Value title = actions.Get(action);
+        if (title.IsString()) {
+          [actionTitles
+              addObject:ToNSString(title.As<Napi::String>().Utf8Value())];
+        }
+      }
+    }
+    RememberCategory(categoryId, actionTitles);
+  }
+  ApplyCategories();
+  return env.Undefined();
 }
 
 Napi::Value Show(const Napi::CallbackInfo &info) {
@@ -605,7 +721,10 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("isSupported", Napi::Function::New(env, IsSupported));
   exports.Set("requestAuthorization",
               Napi::Function::New(env, RequestAuthorization));
-  exports.Set("reassertDelegate", Napi::Function::New(env, ReassertDelegate));
+  exports.Set("registerCategories",
+              Napi::Function::New(env, RegisterCategories));
+  exports.Set("restoreDelegate",
+              Napi::Function::New(env, RestoreDelegateBinding));
   exports.Set("show", Napi::Function::New(env, Show));
   return exports;
 }

--- a/clients/macos/package.json
+++ b/clients/macos/package.json
@@ -5,7 +5,7 @@
   "description": "Electron wrapper for the Vellum Assistant macOS app.",
   "main": "out/main/index.js",
   "scripts": {
-    "setup": "node node_modules/electron/install.js && bash scripts/build-mac-helper.sh && bash scripts/build-notifier.sh",
+    "setup": "node node_modules/electron/install.js && bash scripts/build-mac-helper.sh && (bash scripts/build-notifier.sh || echo 'notifier unavailable; notifications fall back to Electron')",
     "dev": "bun run install:all && bun scripts/dev.ts",
     "dev:standalone": "bun run install:all && bun run scripts/reclaim-dev-port.ts && concurrently --kill-others --names web,electron --prefix-colors blue,green \"bun run dev:web\" \"bun run dev:electron\"",
     "dev:electron-only": "bun install && bun run setup && bun run prepare:electron-dev && electron-vite dev",

--- a/clients/macos/scripts/afterSign.js
+++ b/clients/macos/scripts/afterSign.js
@@ -18,9 +18,7 @@ function getConfiguredQualifier(options) {
     return options.identity;
   }
 
-  return (
-    process.env.CSC_NAME || process.env.APPLE_SIGNING_IDENTITY || undefined
-  );
+  return process.env.CSC_NAME || process.env.APPLE_SIGNING_IDENTITY || undefined;
 }
 
 function getCertificateTypes(isDevelopment) {
@@ -69,7 +67,7 @@ async function resolveSigningIdentity(context) {
 
   if (identity == null) {
     throw new Error(
-      "afterSign: unable to resolve the macOS signing identity that electron-builder used",
+      "afterSign: unable to resolve the macOS signing identity that electron-builder used"
     );
   }
 
@@ -183,26 +181,27 @@ exports.default = async function afterSign(context) {
   for (const executable of executables) {
     if (!fs.existsSync(executable.path)) {
       console.warn(
-        `afterSign: ${executable.name} not found at ${executable.path}, skipping codesign`,
+        `afterSign: ${executable.name} not found at ${executable.path}, skipping codesign`
       );
       continue;
     }
 
     console.log(
-      `afterSign: codesigning ${executable.name} with identity="${identity.name}"`,
+      `afterSign: codesigning ${executable.name} with identity="${identity.name}"`
     );
     codesign(executable.path, executable.entitlements, identity);
   }
 
   console.log(
-    `afterSign: re-signing ${productName}.app with identity="${identity.name}"`,
+    `afterSign: re-signing ${productName}.app with identity="${identity.name}"`
   );
-  // Mirrors electron-builder.config.cjs: a build with a provisioning profile
-  // carries the restricted Communication Notifications entitlement, and every
-  // other build must not. Deriving here rather than reading a checked-in copy
-  // keeps this pass on the same entitlement set electron-builder signed with.
-  const appEntitlements = process.env.VELLUM_MAC_PROVISIONING_PROFILE
-    ? deriveCommunicationEntitlements()
+  // Read back the decision electron-builder.config.cjs already made, rather
+  // than re-reading the environment: only a build configured with a
+  // provisioning profile may carry the restricted Communication Notifications
+  // entitlement, and this pass has to sign the same set electron-builder did.
+  const macOptions = packager.platformSpecificBuildOptions || {};
+  const appEntitlements = macOptions.provisioningProfile
+    ? macOptions.entitlements || deriveCommunicationEntitlements()
     : path.join(entitlementsDir, "app.plist");
   codesign(appDir, appEntitlements, identity);
 };

--- a/clients/macos/scripts/build-notifier.sh
+++ b/clients/macos/scripts/build-notifier.sh
@@ -54,6 +54,10 @@ if [ ! -f "$BUILT" ]; then
   exit 1
 fi
 
+# One build produces one architecture, and electron-builder packs whatever is
+# under resources/notifier, so a previous build for another arch is cleared
+# rather than shipped alongside this one.
+rm -rf "$ROOT_DIR/resources/notifier"
 OUTPUT_DIR="$ROOT_DIR/resources/notifier/$ARCH"
 mkdir -p "$OUTPUT_DIR"
 cp "$BUILT" "$OUTPUT_DIR/vellum-notifier.node"

--- a/clients/macos/scripts/entitlements/derive-communication-entitlements.js
+++ b/clients/macos/scripts/entitlements/derive-communication-entitlements.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 // `com.apple.developer.usernotifications.communication` is a restricted
 // entitlement: an app that declares it without an authorizing provisioning
 // profile is killed at launch, so only a build with

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -106,8 +106,11 @@ import {
 } from "./move-to-applications";
 import { markRelocationSkipped } from "./install-location";
 import { installNativeAuth } from "./native-auth.client";
-import { createNativeNotificationFactory } from "./native-notifications";
-import { isNotifierAvailable, startNotifierDelegateGuard } from "./notifier";
+import {
+  createNativeNotificationFactory,
+  registerNativeNotificationCategories,
+} from "./native-notifications";
+import { getNotifier, restoreNotifierDelegate } from "./notifier";
 import { installPermissionsService } from "./permissions-service";
 import {
   installCompanionWindow,
@@ -459,12 +462,13 @@ app
     // panel. Distinct from `installShare`, which is the "send elsewhere" intent.
     installDownloads({ handle });
     installPowerEvents();
-    // The native addon owns the notification center when it is present, which
-    // is what lets a notification carry the assistant's avatar. `isSupported`
-    // ships with `create`: without it the shared module falls back to
-    // `electron.Notification.isSupported()`, and that call alone constructs
-    // Electron's presenter, which claims the center's delegate.
-    const nativeNotifications = isNotifierAvailable()
+    // The addon owns the notification center only when it says it can have it:
+    // an unbundled run loads it fine and then reports unsupported, because
+    // UNUserNotificationCenter raises there. `isSupported` ships with `create`
+    // rather than being left to the shared module's default; see the delegate
+    // rule in README.md.
+    const notifier = getNotifier();
+    const nativeNotifications = notifier?.isSupported()
       ? createNativeNotificationFactory()
       : null;
     configureNotifications({
@@ -473,13 +477,11 @@ app
       logger: log,
       ...(nativeNotifications ?? {}),
     });
+    if (nativeNotifications) {
+      registerNativeNotificationCategories();
+      app.on("before-quit", restoreNotifierDelegate);
+    }
     installNotifications();
-    // Insurance for the delegate the addon installs: no main-process path
-    // builds Electron's presenter while the addon is loaded, but one that
-    // appeared some other way would hold the notification center's delegate
-    // until the next native post and swallow clicks in the meantime.
-    const stopNotifierDelegateGuard = startNotifierDelegateGuard();
-    app.on("before-quit", stopNotifierDelegateGuard);
     installWindowAttentionFeature();
     // Register the status channel before the tray installs so the tray's
     // initial render reflects any status the renderer publishes during

--- a/clients/macos/src/main/native-notifications.test.ts
+++ b/clients/macos/src/main/native-notifications.test.ts
@@ -1,17 +1,15 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-} from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import type { NotificationCreateOptions } from "@vellumai/electron-desktop/notifications";
 
-import type { NotifierEvent, NotifierRequest } from "./notifier";
+import type {
+  NotifierCategory,
+  NotifierEvent,
+  NotifierRequest,
+} from "./notifier";
 
 const userDataDir = mkdtempSync(path.join(tmpdir(), "vellum-notif-avatars-"));
 
@@ -21,8 +19,12 @@ mock.module("electron", () => ({
   },
 }));
 
+const warnings: unknown[][] = [];
 mock.module("./logger", () => ({
-  default: { info: () => undefined, warn: () => undefined },
+  default: {
+    info: () => undefined,
+    warn: (...args: unknown[]) => warnings.push(args),
+  },
 }));
 
 interface Call {
@@ -31,17 +33,22 @@ interface Call {
 }
 
 const calls: Call[] = [];
+const registered: NotifierCategory[][] = [];
 let notifierSupported = true;
 let notifierPresent = true;
 let showThrows = false;
 
 mock.module("./notifier", () => ({
+  registerNotifierCategories: (categories: NotifierCategory[]) => {
+    registered.push(categories);
+  },
   getNotifier: () =>
     notifierPresent
       ? {
           isSupported: () => notifierSupported,
           requestAuthorization: () => undefined,
-          reassertDelegate: () => undefined,
+          registerCategories: () => undefined,
+          restoreDelegate: () => undefined,
           show: (
             request: NotifierRequest,
             callback: (event: NotifierEvent) => void,
@@ -55,8 +62,10 @@ mock.module("./notifier", () => ({
       : null,
 }));
 
-const { createNativeNotificationFactory } =
-  await import("./native-notifications");
+const {
+  createNativeNotificationFactory,
+  registerNativeNotificationCategories,
+} = await import("./native-notifications");
 
 const avatarPng = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 
@@ -77,7 +86,8 @@ const sender = {
   id: "assistant-1",
   name: "Ada",
   avatarPng,
-  avatarHash: "abc123",
+  avatarHash:
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 };
 
 afterAll(() => {
@@ -86,12 +96,43 @@ afterAll(() => {
 
 beforeEach(() => {
   calls.length = 0;
+  registered.length = 0;
+  warnings.length = 0;
   notifierSupported = true;
   notifierPresent = true;
   showThrows = false;
   rmSync(path.join(userDataDir, "notification-avatars"), {
     recursive: true,
     force: true,
+  });
+});
+
+describe("registerNativeNotificationCategories", () => {
+  test("registers every action set once, up front", () => {
+    registerNativeNotificationCategories();
+
+    expect(registered.length).toBe(1);
+    const categories = registered[0]!;
+    expect(categories.map((category) => category.actions)).toEqual([
+      ["View Results"],
+      ["Allow", "Deny"],
+      ["View Response"],
+      ["View"],
+    ]);
+    for (const category of categories) {
+      expect(category.categoryId).toMatch(/^vellum\.actions\.[0-9a-f]{16}$/);
+    }
+    expect(
+      new Set(categories.map((category) => category.categoryId)).size,
+    ).toBe(4);
+  });
+
+  test("registers the id a notification with those actions will post under", () => {
+    registerNativeNotificationCategories();
+    createNativeNotificationFactory().create(options()).show();
+
+    const registeredIds = registered[0]!.map((category) => category.categoryId);
+    expect(registeredIds).toContain(calls[0]!.request.categoryId);
   });
 });
 
@@ -162,49 +203,30 @@ describe("createNativeNotificationFactory", () => {
     expect(request.sender?.conversationId).toBe("assistant-1");
   });
 
-  test("writes the avatar under the user data directory keyed by its hash", () => {
+  test("stages the avatar through the shared cache", () => {
     createNativeNotificationFactory().create(options({ sender })).show();
 
     const avatarPath = calls[0]!.request.sender!.avatarPngPath;
     expect(avatarPath).toBe(
-      path.join(userDataDir, "notification-avatars", "abc123.png"),
+      path.join(
+        userDataDir,
+        "notification-avatars",
+        `${sender.avatarHash}.png`,
+      ),
     );
     expect(readFileSync(avatarPath)).toEqual(avatarPng);
   });
 
-  test("prunes the avatar cache to the eight newest files", () => {
-    const factory = createNativeNotificationFactory();
-    for (let index = 0; index < 12; index++) {
-      factory
-        .create(options({ sender: { ...sender, avatarHash: `hash${index}` } }))
-        .show();
-    }
-
-    const dir = path.join(userDataDir, "notification-avatars");
-    expect(readdirSync(dir).length).toBe(8);
-    expect(existsSync(path.join(dir, "hash11.png"))).toBe(true);
-  });
-
-  test("rejects a hash that would escape the avatar directory", () => {
-    createNativeNotificationFactory()
-      .create(options({ sender: { ...sender, avatarHash: "../../escape" } }))
-      .show();
-
-    const { request } = calls[0]!;
-    expect(request.sender!.avatarPngPath).toBe(
-      path.join(userDataDir, "notification-avatars", "______escape.png"),
-    );
-  });
-
   test("falls back to the plain layout when the avatar cannot be staged", () => {
     createNativeNotificationFactory()
-      .create(options({ sender: { ...sender, avatarHash: "" } }))
+      .create(options({ sender: { ...sender, avatarHash: "../../escape" } }))
       .show();
 
     const { request } = calls[0]!;
     expect(request.sender).toBeUndefined();
     expect(request.title).toBe("Weekly plan");
     expect(request.subtitle).toBeUndefined();
+    expect(warnings.length).toBe(1);
   });
 
   test("maps addon events onto the notification listeners", () => {
@@ -225,10 +247,27 @@ describe("createNativeNotificationFactory", () => {
     emit({ kind: "click" });
     emit({ kind: "action", actionIndex: 1 });
     emit({ kind: "action" });
-    emit({ kind: "dismiss" });
+    // The addon evicts a dismissed notification itself, so "dismiss" is not in
+    // the JS event union and anything outside it is ignored.
+    emit({ kind: "dismiss" } as unknown as NotifierEvent);
     emit({ kind: "failed", error: "denied" });
 
     expect(events).toEqual(["show", "click", "action:1", "failed:denied"]);
+  });
+
+  test("shows a degraded notification and logs why", () => {
+    const events: string[] = [];
+    const notification = createNativeNotificationFactory().create(options());
+    notification.on("show", () => events.push("show"));
+    notification.show();
+
+    calls[0]!.emit({
+      kind: "shown",
+      degraded: "the avatar file could not be read",
+    });
+
+    expect(events).toEqual(["show"]);
+    expect(String(warnings[0]?.[1])).toBe("the avatar file could not be read");
   });
 
   test("acks a failure when the addon is gone", () => {

--- a/clients/macos/src/main/native-notifications.ts
+++ b/clients/macos/src/main/native-notifications.ts
@@ -16,18 +16,10 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
-import path from "node:path";
 
 import { app } from "electron";
 
+import { ensureNotificationAvatarFile } from "@vellumai/electron-desktop/notification-avatar-file";
 import type {
   CategoryAction,
   NotificationCreateOptions,
@@ -35,58 +27,12 @@ import type {
 } from "@vellumai/electron-desktop/notifications";
 
 import log from "./logger";
-import { getNotifier, type NotifierRequest } from "./notifier";
-
-/**
- * The addon reads the avatar from disk (Intents takes image data, not a
- * buffer over IPC), so the PNG is cached under the user data directory keyed
- * by its content hash.
- */
-const AVATAR_DIR_NAME = "notification-avatars";
-const MAX_AVATAR_FILES = 8;
-
-// The hash arrives over IPC; folding every other character to an underscore is
-// what stops a crafted value from naming a path outside the avatar directory,
-// while keeping two different hashes on two different filenames.
-const sanitizeHash = (avatarHash: string): string =>
-  avatarHash.replace(/[^a-zA-Z0-9]/g, "_").slice(0, 64);
-
-// `keepPath` is the avatar this notification is about to hand the addon, so it
-// survives the cap no matter how old the cached file is.
-const pruneAvatarFiles = (dir: string, keepPath: string): void => {
-  const files = readdirSync(dir)
-    .filter((name) => name.endsWith(".png"))
-    .map((name) => path.join(dir, name))
-    .filter((filePath) => filePath !== keepPath)
-    .map((filePath) => ({ filePath, mtimeMs: statSync(filePath).mtimeMs }))
-    .sort((a, b) => b.mtimeMs - a.mtimeMs);
-  for (const stale of files.slice(MAX_AVATAR_FILES - 1)) {
-    try {
-      rmSync(stale.filePath, { force: true });
-    } catch {
-      // A file another process is holding stays; the cap is advisory.
-    }
-  }
-};
-
-const ensureNotificationAvatarFile = (
-  userDataDir: string,
-  avatarPng: Buffer,
-  avatarHash: string,
-): string => {
-  const hash = sanitizeHash(avatarHash);
-  if (hash.length === 0) {
-    throw new Error("Notification avatar hash is empty");
-  }
-  const dir = path.join(userDataDir, AVATAR_DIR_NAME);
-  mkdirSync(dir, { recursive: true });
-  const filePath = path.join(dir, `${hash}.png`);
-  if (!existsSync(filePath)) {
-    writeFileSync(filePath, avatarPng);
-    pruneAvatarFiles(dir, filePath);
-  }
-  return filePath;
-};
+import {
+  getNotifier,
+  registerNotifierCategories,
+  type NotifierCategory,
+  type NotifierRequest,
+} from "./notifier";
 
 type Listeners = {
   click?: () => void;
@@ -104,12 +50,45 @@ type Listeners = {
  * action labels gives every distinct set its own category, an empty set
  * included, and keeps a repeated set on the one registration.
  */
-const categoryIdForActions = (actions: readonly CategoryAction[]): string => {
+const categoryIdForLabels = (labels: readonly string[]): string => {
   const digest = createHash("sha256")
-    .update(JSON.stringify(actions.map((action) => action.text)))
+    .update(JSON.stringify(labels))
     .digest("hex")
     .slice(0, 16);
   return `vellum.actions.${digest}`;
+};
+
+const categoryIdForActions = (actions: readonly CategoryAction[]): string =>
+  categoryIdForLabels(actions.map((action) => action.text));
+
+/**
+ * The action labels of every category the app posts, copied from
+ * `CATEGORY_ACTIONS` in `@vellumai/electron-desktop/notifications`, which does
+ * not export them.
+ */
+const CATEGORY_ACTION_LABELS: readonly (readonly string[])[] = [
+  ["View Results"],
+  ["Allow", "Deny"],
+  ["View Response"],
+  ["View"],
+];
+
+/**
+ * Registers every category up front.
+ *
+ * `setNotificationCategories:` applies asynchronously, so a category first
+ * registered in the runloop turn its notification is posted can miss it and
+ * the buttons never render. Registering at startup gives macOS the whole set
+ * long before the first notification.
+ */
+export const registerNativeNotificationCategories = (): void => {
+  const categories: NotifierCategory[] = CATEGORY_ACTION_LABELS.map(
+    (labels) => ({
+      categoryId: categoryIdForLabels(labels),
+      actions: [...labels],
+    }),
+  );
+  registerNotifierCategories(categories);
 };
 
 export const createNativeNotificationFactory = (): {
@@ -132,6 +111,8 @@ export const createNativeNotificationFactory = (): {
         return {
           id: sender.id,
           name: sender.name,
+          // The addon reads the avatar from disk: Intents takes image data,
+          // not a buffer over IPC.
           avatarPngPath: ensureNotificationAvatarFile(
             app.getPath("userData"),
             sender.avatarPng,
@@ -166,6 +147,12 @@ export const createNativeNotificationFactory = (): {
       try {
         notifier.show(request, (event) => {
           if (event.kind === "shown") {
+            if (event.degraded) {
+              log.warn(
+                "[notifications] posted without the avatar:",
+                event.degraded,
+              );
+            }
             listeners.show?.();
           } else if (event.kind === "failed") {
             listeners.failed?.(

--- a/clients/macos/src/main/notifier.test.ts
+++ b/clients/macos/src/main/notifier.test.ts
@@ -1,18 +1,30 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import type { Notifier, NotifierAuthorizationResult } from "./notifier";
+import type {
+  Notifier,
+  NotifierAuthorizationResult,
+  NotifierCategory,
+} from "./notifier";
 
 const appPath = mkdtempSync(path.join(tmpdir(), "vellum-notifier-"));
 
-mock.module("electron", () => ({
-  app: {
-    isPackaged: false,
-    getAppPath: () => appPath,
-  },
-}));
+const electronApp = {
+  isPackaged: false,
+  getAppPath: () => appPath,
+};
+
+mock.module("electron", () => ({ app: electronApp }));
 
 const warnings: unknown[][] = [];
 const infos: unknown[][] = [];
@@ -27,37 +39,38 @@ const {
   __resetNotifierForTesting,
   __setNotifierForTesting,
   getNotifier,
-  isNotifierAvailable,
-  reassertNotifierDelegate,
+  registerNotifierCategories,
   requestNotifierAuthorization,
-  startNotifierDelegateGuard,
+  restoreNotifierDelegate,
 } = await import("./notifier");
 
 interface FakeNotifier extends Notifier {
   authorizationCalls: number;
-  reassertCalls: number;
+  restoreCalls: number;
+  registered: NotifierCategory[][];
 }
 
 const fakeNotifier = (overrides: Partial<Notifier> = {}): FakeNotifier => {
   const fake: FakeNotifier = {
     authorizationCalls: 0,
-    reassertCalls: 0,
+    restoreCalls: 0,
+    registered: [],
     isSupported: () => true,
     requestAuthorization: (callback) => {
       fake.authorizationCalls += 1;
       callback?.({ granted: true });
     },
-    reassertDelegate: () => {
-      fake.reassertCalls += 1;
+    registerCategories: (categories) => {
+      fake.registered.push(categories);
+    },
+    restoreDelegate: () => {
+      fake.restoreCalls += 1;
     },
     show: () => undefined,
     ...overrides,
   };
   return fake;
 };
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 const addonPath = path.join(
   appPath,
@@ -66,6 +79,11 @@ const addonPath = path.join(
   process.arch,
   "vellum-notifier.node",
 );
+
+const writeFakeAddon = (): void => {
+  mkdirSync(path.dirname(addonPath), { recursive: true });
+  writeFileSync(addonPath, "not a mach-o dylib");
+};
 
 afterAll(() => {
   rmSync(appPath, { recursive: true, force: true });
@@ -80,29 +98,102 @@ describe("notifier addon loading", () => {
   });
 
   test("reports unavailable without throwing when the addon is missing", () => {
-    expect(isNotifierAvailable()).toBe(false);
     expect(getNotifier()).toBeNull();
     expect(infos.length).toBe(1);
   });
 
   test("resolves the addon under resources/notifier/<arch> in a dev build", () => {
-    isNotifierAvailable();
+    getNotifier();
     expect(String(infos[0]?.[0])).toContain(addonPath);
   });
 
   test("reports unavailable without throwing when the file is not an addon", () => {
-    mkdirSync(path.dirname(addonPath), { recursive: true });
-    writeFileSync(addonPath, "not a mach-o dylib");
+    writeFakeAddon();
 
-    expect(isNotifierAvailable()).toBe(false);
+    expect(getNotifier()).toBeNull();
     expect(warnings.length).toBe(1);
   });
 
   test("caches the load result so a failure is not retried per call", () => {
-    isNotifierAvailable();
-    isNotifierAvailable();
-    isNotifierAvailable();
+    getNotifier();
+    getNotifier();
+    getNotifier();
     expect(infos.length).toBe(1);
+  });
+});
+
+describe("notifier addon path in a packaged app", () => {
+  const resourcesPath = path.join(appPath, "packaged-resources");
+  const processWithResources = process as unknown as {
+    resourcesPath?: string;
+  };
+  const originalResourcesPath = processWithResources.resourcesPath;
+
+  beforeEach(() => {
+    __resetNotifierForTesting();
+    infos.length = 0;
+    electronApp.isPackaged = true;
+    processWithResources.resourcesPath = resourcesPath;
+  });
+
+  afterEach(() => {
+    electronApp.isPackaged = false;
+    if (originalResourcesPath === undefined) {
+      delete processWithResources.resourcesPath;
+    } else {
+      processWithResources.resourcesPath = originalResourcesPath;
+    }
+  });
+
+  // electron-builder.config.cjs packs resources/notifier to `bin/notifier`, so
+  // a change to either side has to move with the other.
+  test("resolves the addon under the packed bin/notifier/<arch>", () => {
+    getNotifier();
+
+    expect(String(infos[0]?.[0])).toContain(
+      path.join(
+        resourcesPath,
+        "bin",
+        "notifier",
+        process.arch,
+        "vellum-notifier.node",
+      ),
+    );
+  });
+});
+
+describe("native notifier kill switch", () => {
+  const originalValue = process.env.VELLUM_DISABLE_NATIVE_NOTIFIER;
+
+  beforeEach(() => {
+    __resetNotifierForTesting();
+    infos.length = 0;
+    warnings.length = 0;
+    writeFakeAddon();
+  });
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.VELLUM_DISABLE_NATIVE_NOTIFIER;
+    } else {
+      process.env.VELLUM_DISABLE_NATIVE_NOTIFIER = originalValue;
+    }
+    rmSync(path.join(appPath, "resources"), { recursive: true, force: true });
+  });
+
+  test("reports unavailable without touching the addon on disk", () => {
+    process.env.VELLUM_DISABLE_NATIVE_NOTIFIER = "1";
+
+    expect(getNotifier()).toBeNull();
+    expect(warnings.length).toBe(0);
+    expect(String(infos[0]?.[0])).toContain("VELLUM_DISABLE_NATIVE_NOTIFIER=1");
+  });
+
+  test("leaves the addon alone for any other value", () => {
+    process.env.VELLUM_DISABLE_NATIVE_NOTIFIER = "0";
+
+    expect(getNotifier()).toBeNull();
+    expect(warnings.length).toBe(1);
   });
 });
 
@@ -165,45 +256,46 @@ describe("notifier authorization", () => {
   });
 });
 
-describe("notifier delegate guard", () => {
+describe("notifier categories and delegate handback", () => {
   beforeEach(() => {
     __resetNotifierForTesting();
     warnings.length = 0;
   });
 
-  test("does nothing when the addon is unavailable", () => {
-    const stop = startNotifierDelegateGuard(1);
+  test("do nothing when the addon is unavailable", () => {
     expect(() => {
-      reassertNotifierDelegate();
+      registerNotifierCategories([{ categoryId: "a", actions: [] }]);
+      restoreNotifierDelegate();
     }).not.toThrow();
-    stop();
   });
 
-  test("reclaims the delegate immediately and then on the interval", async () => {
+  test("pass the categories through and hand the delegate back", () => {
     const notifier = fakeNotifier();
     __setNotifierForTesting(notifier);
 
-    const stop = startNotifierDelegateGuard(1);
-    expect(notifier.reassertCalls).toBe(1);
-    await sleep(20);
-    expect(notifier.reassertCalls).toBeGreaterThan(1);
+    registerNotifierCategories([{ categoryId: "a", actions: ["Allow"] }]);
+    restoreNotifierDelegate();
 
-    stop();
-    const afterStop = notifier.reassertCalls;
-    await sleep(20);
-    expect(notifier.reassertCalls).toBe(afterStop);
+    expect(notifier.registered).toEqual([
+      [{ categoryId: "a", actions: ["Allow"] }],
+    ]);
+    expect(notifier.restoreCalls).toBe(1);
   });
 
-  test("swallows an addon that throws on reassert", () => {
+  test("swallow an addon that throws", () => {
     __setNotifierForTesting(
       fakeNotifier({
-        reassertDelegate: () => {
+        registerCategories: () => {
+          throw new Error("addon exploded");
+        },
+        restoreDelegate: () => {
           throw new Error("addon exploded");
         },
       }),
     );
 
-    reassertNotifierDelegate();
-    expect(warnings.length).toBe(1);
+    registerNotifierCategories([]);
+    restoreNotifierDelegate();
+    expect(warnings.length).toBe(2);
   });
 });

--- a/clients/macos/src/main/notifier.ts
+++ b/clients/macos/src/main/notifier.ts
@@ -16,6 +16,12 @@ import log from "./logger";
 
 const ADDON_FILENAME = "vellum-notifier.node";
 
+/**
+ * Kill switch for a build where the addon misbehaves: the loader reports
+ * unavailable and every notification goes back through Electron.
+ */
+const DISABLE_ENV_VAR = "VELLUM_DISABLE_NATIVE_NOTIFIER";
+
 export interface NotifierSender {
   id: string;
   name: string;
@@ -33,10 +39,21 @@ export interface NotifierRequest {
   sender?: NotifierSender;
 }
 
+export interface NotifierCategory {
+  categoryId: string;
+  actions: string[];
+}
+
 export interface NotifierEvent {
-  kind: "shown" | "failed" | "click" | "action" | "dismiss";
+  kind: "shown" | "failed" | "click" | "action";
   actionIndex?: number;
   error?: string;
+  /**
+   * Present on `shown` when the notification posted without the Communication
+   * Notification treatment, naming why. The notification itself is fine, so
+   * this is diagnostic rather than a failure.
+   */
+  degraded?: string;
 }
 
 export interface NotifierAuthorizationResult {
@@ -50,8 +67,13 @@ export interface Notifier {
   requestAuthorization(
     callback?: (result: NotifierAuthorizationResult) => void,
   ): void;
-  /** Reclaims the notification center's delegate. Idempotent. */
-  reassertDelegate(): void;
+  /**
+   * Registers notification categories with the notification center, unioned
+   * with whatever is already registered.
+   */
+  registerCategories(categories: NotifierCategory[]): void;
+  /** Hands the notification center's delegate back to whoever held it. */
+  restoreDelegate(): void;
   show(
     request: NotifierRequest,
     callback: (event: NotifierEvent) => void,
@@ -73,7 +95,8 @@ const isNotifier = (value: unknown): value is Notifier => {
   return (
     typeof candidate.isSupported === "function" &&
     typeof candidate.requestAuthorization === "function" &&
-    typeof candidate.reassertDelegate === "function" &&
+    typeof candidate.registerCategories === "function" &&
+    typeof candidate.restoreDelegate === "function" &&
     typeof candidate.show === "function"
   );
 };
@@ -86,6 +109,10 @@ const loadNotifier = (): Notifier | null => {
     return cached;
   }
   cached = null;
+  if (process.env[DISABLE_ENV_VAR] === "1") {
+    log.info(`[notifier] ${DISABLE_ENV_VAR}=1; using Electron notifications`);
+    return cached;
+  }
   const addonPath = resolveAddonPath();
   if (!existsSync(addonPath)) {
     log.info(
@@ -108,8 +135,6 @@ const loadNotifier = (): Notifier | null => {
 };
 
 export const getNotifier = (): Notifier | null => loadNotifier();
-
-export const isNotifierAvailable = (): boolean => loadNotifier() !== null;
 
 /**
  * Prompts for notification authorization through the addon, which keeps the
@@ -140,41 +165,35 @@ export const requestNotifierAuthorization =
     });
   };
 
-export const reassertNotifierDelegate = (): void => {
+/** Registers every notification category the app can post, once, at startup. */
+export const registerNotifierCategories = (
+  categories: NotifierCategory[],
+): void => {
   const notifier = loadNotifier();
   if (!notifier) {
     return;
   }
   try {
-    notifier.reassertDelegate();
+    notifier.registerCategories(categories);
   } catch (error) {
-    log.warn("[notifier] reassertDelegate failed:", error);
+    log.warn("[notifier] registerCategories failed:", error);
   }
 };
 
-const DELEGATE_GUARD_INTERVAL_MS = 30_000;
-
 /**
- * Takes the notification center's delegate back on a timer.
- *
- * Nothing in the main process constructs `electron.Notification` while the
- * addon is loaded, so this is insurance rather than the mechanism: a presenter
- * built by some other path would otherwise hold the delegate until the next
- * native post, and clicks on notifications already on screen would be dropped.
- * Reclaiming is a delegate comparison and an assignment.
+ * Returns the notification center's delegate to whoever held it before the
+ * addon installed its own, so the app quits leaving the seat as it found it.
  */
-export const startNotifierDelegateGuard = (
-  intervalMs: number = DELEGATE_GUARD_INTERVAL_MS,
-): (() => void) => {
-  if (!isNotifierAvailable()) {
-    return () => undefined;
+export const restoreNotifierDelegate = (): void => {
+  const notifier = loadNotifier();
+  if (!notifier) {
+    return;
   }
-  reassertNotifierDelegate();
-  const timer = setInterval(reassertNotifierDelegate, intervalMs);
-  timer.unref?.();
-  return () => {
-    clearInterval(timer);
-  };
+  try {
+    notifier.restoreDelegate();
+  } catch (error) {
+    log.warn("[notifier] restoreDelegate failed:", error);
+  }
 };
 
 // Test seam: clears the one-shot load result so a test can point the loader

--- a/clients/macos/src/main/permissions-service.test.ts
+++ b/clients/macos/src/main/permissions-service.test.ts
@@ -75,7 +75,8 @@ const { PermissionsService } = await import("./permissions-service");
 const nativeNotifier = (isSupported = true): Notifier => ({
   isSupported: () => isSupported,
   requestAuthorization: () => undefined,
-  reassertDelegate: () => undefined,
+  registerCategories: () => undefined,
+  restoreDelegate: () => undefined,
   show: () => undefined,
 });
 

--- a/clients/macos/src/main/permissions-service.ts
+++ b/clients/macos/src/main/permissions-service.ts
@@ -131,9 +131,37 @@ const settingsPaneUrl = (kind: PermissionKind): string => {
 // the outcome is called unknown.
 const NOTIFICATION_PROMPT_TIMEOUT_MS = 30_000;
 
-// The native notifier owns the notification center whenever it is loaded, and
-// `electron.Notification.isSupported()` alone builds Electron's presenter,
-// which takes the center's delegate. Ask the addon instead.
+/**
+ * Runs `probe` and resolves whatever it settles on, or `null` once `timeoutMs`
+ * passes with no answer. The first settle wins, so a probe that answers twice
+ * (or answers after the timeout) cannot change the outcome.
+ */
+const settleWithin = <T>(
+  timeoutMs: number,
+  probe: (settle: (value: T | null) => void) => void,
+): Promise<T | null> =>
+  new Promise((resolve) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const settle = (value: T | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      resolve(value);
+    };
+    timeout = setTimeout(() => {
+      settle(null);
+    }, timeoutMs);
+    timeout.unref?.();
+    probe(settle);
+  });
+
+// Asking the addon rather than `electron.Notification.isSupported()`, which
+// builds Electron's presenter and takes the notification center's delegate.
 const initialNotificationStatus = (): PermissionStatus => {
   const notifier = getNotifier();
   const supported = notifier
@@ -315,25 +343,17 @@ export class PermissionsService {
     return this.requestElectronNotifications();
   }
 
-  // The addon prompts through UNUserNotificationCenter directly. Probing with
-  // `electron.Notification` here would build Electron's presenter, which takes
-  // the notification center's delegate, and clicks on notifications the addon
-  // already delivered would stop reaching the app.
+  // Prompting through the addon rather than `electron.Notification` is half of
+  // what keeps the delegate with the addon; see the delegate rule in README.md.
   private async requestNativeNotifications(notifier: Notifier): Promise<void> {
     if (!notifier.isSupported()) {
       this.notificationStatus = "restricted";
       return;
     }
-    const result = await new Promise<NotifierAuthorizationResult | null>(
-      (resolve) => {
-        const timeout = setTimeout(() => {
-          resolve(null);
-        }, NOTIFICATION_PROMPT_TIMEOUT_MS);
-        timeout.unref?.();
-        void requestNotifierAuthorization().then((value) => {
-          clearTimeout(timeout);
-          resolve(value);
-        });
+    const result = await settleWithin<NotifierAuthorizationResult>(
+      NOTIFICATION_PROMPT_TIMEOUT_MS,
+      (settle) => {
+        void requestNotifierAuthorization().then(settle);
       },
     );
     if (result === null) {
@@ -343,42 +363,29 @@ export class PermissionsService {
     this.notificationStatus = result.granted ? "granted" : "denied";
   }
 
-  private requestElectronNotifications(): Promise<void> {
+  private async requestElectronNotifications(): Promise<void> {
     if (!Notification.isSupported()) {
       this.notificationStatus = "restricted";
-      return Promise.resolve();
+      return;
     }
-
-    return new Promise((resolve) => {
-      let settled = false;
-      let timeout: ReturnType<typeof setTimeout> | null = null;
-      const notification = new Notification({
-        title: "Vellum",
-        body: "Notifications are enabled.",
-        silent: false,
-      });
-
-      const settle = (status: PermissionStatus) => {
-        if (settled) return;
-        settled = true;
-        if (timeout) clearTimeout(timeout);
-        this.notificationStatus = status;
-        resolve();
-      };
-
-      timeout = setTimeout(() => {
-        settle("unknown");
-      }, NOTIFICATION_PROMPT_TIMEOUT_MS);
-      timeout.unref?.();
-
-      notification.once("show", () => settle("granted"));
-      notification.once("failed", () => settle("denied"));
-      try {
-        notification.show();
-      } catch {
-        settle("unknown");
-      }
-    });
+    const status = await settleWithin<PermissionStatus>(
+      NOTIFICATION_PROMPT_TIMEOUT_MS,
+      (settle) => {
+        const notification = new Notification({
+          title: "Vellum",
+          body: "Notifications are enabled.",
+          silent: false,
+        });
+        notification.once("show", () => settle("granted"));
+        notification.once("failed", () => settle("denied"));
+        try {
+          notification.show();
+        } catch {
+          settle(null);
+        }
+      },
+    );
+    this.notificationStatus = status ?? "unknown";
   }
 
   private startPolling(kind: PermissionKind, sender?: WebContents): void {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for avatar-notification-icon.md.

- **Shared avatar-file helper.** `native-notifications.ts` reimplemented `ensureNotificationAvatarFile` with a non-atomic write and a weaker hash rule. It now imports the shared one from `@vellumai/electron-desktop/notification-avatar-file`; the duplicated cache tests are gone and the sender fixture carries a real 64-hex hash.
- **Kill switch and a real gate.** The addon takes over only when it says it can (`getNotifier()?.isSupported()`), not merely because it dlopened, and `VELLUM_DISABLE_NATIVE_NOTIFIER=1` forces the Electron path. Both are documented and tested.
- **Categories registered up front.** `setNotificationCategories:` applies asynchronously, so a category minted in the runloop turn its notification is posted could render without buttons. The addon exports `registerCategories`, `index.ts` calls it once after `configureNotifications` with every action set, and the addon unions with `getNotificationCategoriesWithCompletionHandler:` instead of replacing the centre's set.
- **Delegate ownership and leaks.** `previousDelegate` is strong and handed back by a new `restoreDelegate()` on `before-quit`; the 30 s reassert timer, `reassertDelegate`, and their tests are gone, since the entry-point re-assert in `Show`/`RequestAuthorization` plus the permissions-service routing is the mechanism (stated once in `notifier.mm` and once in the README). `RequestAuthorization` holds its ThreadSafeFunction in a `std::shared_ptr` released when the block is destroyed, and `contentByUpdatingWithProvider:` failures surface as a non-fatal `{ kind: "shown", degraded }` plus an `os_log` with a stable prefix.
- **Entitlement switch keys on the profile, not the env var alone.** `electron-builder.config.cjs` applies the communication entitlements and `provisioningProfile` only when the variable names a file that exists, and throws when it names one that does not; `afterSign.js` reads the decision back off `context.packager.platformSpecificBuildOptions`; the release workflows validate the decoded profile with `security cms -D`. The inert `// @ts-check` pragmas are removed.
- **Permissions-service duplication.** One `settleWithin(timeoutMs, probe)` helper replaces the two copies of the 30 s timeout dance.
- **CI and build hygiene.** The `native` job now runs on main too and gates that file's `checks` aggregate; `build-notifier.sh` clears `resources/notifier` so a stale arch is never packed; `setup` tolerates a notifier build failure while `pack.sh` stays fatal; a new test pins the packaged addon path to `extraResources` `to: "bin/notifier"`; the four unrelated formatting hunks PR 11 introduced in `afterSign.js` are reverted.
- **Event union.** `"dismiss"` is dropped from the JS `NotifierEvent.kind`; the addon keeps its native eviction and JS ignores the event.

## Verification
- Addon rebuilt with zero warnings and smoke-loaded under Electron: exports are `isSupported, registerCategories, requestAuthorization, restoreDelegate, show`.
- `bunx tsc --noEmit` clean; `bun scripts/run-tests.ts` 37/37 files pass.
- `node -c scripts/afterSign.js`; `electron-builder.config.cjs` loads with no env var, loads with the var pointing at a real file (derived plist + profile), and throws with the var pointing at a missing file.
- All four workflows parse as YAML.