### PR TITLE
fix(ios): accept chunked avatar responses, cap the cache read, split the profile preflight

### DIFF
--- a/.github/workflows/ci-main-native-drift.yaml
+++ b/.github/workflows/ci-main-native-drift.yaml
@@ -25,10 +25,15 @@ on:
       # and the desktop shells keep their own per-environment icon manifests.
       - 'clients/ios/App/App/Config/**'
       # The Communication Notifications guard pins the app entitlements and
-      # Info.plist to each other.
+      # Info.plist to each other, and to the extension Info.plist that must not
+      # claim the intent.
       - 'clients/ios/App/App/App.entitlements'
       - 'clients/ios/App/App/App-Dev.entitlements'
       - 'clients/ios/App/App/Info.plist'
+      - 'clients/ios/App/NotificationService/Info.plist'
+      # The same guard reads the NotificationService profile names out of the
+      # release workflow.
+      - '.github/workflows/release-ios.yaml'
       - 'clients/macos/build-resources/icons/**'
       - 'clients/linux/build-resources/icons/**'
       # Linux converts its ground at build time, and the drift guard runs that

--- a/.github/workflows/pr-native-drift.yaml
+++ b/.github/workflows/pr-native-drift.yaml
@@ -24,10 +24,15 @@ on:
       # and the desktop shells keep their own per-environment icon manifests.
       - 'clients/ios/App/App/Config/**'
       # The Communication Notifications guard pins the app entitlements and
-      # Info.plist to each other.
+      # Info.plist to each other, and to the extension Info.plist that must not
+      # claim the intent.
       - 'clients/ios/App/App/App.entitlements'
       - 'clients/ios/App/App/App-Dev.entitlements'
       - 'clients/ios/App/App/Info.plist'
+      - 'clients/ios/App/NotificationService/Info.plist'
+      # The same guard reads the NotificationService profile names out of the
+      # release workflow.
+      - '.github/workflows/release-ios.yaml'
       - 'clients/macos/build-resources/icons/**'
       - 'clients/linux/build-resources/icons/**'
       # Linux converts its ground at build time, and the drift guard runs that

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -197,6 +197,8 @@ jobs:
           IOS_PROVISIONING_PROFILE_NSE_STAGING: ${{ secrets.IOS_PROVISIONING_PROFILE_NSE_STAGING }}
           IOS_PROVISIONING_PROFILE_NSE_DEV: ${{ secrets.IOS_PROVISIONING_PROFILE_NSE_DEV }}
         run: |
+          set -o pipefail
+
           PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
           mkdir -p "$PROFILE_DIR"
 
@@ -205,15 +207,44 @@ jobs:
           # as an opaque export error.
           #
           # Returns non-zero when the secret is empty, leaving how fatal that
-          # is to the caller.
+          # is to the caller. A secret that is present but not base64 is a
+          # different fault with a different fix, so it exits here rather than
+          # returning the "empty" status a caller may choose to tolerate.
           install_profile() {
             local key="$1" filename="$2"
             local b64="${!key}"
             if [ -z "$b64" ]; then
               return 1
             fi
-            echo "$b64" | base64 -D > "$PROFILE_DIR/$filename"
+            if ! echo "$b64" | base64 -D > "$PROFILE_DIR/$filename"; then
+              echo "::error::Provisioning profile secret $key is not valid base64. Re-encode the downloaded .mobileprovision with 'base64 -i <file>' and replace the secret."
+              exit 1
+            fi
             echo "Provisioning profile installed from $key"
+          }
+
+          # Fails the run when an installed profile does not grant $key.
+          #
+          # Decoding and checking are separate steps on purpose: a profile that
+          # is not CMS-signed at all (a mis-encoded secret, a truncated
+          # download) fails the decode, and folding that into the entitlement
+          # test would report a missing capability and send the operator to the
+          # portal for a fault that is in the secret. The decoded plist is read
+          # by key path rather than grepped, so the check is anchored to
+          # Entitlements and asserts the value is true.
+          require_entitlement() {
+            local filename="$1" key="$2" secret="$3" remedy="$4"
+            local plist="$RUNNER_TEMP/$filename.plist"
+            if ! security cms -D -i "$PROFILE_DIR/$filename" > "$plist"; then
+              echo "::error::Could not decode the profile installed from $secret with 'security cms -D'. The secret does not hold a CMS-signed .mobileprovision: re-download the profile from the Apple Developer portal, re-encode it with 'base64 -i <file>', and replace $secret."
+              exit 1
+            fi
+            local granted
+            granted=$(/usr/libexec/PlistBuddy -c "Print :Entitlements:$key" "$plist" 2>/dev/null || true)
+            if [ "$granted" != "true" ]; then
+              echo "::error::$remedy"
+              exit 1
+            fi
           }
 
           # The app profile is non-negotiable: without it there is no build to
@@ -230,10 +261,12 @@ jobs:
           # does not grant it. Xcode only notices at Archive, long after the
           # build has started, with an error that names neither the entitlement
           # nor the fix, so the profile is decoded and checked here instead.
-          if ! security cms -D -i "$PROFILE_DIR/ios_distribution.mobileprovision" | grep -q usernotifications.communication; then
-            echo "::error::Provisioning profile $APP_PROFILE_KEY does not grant com.apple.developer.usernotifications.communication, which App.entitlements and App-Dev.entitlements declare. Archive would fail while signing the app target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md, steps 2 and 4 for this environment's app row: tick Communication Notifications on the app App ID, reissue its distribution profile under the identical name, then replace $APP_PROFILE_KEY."
-            exit 1
-          fi
+          # The appexes carry no entitlement of their own beyond the App Group,
+          # so this check belongs to the app profile alone.
+          require_entitlement ios_distribution.mobileprovision \
+            com.apple.developer.usernotifications.communication \
+            "$APP_PROFILE_KEY" \
+            "Provisioning profile $APP_PROFILE_KEY does not grant com.apple.developer.usernotifications.communication, which App.entitlements and App-Dev.entitlements declare. Archive would fail while signing the app target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md, steps 2 and 4 for this environment's app row: tick Communication Notifications on the app App ID, reissue its distribution profile under the identical name, then replace $APP_PROFILE_KEY."
 
           # A missing extension profile is tolerated: the App IDs and profiles
           # behind IOS_PROVISIONING_PROFILE_EXT* do not exist in the Apple

--- a/clients/ios/App/AppTests/AvatarCacheTests.swift
+++ b/clients/ios/App/AppTests/AvatarCacheTests.swift
@@ -11,6 +11,7 @@ final class AvatarCacheTests: XCTestCase {
         cache = AvatarCache(rootURL: root)
         URLProtocol.registerClass(CountingURLProtocol.self)
         loadCounter.reset()
+        stubbedResponse.clear()
     }
 
     override func tearDown() {
@@ -103,6 +104,17 @@ final class AvatarCacheTests: XCTestCase {
         XCTAssertEqual(cache.data(forHash: hashes[0]), avatar(0))
     }
 
+    func testDropsACachedFilePastTheByteCap() throws {
+        let oversized = Data(repeating: 0x41, count: AvatarCache.maxBytes + 1)
+        let hash = AvatarCache.sha256Hex(oversized)
+        let url = try XCTUnwrap(cache.fileURL(forHash: hash))
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try oversized.write(to: url)
+
+        XCTAssertNil(cache.data(forHash: hash))
+        XCTAssertEqual(storedFileCount(), 0)
+    }
+
     func testDropsACachedFileWhoseBytesNoLongerMatchItsName() throws {
         let hash = AvatarCache.sha256Hex(avatar(1))
         let url = try XCTUnwrap(cache.fileURL(forHash: hash))
@@ -144,15 +156,15 @@ final class AvatarCacheTests: XCTestCase {
 
     func testFetchRefusesANonHttpsURL() async throws {
         let url = try XCTUnwrap(URL(string: "http://storage.example.com/avatar.png"))
-        let bytes = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(avatar(1)))
-        XCTAssertNil(bytes)
+        let result = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(avatar(1)))
+        XCTAssertEqual(result.reason, .insecureURL)
         XCTAssertEqual(loadCounter.count, 0)
     }
 
     func testFetchRefusesAMalformedHash() async throws {
         let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
-        let bytes = await cache.fetch(url: url, hash: "../etc/passwd")
-        XCTAssertNil(bytes)
+        let result = await cache.fetch(url: url, hash: "../etc/passwd")
+        XCTAssertEqual(result.reason, .badHash)
         XCTAssertEqual(loadCounter.count, 0)
     }
 
@@ -161,15 +173,61 @@ final class AvatarCacheTests: XCTestCase {
     /// does reach the URL loading system.
     func testFetchReachesTheNetworkOnceTheGuardsPass() async throws {
         let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
-        let bytes = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(avatar(1)))
-        XCTAssertNil(bytes)
+        let result = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(avatar(1)))
+        XCTAssertEqual(result.reason, .requestFailed)
         XCTAssertEqual(loadCounter.count, 1)
+    }
+
+    /// A chunked response declares no length at all, so a fetch that insisted on
+    /// a declared one would miss every cache and refill it from nothing.
+    func testFetchAcceptsAResponseThatDeclaresNoLength() async throws {
+        let bytes = avatar(1)
+        let hash = AvatarCache.sha256Hex(bytes)
+        stubbedResponse.set(headerFields: [:], body: bytes)
+
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
+        let result = await cache.fetch(url: url, hash: hash)
+        XCTAssertEqual(try result.get(), bytes)
+        XCTAssertEqual(cache.data(forHash: hash), bytes)
+    }
+
+    func testFetchRejectsABodyItDeclaresIsPastTheByteCap() async throws {
+        let bytes = avatar(1)
+        stubbedResponse.set(
+            headerFields: ["Content-Length": "\(AvatarCache.maxBytes + 1)"],
+            body: bytes
+        )
+
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
+        let result = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(bytes))
+        XCTAssertEqual(result.reason, .declaredTooLarge)
+        XCTAssertEqual(storedFileCount(), 0)
+    }
+
+    func testFetchRejectsBytesThatDoNotMatchTheHash() async throws {
+        stubbedResponse.set(headerFields: [:], body: avatar(2))
+
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
+        let result = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(avatar(1)))
+        XCTAssertEqual(result.reason, .digestMismatch)
+        XCTAssertEqual(storedFileCount(), 0)
     }
 }
 
-/// Counts the requests that reach the URL loading system and fails every one of
-/// them, so a test can tell a guard that returned early apart from a request
-/// that went out and came back empty.
+private extension Result where Failure == AvatarCache.UnavailableReason {
+    /// The reason a fetch gave up, or `nil` when it succeeded.
+    var reason: AvatarCache.UnavailableReason? {
+        guard case .failure(let reason) = self else {
+            return nil
+        }
+        return reason
+    }
+}
+
+/// Counts the requests that reach the URL loading system, so a test can tell a
+/// guard that returned early apart from a request that went out. Serves
+/// ``stubbedResponse`` when one is set and fails the request otherwise, which
+/// keeps the tests that assert on a failed request unchanged.
 private final class CountingURLProtocol: URLProtocol {
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -181,10 +239,49 @@ private final class CountingURLProtocol: URLProtocol {
 
     override func startLoading() {
         loadCounter.increment()
-        client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+        guard let url = request.url,
+              let stub = stubbedResponse.current,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 200,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: stub.headerFields
+              )
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body)
+        client?.urlProtocolDidFinishLoading(self)
     }
 
     override func stopLoading() {}
+}
+
+/// Shared for the same reason ``loadCounter`` is.
+private let stubbedResponse = StubbedResponse()
+
+private final class StubbedResponse: @unchecked Sendable {
+    struct Stub {
+        let headerFields: [String: String]
+        let body: Data
+    }
+
+    private let lock = NSLock()
+    private var stub: Stub?
+
+    var current: Stub? { lock.withLock { stub } }
+
+    /// Headers with no `Content-Length` are what a chunked response looks like
+    /// to `URLSession`: `expectedContentLength` comes back as -1.
+    func set(headerFields: [String: String], body: Data) {
+        lock.withLock { stub = Stub(headerFields: headerFields, body: body) }
+    }
+
+    func clear() {
+        lock.withLock { stub = nil }
+    }
 }
 
 /// Shared because `URLProtocol` instances are created by the loading system,

--- a/clients/ios/App/NotificationService/AvatarCache.swift
+++ b/clients/ios/App/NotificationService/AvatarCache.swift
@@ -20,8 +20,23 @@ struct AvatarCache {
     /// recently, in a container shared with the app's own data.
     static let maxEntries = 8
     static let maxBytes = 512 * 1024
-    static let defaultTimeout: TimeInterval = 8
+    static let requestTimeout: TimeInterval = 8
     static let readChunkSize = 16 * 1024
+
+    /// Why no avatar reached the notification. Every cause has its own stable
+    /// token, so the Console line names which one it was instead of standing
+    /// for any of them.
+    enum UnavailableReason: String, Error {
+        case missingURL = "no_url"
+        case badHash = "bad_hash"
+        case insecureURL = "insecure_url"
+        case requestFailed = "request_failed"
+        case badStatus = "bad_status"
+        case declaredTooLarge = "declared_too_large"
+        case bodyTooLarge = "body_too_large"
+        case readFailed = "read_failed"
+        case digestMismatch = "digest_mismatch"
+    }
 
     let rootURL: URL
 
@@ -43,14 +58,26 @@ struct AvatarCache {
 
     /// The cached bytes for `hash`, or `nil` when nothing is stored under it.
     ///
-    /// The bytes are re-hashed on the way out, not only on the way in: the
-    /// container is shared with the app, and a file that no longer matches its
-    /// own name is deleted rather than rendered.
+    /// The container is shared with the app, so a stored file is held to the
+    /// same bounds a download is: its size is read before its bytes, anything
+    /// past ``maxBytes`` is deleted unread, and a file that no longer matches
+    /// its own name is deleted rather than rendered.
     ///
     /// A hit stamps the file with the current time so eviction, which ranks by
     /// modification date, treats a recently used avatar as recent.
     func data(forHash hash: String) -> Data? {
-        guard let url = fileURL(forHash: hash), let data = try? Data(contentsOf: url) else {
+        guard let url = fileURL(forHash: hash) else {
+            return nil
+        }
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        guard let size = attributes?[.size] as? Int else {
+            return nil
+        }
+        guard size <= Self.maxBytes else {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+        guard let data = try? Data(contentsOf: url) else {
             return nil
         }
         guard Self.sha256Hex(data) == hash else {
@@ -83,71 +110,100 @@ struct AvatarCache {
     }
 
     /// Download the avatar at `url`, verify it against `hash`, cache it, and
-    /// return the bytes. Any failure returns `nil` and the caller delivers the
-    /// notification unchanged.
+    /// return the bytes. Any failure returns the reason it gave up instead, and
+    /// the caller delivers the notification unchanged.
     ///
     /// The URL arrives in the push payload, so only `https` is followed and only
-    /// bytes that hash to `hash` are used. A response that declares no length or
-    /// one past ``maxBytes`` is dropped before its body is read, and the body
-    /// itself is abandoned the moment it goes past the same cap, which keeps an
-    /// oversized or malformed response from filling the extension's memory
-    /// budget. `timeout` bounds how long the read may take.
-    func fetch(url: URL, hash: String, timeout: TimeInterval = defaultTimeout) async -> Data? {
-        guard Self.isValidHash(hash), url.scheme == "https" else {
-            return nil
+    /// bytes that hash to `hash` are used. A response declaring a length past
+    /// ``maxBytes`` is dropped before its body is read; a response declaring no
+    /// length at all, as a chunked one does, is read under the same cap and
+    /// abandoned the moment it crosses it. The streaming cap, not the declared
+    /// length, is what keeps an oversized or malformed response out of the
+    /// extension's memory budget.
+    ///
+    /// ``requestTimeout`` is the request's idle timeout: it bounds how long the
+    /// transfer may stall without new bytes, not how long it may run in total.
+    /// The total bound is the extension's own budget, whose expiry cancels the
+    /// task this runs in.
+    func fetch(url: URL, hash: String) async -> Result<Data, UnavailableReason> {
+        guard Self.isValidHash(hash) else {
+            return .failure(.badHash)
+        }
+        guard url.scheme == "https" else {
+            return .failure(.insecureURL)
         }
         let request = URLRequest(
             url: url,
             cachePolicy: .reloadIgnoringLocalCacheData,
-            timeoutInterval: timeout
+            timeoutInterval: Self.requestTimeout
         )
         guard let (bytes, response) = try? await URLSession.shared.bytes(for: request) else {
-            return nil
+            return .failure(.requestFailed)
         }
-        guard let http = response as? HTTPURLResponse,
-              http.statusCode == 200,
-              http.expectedContentLength >= 0,
-              http.expectedContentLength <= Int64(Self.maxBytes)
-        else {
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             bytes.task.cancel()
-            return nil
+            return .failure(.badStatus)
         }
-        guard let data = try? await Self.readAtMost(Self.maxBytes, from: bytes),
-              Self.sha256Hex(data) == hash
-        else {
+        // A response that declares no length reports NSURLResponseUnknownLength,
+        // which is negative and so passes this cap on its way to the streaming
+        // one.
+        let declared = http.expectedContentLength
+        guard declared <= Int64(Self.maxBytes) else {
             bytes.task.cancel()
-            return nil
+            return .failure(.declaredTooLarge)
+        }
+        let body: Data?
+        do {
+            body = try await Self.readAtMost(
+                Self.maxBytes,
+                from: bytes,
+                expecting: declared >= 0 ? Int(declared) : nil
+            )
+        } catch {
+            bytes.task.cancel()
+            return .failure(.readFailed)
+        }
+        guard let data = body else {
+            bytes.task.cancel()
+            return .failure(.bodyTooLarge)
+        }
+        guard Self.sha256Hex(data) == hash else {
+            return .failure(.digestMismatch)
         }
         store(data, hash: hash)
-        return data
+        return .success(data)
     }
 
     /// Collect `bytes` until the sequence ends, or return `nil` as soon as more
     /// than `limit` bytes arrive so an oversized body is never held whole.
     ///
-    /// Bytes land in an array first and reach the `Data` a chunk at a time:
-    /// appending each byte to `Data` individually costs a bounds check and a
-    /// possible reallocation per byte, which is the whole of the extension's
-    /// CPU budget on a 512 KB avatar.
+    /// `expectedCount` is the length the response declared, when it declared
+    /// one, so a known-size body is reserved for once instead of growing into
+    /// place. Bytes land in a preallocated buffer and reach the `Data` a chunk
+    /// at a time: appending each byte to `Data` on its own costs a bounds check
+    /// and a possible reallocation per byte, which is the whole of the
+    /// extension's CPU budget on a 512 KB avatar.
     static func readAtMost<Bytes: AsyncSequence>(
         _ limit: Int,
-        from bytes: Bytes
+        from bytes: Bytes,
+        expecting expectedCount: Int? = nil
     ) async throws -> Data? where Bytes.Element == UInt8 {
         var data = Data()
-        data.reserveCapacity(min(limit, readChunkSize))
-        var chunk = [UInt8]()
-        chunk.reserveCapacity(min(limit, readChunkSize))
+        data.reserveCapacity(min(limit, expectedCount ?? readChunkSize))
+        var chunk = [UInt8](repeating: 0, count: min(limit, readChunkSize))
+        var filled = 0
         for try await byte in bytes {
-            if data.count + chunk.count >= limit {
+            if data.count + filled >= limit {
                 return nil
             }
-            chunk.append(byte)
-            if chunk.count == readChunkSize {
+            chunk[filled] = byte
+            filled += 1
+            if filled == chunk.count {
                 data.append(contentsOf: chunk)
-                chunk.removeAll(keepingCapacity: true)
+                filled = 0
             }
         }
-        data.append(contentsOf: chunk)
+        data.append(contentsOf: chunk[0..<filled])
         return data
     }
 

--- a/clients/ios/App/NotificationService/NotificationService.swift
+++ b/clients/ios/App/NotificationService/NotificationService.swift
@@ -28,6 +28,7 @@ final class NotificationService: UNNotificationServiceExtension {
     private let lock = NSLock()
     private var contentHandler: ((UNNotificationContent) -> Void)?
     private var unchangedContent: UNNotificationContent?
+    private var rewrite: Task<Void, Never>?
 
     override func didReceive(
         _ request: UNNotificationRequest,
@@ -49,15 +50,22 @@ final class NotificationService: UNNotificationServiceExtension {
             return
         }
 
-        Task {
-            var avatar = cache.data(forHash: sender.avatarHash)
-            if avatar == nil, let url = sender.avatarURL {
-                avatar = await cache.fetch(url: url, hash: sender.avatarHash)
-            }
-            guard let avatar else {
-                Self.logger.info("nse.avatar_unavailable: cache miss and no usable download")
-                self.deliver(request.content)
-                return
+        let task = Task {
+            let avatar: Data
+            if let cached = cache.data(forHash: sender.avatarHash) {
+                avatar = cached
+            } else {
+                guard let url = sender.avatarURL else {
+                    self.deliverWithoutAvatar(.missingURL, content: request.content)
+                    return
+                }
+                switch await cache.fetch(url: url, hash: sender.avatarHash) {
+                case .success(let downloaded):
+                    avatar = downloaded
+                case .failure(let reason):
+                    self.deliverWithoutAvatar(reason, content: request.content)
+                    return
+                }
             }
             do {
                 self.deliver(
@@ -74,6 +82,9 @@ final class NotificationService: UNNotificationServiceExtension {
                 self.deliver(request.content)
             }
         }
+        lock.lock()
+        rewrite = task
+        lock.unlock()
     }
 
     /// Called when the extension runs out of its budget. Delivering the push as
@@ -81,11 +92,28 @@ final class NotificationService: UNNotificationServiceExtension {
     override func serviceExtensionTimeWillExpire() {
         lock.lock()
         let content = unchangedContent
+        let pending = rewrite
+        rewrite = nil
         lock.unlock()
+        // Cancelling propagates into the avatar download, whose only bound
+        // otherwise is an idle timeout the system has already outlasted.
+        pending?.cancel()
         if let content {
             Self.logger.info("nse.expired: budget ran out before the rewrite finished")
             deliver(content)
         }
+    }
+
+    /// Logs why the notification has no avatar, then delivers the push as it
+    /// arrived.
+    private func deliverWithoutAvatar(
+        _ reason: AvatarCache.UnavailableReason,
+        content: UNNotificationContent
+    ) {
+        Self.logger.info(
+            "nse.avatar_unavailable reason=\(reason.rawValue, privacy: .public)"
+        )
+        deliver(content)
     }
 
     /// Hands `content` to the system once. Later calls are dropped: iOS accepts

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -179,9 +179,9 @@ targetTemplates:
       configs:
         Debug:
           OTHER_SWIFT_FLAGS: '$(inherited) "-DDEBUG"'
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG NOTIFICATION_SERVICE_EXTENSION
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
         Release:
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: NOTIFICATION_SERVICE_EXTENSION
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: ""
     preBuildScripts: *projectSpecFreshnessGuard
 
   # Share Sheet extension. One per environment for the same prefix rule as

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -728,7 +728,49 @@ once every extension row is complete.
 
 The appex's own entitlements file stays App Group-only, the same file the
 other two extensions use: the extension reads cached avatars out of the
-shared container and needs nothing more.
+shared container and needs nothing more. The capability is an app-target one.
+Apple's [Implementing communication
+notifications](https://developer.apple.com/documentation/usernotifications/implementing-communication-notifications)
+says to "Enable the Communication Notifications capability in your app target",
+and [WWDC21 session 10091](https://developer.apple.com/videos/play/wwdc2021/10091/)
+splits the two halves the same way: "enable the communication capability via
+Xcode for your application" against "start donating incoming StartCall and
+SendMessage intents in your service extension". Vendor integration guides that
+walk the same setup, such as [Smartsupp's Communication
+Notifications](https://docs.smartsupp.com/mobile-sdk/ios/communication-notifications/)
+page, add the capability once at the project's app target and give the
+extension only its Info.plist and code. Do not add the entitlement to the appex
+speculatively: a target declaring an entitlement its profile does not grant
+fails to sign, so it would break every environment's release until the NSE App
+IDs carried the capability too.
+
+#### The push payload the extension reads
+
+APNs carries JSON, so the sender arrives as a nested object beside `aps`:
+
+```json
+{
+  "aps": {
+    "alert": { "title": "<conversation title>", "body": "<message>" },
+    "mutable-content": 1
+  },
+  "sender": {
+    "id": "<assistant id>",
+    "name": "<assistant name>",
+    "avatar_url": "https://.../avatar.png",
+    "avatar_hash": "<sha-256 hex of the bytes at avatar_url>"
+  }
+}
+```
+
+`mutable-content: 1` is what makes iOS run the extension at all. `id`, `name`,
+and `avatar_hash` must all be non-empty or the push is delivered untouched.
+`avatar_url` is optional: it is the first field the platform drops when a
+payload nears the APNs size limit, and the hash alone still hits a warm cache.
+The thread is the assistant id, so every conversation with one assistant
+threads together. Android reads the same four fields as flat `sender_*` entries
+in the FCM data map, which is a string map rather than JSON: the two consumers
+differ by transport, not by contract.
 
 ### Manual Apple Developer portal setup
 
@@ -877,21 +919,38 @@ codesign -d --entitlements - "Payload/App Dev.app" 2>&1 | grep usernotifications
 Then check the notification avatar itself on a device: send a push while the
 app is killed, backgrounded, and foregrounded; send a second push for the same
 avatar and confirm Console shows no network fetch; change the avatar on the
-daemon and confirm the next push picks it up; tap through to the conversation.
-Every path that gives up logs one `nse.` prefix
+assistant and confirm the next push picks it up; tap through to the
+conversation. Every path that gives up logs one `nse.` prefix
 (`nse.no_sender`, `nse.no_app_group`, `nse.avatar_unavailable`,
 `nse.intent_failed`, `nse.expired`), so filter Console on `nse.` before
 guessing.
 
-If the avatar never appears, the first thing to **check** is whether the appex
-needs `com.apple.developer.usernotifications.communication` too. It is on the
-app alone today, following Apple's Notification Service Extension guide, and
-`updating(from:)` fails closed when the entitlement is missing from whichever
-bundle iOS looks at, which lands in `nse.intent_failed`. The first thing to
-**restore** is the `NSExtensionAttributes` / `IntentsSupported` dict in
-`App/NotificationService/Info.plist`: it was removed because `IntentsSupported`
-belongs to the Intents extension point rather than the notification-service
-one, and it is the cheapest change to undo.
+`nse.avatar_unavailable` carries a `reason=` token naming the cause, so one
+line is enough to tell a trimmed payload from a rejected download:
+
+| `reason=` | What it means |
+|-----------|---------------|
+| `no_url` | Cache miss and the payload carried no `avatar_url` (usually a payload trimmed for size). |
+| `bad_hash` | `avatar_hash` is not 64 lowercase hex characters. |
+| `insecure_url` | `avatar_url` is not `https`. |
+| `request_failed` | The request never produced a response (offline, DNS, TLS). |
+| `bad_status` | The response was not an HTTP 200. |
+| `declared_too_large` | The response declared a `Content-Length` past 512 KB. |
+| `body_too_large` | The body crossed 512 KB while streaming, declared or not. |
+| `read_failed` | The body stopped mid-transfer, including on extension expiry. |
+| `digest_mismatch` | The bytes did not hash to `avatar_hash`. |
+
+A banner with no avatar and no `nse.` line at all is the entitlement and
+profile case rather than a code one. `updating(from:)` may throw, which lands
+in `nse.intent_failed`, or return the content unchanged, which logs nothing at
+all, so check both: a plain banner without `nse.intent_failed` still points at
+Communication Notifications on the app's App ID and the profile that has to
+grant it. The extension's `Info.plist` carries no `IntentsSupported` (that key
+belongs to the Intents extension point, not to
+`com.apple.usernotifications.service`); the app's `Info.plist` carries
+`NSUserActivityTypes: [INSendMessageIntent]`, which is the declaration the
+rewrite needs. `clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts`
+pins both.
 
 > **Profiles expire after one year.** Renewal is the same loop:
 > regenerate in the portal under the identical name, re-encode, update

--- a/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
+++ b/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { readSetting } from "./xcconfig-fixtures";
 
 const APP_DIR = join(import.meta.dir, "../../App/App");
+const NSE_DIR = join(import.meta.dir, "../../App/NotificationService");
 
 const PAIRS = [
   { app: "App.xcconfig", nse: "NotificationService.xcconfig" },
@@ -29,8 +30,9 @@ describe("NotificationService xcconfigs stay prefixed by their host app", () => 
 describe("Communication Notifications is declared on both sides", () => {
   // App and App Staging sign against App.entitlements, App Dev against
   // App-Dev.entitlements, so the pair covers all three app targets. Without the
-  // entitlement `UNNotificationContent.updating(from:)` silently returns the
-  // unmodified content.
+  // entitlement `UNNotificationContent.updating(from:)` either throws or
+  // returns the unmodified content, so the banner loses its avatar with or
+  // without a log line to explain it.
   for (const file of ["App.entitlements", "App-Dev.entitlements"]) {
     test(`${file} carries the communication entitlement`, () => {
       expect(readFileSync(join(APP_DIR, file), "utf8")).toContain(
@@ -45,6 +47,16 @@ describe("Communication Notifications is declared on both sides", () => {
     const plist = readFileSync(join(APP_DIR, "Info.plist"), "utf8");
     expect(plist).toContain("<key>NSUserActivityTypes</key>");
     expect(plist).toContain("<string>INSendMessageIntent</string>");
+  });
+
+  // `IntentsSupported` belongs to the Intents extension point, not to
+  // `com.apple.usernotifications.service`. The app's NSUserActivityTypes above
+  // is what declares the intent; claiming it here again buys nothing and gives
+  // the next reader a second, wrong place to look.
+  test("the extension Info.plist declares no IntentsSupported", () => {
+    expect(readFileSync(join(NSE_DIR, "Info.plist"), "utf8")).not.toContain(
+      "IntentsSupported",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- `AvatarCache.fetch` no longer requires a declared `Content-Length`. A chunked response reports `NSURLResponseUnknownLength` (-1), so every cache-miss fetch failed and the cache never warmed. The declared-length cap still rejects anything over 512 KB when a length is declared, and the streaming cap is the real bound.
- Each way a fetch can give up now logs its own `nse.avatar_unavailable reason=<token>` line: `no_url`, `bad_hash`, `insecure_url`, `request_failed`, `bad_status`, `declared_too_large`, `body_too_large`, `read_failed`, `digest_mismatch`.
- `readAtMost` reserves the declared length when there is one and reads into a preallocated buffer instead of appending byte by byte. The exact-at-limit cap behavior and its tests are unchanged.
- `data(forHash:)` checks the file size before reading it, and deletes anything past the cap as a poisoned entry, so the cache-hit path is bounded like the download path.
- `serviceExtensionTimeWillExpire` cancels the in-flight download task instead of leaving it running against a spent handler.
- Release preflight: decoding a profile and checking its entitlement are separate steps, so a mis-encoded secret reports itself instead of reading as a missing capability. The entitlement is read by key path with PlistBuddy and asserted true, and `base64 -D` failures are caught.
- Communication Notifications stays on the app target only. Apple's [Implementing communication notifications](https://developer.apple.com/documentation/usernotifications/implementing-communication-notifications) says to enable it "in your app target", and [WWDC21 session 10091](https://developer.apple.com/videos/play/wwdc2021/10091/) enables the capability for the application while the extension only donates the intent. The README now records that with its sources, and the triage step that told the next engineer to try the entitlement on the appex is gone.
- README: the present state of the extension Info.plist (no `IntentsSupported`) and the app Info.plist (`NSUserActivityTypes: [INSendMessageIntent]`), a triage recipe that covers `updating(from:)` both throwing and returning content unchanged, the APNs payload shape the extension reads, and "assistant" rather than "daemon".
- Drift guards: `release-ios.yaml` and the extension Info.plist are in the `paths:` filters of both native-drift workflows, and the guard now pins the extension Info.plist to carrying no `IntentsSupported`.
- Removed the unused `timeout:` parameter on `AvatarCache.fetch` and the `NOTIFICATION_SERVICE_EXTENSION` compilation condition, which has no `#if` site.

Round-2 self-review fixes for the notification avatar feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1