### PR TITLE
Fix Windows ARM signing and certificate rotation checks

### DIFF
--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -66,8 +66,8 @@ jobs:
           fi
           echo "sentry_upload=$HAS_SENTRY" >> "$GITHUB_OUTPUT"
 
-  build-and-sign:
-    name: Build and sign (Windows ${{ matrix.arch }})
+  build:
+    name: Build native payload (Windows ${{ matrix.arch }})
     needs: [preflight]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
@@ -157,12 +157,71 @@ jobs:
           SENTRY_ALLOW_UPLOAD_FAILURE: "true"
         run: bun run build:runtime
 
+      - name: Archive native payload
+        shell: bash
+        run: |
+          tar -cf native-build.tar \
+            package.json \
+            resources/cli-runtime \
+            "resources/native-helper/$ELECTRON_TARGET_ARCH" \
+            native/Vellum.PreviewHandler/build/*/Release/Vellum.PreviewHandler.dll \
+            native/Vellum.PreviewHandler/build/*/Release/registration.json
+
+      - name: Upload native payload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-native-${{ matrix.arch }}
+          path: clients/windows/native-build.tar
+          if-no-files-found: error
+          compression-level: 1
+          retention-days: 1
+
+  package-and-sign:
+    name: Package and sign (Windows ${{ matrix.arch }})
+    needs: [build]
+    # Azure Artifact Signing does not support Windows ARM runners.
+    runs-on: windows-2025
+    timeout-minutes: 90
+    environment: ${{ inputs.environment }}
+    continue-on-error: ${{ matrix.arch == 'arm64' && inputs.environment == 'dev' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    defaults:
+      run:
+        working-directory: clients/windows
+    env:
+      ELECTRON_TARGET_ARCH: ${{ matrix.arch }}
+      VELLUM_ENVIRONMENT: ${{ inputs.environment }}
+      WINDOWS_SIGNING_PUBLISHER_NAME: Vocify Inc.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download native payload
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: windows-native-${{ matrix.arch }}
+          path: clients/windows
+
+      - name: Restore native payload and release version
+        shell: bash
+        run: tar -xf native-build.tar
+
       - name: Package and sign NSIS installer
         env:
           SENTRY_DSN_WINDOWS: ${{ secrets.SENTRY_DSN_WINDOWS }}
           WINDOWS_SIGNING_PROVIDER: azure-trusted-signing
           WINDOWS_SIGNING_TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL }}
-          WINDOWS_SIGNING_PUBLISHER_NAME: Vocify Inc.
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
@@ -171,9 +230,7 @@ jobs:
           AZURE_TRUSTED_SIGNING_PROFILE: vellum-assistant
         run: bunx electron-builder --win --config electron-builder.config.cjs --publish never
 
-      # Every binary in the signing manifest (app executable, CLI runtime,
-      # helper, preview-handler DLL) plus the installer must carry a valid
-      # Authenticode signature from one certificate.
+      # Azure rotates certificates; verify the publisher instead of a thumbprint.
       - name: Verify signatures
         shell: pwsh
         run: |
@@ -182,15 +239,15 @@ jobs:
           $appOutDir = if ($arch -eq "x64") { "dist/win-unpacked" } else { "dist/win-$arch-unpacked" }
           $targets = @($manifest.files | ForEach-Object { Join-Path $appOutDir $_.path }) + @($manifest.installers | ForEach-Object { Join-Path "dist" $_.path })
           if ($manifest.installers.Count -lt 1) { throw "signing manifest lists no installer" }
-          $bad = @(); $thumbprints = @{}
+          $bad = @()
           foreach ($file in $targets) {
             $sig = Get-AuthenticodeSignature -FilePath $file
             if ($sig.Status -ne "Valid") { $bad += "$file ($($sig.Status))"; continue }
-            $thumbprints[$sig.SignerCertificate.Thumbprint] = $true
+            $publisher = $sig.SignerCertificate.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
+            if ($publisher -cne $env:WINDOWS_SIGNING_PUBLISHER_NAME) { $bad += "$file (unexpected publisher '$publisher')" }
           }
           if ($bad.Count -gt 0) { throw "Unsigned or invalid signatures:`n$($bad -join "`n")" }
-          if ($thumbprints.Count -ne 1) { throw "Expected one signing certificate, found $($thumbprints.Count)" }
-          Write-Host "Verified $($targets.Count) signatures (certificate $($thumbprints.Keys -join ','))"
+          Write-Host "Verified $($targets.Count) signatures from $env:WINDOWS_SIGNING_PUBLISHER_NAME"
           if (-not (Test-Path "dist/latest.yml")) { throw "electron-builder did not write dist/latest.yml" }
 
       - name: Upload release artifacts
@@ -207,7 +264,7 @@ jobs:
 
   publish:
     name: Publish update feed
-    needs: [preflight, build-and-sign]
+    needs: [preflight, package-and-sign]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: ${{ inputs.environment }}

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -151,12 +151,15 @@ uninstall-tests the installer.
 `.github/workflows/release-windows.yaml` is the reusable release: both
 `dev-release.yaml` and `release.yml` call it with `{ environment, version }`.
 Dev runs on every dev release, while staging and production stay behind the
-`WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED` variables. Per
-architecture (x64 on `windows-2025`, arm64 on the `windows-11-vs2026-arm`
-preview runner) it stamps the version, builds the helper, preview handler,
-CLI runtime, and renderer, packages and signs through `electron-builder`,
-verifies every manifest binary and the installer with
-`Get-AuthenticodeSignature`, and publishes to the
+`WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED` variables. It stamps the version
+and builds the helper, preview handler, CLI runtime, and renderer on native
+runners (x64 on `windows-2025`, arm64 on `windows-11-vs2026-arm`). Each native
+payload and its stamped app manifest transfer to an x64 `windows-2025` runner
+for packaging and signing through `electron-builder`, because
+[Azure Artifact Signing does not support Windows ARM runners](https://github.com/Azure/artifact-signing-action#runner-requirements).
+The workflow verifies every manifest binary and the installer with
+`Get-AuthenticodeSignature`, requiring valid signatures from the configured
+publisher while allowing Azure certificate rotation, and publishes to the
 `vellum-ai-<env>-releases/win-electron/<arch>/` feed: installer and blockmap
 first, then the `<env>.yml` channel manifest. Dev also publishes the installer
 as `vellum-assistant-dev-<arch>.exe` for stable download-page links.


### PR DESCRIPTION
## Summary

- Build the CLI runtime, helper, and preview handler on native x64/ARM64 runners, then transfer those payloads and the stamped app manifest to x64 runners for packaging and signing. Azure Artifact Signing does not support Windows ARM runners, which causes the ARM job's `SignTool failed with exit code 3`.
- Require every manifest binary and installer to have a valid Authenticode signature from the configured publisher. Azure certificate rotation can produce multiple valid thumbprints within one release; the x64 job failed the previous single-thumbprint check after signing succeeded.
- Document the build and signing stages. The existing dev-only ARM failure allowance and staging/production gates are preserved.

## Validation

- `actionlint` passes with only the existing `windows-11-vs2026-arm` label excluded from its outdated runner catalog.
- `git diff --check` passes.
- Checked the payload archive against electron-builder's resource inputs and native target selection. End-to-end signing still requires a Windows release run.
- Evidence: [failed release run](https://github.com/vellum-ai/vellum-assistant/actions/runs/34284807561), [Azure runner requirements](https://github.com/Azure/artifact-signing-action#runner-requirements).

## Original prompt

Finish setting up Windows signing in CD after configuring the shared Azure signing account. The ARM release failed during signing, and the same release's x64 job then rejected valid signatures with two certificate thumbprints. Fix these failures while retaining the shared signing configuration and GitHub credential secrets.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->