### PR TITLE
feat(web): render the chat-info view in the right drawer and as a mobile overlay

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -17,7 +17,6 @@ import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-dr
 import { ProgressStack } from "@/domains/chat/components/progress-stack";
 import { SideControlPlacementBoundary } from "@/domains/chat/components/side-control-placement";
 import { LazyBoundary } from "@/components/lazy-boundary";
-import { chatInfoPanelKey } from "@/domains/chat/components/chat-info-panel";
 import { AppViewerContainer } from "@/components/app-viewer-container";
 import { DocumentViewerContainer } from "@/domains/chat/components/document-viewer-container";
 import { FilePreviewContainer } from "@/domains/chat/components/local-file/preview/file-preview-container";
@@ -31,7 +30,7 @@ import { useConversationStore } from "@/stores/conversation-store";
 import { paneState } from "@/stores/pane-state";
 import { WorkspacePanes } from "@/domains/chat/components/workspace-panes";
 import { useDeployStore } from "@/stores/deploy-store";
-import { useViewerStore } from "@/stores/viewer-store";
+import { chatInfoTargetKey, useViewerStore } from "@/stores/viewer-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
@@ -583,7 +582,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
               than reusing one whose preview and delete state belong to the
               previous chat. */}
           <ChatInfoPanel
-            key={chatInfoPanelKey(activeChatInfo)}
+            key={chatInfoTargetKey(activeChatInfo)}
             payload={activeChatInfo}
             onClose={closeChatInfo}
             onSelectCategory={setChatInfoCategory}

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -17,6 +17,7 @@ import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-dr
 import { ProgressStack } from "@/domains/chat/components/progress-stack";
 import { SideControlPlacementBoundary } from "@/domains/chat/components/side-control-placement";
 import { LazyBoundary } from "@/components/lazy-boundary";
+import { chatInfoPanelKey } from "@/domains/chat/components/chat-info-panel";
 import { AppViewerContainer } from "@/components/app-viewer-container";
 import { DocumentViewerContainer } from "@/domains/chat/components/document-viewer-container";
 import { FilePreviewContainer } from "@/domains/chat/components/local-file/preview/file-preview-container";
@@ -582,7 +583,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
               than reusing one whose preview and delete state belong to the
               previous chat. */}
           <ChatInfoPanel
-            key={activeChatInfo.conversationId}
+            key={chatInfoPanelKey(activeChatInfo)}
             payload={activeChatInfo}
             onClose={closeChatInfo}
             onSelectCategory={setChatInfoCategory}

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -6,8 +6,8 @@
  * and hands the surfaces to `WorkspacePanes`, which draws them. Side panels
  * and overlays keep their own shells.
  *
- * Side-panel state (app, document, subagent, tool-detail) is read directly
- * from stores — no props required for layout decisions.
+ * Side-panel state (app, document, subagent, tool-detail, chat-info) is read
+ * directly from stores: no props required for layout decisions.
  */
 
 import { lazy, useCallback, useEffect, type ReactNode } from "react";
@@ -53,6 +53,8 @@ const importActivityStepsPanel = () =>
   import("@/domains/chat/components/activity-steps-panel");
 const importMessageFilesPanel = () =>
   import("@/domains/chat/components/message-files-panel");
+const importChatInfoPanel = () =>
+  import("@/domains/chat/components/chat-info-panel");
 const importAcpRunDetailPanel = () =>
   import("@/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel");
 const importWorkflowDetailPanel = () =>
@@ -81,6 +83,9 @@ const ActivityStepsPanel = lazy(() =>
 );
 const MessageFilesPanel = lazy(() =>
   importMessageFilesPanel().then((m) => ({ default: m.MessageFilesPanel })),
+);
+const ChatInfoPanel = lazy(() =>
+  importChatInfoPanel().then((m) => ({ default: m.ChatInfoPanel })),
 );
 const BackgroundTaskDetailPanel = lazy(() =>
   importBackgroundTaskDetailPanel().then((m) => ({
@@ -116,6 +121,9 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   const closeActivitySteps = useViewerStore.use.closeActivitySteps();
   const activeMessageFiles = useViewerStore.use.activeMessageFiles();
   const closeMessageFiles = useViewerStore.use.closeMessageFiles();
+  const activeChatInfo = useViewerStore.use.activeChatInfo();
+  const closeChatInfo = useViewerStore.use.closeChatInfo();
+  const setChatInfoCategory = useViewerStore.use.setChatInfoCategory();
   // Subscribe to only the active subagent's entry rather than the whole `byId`
   // map, so streaming events from *other* subagents don't re-render the chat
   // layout (and the chat transcript it hosts) on every token.
@@ -348,6 +356,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       importToolDetailPanel().catch(() => {});
       importActivityStepsPanel().catch(() => {});
       importMessageFilesPanel().catch(() => {});
+      importChatInfoPanel().catch(() => {});
       importAcpRunDetailPanel().catch(() => {});
       importWorkflowDetailPanel().catch(() => {});
       importBackgroundTaskDetailPanel().catch(() => {});
@@ -448,8 +457,8 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     </SideControlPlacementBoundary>
   );
 
-  // Right-hand detail panels — document viewer, subagent detail, tool detail,
-  // and workflow detail — all share ONE AnimatedRightDrawer so the chat
+  // Right-hand detail panels (document viewer, subagent detail, tool detail,
+  // workflow detail, chat info) all share ONE AnimatedRightDrawer so the chat
   // (`left`) keeps a stable position in the React tree and is NEVER unmounted
   // when a panel opens, closes, or switches between them. Only the (lazy,
   // lightweight) right-pane subtree changes; the transcript keeps its DOM and
@@ -563,6 +572,20 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             key={activeMessageFiles.messageId}
             payload={activeMessageFiles}
             onClose={closeMessageFiles}
+          />
+        </LazyBoundary>
+      );
+    } else if (mainView === "chat-info" && activeChatInfo) {
+      rightPanel = (
+        <LazyBoundary>
+          {/* Re-key per conversation so a switch remounts the panel rather
+              than reusing one whose preview and delete state belong to the
+              previous chat. */}
+          <ChatInfoPanel
+            key={activeChatInfo.conversationId}
+            payload={activeChatInfo}
+            onClose={closeChatInfo}
+            onSelectCategory={setChatInfoCategory}
           />
         </LazyBoundary>
       );

--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -51,17 +51,6 @@ export interface ChatInfoPanelProps {
   onSelectCategory: (category: ChatInfoCategory | null) => void;
 }
 
-/**
- * The React key a host gives the panel. Conversation ids are assistant-scoped,
- * so a retarget to another assistant remounts the panel rather than carrying
- * its preview and pending-delete state across.
- */
-export function chatInfoPanelKey(
-  payload: Pick<ChatInfoPayload, "assistantId" | "conversationId">,
-): string {
-  return `${payload.assistantId}:${payload.conversationId}`;
-}
-
 /** The drilled-in header's title cluster: title · N, as every detail panel draws it. */
 function TitleWithCount({ title, count }: { title: string; count: number }) {
   return (

--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -51,6 +51,17 @@ export interface ChatInfoPanelProps {
   onSelectCategory: (category: ChatInfoCategory | null) => void;
 }
 
+/**
+ * The React key a host gives the panel. Conversation ids are assistant-scoped,
+ * so a retarget to another assistant remounts the panel rather than carrying
+ * its preview and pending-delete state across.
+ */
+export function chatInfoPanelKey(
+  payload: Pick<ChatInfoPayload, "assistantId" | "conversationId">,
+): string {
+  return `${payload.assistantId}:${payload.conversationId}`;
+}
+
 /** The drilled-in header's title cluster: title · N, as every detail panel draws it. */
 function TitleWithCount({ title, count }: { title: string; count: number }) {
   return (

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.stories.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.stories.tsx
@@ -1,0 +1,97 @@
+/**
+ * The phone host for Chat Info: the same panel the drawer shows, given the
+ * whole screen.
+ *
+ * There is no frame around it. The overlay is `position: fixed` under the
+ * safe-area inset, so what these stories document is the presentation itself:
+ * the panel's own header sits at the top of the viewport and its rows run to
+ * both screen edges, with no drawer chrome and nothing of the chat behind it.
+ *
+ * The conversation comes from the shared Chat Info fixtures, so this shows the
+ * same apps, documents, and images the panel stories do, built by the panel's
+ * real hooks rather than a stand-in.
+ *
+ * Only ever mounted on a narrow window, hence the Mobile viewport on the meta.
+ */
+
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { fn } from "storybook/test";
+
+import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import {
+  CHAT_INFO_ASSISTANT_ID,
+  CHAT_INFO_CONVERSATION_ID,
+  chatInfoApps,
+  chatInfoDocuments,
+  chatInfoMessages,
+  resetChatInfoTranscript,
+  seedChatInfoQueries,
+  seedChatInfoTranscript,
+} from "@/domains/chat/components/chat-info-story-fixtures";
+
+import { MobileChatInfoOverlay } from "./mobile-chat-info-overlay";
+
+/** Seeds the two sources the panel's hooks read, on a client of this story's own. */
+const inConversation: Decorator = function InConversation(Story) {
+  const [client] = useState(() => {
+    const created = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    seedChatInfoQueries(created, {
+      apps: chatInfoApps(12),
+      documents: chatInfoDocuments(2),
+    });
+    seedChatInfoTranscript(chatInfoMessages(makePreviewableImages(2)));
+    return created;
+  });
+  useEffect(() => resetChatInfoTranscript, []);
+
+  return (
+    <QueryClientProvider client={client}>
+      <Story />
+    </QueryClientProvider>
+  );
+};
+
+const meta: Meta<typeof MobileChatInfoOverlay> = {
+  title: "Chat/MobileChatInfoOverlay",
+  component: MobileChatInfoOverlay,
+  parameters: { layout: "fullscreen" },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+  decorators: [inConversation],
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: null,
+    },
+    onClose: fn(),
+    onSelectCategory: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MobileChatInfoOverlay>;
+
+/**
+ * The top level, full screen: every category shows one row of tiles that
+ * scrolls horizontally past the screen edge, and the close control is the
+ * panel's own.
+ */
+export const Open: Story = {};
+
+/**
+ * Drilled into Apps. The level lives in the payload rather than the panel, so
+ * the overlay can remount without losing it.
+ */
+export const AppsLevel: Story = {
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: "apps",
+    },
+  },
+};

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.test.tsx
@@ -33,7 +33,9 @@ mock.module(
         mountCount += 1;
       }, []);
       return (
-        <div data-testid={`panel-${payload.assistantId}-${payload.conversationId}`}>
+        <div
+          data-testid={`panel-${payload.assistantId}-${payload.conversationId}`}
+        >
           {payload.conversationId}
         </div>
       );
@@ -84,7 +86,11 @@ describe("MobileChatInfoOverlay", () => {
       />,
     );
     expect(
-      await screen.findByTestId("panel-assistant-1-conv-1", undefined, LAZY_WAIT),
+      await screen.findByTestId(
+        "panel-assistant-1-conv-1",
+        undefined,
+        LAZY_WAIT,
+      ),
     ).toBeDefined();
   });
 

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for `MobileChatInfoOverlay`, the mobile full-screen host for the
+ * chat-info panel.
+ *
+ * The panel itself is stubbed: what the host owns is whether it renders at
+ * all, and whether a conversation switch remounts what it hosts rather than
+ * feeding a new payload into a panel still holding the previous chat's
+ * preview and delete state.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+
+import type * as ChatInfoPanelModule from "@/domains/chat/components/chat-info-panel";
+import type { ChatInfoPayload } from "@/stores/viewer-store";
+
+let mountCount = 0;
+
+mock.module(
+  "@/domains/chat/components/chat-info-panel",
+  (): Partial<typeof ChatInfoPanelModule> => ({
+    ChatInfoPanel: ({ payload }) => {
+      useEffect(() => {
+        mountCount += 1;
+      }, []);
+      return (
+        <div data-testid={`panel-${payload.conversationId}`}>
+          {payload.conversationId}
+        </div>
+      );
+    },
+  }),
+);
+
+const { MobileChatInfoOverlay } =
+  await import("@/domains/chat/components/mobile-chat-info-overlay");
+
+const noop = () => {};
+
+// The panel is lazy-loaded behind a LazyBoundary, so first paint can exceed
+// findBy's 1000ms default under CI load.
+const LAZY_WAIT = { timeout: 5000 };
+
+function makePayload(conversationId: string): ChatInfoPayload {
+  return {
+    assistantId: "assistant-1",
+    conversationId,
+    category: null,
+  };
+}
+
+beforeEach(() => {
+  mountCount = 0;
+});
+afterEach(cleanup);
+afterAll(() => mock.restore());
+
+describe("MobileChatInfoOverlay", () => {
+  test("renders nothing when payload is null", () => {
+    const { container } = render(
+      <MobileChatInfoOverlay
+        payload={null}
+        onClose={noop}
+        onSelectCategory={noop}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test("renders the panel when given a payload", async () => {
+    render(
+      <MobileChatInfoOverlay
+        payload={makePayload("conv-1")}
+        onClose={noop}
+        onSelectCategory={noop}
+      />,
+    );
+    expect(
+      await screen.findByTestId("panel-conv-1", undefined, LAZY_WAIT),
+    ).toBeDefined();
+  });
+
+  test("switching conversation remounts the panel", async () => {
+    const { rerender } = render(
+      <MobileChatInfoOverlay
+        payload={makePayload("conv-1")}
+        onClose={noop}
+        onSelectCategory={noop}
+      />,
+    );
+    await screen.findByTestId("panel-conv-1", undefined, LAZY_WAIT);
+    expect(mountCount).toBe(1);
+
+    rerender(
+      <MobileChatInfoOverlay
+        payload={makePayload("conv-2")}
+        onClose={noop}
+        onSelectCategory={noop}
+      />,
+    );
+    await screen.findByTestId("panel-conv-2", undefined, LAZY_WAIT);
+    expect(screen.queryByTestId("panel-conv-1")).toBeNull();
+    expect(mountCount).toBe(2);
+  });
+});

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.test.tsx
@@ -33,7 +33,7 @@ mock.module(
         mountCount += 1;
       }, []);
       return (
-        <div data-testid={`panel-${payload.conversationId}`}>
+        <div data-testid={`panel-${payload.assistantId}-${payload.conversationId}`}>
           {payload.conversationId}
         </div>
       );
@@ -50,12 +50,11 @@ const noop = () => {};
 // findBy's 1000ms default under CI load.
 const LAZY_WAIT = { timeout: 5000 };
 
-function makePayload(conversationId: string): ChatInfoPayload {
-  return {
-    assistantId: "assistant-1",
-    conversationId,
-    category: null,
-  };
+function makePayload(
+  conversationId: string,
+  assistantId = "assistant-1",
+): ChatInfoPayload {
+  return { assistantId, conversationId, category: null };
 }
 
 beforeEach(() => {
@@ -85,7 +84,7 @@ describe("MobileChatInfoOverlay", () => {
       />,
     );
     expect(
-      await screen.findByTestId("panel-conv-1", undefined, LAZY_WAIT),
+      await screen.findByTestId("panel-assistant-1-conv-1", undefined, LAZY_WAIT),
     ).toBeDefined();
   });
 
@@ -97,7 +96,7 @@ describe("MobileChatInfoOverlay", () => {
         onSelectCategory={noop}
       />,
     );
-    await screen.findByTestId("panel-conv-1", undefined, LAZY_WAIT);
+    await screen.findByTestId("panel-assistant-1-conv-1", undefined, LAZY_WAIT);
     expect(mountCount).toBe(1);
 
     rerender(
@@ -107,8 +106,30 @@ describe("MobileChatInfoOverlay", () => {
         onSelectCategory={noop}
       />,
     );
-    await screen.findByTestId("panel-conv-2", undefined, LAZY_WAIT);
-    expect(screen.queryByTestId("panel-conv-1")).toBeNull();
+    await screen.findByTestId("panel-assistant-1-conv-2", undefined, LAZY_WAIT);
+    expect(screen.queryByTestId("panel-assistant-1-conv-1")).toBeNull();
+    expect(mountCount).toBe(2);
+  });
+
+  test("switching assistant remounts the panel for the same conversation id", async () => {
+    const { rerender } = render(
+      <MobileChatInfoOverlay
+        payload={makePayload("conv-1")}
+        onClose={noop}
+        onSelectCategory={noop}
+      />,
+    );
+    await screen.findByTestId("panel-assistant-1-conv-1", undefined, LAZY_WAIT);
+
+    rerender(
+      <MobileChatInfoOverlay
+        payload={makePayload("conv-1", "assistant-2")}
+        onClose={noop}
+        onSelectCategory={noop}
+      />,
+    );
+    await screen.findByTestId("panel-assistant-2-conv-1", undefined, LAZY_WAIT);
+    expect(screen.queryByTestId("panel-assistant-1-conv-1")).toBeNull();
     expect(mountCount).toBe(2);
   });
 });

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.tsx
@@ -1,6 +1,7 @@
 import { lazy } from "react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
+import { chatInfoPanelKey } from "@/domains/chat/components/chat-info-panel";
 import { useMobileOverlayViewportStyle } from "@/hooks/use-mobile-overlay-viewport-style";
 import type { ChatInfoCategory, ChatInfoPayload } from "@/stores/viewer-store";
 
@@ -41,11 +42,11 @@ export function MobileChatInfoOverlay({
   return (
     <div className="fixed inset-x-0 z-30" style={shellStyle}>
       <LazyBoundary>
-        {/* Re-key per conversation so a switch remounts the panel rather than
+        {/* Re-key per target so a switch remounts the panel rather than
             reusing one whose preview and delete state belong to the previous
             chat. */}
         <ChatInfoPanel
-          key={payload.conversationId}
+          key={chatInfoPanelKey(payload)}
           payload={payload}
           onClose={onClose}
           onSelectCategory={onSelectCategory}

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.tsx
@@ -1,9 +1,9 @@
 import { lazy } from "react";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
-import { chatInfoPanelKey } from "@/domains/chat/components/chat-info-panel";
 import { useMobileOverlayViewportStyle } from "@/hooks/use-mobile-overlay-viewport-style";
 import type { ChatInfoCategory, ChatInfoPayload } from "@/stores/viewer-store";
+import { chatInfoTargetKey } from "@/stores/viewer-store";
 
 const ChatInfoPanel = lazy(() =>
   import("@/domains/chat/components/chat-info-panel").then((m) => ({
@@ -46,7 +46,7 @@ export function MobileChatInfoOverlay({
             reusing one whose preview and delete state belong to the previous
             chat. */}
         <ChatInfoPanel
-          key={chatInfoPanelKey(payload)}
+          key={chatInfoTargetKey(payload)}
           payload={payload}
           onClose={onClose}
           onSelectCategory={onSelectCategory}

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.tsx
@@ -1,0 +1,56 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import { useMobileOverlayViewportStyle } from "@/hooks/use-mobile-overlay-viewport-style";
+import type { ChatInfoCategory, ChatInfoPayload } from "@/stores/viewer-store";
+
+const ChatInfoPanel = lazy(() =>
+  import("@/domains/chat/components/chat-info-panel").then((m) => ({
+    default: m.ChatInfoPanel,
+  })),
+);
+
+interface MobileChatInfoOverlayProps {
+  /** When `null`, the overlay renders nothing. */
+  payload: ChatInfoPayload | null;
+  /** Closes the overlay. */
+  onClose: () => void;
+  /** See All drills in with a category; the back control passes `null`. */
+  onSelectCategory: (category: ChatInfoCategory | null) => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the chat-info panel (one
+ * conversation's apps, documents and images, and camera frames, each category
+ * drilling into its own See All level).
+ *
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
+ */
+export function MobileChatInfoOverlay({
+  payload,
+  onClose,
+  onSelectCategory,
+}: MobileChatInfoOverlayProps) {
+  const shellStyle = useMobileOverlayViewportStyle();
+
+  if (!payload) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-x-0 z-30" style={shellStyle}>
+      <LazyBoundary>
+        {/* Re-key per conversation so a switch remounts the panel rather than
+            reusing one whose preview and delete state belong to the previous
+            chat. */}
+        <ChatInfoPanel
+          key={payload.conversationId}
+          payload={payload}
+          onClose={onClose}
+          onSelectCategory={onSelectCategory}
+        />
+      </LazyBoundary>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -1,7 +1,8 @@
 /**
  * Portal-based mobile overlay container for the app, document,
  * subagent-detail, workflow-detail, acp-run-detail, background-task-detail,
- * tool-detail, activity-steps, message-files, and channel-transcript viewers.
+ * tool-detail, activity-steps, message-files, chat-info, and
+ * channel-transcript viewers.
  * Reads from Zustand stores directly so the parent (ActiveChatView) doesn't
  * need to assemble inline handlers.
  *
@@ -19,7 +20,7 @@ import { useAcpRunStore } from "@/domains/chat/acp-run-store";
 import { useBackgroundTaskStore } from "@/domains/chat/background-task-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
-import { useViewerStore } from "@/stores/viewer-store";
+import { type ChatInfoCategory, useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 import { MobileChannelTranscriptOverlay } from "@/domains/chat/channel-sidecar/mobile-channel-transcript-overlay";
@@ -27,6 +28,7 @@ import { MobileAcpRunDetailOverlay } from "@/domains/chat/components/mobile-acp-
 import { MobileActivityStepsOverlay } from "@/domains/chat/components/mobile-activity-steps-overlay";
 import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileBackgroundTaskDetailOverlay } from "@/domains/chat/components/mobile-background-task-detail-overlay";
+import { MobileChatInfoOverlay } from "@/domains/chat/components/mobile-chat-info-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
 import { MobileMessageFilesOverlay } from "@/domains/chat/components/mobile-message-files-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
@@ -48,6 +50,7 @@ export function MobileChatOverlays() {
   const activeToolDetail = useViewerStore.use.activeToolDetail();
   const activeActivitySteps = useViewerStore.use.activeActivitySteps();
   const activeMessageFiles = useViewerStore.use.activeMessageFiles();
+  const activeChatInfo = useViewerStore.use.activeChatInfo();
   const activeWorkflowRunId = useViewerStore.use.activeWorkflowRunId();
   const activeAcpRunId = useViewerStore.use.activeAcpRunId();
   const activeBackgroundTaskId = useViewerStore.use.activeBackgroundTaskId();
@@ -159,6 +162,17 @@ export function MobileChatOverlays() {
     useViewerStore.getState().closeMessageFiles();
   }, []);
 
+  const handleCloseChatInfo = useCallback(() => {
+    useViewerStore.getState().closeChatInfo();
+  }, []);
+
+  const handleSelectChatInfoCategory = useCallback(
+    (category: ChatInfoCategory | null) => {
+      useViewerStore.getState().setChatInfoCategory(category);
+    },
+    [],
+  );
+
   const handleCloseChannelTranscript = useCallback(() => {
     useViewerStore.getState().closeChannelTranscript();
   }, []);
@@ -242,6 +256,11 @@ export function MobileChatOverlays() {
       <MobileMessageFilesOverlay
         payload={mainView === "message-files" ? activeMessageFiles : null}
         onClose={handleCloseMessageFiles}
+      />
+      <MobileChatInfoOverlay
+        payload={mainView === "chat-info" ? activeChatInfo : null}
+        onClose={handleCloseChatInfo}
+        onSelectCategory={handleSelectChatInfoCategory}
       />
       <MobileChannelTranscriptOverlay
         sidecarRef={

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -474,6 +474,17 @@ export interface ChatInfoPayload {
   category: ChatInfoCategory | null;
 }
 
+/**
+ * The identity of a chat-info target. Conversation ids are assistant-scoped,
+ * so both halves name it; hosts key the panel on this so a retarget remounts
+ * it rather than carrying preview and pending-delete state across.
+ */
+export function chatInfoTargetKey(
+  target: Pick<ChatInfoPayload, "assistantId" | "conversationId">,
+): string {
+  return `${target.assistantId}:${target.conversationId}`;
+}
+
 /** The identity fields a thinking drawer target is matched on. */
 type ThinkingTarget = Pick<
   ToolDetailPayload,
@@ -1270,11 +1281,10 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   toggleChatInfo: (target) => {
     const state = get();
-    // Conversation ids are assistant-scoped, so both halves name the target.
     const isSameTarget =
       state.mainView === "chat-info" &&
-      state.activeChatInfo?.assistantId === target.assistantId &&
-      state.activeChatInfo.conversationId === target.conversationId;
+      state.activeChatInfo !== null &&
+      chatInfoTargetKey(state.activeChatInfo) === chatInfoTargetKey(target);
     if (isSameTarget) {
       get().closeChatInfo();
     } else {


### PR DESCRIPTION
## Summary
- The `chat-info` viewer view now renders `ChatInfoPanel` in the shared right drawer on a roomy window and as a full-screen overlay on a narrow one, keyed per conversation
- Category drill-in and close route through the viewer store, so Escape and the X agree on both hosts
- Story for the mobile overlay at the Mobile viewport; no header trigger yet

Part of plan: chat-info-assets-panel.md (PR 8 of 12)