### PR TITLE
feat(web): the Chat Info panel, with a See All level per category

### DIFF
--- a/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
@@ -1,0 +1,203 @@
+/**
+ * The Chat Info panel: a conversation's apps, its documents and images, and
+ * the See All grid each category drills into.
+ *
+ * Nothing here is a stand-in. Every story seeds the two sources the panel's
+ * real hooks read (the query cache for apps and documents, the chat-session
+ * store for the transcript the attachments come from), so the rows are built
+ * by the shipped code path and the app tiles render live previews.
+ *
+ * The frame is the shipped drawer, so a story opens at its 400px default and
+ * the rows fit what that width holds. Drag the drawer's left edge to walk the
+ * fit rule out to the mock's wider column.
+ *
+ * Read the phone stories at the Mobile viewports: there the rows become
+ * horizontal strips that run past the panel's body inset to the screen edge.
+ */
+
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { fn, userEvent, within } from "storybook/test";
+
+import {
+  makeMixedAttachments,
+  makePreviewableImages,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import {
+  CHAT_INFO_ASSISTANT_ID,
+  CHAT_INFO_CONVERSATION_ID,
+  chatInfoApps,
+  chatInfoDocuments,
+  chatInfoMessages,
+  resetChatInfoTranscript,
+  seedChatInfoQueries,
+  seedChatInfoTranscript,
+} from "@/domains/chat/components/chat-info-story-fixtures";
+import { DetailPanelStoryFrame } from "@/domains/chat/components/detail-panel-story-frame";
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+import type { ChatInfoCategory } from "@/stores/viewer-store";
+
+import { ChatInfoPanel } from "./chat-info-panel";
+
+interface Conversation {
+  appCount: number;
+  documentCount: number;
+  attachments: DisplayAttachment[];
+}
+
+/** A worked-in trip conversation, the set most stories are shown against. */
+const SMALL_TRIP: Conversation = {
+  appCount: 12,
+  documentCount: 2,
+  attachments: makePreviewableImages(2),
+};
+
+/** A file-heavy conversation, so the Documents & Images grid is worth seeing. */
+const FILE_HEAVY: Conversation = {
+  appCount: 3,
+  documentCount: 3,
+  attachments: [...makePreviewableImages(8), ...makeMixedAttachments()],
+};
+
+function ChatInfoConversation({
+  appCount,
+  documentCount,
+  attachments,
+  children,
+}: Conversation & { children: ReactNode }) {
+  // Own client per story, so one story's conversation cannot leak into the
+  // next through the preview's shared one.
+  const [client] = useState(() => {
+    const created = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    seedChatInfoQueries(created, {
+      apps: chatInfoApps(appCount),
+      documents: chatInfoDocuments(documentCount),
+    });
+    seedChatInfoTranscript(chatInfoMessages(attachments));
+    return created;
+  });
+  useEffect(() => resetChatInfoTranscript, []);
+
+  return (
+    <QueryClientProvider client={client}>
+      <DetailPanelStoryFrame>{children}</DetailPanelStoryFrame>
+    </QueryClientProvider>
+  );
+}
+
+function inConversation(conversation: Conversation): Decorator {
+  return (Story) => (
+    <ChatInfoConversation {...conversation}>
+      <Story />
+    </ChatInfoConversation>
+  );
+}
+
+const meta: Meta<typeof ChatInfoPanel> = {
+  title: "Chat/ChatInfoPanel",
+  component: ChatInfoPanel,
+  parameters: { layout: "fullscreen" },
+  decorators: [inConversation(SMALL_TRIP)],
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: null,
+    },
+    onClose: fn(),
+    onSelectCategory: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatInfoPanel>;
+
+/**
+ * The panel as a working conversation leaves it: twelve apps and four files,
+ * both more than one line of the default-width drawer holds, so each row is
+ * truncated to what fits and offers See All.
+ */
+export const Default: Story = {};
+
+/**
+ * A young conversation, sized to the default drawer: one app and one document,
+ * so every tile is on show and neither header carries a See All.
+ */
+export const FewAssets: Story = {
+  decorators: [
+    inConversation({
+      appCount: 1,
+      documentCount: 1,
+      attachments: [],
+    }),
+  ],
+};
+
+/**
+ * Drilled into Apps: the back control takes the header's leading slot, the
+ * title becomes the category and its total, and every app gets a tile.
+ */
+export const AppsSeeAll: Story = {
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: "apps",
+    },
+  },
+};
+
+/** The same drill-in for Documents & Images, where the tiles wrap rather than grid. */
+export const FilesSeeAll: Story = {
+  decorators: [inConversation(FILE_HEAVY)],
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: "files",
+    },
+  },
+};
+
+/** The phone treatment: each row scrolls horizontally past the screen edge. */
+export const Mobile: Story = {
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+};
+
+/** The same strips on the narrowest phone the app runs on. */
+export const NarrowPhone: Story = {
+  globals: { viewport: { value: "sbNarrowPhone", isRotated: false } },
+};
+
+/**
+ * The drill-in as the app runs it. The args-backed stories cannot show the
+ * transition, because their `onSelectCategory` is a spy; this one owns the
+ * category itself, so See All actually walks the panel to its second level.
+ */
+export const LevelTwoInteraction: StoryObj = {
+  decorators: [inConversation(SMALL_TRIP)],
+  render: function LevelTwoInteraction() {
+    const [category, setCategory] = useState<ChatInfoCategory | null>(null);
+    return (
+      <ChatInfoPanel
+        payload={{
+          assistantId: CHAT_INFO_ASSISTANT_ID,
+          conversationId: CHAT_INFO_CONVERSATION_ID,
+          category,
+        }}
+        onClose={() => setCategory(null)}
+        onSelectCategory={setCategory}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByLabelText("See all apps"));
+    // Finding the back control is the assertion: the second level is up.
+    await canvas.findByLabelText("Back to chat info");
+  },
+};

--- a/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
@@ -1,0 +1,390 @@
+/**
+ * `ChatInfoPanel` at both of its levels: the three category rows, and the
+ * grid a See All drills into.
+ *
+ * The conversation's assets, the row's measured width, and the window-size
+ * axis all arrive through module mocks, since happy-dom reports a zero box for
+ * everything and the real hook would want a daemon behind it. What is left is
+ * what this component owns: which sections exist, where See All appears, which
+ * level renders, and the sequence each tile runs when it is opened.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import type { ReactElement } from "react";
+
+import * as appHtmlCache from "@/utils/app-html-cache";
+import type * as ConversationAssetsModule from "@/domains/chat/hooks/use-conversation-assets";
+import type * as ElementSizeModule from "@/hooks/use-element-size";
+import type * as IsMobileModule from "@/hooks/use-is-mobile";
+import type * as OpenAppModule from "@/domains/chat/hooks/use-open-app-from-chat";
+import type { AppSummary } from "@/types/app-types";
+import type { ChatInfoCategory } from "@/stores/viewer-store";
+import type { DocumentSummary } from "@/types/document-types";
+
+type ConversationAssets = ConversationAssetsModule.ConversationAssets;
+type ConversationFileAsset = ConversationAssetsModule.ConversationFileAsset;
+
+const ASSISTANT_ID = "asst-1";
+const CONVERSATION_ID = "conv-1";
+/** The drawer's body width on the desktop mock: 3 app tiles, 4 file tiles. */
+const DRAWER_WIDTH = 569;
+
+// happy-dom implements neither object URLs nor IntersectionObserver.
+globalThis.URL.createObjectURL = mock(
+  (_obj: Blob | MediaSource): string => "blob:chat-info-panel",
+);
+globalThis.URL.revokeObjectURL = mock((_url: string): void => undefined);
+
+class ImmediateIntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds: number[] = [];
+  constructor(private readonly callback: IntersectionObserverCallback) {}
+  observe(target: Element): void {
+    this.callback(
+      [{ isIntersecting: true, target } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+globalThis.IntersectionObserver =
+  ImmediateIntersectionObserver as unknown as typeof IntersectionObserver;
+
+mock.module(
+  "@/hooks/use-element-size",
+  (): Partial<typeof ElementSizeModule> => ({
+    useElementSize: () => ({ ref: () => {}, size: { w: DRAWER_WIDTH, h: 0 } }),
+  }),
+);
+
+mock.module(
+  "@/hooks/use-is-mobile",
+  (): Partial<typeof IsMobileModule> => ({
+    useIsMobile: () => false,
+    MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+  }),
+);
+
+// The app tile's live preview would otherwise call the daemon's open endpoint.
+mock.module(
+  "@/utils/app-html-cache",
+  (): Partial<typeof appHtmlCache> => ({
+    ...appHtmlCache,
+    getCachedAppHtml: async () => "<!doctype html><title>App</title>",
+  }),
+);
+
+const assetsRef = { value: null as ConversationAssets | null };
+mock.module(
+  "@/domains/chat/hooks/use-conversation-assets",
+  (): Partial<typeof ConversationAssetsModule> => ({
+    useConversationAssets: () => assetsRef.value!,
+  }),
+);
+
+const calls: string[] = [];
+const openApp = mock(async (_appId: string): Promise<void> => {
+  calls.push("openApp");
+});
+mock.module(
+  "@/domains/chat/hooks/use-open-app-from-chat",
+  (): Partial<typeof OpenAppModule> => ({
+    useOpenAppFromChat: () => openApp,
+  }),
+);
+
+const { ChatInfoPanel } =
+  await import("@/domains/chat/components/chat-info-panel");
+const { useViewerStore } = await import("@/stores/viewer-store");
+const { appsGetQueryKey } =
+  await import("@/generated/daemon/@tanstack/react-query.gen");
+const { makeDisplayAttachment, SAMPLE_PREVIEWS } =
+  await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const APPS: AppSummary[] = Array.from({ length: 12 }, (_, index) => ({
+  id: `app-${index + 1}`,
+  name: `App ${index + 1}`,
+  icon: "🧭",
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000 + index,
+  version: "1.0.0",
+  contentId: `content-${index + 1}`,
+  origin: "workspace",
+}));
+
+function makeDoc(surfaceId: string, title: string): DocumentSummary {
+  return {
+    surfaceId,
+    conversationId: CONVERSATION_ID,
+    title,
+    wordCount: 120,
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_001,
+  };
+}
+
+const TRIP_NOTES = makeDoc("surface-trip-notes", "Trip Notes");
+const PACKING_LIST = makeDoc("surface-packing-list", "Packing List");
+
+function documentAsset(doc: DocumentSummary): ConversationFileAsset {
+  return {
+    kind: "document",
+    id: `doc-${doc.surfaceId}`,
+    title: doc.title,
+    doc,
+  };
+}
+
+function imageAsset(index: number): ConversationFileAsset {
+  const attachment = makeDisplayAttachment({
+    id: `img-${index}`,
+    filename: `photo-${index}.png`,
+    previewUrl: SAMPLE_PREVIEWS[index]!,
+  });
+  return {
+    kind: "attachment",
+    id: `att-${attachment.id}`,
+    title: attachment.filename,
+    attachment,
+  };
+}
+
+function frameAsset(index: number): ConversationFileAsset {
+  const attachment = makeDisplayAttachment({
+    id: `frame-${index}`,
+    filename: `frame-${index}.png`,
+    previewUrl: SAMPLE_PREVIEWS[index]!,
+  });
+  return {
+    kind: "frame",
+    id: `frame-${attachment.id}`,
+    title: attachment.filename,
+    attachment,
+    capturedAt: null,
+  };
+}
+
+const FILES: ConversationFileAsset[] = [
+  documentAsset(TRIP_NOTES),
+  documentAsset(PACKING_LIST),
+  imageAsset(0),
+  imageAsset(1),
+];
+const FRAMES: ConversationFileAsset[] = [
+  frameAsset(2),
+  frameAsset(3),
+  frameAsset(4),
+];
+
+const loadMoreFiles = mock((): void => undefined);
+const loadMoreFrames = mock((): void => undefined);
+
+function makeAssets(
+  overrides: Partial<ConversationAssets> = {},
+): ConversationAssets {
+  const apps = overrides.apps ?? APPS;
+  const files = overrides.files ?? FILES;
+  const frames = overrides.frames ?? FRAMES;
+  return {
+    apps,
+    files,
+    frames,
+    counts: { apps: apps.length, files: files.length, frames: frames.length },
+    count: apps.length + files.length + frames.length,
+    hasMoreFiles: false,
+    hasMoreFrames: true,
+    loadMoreFiles,
+    loadMoreFrames,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const closeChatInfo = mock((): void => {
+  calls.push("closeChatInfo");
+});
+const loadDocument = mock(
+  async (_assistantId: string, _surfaceId: string): Promise<void> => {
+    calls.push("loadDocument");
+  },
+);
+
+const onClose = mock((): void => undefined);
+const onSelectCategory = mock(
+  (_category: ChatInfoCategory | null): void => undefined,
+);
+
+function renderPanel(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  // Seeded so an app tile's options menu never reaches the daemon for its pin.
+  client.setQueryData(
+    appsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+    { apps: APPS },
+  );
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+/** Awaited so each app tile's preview html settles inside the test. */
+async function renderChatInfo(
+  category: ChatInfoCategory | null = null,
+): Promise<void> {
+  await act(async () => {
+    renderPanel(
+      <ChatInfoPanel
+        payload={{
+          assistantId: ASSISTANT_ID,
+          conversationId: CONVERSATION_ID,
+          category,
+        }}
+        onClose={onClose}
+        onSelectCategory={onSelectCategory}
+      />,
+    );
+  });
+}
+
+beforeEach(() => {
+  assetsRef.value = makeAssets();
+  calls.length = 0;
+  openApp.mockClear();
+  closeChatInfo.mockClear();
+  loadDocument.mockClear();
+  loadMoreFiles.mockClear();
+  loadMoreFrames.mockClear();
+  onClose.mockClear();
+  onSelectCategory.mockClear();
+  useViewerStore.setState({ closeChatInfo, loadDocument });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ChatInfoPanel top level", () => {
+  test("heads every non-empty category with its title and exact total", async () => {
+    await renderChatInfo();
+
+    expect(screen.getByText("Apps")).toBeDefined();
+    expect(screen.getByText("Documents & Images")).toBeDefined();
+    expect(screen.getByText("Camera Frames")).toBeDefined();
+    expect(screen.getByText("12")).toBeDefined();
+    expect(screen.getByText("4")).toBeDefined();
+    expect(screen.getByText("3")).toBeDefined();
+  });
+
+  test("offers See All only where the total exceeds the fitted row", async () => {
+    await renderChatInfo();
+
+    expect(screen.getByLabelText("See all apps")).toBeDefined();
+    expect(screen.queryByLabelText("See all documents and images")).toBeNull();
+  });
+
+  test("drills into a category from its See All control", async () => {
+    await renderChatInfo();
+
+    fireEvent.click(screen.getByLabelText("See all apps"));
+
+    expect(onSelectCategory).toHaveBeenCalledWith("apps");
+  });
+
+  test("closes from the header control", async () => {
+    await renderChatInfo();
+
+    fireEvent.click(screen.getByLabelText("Close chat info"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("leaves the panel before opening an app", async () => {
+    await renderChatInfo();
+
+    fireEvent.click(screen.getByLabelText("Open App 1"));
+
+    expect(calls).toEqual(["closeChatInfo", "openApp"]);
+    expect(openApp).toHaveBeenCalledWith("app-1");
+  });
+
+  test("leaves the panel before opening a document", async () => {
+    await renderChatInfo();
+
+    fireEvent.click(screen.getByLabelText("Open Trip Notes"));
+
+    expect(calls).toEqual(["closeChatInfo", "loadDocument"]);
+    expect(loadDocument).toHaveBeenCalledWith(
+      ASSISTANT_ID,
+      TRIP_NOTES.surfaceId,
+    );
+  });
+
+  test("opens an image attachment in the shared preview, panel still open", async () => {
+    await renderChatInfo();
+
+    fireEvent.click(screen.getByLabelText("Preview photo-0.png"));
+
+    expect(screen.getByRole("dialog")).toBeDefined();
+    expect(closeChatInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChatInfoPanel See All level", () => {
+  test("lists every tile in the category and offers a way back", async () => {
+    await renderChatInfo("apps");
+
+    expect(screen.getAllByLabelText(/^Open App \d+$/)).toHaveLength(12);
+
+    fireEvent.click(screen.getByLabelText("Back to chat info"));
+
+    expect(onSelectCategory).toHaveBeenCalledWith(null);
+  });
+
+  test("grows a paged category from its Load more control", async () => {
+    await renderChatInfo("frames");
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    expect(loadMoreFrames).toHaveBeenCalledTimes(1);
+    expect(loadMoreFiles).not.toHaveBeenCalled();
+  });
+
+  test("holds no Load more for a category that has everything", async () => {
+    await renderChatInfo("files");
+
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
+
+  test("falls back to the top level once the category empties", async () => {
+    assetsRef.value = makeAssets({ apps: [] });
+    await renderChatInfo("apps");
+
+    expect(screen.getByText("Chat Info")).toBeDefined();
+    expect(screen.queryByLabelText("Back to chat info")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -1,0 +1,297 @@
+/**
+ * The Chat Info panel: a conversation's apps, its documents and images, and
+ * its camera frames, each as one fitted row of tiles.
+ *
+ * A category holding more than the row shows offers See All, which drills into
+ * a second level inside this same panel: the back control takes the header's
+ * leading slot, the title becomes "Category · N", and the body becomes a
+ * wrapping grid of the whole category. The drilled-in category lives in the
+ * payload, so a remount of the mobile overlay cannot lose it.
+ */
+
+import { ChevronLeft, Layers } from "lucide-react";
+import type { ReactNode } from "react";
+import { useCallback, useMemo } from "react";
+
+import { Button, Typography } from "@vellumai/design-library";
+
+import { DeleteAppDialog } from "@/components/delete-app-dialog";
+import {
+  DetailShell,
+  type DetailShellHeaderProps,
+} from "@/components/detail-shell";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import {
+  CHAT_INFO_APP_TILE_WIDTH_PX,
+  ChatInfoAppTile,
+} from "@/domains/chat/components/chat-info-app-tile";
+import {
+  CHAT_INFO_FILE_TILE_WIDTH_PX,
+  ChatInfoFileTile,
+} from "@/domains/chat/components/chat-info-file-tile";
+import { ChatInfoSection } from "@/domains/chat/components/chat-info-section";
+import {
+  type ConversationFileAsset,
+  useConversationAssets,
+} from "@/domains/chat/hooks/use-conversation-assets";
+import { useOpenAppFromChat } from "@/domains/chat/hooks/use-open-app-from-chat";
+import { useAppDelete } from "@/hooks/use-app-delete";
+import { useTranslation } from "@/i18n";
+import {
+  type ChatInfoCategory,
+  type ChatInfoPayload,
+  useViewerStore,
+} from "@/stores/viewer-store";
+import { haptic } from "@/utils/haptics";
+
+export interface ChatInfoPanelProps {
+  payload: ChatInfoPayload;
+  onClose: () => void;
+  /** See All drills in with a category; the back control passes `null`. */
+  onSelectCategory: (category: ChatInfoCategory | null) => void;
+}
+
+/** The drilled-in header's title cluster: title · N, as every detail panel draws it. */
+function TitleWithCount({ title, count }: { title: string; count: number }) {
+  return (
+    <span className="flex min-w-0 items-center gap-1.5 py-0.5">
+      <Typography
+        variant="title-medium"
+        className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
+      >
+        {title}
+      </Typography>
+      <span
+        aria-hidden
+        className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
+      />
+      <Typography
+        variant="title-medium"
+        className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"
+      >
+        {count}
+      </Typography>
+    </span>
+  );
+}
+
+export function ChatInfoPanel({
+  payload,
+  onClose,
+  onSelectCategory,
+}: ChatInfoPanelProps) {
+  const { t } = useTranslation("chat");
+  const { assistantId, conversationId } = payload;
+
+  // No `refreshKey`: the header trigger owns invalidation.
+  const {
+    apps,
+    files,
+    frames,
+    counts,
+    hasMoreFiles,
+    hasMoreFrames,
+    loadMoreFiles,
+    loadMoreFrames,
+  } = useConversationAssets({ assistantId, conversationId });
+
+  // The gallery spans both file categories, so arrowing out of the frames
+  // grid walks into the conversation's own photos rather than stopping.
+  const previewable = useMemo(
+    () =>
+      [...files, ...frames].flatMap((file) =>
+        file.kind === "document" ? [] : [file.attachment],
+      ),
+    [files, frames],
+  );
+  const { openPreview, previewModal } = useAttachmentPreview(
+    assistantId,
+    previewable,
+  );
+
+  const appDelete = useAppDelete(assistantId);
+  const openApp = useOpenAppFromChat();
+
+  // Closing first returns the viewer to whatever the panel was opened from,
+  // so the asset lands there rather than behind the panel.
+  const handleOpenApp = useCallback(
+    (appId: string) => {
+      useViewerStore.getState().closeChatInfo();
+      void openApp(appId);
+    },
+    [openApp],
+  );
+
+  const handleOpenFile = useCallback(
+    (file: ConversationFileAsset) => {
+      if (file.kind === "document") {
+        haptic.light();
+        useViewerStore.getState().closeChatInfo();
+        void useViewerStore
+          .getState()
+          .loadDocument(assistantId, file.doc.surfaceId);
+        return;
+      }
+      // The modal sits above the panel, so the panel stays open behind it.
+      openPreview(file.attachment);
+    },
+    [assistantId, openPreview],
+  );
+
+  const categoryTitles: Record<ChatInfoCategory, string> = {
+    apps: t("chatInfoPanel.appsTitle"),
+    files: t("chatInfoPanel.filesTitle"),
+    frames: t("chatInfoPanel.framesTitle"),
+  };
+  const categoryLists = { apps, files, frames };
+
+  // A category emptied while drilled in (the last app deleted) falls back to
+  // the top level rather than rendering an empty page.
+  const level =
+    payload.category !== null && categoryLists[payload.category].length > 0
+      ? payload.category
+      : null;
+
+  const renderFileSection = (category: "files" | "frames") => {
+    const items = categoryLists[category];
+    if (items.length === 0) {
+      return null;
+    }
+    return (
+      <ChatInfoSection
+        title={categoryTitles[category]}
+        count={counts[category]}
+        items={items}
+        tileWidth={CHAT_INFO_FILE_TILE_WIDTH_PX}
+        seeAllAriaLabel={
+          category === "files"
+            ? t("chatInfoPanel.seeAllFilesAria")
+            : t("chatInfoPanel.seeAllFramesAria")
+        }
+        onSeeAll={() => onSelectCategory(category)}
+        renderTile={(file) => (
+          <ChatInfoFileTile
+            key={file.id}
+            file={file}
+            assistantId={assistantId}
+            onOpen={handleOpenFile}
+          />
+        )}
+      />
+    );
+  };
+
+  let body: ReactNode;
+  if (level === "apps") {
+    body = (
+      <div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(184px,1fr))]">
+        {apps.map((app) => (
+          <ChatInfoAppTile
+            key={app.id}
+            app={app}
+            assistantId={assistantId}
+            stretch
+            onOpen={handleOpenApp}
+            onRequestDelete={appDelete.requestDelete}
+          />
+        ))}
+      </div>
+    );
+  } else if (level !== null) {
+    const items = categoryLists[level];
+    const hasMore = level === "files" ? hasMoreFiles : hasMoreFrames;
+    const loadMore = level === "files" ? loadMoreFiles : loadMoreFrames;
+    body = (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap gap-2">
+          {items.map((file) => (
+            <ChatInfoFileTile
+              key={file.id}
+              file={file}
+              assistantId={assistantId}
+              onOpen={handleOpenFile}
+            />
+          ))}
+        </div>
+        {hasMore && (
+          <Button variant="outlined" onClick={loadMore} className="self-start">
+            {t("chatInfoPanel.loadMore")}
+          </Button>
+        )}
+      </div>
+    );
+  } else {
+    body = (
+      <div className="flex flex-col gap-8">
+        {apps.length > 0 && (
+          <ChatInfoSection
+            title={categoryTitles.apps}
+            count={counts.apps}
+            items={apps}
+            tileWidth={CHAT_INFO_APP_TILE_WIDTH_PX}
+            seeAllAriaLabel={t("chatInfoPanel.seeAllAppsAria")}
+            onSeeAll={() => onSelectCategory("apps")}
+            renderTile={(app, _index, layout) => (
+              <ChatInfoAppTile
+                key={app.id}
+                app={app}
+                assistantId={assistantId}
+                stretch={layout === "fitted"}
+                onOpen={handleOpenApp}
+                onRequestDelete={appDelete.requestDelete}
+              />
+            )}
+          />
+        )}
+        {renderFileSection("files")}
+        {renderFileSection("frames")}
+      </div>
+    );
+  }
+
+  const headerProps: Pick<
+    DetailShellHeaderProps,
+    "Glyph" | "icon" | "title" | "titleNode"
+  > =
+    level === null
+      ? { Glyph: Layers, title: t("chatInfoPanel.title") }
+      : {
+          // The back control takes the leading slot the glyph would occupy,
+          // matching the activity-steps, subagent, and ACP run panels.
+          icon: (
+            <Button
+              variant="outlined"
+              iconOnly={<ChevronLeft />}
+              aria-label={t("chatInfoPanel.backAria")}
+              tooltip={t("chatInfoPanel.backTooltip")}
+              onClick={() => onSelectCategory(null)}
+              className="shrink-0"
+            />
+          ),
+          titleNode: (
+            <TitleWithCount
+              title={categoryTitles[level]}
+              count={counts[level]}
+            />
+          ),
+        };
+
+  return (
+    <DetailShell
+      {...headerProps}
+      closeLabel={t("chatInfoPanel.closeAria")}
+      closeTooltip={t("chatInfoPanel.closeAria")}
+      onClose={onClose}
+    >
+      {body}
+      {/* Both overlays live in the body so a level switch cannot unmount them. */}
+      {previewModal}
+      <DeleteAppDialog
+        app={appDelete.pendingDelete}
+        isDeleting={appDelete.isDeleting}
+        onConfirm={appDelete.confirmDelete}
+        onCancel={appDelete.cancelDelete}
+      />
+    </DetailShell>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.ts
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.ts
@@ -1,0 +1,203 @@
+/**
+ * Fixtures for the Chat Info stories.
+ *
+ * The panel reads its assets through the real hooks, so a story has to fill
+ * the two sources those hooks go to: the query cache holds the conversation's
+ * apps and documents, and the chat-session store holds the transcript the
+ * attachments are derived from. Everything here seeds one of those, so the
+ * panel story and the mobile-overlay story can show the same conversation.
+ *
+ * No JSX and no test-runner import: this is data plus the calls that install
+ * it, and the decorators that use it live in the story files.
+ */
+
+import type { QueryClient } from "@tanstack/react-query";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import type {
+  DisplayAttachment,
+  DisplayMessage,
+} from "@/domains/chat/types/types";
+import {
+  appsGetQueryKey,
+  documentsGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { AppSummary } from "@/types/app-types";
+import type { DocumentSummary } from "@/types/document-types";
+import { primeAppHtmlCache } from "@/utils/app-html-cache";
+
+export const CHAT_INFO_ASSISTANT_ID = "story-assistant";
+export const CHAT_INFO_CONVERSATION_ID = "story-conversation";
+
+const T0 = 1_760_000_000_000;
+
+/** Name, icon, and preview lines for each app a story can ask for. */
+const APP_SEEDS: Array<{ name: string; icon: string; lines: string[] }> = [
+  {
+    name: "Trip Planner",
+    icon: "🧭",
+    lines: ["Book the ferry", "Pack a rain shell", "Confirm the tour"],
+  },
+  {
+    name: "Packing List",
+    icon: "🧳",
+    lines: ["Rain shell", "Walking boots", "Ferry tickets"],
+  },
+  {
+    name: "Ferry Times",
+    icon: "⛴️",
+    lines: ["07:40 harbour", "11:15 harbour", "16:50 harbour"],
+  },
+  {
+    name: "Harbour Map",
+    icon: "🗺️",
+    lines: ["Pier 3 departures", "Long stay parking", "Ticket office"],
+  },
+  {
+    name: "Tide Table",
+    icon: "🌊",
+    lines: ["High 06:12", "Low 12:38", "High 18:47"],
+  },
+  {
+    name: "Weather Watch",
+    icon: "🌦️",
+    lines: ["Showers by noon", "Gusts 24 knots", "Clearing overnight"],
+  },
+  {
+    name: "Budget Tracker",
+    icon: "💷",
+    lines: ["Ferry 42", "Guesthouse 118", "Meals 64"],
+  },
+  {
+    name: "Coastal Walks",
+    icon: "🥾",
+    lines: ["Cliff loop 6km", "Lighthouse 9km", "Dune path 3km"],
+  },
+  {
+    name: "Bird Log",
+    icon: "🐦",
+    lines: ["Guillemot", "Fulmar", "Oystercatcher"],
+  },
+  {
+    name: "Photo Picks",
+    icon: "📷",
+    lines: ["Dawn harbour", "Ferry deck", "Cliff path"],
+  },
+  {
+    name: "Reading List",
+    icon: "📚",
+    lines: ["Island histories", "Tidal atlas", "Seabird guide"],
+  },
+  {
+    name: "Field Notes",
+    icon: "📓",
+    lines: ["Wind picked up", "Colony nesting", "Fog off the point"],
+  },
+];
+
+/** A small page for the preview iframe, in system colours so it reads in either theme. */
+function previewHtml(title: string, lines: string[]): string {
+  const items = lines.map((line) => `<li>${line}</li>`).join("");
+  return `<!doctype html><meta charset="utf-8"><title>${title}</title><style>body{margin:0;padding:24px;font-family:system-ui,sans-serif;background:Canvas;color:CanvasText}h1{margin:0 0 12px;font-size:28px}ul{margin:0;padding-left:22px;font-size:18px;line-height:1.7}</style><h1>${title}</h1><ul>${items}</ul>`;
+}
+
+/** The first `count` fixture apps, newest first. */
+export function chatInfoApps(count: number): AppSummary[] {
+  return APP_SEEDS.slice(0, count).map((seed, index) => ({
+    id: `app-${index + 1}`,
+    name: seed.name,
+    icon: seed.icon,
+    createdAt: T0,
+    updatedAt: T0 + (count - index) * 1_000,
+    version: "1.0.0",
+    contentId: `content-${index + 1}`,
+    origin: "workspace",
+  }));
+}
+
+const DOCUMENT_TITLES = [
+  "Trip Notes",
+  "Harbour Itinerary",
+  "Ferry Booking Summary",
+];
+
+/** The first `count` fixture documents, newest first. */
+export function chatInfoDocuments(count: number): DocumentSummary[] {
+  return DOCUMENT_TITLES.slice(0, count).map((title, index) => ({
+    surfaceId: `surface-${index + 1}`,
+    conversationId: CHAT_INFO_CONVERSATION_ID,
+    title,
+    wordCount: 320 + index * 140,
+    createdAt: T0,
+    updatedAt: T0 + (count - index) * 1_000,
+  }));
+}
+
+/**
+ * Two transcript rows carrying `attachments`: the user's upload, then the
+ * assistant's reply. This is the source `useConversationAttachments` reads,
+ * so the panel's Documents & Images row lists exactly these files.
+ */
+export function chatInfoMessages(
+  attachments: DisplayAttachment[],
+): DisplayMessage[] {
+  const half = Math.ceil(attachments.length / 2);
+  return [
+    {
+      id: "msg-user",
+      role: "user",
+      timestamp: T0,
+      textSegments: ["Here are the shots from the harbour."],
+      contentOrder: [{ type: "text", id: "0" }],
+      attachments: attachments.slice(0, half),
+    },
+    {
+      id: "msg-assistant",
+      role: "assistant",
+      timestamp: T0 + 1_000,
+      textSegments: ["Added them to the trip notes."],
+      contentOrder: [{ type: "text", id: "0" }],
+      attachments: attachments.slice(half),
+    },
+  ];
+}
+
+/**
+ * Fills the query cache the way the daemon would, and primes each app's html
+ * so the tiles render a live preview instead of the icon placeholder.
+ */
+export function seedChatInfoQueries(
+  client: QueryClient,
+  { apps, documents }: { apps: AppSummary[]; documents: DocumentSummary[] },
+): void {
+  const path = { assistant_id: CHAT_INFO_ASSISTANT_ID };
+  const query = { conversationId: CHAT_INFO_CONVERSATION_ID };
+  client.setQueryData(appsGetQueryKey({ path, query }), { apps });
+  // The app options menu reads the unscoped list to know whether a pin exists.
+  client.setQueryData(appsGetQueryKey({ path }), { apps });
+  client.setQueryData(documentsGetQueryKey({ path, query }), { documents });
+  for (const [index, app] of apps.entries()) {
+    const seed = APP_SEEDS[index % APP_SEEDS.length]!;
+    primeAppHtmlCache(
+      CHAT_INFO_ASSISTANT_ID,
+      app.id,
+      previewHtml(app.name, seed.lines),
+    );
+  }
+}
+
+/** Installs `messages` as the rendered transcript. */
+export function seedChatInfoTranscript(messages: DisplayMessage[]): void {
+  useChatSessionStore.getState().seedSnapshot(CHAT_INFO_CONVERSATION_ID, {
+    messages,
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+    seq: 1,
+  });
+}
+
+/** Drops the seeded transcript, so a story cannot leak into the next one. */
+export function resetChatInfoTranscript(): void {
+  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+}


### PR DESCRIPTION
## Summary
- `ChatInfoPanel`: Apps, Documents & Images, and Camera Frames rows built from the shared section and tiles, with See All drilling into a per-category grid (back control, Load more for paged categories)
- Opens apps and documents the way the header pill does; attachments and frames open the shared preview modal
- Stories seed the real hooks (query cache plus the chat session store) and cover both levels and the mobile strips

Part of plan: chat-info-assets-panel.md (PR 7 of 12)