### PR TITLE
fix(macos): verify the profile grants the entitlement, route sender-less notifications through Electron, derive category labels

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -131,9 +131,13 @@ jobs:
           console.log("vellum-notifier loaded; isSupported =", addon.exports.isSupported());
           process.exit(0);
           JS
+          # build-notifier.sh writes one architecture and clears the rest, so
+          # the addon is whatever it left behind. Resolving it that way keeps
+          # the smoke load honest about the arch the build actually produced.
+          ADDON="$(ls resources/notifier/*/vellum-notifier.node)"
           ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron \
             "$RUNNER_TEMP/smoke-notifier.js" \
-            "resources/notifier/$(node -p 'process.arch')/vellum-notifier.node"
+            "$ADDON"
 
   checks:
     name: Type Check, Build & Test

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1742,21 +1742,45 @@ jobs:
 
       # The Communication Notifications entitlement is restricted: it may only
       # be signed into a build that embeds a provisioning profile authorizing
-      # it. Without the secret the pack signs the plain entitlements and posts
-      # plain notifications.
+      # it for that build's bundle id. Without the secret the pack signs the
+      # plain entitlements and posts plain notifications.
       - name: Provision the Communication Notifications profile
         env:
           MAC_PROVISIONING_PROFILE: ${{ secrets.MAC_PROVISIONING_PROFILE }}
+          # electron-builder.config.cjs derives the app id from
+          # VELLUM_ENVIRONMENT, and the pack step below runs --environment dev.
+          EXPECTED_BUNDLE_ID: com.vellum.vellum-assistant-electron-dev
         run: |
           if [ -z "$MAC_PROVISIONING_PROFILE" ]; then
-            echo "MAC_PROVISIONING_PROFILE is unset; packaging without the Communication Notifications entitlement"
+            echo "::warning::MAC_PROVISIONING_PROFILE is unset, so the native notifier ships disabled: notifications post through Electron without the assistant avatar."
             exit 0
           fi
           PROFILE_PATH="$RUNNER_TEMP/vellum-communication.provisionprofile"
           echo "$MAC_PROVISIONING_PROFILE" | base64 -D > "$PROFILE_PATH"
+          DECODED_PATH="$RUNNER_TEMP/vellum-communication-profile.plist"
           # A truncated or mis-encoded secret decodes to a file that codesign
           # accepts and macOS then rejects at launch, so prove it parses here.
-          security cms -D -i "$PROFILE_PATH" > /dev/null
+          if ! security cms -D -i "$PROFILE_PATH" > "$DECODED_PATH"; then
+            echo "::error::MAC_PROVISIONING_PROFILE does not decode as a provisioning profile. Re-export the .provisionprofile from the Apple Developer portal and store it base64-encoded in the secret."
+            exit 1
+          fi
+          # Exporting the variable below makes the pack sign
+          # com.apple.developer.usernotifications.communication unconditionally,
+          # and macOS kills an app whose embedded profile does not authorize
+          # that entitlement for its bundle id. Parsing is therefore not enough.
+          GRANTED="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.usernotifications.communication" "$DECODED_PATH" 2>/dev/null || true)"
+          if [ "$GRANTED" != "true" ]; then
+            echo "::error::The provisioning profile does not grant com.apple.developer.usernotifications.communication. Enable Communication Notifications on the $EXPECTED_BUNDLE_ID App ID in the Apple Developer portal, regenerate the profile, and update the MAC_PROVISIONING_PROFILE secret."
+            exit 1
+          fi
+          APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          case "$APPLICATION_ID" in
+            *".$EXPECTED_BUNDLE_ID") ;;
+            *)
+              echo "::error::The provisioning profile authorizes '$APPLICATION_ID', not the '$EXPECTED_BUNDLE_ID' bundle this build packages. Regenerate the profile for that App ID and update the MAC_PROVISIONING_PROFILE secret."
+              exit 1
+              ;;
+          esac
           echo "VELLUM_MAC_PROVISIONING_PROFILE=$PROFILE_PATH" >> "$GITHUB_ENV"
 
       - name: Build and package Electron app

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -131,9 +131,13 @@ jobs:
           console.log("vellum-notifier loaded; isSupported =", addon.exports.isSupported());
           process.exit(0);
           JS
+          # build-notifier.sh writes one architecture and clears the rest, so
+          # the addon is whatever it left behind. Resolving it that way keeps
+          # the smoke load honest about the arch the build actually produced.
+          ADDON="$(ls resources/notifier/*/vellum-notifier.node)"
           ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron \
             "$RUNNER_TEMP/smoke-notifier.js" \
-            "resources/notifier/$(node -p 'process.arch')/vellum-notifier.node"
+            "$ADDON"
 
   checks:
     name: Type Check, Build & Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2127,21 +2127,46 @@ jobs:
 
       # The Communication Notifications entitlement is restricted: it may only
       # be signed into a build that embeds a provisioning profile authorizing
-      # it. Without the secret the pack signs the plain entitlements and posts
-      # plain notifications.
+      # it for that build's bundle id. Without the secret the pack signs the
+      # plain entitlements and posts plain notifications.
       - name: Provision the Communication Notifications profile
         env:
           MAC_PROVISIONING_PROFILE: ${{ secrets.MAC_PROVISIONING_PROFILE }}
+          # electron-builder.config.cjs derives the app id from
+          # VELLUM_ENVIRONMENT, which the pack step below sets from the same
+          # staging/production switch.
+          EXPECTED_BUNDLE_ID: ${{ needs.extract-version.outputs.is_staging == 'true' && 'com.vellum.vellum-assistant-electron-staging' || 'com.vellum.vellum-assistant-electron' }}
         run: |
           if [ -z "$MAC_PROVISIONING_PROFILE" ]; then
-            echo "MAC_PROVISIONING_PROFILE is unset; packaging without the Communication Notifications entitlement"
+            echo "::warning::MAC_PROVISIONING_PROFILE is unset, so the native notifier ships disabled: notifications post through Electron without the assistant avatar."
             exit 0
           fi
           PROFILE_PATH="$RUNNER_TEMP/vellum-communication.provisionprofile"
           echo "$MAC_PROVISIONING_PROFILE" | base64 -D > "$PROFILE_PATH"
+          DECODED_PATH="$RUNNER_TEMP/vellum-communication-profile.plist"
           # A truncated or mis-encoded secret decodes to a file that codesign
           # accepts and macOS then rejects at launch, so prove it parses here.
-          security cms -D -i "$PROFILE_PATH" > /dev/null
+          if ! security cms -D -i "$PROFILE_PATH" > "$DECODED_PATH"; then
+            echo "::error::MAC_PROVISIONING_PROFILE does not decode as a provisioning profile. Re-export the .provisionprofile from the Apple Developer portal and store it base64-encoded in the secret."
+            exit 1
+          fi
+          # Exporting the variable below makes the pack sign
+          # com.apple.developer.usernotifications.communication unconditionally,
+          # and macOS kills an app whose embedded profile does not authorize
+          # that entitlement for its bundle id. Parsing is therefore not enough.
+          GRANTED="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.usernotifications.communication" "$DECODED_PATH" 2>/dev/null || true)"
+          if [ "$GRANTED" != "true" ]; then
+            echo "::error::The provisioning profile does not grant com.apple.developer.usernotifications.communication. Enable Communication Notifications on the $EXPECTED_BUNDLE_ID App ID in the Apple Developer portal, regenerate the profile, and update the MAC_PROVISIONING_PROFILE secret."
+            exit 1
+          fi
+          APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          case "$APPLICATION_ID" in
+            *".$EXPECTED_BUNDLE_ID") ;;
+            *)
+              echo "::error::The provisioning profile authorizes '$APPLICATION_ID', not the '$EXPECTED_BUNDLE_ID' bundle this build packages. Regenerate the profile for that App ID and update the MAC_PROVISIONING_PROFILE secret."
+              exit 1
+              ;;
+          esac
           echo "VELLUM_MAC_PROVISIONING_PROFILE=$PROFILE_PATH" >> "$GITHUB_ENV"
 
       - name: Build and package Electron app

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -208,12 +208,24 @@ own notifications, and so does an addon that loads but answers
 `VELLUM_DISABLE_NATIVE_NOTIFIER=1` to force that fallback in a build that
 would otherwise use the addon.
 
+**Which notifications the addon posts.** The addon posts only notifications
+that carry a sender; everything else uses Electron's presenter, through the
+shared `createElectronNotification`. The avatar is the one thing the addon
+renders that Electron cannot, and the renderer attaches a sender only under the
+`push-avatar-sender` flag, so turning that flag off restores Electron as the
+delivery path for every notification without shipping a new build.
+
 Notification categories carry the action buttons, and
 `setNotificationCategories:` applies asynchronously, so a category first
 registered in the runloop turn its notification is posted can miss it and the
 buttons never render. `src/main/index.ts` registers every action set through
-`registerCategories` at startup instead, and the addon unions its own set with
-whatever the notification center already holds rather than replacing it.
+`registerCategories` at startup instead, deriving the set from the shared
+`NOTIFICATION_CATEGORIES` and `CATEGORY_ACTIONS` pair so it covers every set
+the app can post, and the addon unions its own set with whatever the
+notification center already holds rather than replacing it. An identifier that
+is still unregistered when a notification is posted cannot be repaired in that
+same runloop turn, so the notification goes out with no category and the
+`shown` event carries the reason.
 
 **Delegate rule.** Electron's `NotificationPresenterMac` claims
 `UNUserNotificationCenter.currentNotificationCenter.delegate` the moment it is
@@ -230,10 +242,11 @@ renderer's Web Notification API all do. Three consequences:
   delegate and strands clicks on notifications already on screen.
 - The addon installs its own delegate, holds a strong reference to the one it
   displaced, forwards every response it does not own there, and re-asserts
-  itself on the way into `show` and `requestAuthorization`. Those two entry
-  points plus the permission probe above are every path in the app that
-  touches the notification center, which is why no periodic reclaim is needed.
-  `restoreDelegate()` hands the seat back at `before-quit`.
+  itself on the way into `show` and `requestAuthorization`. Electron builds its
+  presenter at most once, so a sender-less notification moves the delegate a
+  single time and the addon's next post takes it back, keeping Electron's
+  presenter as the delegate it forwards to. `restoreDelegate()` hands the seat
+  back at `before-quit`.
 
 **Rebuild:**
 
@@ -244,7 +257,12 @@ bash scripts/build-notifier.sh   # also runs as part of `bun run setup` and `bun
 It compiles against the headers for the Electron version pinned in
 `package.json` and writes `resources/notifier/<arch>/vellum-notifier.node`,
 which `electron-builder` packs to `bin/notifier/` and `scripts/afterSign.js`
-re-signs with `inherit.plist`.
+re-signs with `inherit.plist`. `ELECTRON_TARGET_ARCH` picks the architecture
+(arm64 by default, the same default `pack.sh` and
+`electron-builder.config.cjs` use). The script fails when the compiled slice is
+not the one that was asked for, and `afterSign.js` fails again when the packed
+addon is not the architecture being packaged, because a mismatched addon does
+not load and the app quietly falls back to plain notifications.
 
 **Provisioning profile switch.** `com.apple.developer.usernotifications.communication`
 is a restricted entitlement: an app declaring it without an authorizing
@@ -253,8 +271,11 @@ provisioning profile is killed at launch. `electron-builder.config.cjs` sets
 profile that exists on disk, and throws when the variable is set to a file that
 is not there rather than quietly signing the plain entitlements under a name
 that says otherwise. The release workflows decode one there from the
-`MAC_PROVISIONING_PROFILE` secret and prove it parses with `security cms -D`
-before exporting the variable.
+`MAC_PROVISIONING_PROFILE` secret, then assert with `PlistBuddy` that its
+entitlements grant `com.apple.developer.usernotifications.communication` and
+that its `application-identifier` ends with the bundle id the environment
+packs, before exporting the variable. An unset secret is a warning saying the
+native notifier ships disabled.
 
 That build signs with an entitlements plist derived at pack time by
 `scripts/entitlements/derive-communication-entitlements.js`, which reads

--- a/clients/macos/electron-builder.config.cjs
+++ b/clients/macos/electron-builder.config.cjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 const fs = require("fs");
 
 const {

--- a/clients/macos/native/notifier/notifier.mm
+++ b/clients/macos/native/notifier/notifier.mm
@@ -51,8 +51,9 @@ struct Event {
   // Negative when the event carries no action index.
   int actionIndex = -1;
   std::string error;
-  // Non-empty on `shown` when the Communication Notification treatment could
-  // not be applied, naming why the plain layout went out instead.
+  // Non-empty on `shown` when the notification went out in a reduced form,
+  // naming why: no Communication Notification treatment, or an unregistered
+  // category and so no action buttons.
   std::string degraded;
 };
 
@@ -103,20 +104,19 @@ bool OwnsNotification(const std::string &id) {
 
 // `final` releases the callback: the notification can produce no further
 // events. `shown` is not final because a click or a dismissal still follows.
+//
+// The lock is held across the call. Handing the thread-safe function out from
+// under it would let an eviction on another thread release the same function
+// mid-call. The queue is unbounded, so `BlockingCall` hands the payload off
+// without waiting and the JavaScript callback runs later on its own thread,
+// which is what makes holding the lock here safe.
 void EmitEvent(const std::string &id, Event event, bool final) {
-  Napi::ThreadSafeFunction tsfn;
-  {
-    std::lock_guard<std::mutex> lock(g_mutex);
-    auto it = g_callbacks.find(id);
-    if (it == g_callbacks.end()) {
-      return;
-    }
-    tsfn = it->second;
-    if (final) {
-      g_callbacks.erase(it);
-      ForgetCallbackLocked(id);
-    }
+  std::lock_guard<std::mutex> lock(g_mutex);
+  auto it = g_callbacks.find(id);
+  if (it == g_callbacks.end()) {
+    return;
   }
+  Napi::ThreadSafeFunction tsfn = it->second;
 
   auto *payload = new Event(std::move(event));
   const napi_status status = tsfn.BlockingCall(
@@ -139,6 +139,8 @@ void EmitEvent(const std::string &id, Event event, bool final) {
     delete payload;
   }
   if (final) {
+    g_callbacks.erase(it);
+    ForgetCallbackLocked(id);
     tsfn.Release();
   }
 }
@@ -275,10 +277,24 @@ void RestoreDelegate() {
   g_delegate.previousDelegate = nil;
 }
 
+// One application of the union at a time, with a request that arrives while
+// one is in flight coalesced into a single re-run. These two flags and
+// `g_categories` are touched only on the main thread: that is where the
+// JavaScript surface runs and where the completion below hands control back.
+bool g_applyingCategories = false;
+bool g_categoriesDirty = false;
+
 // Hands the notification center the union of what it already holds and every
 // category this addon has registered. Replacing the set instead would drop
-// categories registered by anything else in the process.
+// categories registered by anything else in the process. The union is a
+// read-modify-write straddling an asynchronous fetch, so two applications that
+// overlapped could each write back a set missing the other's categories.
 void ApplyCategories() {
+  if (g_applyingCategories) {
+    g_categoriesDirty = true;
+    return;
+  }
+  g_applyingCategories = true;
   UNUserNotificationCenter *center =
       [UNUserNotificationCenter currentNotificationCenter];
   NSDictionary<NSString *, UNNotificationCategory *> *ours =
@@ -294,6 +310,13 @@ void ApplyCategories() {
     // ordered action set, so a collision means the same buttons either way.
     [merged addEntriesFromDictionary:ours];
     [center setNotificationCategories:[NSSet setWithArray:merged.allValues]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      g_applyingCategories = false;
+      if (g_categoriesDirty) {
+        g_categoriesDirty = false;
+        ApplyCategories();
+      }
+    });
   }];
 }
 
@@ -429,17 +452,21 @@ SenderContent ContentWithSenderIntent(UNMutableNotificationContent *content,
 
 void PostNotification(const ShowRequest &request) {
   NSString *categoryId = ToNSString(request.categoryId);
-  // Every action set the app posts is registered at startup through
-  // `registerCategories`, because `setNotificationCategories:` applies
-  // asynchronously and a category minted in the runloop turn its notification
-  // is posted can miss it. This covers a set that was not registered there.
-  if (g_categories[categoryId] == nil) {
-    NSMutableArray<NSString *> *actionTitles = [NSMutableArray array];
-    for (const std::string &action : request.actions) {
-      [actionTitles addObject:ToNSString(action)];
-    }
-    RememberCategory(categoryId, actionTitles);
-    ApplyCategories();
+  // Every action set the app posts is registered through `registerCategories`
+  // at startup, because `setNotificationCategories:` applies asynchronously
+  // and a category minted in the runloop turn its notification is posted can
+  // miss it. An identifier that is not registered by then cannot be repaired
+  // here for the same reason, so the notification goes out without one and the
+  // `shown` event names the reason. An empty identifier is a notification that
+  // asks for no buttons.
+  std::string degraded;
+  const bool hasCategory =
+      categoryId.length > 0 && g_categories[categoryId] != nil;
+  if (categoryId.length > 0 && !hasCategory) {
+    degraded = "the category " + request.categoryId +
+               " is not registered, so the action buttons are missing";
+    os_log_error(OS_LOG_DEFAULT, "vellum-notifier: %{public}s",
+                 degraded.c_str());
   }
 
   UNMutableNotificationContent *content =
@@ -450,14 +477,18 @@ void PostNotification(const ShowRequest &request) {
   }
   content.body = ToNSString(request.body);
   content.sound = [UNNotificationSound defaultSound];
-  content.categoryIdentifier = categoryId;
+  if (hasCategory) {
+    content.categoryIdentifier = categoryId;
+  }
 
   UNNotificationContent *finalContent = content;
-  std::string degraded;
   if (request.hasSender) {
     SenderContent applied = ContentWithSenderIntent(content, request);
     finalContent = applied.content;
-    degraded = applied.degraded;
+    if (!applied.degraded.empty()) {
+      degraded = degraded.empty() ? applied.degraded
+                                  : degraded + "; " + applied.degraded;
+    }
   }
 
   const std::string id = request.id;

--- a/clients/macos/scripts/afterSign.js
+++ b/clients/macos/scripts/afterSign.js
@@ -9,9 +9,48 @@ const fs = require("fs");
 const path = require("path");
 const { Arch } = require("builder-util");
 const { findIdentity } = require("app-builder-lib/out/codeSign/macCodeSign");
-const {
-  deriveCommunicationEntitlements,
-} = require("./entitlements/derive-communication-entitlements");
+
+// `lipo -archs` names the x64 slice x86_64, and electron-builder.config.cjs
+// only ever targets one of these two.
+const NOTIFIER_SLICE = {
+  arm64: "arm64",
+  x64: "x86_64",
+};
+
+/**
+ * The addon is compiled for one architecture, is looked up at runtime under
+ * `bin/notifier/<process.arch>/`, and electron-builder packs whatever sits
+ * under resources/notifier. An addon built for the other architecture would
+ * ship an app that quietly falls back to plain notifications, so fail the
+ * build instead.
+ *
+ * @param {{ name: string, path: string }} addon
+ * @param {string | undefined} packagedArch
+ */
+function assertNotifierArch(addon, packagedArch) {
+  const expected = packagedArch ? NOTIFIER_SLICE[packagedArch] : undefined;
+  if (!expected) {
+    throw new Error(
+      `afterSign: cannot check ${addon.name} against packaged architecture "${packagedArch}"; the notifier addon supports ${Object.keys(NOTIFIER_SLICE).join(" and ")}`
+    );
+  }
+  const remedy = `Rebuild it with ELECTRON_TARGET_ARCH=${packagedArch} bash scripts/build-notifier.sh.`;
+  if (!addon.name.startsWith(`notifier/${packagedArch}/`)) {
+    throw new Error(
+      `afterSign: ${addon.name} is not under notifier/${packagedArch}/, so the runtime lookup by process.arch would miss it. ${remedy}`
+    );
+  }
+  const slices = execFileSync("lipo", ["-archs", addon.path], {
+    encoding: "utf8",
+  })
+    .trim()
+    .split(/\s+/);
+  if (!slices.includes(expected)) {
+    throw new Error(
+      `afterSign: ${addon.name} is built for ${slices.join(", ")}, but this build packages ${packagedArch}. ${remedy}`
+    );
+  }
+}
 
 function getConfiguredQualifier(options) {
   if (options.identity !== undefined) {
@@ -99,7 +138,7 @@ exports.default = async function afterSign(context) {
     return;
   }
 
-  const { appOutDir, packager } = context;
+  const { appOutDir, arch, packager } = context;
   const productName = packager.appInfo.productFilename;
   const appDir = path.join(appOutDir, `${productName}.app`);
   const resourcesDir = path.join(appDir, "Contents", "Resources");
@@ -142,6 +181,7 @@ exports.default = async function afterSign(context) {
   // The notifier addon is packed per architecture under bin/notifier/<arch>/,
   // so collect whatever architectures this build shipped.
   const notifierAddons = [];
+  const packagedArch = Arch[arch];
   const notifierDir = path.join(binDir, "notifier");
   if (fs.existsSync(notifierDir)) {
     for (const archEntry of fs.readdirSync(notifierDir, {
@@ -155,11 +195,13 @@ exports.default = async function afterSign(context) {
         if (!file.endsWith(".node")) {
           continue;
         }
-        notifierAddons.push({
+        const addon = {
           name: `notifier/${archEntry.name}/${file}`,
           path: path.join(archDir, file),
           entitlements: path.join(entitlementsDir, "inherit.plist"),
-        });
+        };
+        assertNotifierArch(addon, packagedArch);
+        notifierAddons.push(addon);
       }
     }
   }
@@ -201,7 +243,7 @@ exports.default = async function afterSign(context) {
   // entitlement, and this pass has to sign the same set electron-builder did.
   const macOptions = packager.platformSpecificBuildOptions || {};
   const appEntitlements = macOptions.provisioningProfile
-    ? macOptions.entitlements || deriveCommunicationEntitlements()
+    ? macOptions.entitlements
     : path.join(entitlementsDir, "app.plist");
   codesign(appDir, appEntitlements, identity);
 };

--- a/clients/macos/scripts/build-notifier.sh
+++ b/clients/macos/scripts/build-notifier.sh
@@ -15,17 +15,21 @@ if ! command -v xcrun >/dev/null 2>&1; then
   exit 1
 fi
 
-ARCH="${ELECTRON_TARGET_ARCH:-}"
-if [ -z "$ARCH" ]; then
-  case "$(uname -m)" in
-    arm64)  ARCH=arm64 ;;
-    x86_64) ARCH=x64 ;;
-    *)
-      echo "build-notifier: unsupported host architecture $(uname -m)" >&2
-      exit 1
-      ;;
-  esac
-fi
+# The packaged app's architecture comes from ELECTRON_TARGET_ARCH, defaulting
+# to arm64 in pack.sh and electron-builder.config.cjs. The addon follows the
+# same variable rather than the host's architecture: electron-builder packs
+# whatever is under resources/notifier, so a host-shaped addon in an arm64 pack
+# ships an app that quietly falls back to plain notifications.
+# `lipo -archs` names the x64 slice x86_64.
+ARCH="${ELECTRON_TARGET_ARCH:-arm64}"
+case "$ARCH" in
+  arm64) EXPECTED_SLICE=arm64 ;;
+  x64)   EXPECTED_SLICE=x86_64 ;;
+  *)
+    echo "build-notifier: unsupported ELECTRON_TARGET_ARCH: $ARCH (use arm64 or x64)" >&2
+    exit 1
+    ;;
+esac
 
 # The addon links against Electron's V8/Node ABI, so it is compiled against the
 # headers for the exact Electron the app ships with.
@@ -60,5 +64,19 @@ fi
 rm -rf "$ROOT_DIR/resources/notifier"
 OUTPUT_DIR="$ROOT_DIR/resources/notifier/$ARCH"
 mkdir -p "$OUTPUT_DIR"
-cp "$BUILT" "$OUTPUT_DIR/vellum-notifier.node"
-echo "build-notifier: wrote $OUTPUT_DIR/vellum-notifier.node"
+OUTPUT="$OUTPUT_DIR/vellum-notifier.node"
+cp "$BUILT" "$OUTPUT"
+
+# A toolchain that ignores --arch produces a host-architecture binary, and
+# electron-builder signs and packs whatever it finds, so the mismatch has to
+# fail here rather than at the user's first notification.
+SLICES="$(lipo -archs "$OUTPUT")"
+case " $SLICES " in
+  *" $EXPECTED_SLICE "*) ;;
+  *)
+    echo "build-notifier: $OUTPUT is built for $SLICES, not $EXPECTED_SLICE ($ARCH)" >&2
+    exit 1
+    ;;
+esac
+
+echo "build-notifier: wrote $OUTPUT ($SLICES)"

--- a/clients/macos/scripts/entitlements/derive-communication-entitlements.js
+++ b/clients/macos/scripts/entitlements/derive-communication-entitlements.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // `com.apple.developer.usernotifications.communication` is a restricted
 // entitlement: an app that declares it without an authorizing provisioning
 // profile is killed at launch, so only a build with
@@ -65,7 +67,6 @@ function deriveCommunicationEntitlements(options = {}) {
 module.exports = {
   COMMUNICATION_KEY,
   BASE_PLIST_PATH,
-  DERIVED_PLIST_PATH,
   addCommunicationEntitlement,
   deriveCommunicationEntitlements,
 };

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -110,7 +110,7 @@ import {
   createNativeNotificationFactory,
   registerNativeNotificationCategories,
 } from "./native-notifications";
-import { getNotifier, restoreNotifierDelegate } from "./notifier";
+import { isNotifierSupported, restoreNotifierDelegate } from "./notifier";
 import { installPermissionsService } from "./permissions-service";
 import {
   installCompanionWindow,
@@ -462,13 +462,12 @@ app
     // panel. Distinct from `installShare`, which is the "send elsewhere" intent.
     installDownloads({ handle });
     installPowerEvents();
-    // The addon owns the notification center only when it says it can have it:
-    // an unbundled run loads it fine and then reports unsupported, because
-    // UNUserNotificationCenter raises there. `isSupported` ships with `create`
-    // rather than being left to the shared module's default; see the delegate
-    // rule in README.md.
-    const notifier = getNotifier();
-    const nativeNotifications = notifier?.isSupported()
+    // The addon takes the notifications the assistant avatar can ride on only
+    // when it says it can have them: an unbundled run loads it fine and then
+    // reports unsupported, because UNUserNotificationCenter raises there.
+    // `isSupported` ships with `create` rather than being left to the shared
+    // module's default; see the delegate rule in README.md.
+    const nativeNotifications = isNotifierSupported()
       ? createNativeNotificationFactory()
       : null;
     configureNotifications({

--- a/clients/macos/src/main/native-notifications.test.ts
+++ b/clients/macos/src/main/native-notifications.test.ts
@@ -13,10 +13,35 @@ import type {
 
 const userDataDir = mkdtempSync(path.join(tmpdir(), "vellum-notif-avatars-"));
 
+interface ElectronNotificationOptions {
+  title: string;
+  body: string;
+  silent: boolean;
+  actions: { type: "button"; text: string }[];
+  icon?: unknown;
+}
+
+const electronNotifications: ElectronNotificationOptions[] = [];
+
+class FakeElectronNotification {
+  constructor(readonly options: ElectronNotificationOptions) {
+    electronNotifications.push(options);
+  }
+
+  on(): this {
+    return this;
+  }
+
+  show(): void {}
+}
+
 mock.module("electron", () => ({
   app: {
     getPath: () => userDataDir,
   },
+  BrowserWindow: { getAllWindows: () => [] },
+  Notification: FakeElectronNotification,
+  nativeImage: { createFromBuffer: (buffer: Buffer) => buffer },
 }));
 
 const warnings: unknown[][] = [];
@@ -42,6 +67,7 @@ mock.module("./notifier", () => ({
   registerNotifierCategories: (categories: NotifierCategory[]) => {
     registered.push(categories);
   },
+  isNotifierSupported: () => notifierPresent && notifierSupported,
   getNotifier: () =>
     notifierPresent
       ? {
@@ -62,6 +88,8 @@ mock.module("./notifier", () => ({
       : null,
 }));
 
+const { CATEGORY_ACTIONS, NOTIFICATION_CATEGORIES } =
+  await import("@vellumai/electron-desktop/notifications");
 const {
   createNativeNotificationFactory,
   registerNativeNotificationCategories,
@@ -69,6 +97,16 @@ const {
 
 const avatarPng = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 
+const sender = {
+  id: "assistant-1",
+  name: "Ada",
+  avatarPng,
+  avatarHash:
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+};
+
+// The addon only takes notifications that carry a sender, so every test that
+// exercises it supplies one.
 const options = (
   overrides: Partial<NotificationCreateOptions> = {},
 ): NotificationCreateOptions => ({
@@ -79,16 +117,9 @@ const options = (
     { type: "button", text: "Allow" },
     { type: "button", text: "Deny" },
   ],
+  sender,
   ...overrides,
 });
-
-const sender = {
-  id: "assistant-1",
-  name: "Ada",
-  avatarPng,
-  avatarHash:
-    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-};
 
 afterAll(() => {
   rmSync(userDataDir, { recursive: true, force: true });
@@ -98,6 +129,7 @@ beforeEach(() => {
   calls.length = 0;
   registered.length = 0;
   warnings.length = 0;
+  electronNotifications.length = 0;
   notifierSupported = true;
   notifierPresent = true;
   showThrows = false;
@@ -108,23 +140,22 @@ beforeEach(() => {
 });
 
 describe("registerNativeNotificationCategories", () => {
-  test("registers every action set once, up front", () => {
+  test("registers every action set the shared categories declare, once, up front", () => {
     registerNativeNotificationCategories();
 
     expect(registered.length).toBe(1);
     const categories = registered[0]!;
-    expect(categories.map((category) => category.actions)).toEqual([
-      ["View Results"],
-      ["Allow", "Deny"],
-      ["View Response"],
-      ["View"],
-    ]);
+    expect(categories.map((category) => category.actions)).toEqual(
+      NOTIFICATION_CATEGORIES.map((category) =>
+        CATEGORY_ACTIONS[category].map((action) => action.text),
+      ),
+    );
     for (const category of categories) {
       expect(category.categoryId).toMatch(/^vellum\.actions\.[0-9a-f]{16}$/);
     }
     expect(
       new Set(categories.map((category) => category.categoryId)).size,
-    ).toBe(4);
+    ).toBe(NOTIFICATION_CATEGORIES.length);
   });
 
   test("registers the id a notification with those actions will post under", () => {
@@ -149,18 +180,36 @@ describe("createNativeNotificationFactory", () => {
     expect(factory.isSupported()).toBe(false);
   });
 
-  test("posts a plain request without a sender", () => {
-    createNativeNotificationFactory().create(options()).show();
+  test("hands a notification without a sender to Electron's presenter", () => {
+    createNativeNotificationFactory()
+      .create(options({ sender: undefined }))
+      .show();
 
-    expect(calls.length).toBe(1);
-    const { request } = calls[0]!;
-    expect(request.title).toBe("Weekly plan");
-    expect(request.subtitle).toBeUndefined();
-    expect(request.body).toBe("Your draft is ready");
-    expect(request.categoryId).toMatch(/^vellum\.actions\.[0-9a-f]{16}$/);
-    expect(request.actions).toEqual(["Allow", "Deny"]);
-    expect(request.sender).toBeUndefined();
-    expect(request.id.length).toBeGreaterThan(0);
+    expect(calls.length).toBe(0);
+    expect(electronNotifications).toEqual([
+      {
+        title: "Weekly plan",
+        body: "Your draft is ready",
+        silent: false,
+        actions: [
+          { type: "button", text: "Allow" },
+          { type: "button", text: "Deny" },
+        ],
+      },
+    ]);
+  });
+
+  test("keeps a sender-less notification off the addon even when the addon is gone", () => {
+    notifierPresent = false;
+    const errors: string[] = [];
+    const notification = createNativeNotificationFactory().create(
+      options({ sender: undefined }),
+    );
+    notification.on("failed", (_event, error) => errors.push(error));
+    notification.show();
+
+    expect(errors).toEqual([]);
+    expect(electronNotifications.length).toBe(1);
   });
 
   test("gives every distinct action set its own category id", () => {
@@ -193,18 +242,20 @@ describe("createNativeNotificationFactory", () => {
   });
 
   test("swaps the sender name into the title and the title into the subtitle", () => {
-    createNativeNotificationFactory().create(options({ sender })).show();
+    createNativeNotificationFactory().create(options()).show();
 
     const { request } = calls[0]!;
     expect(request.title).toBe("Ada");
     expect(request.subtitle).toBe("Weekly plan");
+    expect(request.body).toBe("Your draft is ready");
     expect(request.sender?.id).toBe("assistant-1");
     expect(request.sender?.name).toBe("Ada");
     expect(request.sender?.conversationId).toBe("assistant-1");
+    expect(request.id.length).toBeGreaterThan(0);
   });
 
   test("stages the avatar through the shared cache", () => {
-    createNativeNotificationFactory().create(options({ sender })).show();
+    createNativeNotificationFactory().create(options()).show();
 
     const avatarPath = calls[0]!.request.sender!.avatarPngPath;
     expect(avatarPath).toBe(
@@ -247,9 +298,9 @@ describe("createNativeNotificationFactory", () => {
     emit({ kind: "click" });
     emit({ kind: "action", actionIndex: 1 });
     emit({ kind: "action" });
-    // The addon evicts a dismissed notification itself, so "dismiss" is not in
-    // the JS event union and anything outside it is ignored.
-    emit({ kind: "dismiss" } as unknown as NotifierEvent);
+    // The addon emits `dismiss` to release its own callback; nothing
+    // downstream acts on one.
+    emit({ kind: "dismiss" });
     emit({ kind: "failed", error: "denied" });
 
     expect(events).toEqual(["show", "click", "action:1", "failed:denied"]);

--- a/clients/macos/src/main/native-notifications.ts
+++ b/clients/macos/src/main/native-notifications.ts
@@ -7,7 +7,9 @@
  * `@vellumai/electron-desktop/notifications` calls, and shapes the payload the
  * addon expects: with a sender the assistant's name is the title and the
  * conversation title drops to the subtitle, which is the layout Communication
- * Notifications render (avatar large, app icon badged in the corner).
+ * Notifications render (avatar large, app icon badged in the corner). A
+ * notification with no sender has nothing to gain from the addon, so `create`
+ * hands it to Electron's presenter instead.
  *
  * `isSupported` has to be supplied alongside `create`: the shared module falls
  * back to `electron.Notification.isSupported()`, and merely calling that
@@ -20,15 +22,19 @@ import { createHash, randomUUID } from "node:crypto";
 import { app } from "electron";
 
 import { ensureNotificationAvatarFile } from "@vellumai/electron-desktop/notification-avatar-file";
-import type {
-  CategoryAction,
-  NotificationCreateOptions,
-  NotificationLike,
+import {
+  CATEGORY_ACTIONS,
+  createElectronNotification,
+  NOTIFICATION_CATEGORIES,
+  type CategoryAction,
+  type NotificationCreateOptions,
+  type NotificationLike,
 } from "@vellumai/electron-desktop/notifications";
 
 import log from "./logger";
 import {
   getNotifier,
+  isNotifierSupported,
   registerNotifierCategories,
   type NotifierCategory,
   type NotifierRequest,
@@ -62,31 +68,21 @@ const categoryIdForActions = (actions: readonly CategoryAction[]): string =>
   categoryIdForLabels(actions.map((action) => action.text));
 
 /**
- * The action labels of every category the app posts, copied from
- * `CATEGORY_ACTIONS` in `@vellumai/electron-desktop/notifications`, which does
- * not export them.
- */
-const CATEGORY_ACTION_LABELS: readonly (readonly string[])[] = [
-  ["View Results"],
-  ["Allow", "Deny"],
-  ["View Response"],
-  ["View"],
-];
-
-/**
  * Registers every category up front.
  *
  * `setNotificationCategories:` applies asynchronously, so a category first
  * registered in the runloop turn its notification is posted can miss it and
  * the buttons never render. Registering at startup gives macOS the whole set
- * long before the first notification.
+ * long before the first notification. The set is derived from the shared
+ * category list, so it covers every action set the app can post and a new
+ * category needs no second edit here.
  */
 export const registerNativeNotificationCategories = (): void => {
-  const categories: NotifierCategory[] = CATEGORY_ACTION_LABELS.map(
-    (labels) => ({
-      categoryId: categoryIdForLabels(labels),
-      actions: [...labels],
-    }),
+  const categories: NotifierCategory[] = NOTIFICATION_CATEGORIES.map(
+    (category) => {
+      const actions = CATEGORY_ACTIONS[category].map((action) => action.text);
+      return { categoryId: categoryIdForLabels(actions), actions };
+    },
   );
   registerNotifierCategories(categories);
 };
@@ -95,32 +91,37 @@ export const createNativeNotificationFactory = (): {
   create: (options: NotificationCreateOptions) => NotificationLike;
   isSupported: () => boolean;
 } => ({
-  isSupported: () => getNotifier()?.isSupported() ?? false,
+  isSupported: isNotifierSupported,
   create: (options) => {
+    // The addon exists for one thing Electron cannot do: render the assistant
+    // avatar as the icon. A notification with no sender has nothing to gain
+    // from it, so Electron's presenter takes it, which is also what makes the
+    // `push-avatar-sender` flag a kill switch.
+    const senderImage = options.sender;
+    if (!senderImage) {
+      return createElectronNotification(options);
+    }
+
     const listeners: Listeners = {};
     const on = ((event: string, listener: unknown): void => {
       Object.assign(listeners, { [event]: listener });
     }) as NotificationLike["on"];
 
     const resolveSender = (): NotifierRequest["sender"] => {
-      const sender = options.sender;
-      if (!sender) {
-        return undefined;
-      }
       try {
         return {
-          id: sender.id,
-          name: sender.name,
+          id: senderImage.id,
+          name: senderImage.name,
           // The addon reads the avatar from disk: Intents takes image data,
           // not a buffer over IPC.
           avatarPngPath: ensureNotificationAvatarFile(
             app.getPath("userData"),
-            sender.avatarPng,
-            sender.avatarHash,
+            senderImage.avatarPng,
+            senderImage.avatarHash,
           ),
           // Groups every notification from one assistant into a single
           // conversation in Notification Center.
-          conversationId: sender.id,
+          conversationId: senderImage.id,
         };
       } catch (error) {
         log.warn("[notifications] could not stage the sender avatar:", error);
@@ -168,6 +169,10 @@ export const createNativeNotificationFactory = (): {
             // An action without a readable index is dropped: defaulting could
             // route an ambiguous press as e.g. a tool-call "Allow".
             listeners.action?.(undefined, event.actionIndex);
+          } else if (event.kind === "dismiss") {
+            // The addon emits `dismiss` as a notification's final event so it
+            // can release the callback. Nothing downstream acts on one, and
+            // Electron has no matching event to map it onto.
           }
         });
       } catch (error) {

--- a/clients/macos/src/main/notifier.test.ts
+++ b/clients/macos/src/main/notifier.test.ts
@@ -39,6 +39,7 @@ const {
   __resetNotifierForTesting,
   __setNotifierForTesting,
   getNotifier,
+  isNotifierSupported,
   registerNotifierCategories,
   requestNotifierAuthorization,
   restoreNotifierDelegate,
@@ -242,7 +243,8 @@ describe("notifier authorization", () => {
     expect(warnings.length).toBe(1);
   });
 
-  test("ignores a second answer from the addon", async () => {
+  // `resolve` is idempotent, so the first answer stands on its own.
+  test("keeps the first answer when the addon answers twice", async () => {
     __setNotifierForTesting(
       fakeNotifier({
         requestAuthorization: (callback) => {
@@ -253,6 +255,40 @@ describe("notifier authorization", () => {
     );
 
     expect(await requestNotifierAuthorization()).toEqual({ granted: true });
+  });
+});
+
+describe("isNotifierSupported", () => {
+  beforeEach(() => {
+    __resetNotifierForTesting();
+    warnings.length = 0;
+  });
+
+  test("is false when the addon is unavailable", () => {
+    expect(isNotifierSupported()).toBe(false);
+  });
+
+  test("reports what the addon says", () => {
+    __setNotifierForTesting(fakeNotifier());
+    expect(isNotifierSupported()).toBe(true);
+
+    __setNotifierForTesting(fakeNotifier({ isSupported: () => false }));
+    expect(isNotifierSupported()).toBe(false);
+  });
+
+  // Called at boot, where a throw would skip every later install step and the
+  // app would come up with no window and no tray.
+  test("is false rather than a throw when the probe explodes", () => {
+    __setNotifierForTesting(
+      fakeNotifier({
+        isSupported: () => {
+          throw new Error("addon exploded");
+        },
+      }),
+    );
+
+    expect(isNotifierSupported()).toBe(false);
+    expect(warnings.length).toBe(1);
   });
 });
 

--- a/clients/macos/src/main/notifier.ts
+++ b/clients/macos/src/main/notifier.ts
@@ -22,7 +22,7 @@ const ADDON_FILENAME = "vellum-notifier.node";
  */
 const DISABLE_ENV_VAR = "VELLUM_DISABLE_NATIVE_NOTIFIER";
 
-export interface NotifierSender {
+interface NotifierSender {
   id: string;
   name: string;
   avatarPngPath: string;
@@ -45,13 +45,18 @@ export interface NotifierCategory {
 }
 
 export interface NotifierEvent {
-  kind: "shown" | "failed" | "click" | "action";
+  /**
+   * `dismiss` is a notification's final event: the addon emits it so it can
+   * release the callback, and nothing downstream acts on one.
+   */
+  kind: "shown" | "failed" | "click" | "action" | "dismiss";
   actionIndex?: number;
   error?: string;
   /**
-   * Present on `shown` when the notification posted without the Communication
-   * Notification treatment, naming why. The notification itself is fine, so
-   * this is diagnostic rather than a failure.
+   * Present on `shown` when the notification posted in a reduced form, naming
+   * why: no Communication Notification treatment, or an unregistered category
+   * and so no action buttons. The notification itself is fine, so this is
+   * diagnostic rather than a failure.
    */
   degraded?: string;
 }
@@ -137,6 +142,25 @@ const loadNotifier = (): Notifier | null => {
 export const getNotifier = (): Notifier | null => loadNotifier();
 
 /**
+ * Whether the addon is loaded and can own the notification center. False when
+ * the addon is absent, disabled, or reports unsupported (an unbundled run),
+ * and false rather than a throw when the probe itself fails, so a caller at
+ * boot cannot be taken down by it.
+ */
+export const isNotifierSupported = (): boolean => {
+  const notifier = loadNotifier();
+  if (!notifier) {
+    return false;
+  }
+  try {
+    return notifier.isSupported();
+  } catch (error) {
+    log.warn("[notifier] isSupported failed:", error);
+    return false;
+  }
+};
+
+/**
  * Prompts for notification authorization through the addon, which keeps the
  * notification center's delegate with the addon. Resolves `null` when the
  * addon is unavailable or the call throws, so callers can fall back.
@@ -148,19 +172,13 @@ export const requestNotifierAuthorization =
       return Promise.resolve(null);
     }
     return new Promise((resolve) => {
-      let settled = false;
-      const settle = (result: NotifierAuthorizationResult | null): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        resolve(result);
-      };
       try {
-        notifier.requestAuthorization(settle);
+        // `resolve` is idempotent, so an addon that answers twice cannot
+        // change the outcome.
+        notifier.requestAuthorization(resolve);
       } catch (error) {
         log.warn("[notifier] requestAuthorization failed:", error);
-        settle(null);
+        resolve(null);
       }
     });
   };

--- a/clients/macos/src/main/permissions-service.test.ts
+++ b/clients/macos/src/main/permissions-service.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { Notifier, NotifierAuthorizationResult } from "./notifier";
+import type {
+  Notifier,
+  NotifierAuthorizationResult,
+  NotifierRequest,
+} from "./notifier";
 
 // Counted rather than asserted on construction: the whole point of the native
 // path is that Electron's presenter is never built, and building it is what
 // hands Electron the notification center's delegate.
 let electronNotificationsConstructed = 0;
 let electronIsSupportedCalls = 0;
+let electronSupported = true;
 
 type ElectronListener = () => void;
 
@@ -19,7 +24,7 @@ class FakeElectronNotification {
 
   static isSupported(): boolean {
     electronIsSupportedCalls += 1;
-    return true;
+    return electronSupported;
   }
 
   once(event: string, listener: ElectronListener): this {
@@ -64,9 +69,11 @@ mock.module("./hotkey-helper", () => ({
 
 let notifier: Notifier | null = null;
 let authorizationResult: NotifierAuthorizationResult | null = { granted: true };
+const nativePosts: NotifierRequest[] = [];
 
 mock.module("./notifier", () => ({
   getNotifier: () => notifier,
+  isNotifierSupported: () => notifier?.isSupported() ?? false,
   requestNotifierAuthorization: async () => authorizationResult,
 }));
 
@@ -77,13 +84,17 @@ const nativeNotifier = (isSupported = true): Notifier => ({
   requestAuthorization: () => undefined,
   registerCategories: () => undefined,
   restoreDelegate: () => undefined,
-  show: () => undefined,
+  show: (request) => {
+    nativePosts.push(request);
+  },
 });
 
 describe("notification permission requests", () => {
   beforeEach(() => {
     electronNotificationsConstructed = 0;
     electronIsSupportedCalls = 0;
+    electronSupported = true;
+    nativePosts.length = 0;
     notifier = nativeNotifier();
     authorizationResult = { granted: true };
   });
@@ -96,6 +107,17 @@ describe("notification permission requests", () => {
     expect(electronIsSupportedCalls).toBe(0);
   });
 
+  // The Electron probe posts a notification to learn its answer, so a granted
+  // permission always ends in a banner; the addon answers without posting one.
+  test("posts the same confirmation banner the Electron probe leaves behind", async () => {
+    await new PermissionsService().request("notifications");
+
+    expect(nativePosts.length).toBe(1);
+    expect(nativePosts[0]!.body).toBe("Notifications are enabled.");
+    expect(nativePosts[0]!.actions).toEqual([]);
+    expect(electronNotificationsConstructed).toBe(0);
+  });
+
   test("records a refused prompt as denied", async () => {
     authorizationResult = { granted: false, error: "not authorized" };
 
@@ -103,15 +125,17 @@ describe("notification permission requests", () => {
 
     expect(item.status).toBe("denied");
     expect(electronNotificationsConstructed).toBe(0);
+    expect(nativePosts.length).toBe(0);
   });
 
-  test("records an addon that cannot notify as restricted", async () => {
+  test("falls back to the Electron probe when the addon cannot notify", async () => {
     notifier = nativeNotifier(false);
 
     const item = await new PermissionsService().request("notifications");
 
-    expect(item.status).toBe("restricted");
-    expect(electronIsSupportedCalls).toBe(0);
+    expect(item.status).toBe("granted");
+    expect(electronNotificationsConstructed).toBe(1);
+    expect(nativePosts.length).toBe(0);
   });
 
   test("falls back to the Electron probe when the addon is unavailable", async () => {
@@ -121,5 +145,15 @@ describe("notification permission requests", () => {
 
     expect(item.status).toBe("granted");
     expect(electronNotificationsConstructed).toBe(1);
+  });
+
+  test("reports restricted only when neither path can post", async () => {
+    notifier = nativeNotifier(false);
+    electronSupported = false;
+
+    const item = await new PermissionsService().request("notifications");
+
+    expect(item.status).toBe("restricted");
+    expect(electronNotificationsConstructed).toBe(0);
   });
 });

--- a/clients/macos/src/main/permissions-service.ts
+++ b/clients/macos/src/main/permissions-service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import {
   BrowserWindow,
   Notification,
@@ -21,8 +23,8 @@ import { handle } from "./ipc";
 import log from "./logger";
 import {
   getNotifier,
+  isNotifierSupported,
   requestNotifierAuthorization,
-  type Notifier,
   type NotifierAuthorizationResult,
 } from "./notifier";
 
@@ -141,34 +143,51 @@ const settleWithin = <T>(
   probe: (settle: (value: T | null) => void) => void,
 ): Promise<T | null> =>
   new Promise((resolve) => {
-    let settled = false;
-    let timeout: ReturnType<typeof setTimeout> | null = null;
-    const settle = (value: T | null): void => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-      resolve(value);
-    };
-    timeout = setTimeout(() => {
-      settle(null);
+    const timeout = setTimeout(() => {
+      resolve(null);
     }, timeoutMs);
     timeout.unref?.();
-    probe(settle);
+    probe((value) => {
+      clearTimeout(timeout);
+      resolve(value);
+    });
   });
+
+/**
+ * The Electron probe learns its answer by posting a notification, so a user
+ * who allows sees a confirmation banner. The addon answers without posting
+ * anything, so the native path posts the same banner itself. It carries no
+ * category because it has no action buttons to route.
+ */
+const postNativeNotificationConfirmation = (): void => {
+  const notifier = getNotifier();
+  if (!notifier) {
+    return;
+  }
+  try {
+    notifier.show(
+      {
+        id: randomUUID(),
+        title: "Vellum",
+        body: "Notifications are enabled.",
+        categoryId: "",
+        actions: [],
+      },
+      () => undefined,
+    );
+  } catch (error) {
+    log.warn("[permissions] confirmation notification failed:", error);
+  }
+};
 
 // Asking the addon rather than `electron.Notification.isSupported()`, which
 // builds Electron's presenter and takes the notification center's delegate.
-const initialNotificationStatus = (): PermissionStatus => {
-  const notifier = getNotifier();
-  const supported = notifier
-    ? notifier.isSupported()
-    : Notification.isSupported();
-  return supported ? "unknown" : "restricted";
-};
+// Electron's own probe is consulted only when the addon cannot post, which is
+// the case where the presenter gets built anyway.
+const initialNotificationStatus = (): PermissionStatus =>
+  isNotifierSupported() || Notification.isSupported()
+    ? "unknown"
+    : "restricted";
 
 export class PermissionsService {
   private lastStateJson: string | null = null;
@@ -336,20 +355,18 @@ export class PermissionsService {
   }
 
   private requestNotifications(_sender?: WebContents): Promise<void> {
-    const notifier = getNotifier();
-    if (notifier) {
-      return this.requestNativeNotifications(notifier);
+    // An addon that loads but reports unsupported is not a dead end: Electron
+    // can still post, so the probe falls back to it rather than calling the
+    // permission restricted.
+    if (isNotifierSupported()) {
+      return this.requestNativeNotifications();
     }
     return this.requestElectronNotifications();
   }
 
   // Prompting through the addon rather than `electron.Notification` is half of
   // what keeps the delegate with the addon; see the delegate rule in README.md.
-  private async requestNativeNotifications(notifier: Notifier): Promise<void> {
-    if (!notifier.isSupported()) {
-      this.notificationStatus = "restricted";
-      return;
-    }
+  private async requestNativeNotifications(): Promise<void> {
     const result = await settleWithin<NotifierAuthorizationResult>(
       NOTIFICATION_PROMPT_TIMEOUT_MS,
       (settle) => {
@@ -361,6 +378,9 @@ export class PermissionsService {
       return;
     }
     this.notificationStatus = result.granted ? "granted" : "denied";
+    if (result.granted) {
+      postNativeNotificationConfirmation();
+    }
   }
 
   private async requestElectronNotifications(): Promise<void> {

--- a/packages/electron-desktop/src/notifications.ts
+++ b/packages/electron-desktop/src/notifications.ts
@@ -134,16 +134,21 @@ export interface CategoryAction {
  * `toolConfirmation`      → "Allow" / "Deny"
  * `voiceResponseComplete` → "View Response"
  * `notificationIntent`    → "View" (follow the deep link)
+ *
+ * Exported because a client that posts through its own `create` factory has
+ * to register the same label sets with the OS ahead of time, and a second copy
+ * of them drifts.
  */
-const CATEGORY_ACTIONS: Record<NotificationCategory, CategoryAction[]> = {
-  activityComplete: [{ type: "button", text: "View Results" }],
-  toolConfirmation: [
-    { type: "button", text: "Allow" },
-    { type: "button", text: "Deny" },
-  ],
-  voiceResponseComplete: [{ type: "button", text: "View Response" }],
-  notificationIntent: [{ type: "button", text: "View" }],
-};
+export const CATEGORY_ACTIONS: Record<NotificationCategory, CategoryAction[]> =
+  {
+    activityComplete: [{ type: "button", text: "View Results" }],
+    toolConfirmation: [
+      { type: "button", text: "Allow" },
+      { type: "button", text: "Deny" },
+    ],
+    voiceResponseComplete: [{ type: "button", text: "View Response" }],
+    notificationIntent: [{ type: "button", text: "View" }],
+  };
 
 /**
  * Per-category cooldown thresholds (milliseconds). Suppresses duplicate
@@ -226,14 +231,14 @@ const pruneStaleEntries = (): void => {
  * Swift client, which acks only after `UNUserNotificationCenter.add(...)`'s
  * completion handler resolves.
  *
- * On the default `electron.Notification` path the very first notification
- * races the macOS permission prompt: neither event fires until the user
- * answers. A client whose `create` factory owns the notification center (the
- * macOS native addon) prompts for authorization up front instead, so its first
- * notification is posted against an answered prompt. The timeout is
- * deliberately generous so a user who takes a few seconds to click "Allow"
- * still acks as delivered; only a genuinely unanswered or dropped notification
- * falls through to the conservative "not confirmed" failure ack.
+ * The first notification races the macOS permission prompt on both delivery
+ * paths: `electron.Notification` posts against a prompt the user has yet to
+ * answer, and the macOS native addon requests authorization inside the post
+ * itself. Neither reports an outcome until the user answers, so the timeout
+ * has to cover the prompt. It is deliberately generous so a user who takes a
+ * few seconds to click "Allow" still acks as delivered; only a genuinely
+ * unanswered or dropped notification falls through to the conservative "not
+ * confirmed" failure ack.
  */
 const DELIVERY_TIMEOUT_MS = 30_000;
 
@@ -268,8 +273,11 @@ interface ShowResult {
  * avatar never reaches this path there: a client that renders the sender on
  * macOS or Windows supplies its own `create` factory, and this path ignores
  * `sender` on both. Windows toasts have no icon slot on this path at all.
+ *
+ * Exported so a `create` factory that only handles some notifications can hand
+ * the rest back to Electron's presenter.
  */
-const createElectronNotification = (
+export const createElectronNotification = (
   options: NotificationCreateOptions,
 ): NotificationLike => {
   const { sender, ...constructorOptions } = options;


### PR DESCRIPTION
## Summary

- Release workflows now decode the provisioning profile to a plist and assert with `PlistBuddy` that it grants `com.apple.developer.usernotifications.communication` and that its `application-identifier` ends with the bundle id the environment packs; an unset secret is a `::warning::` saying the native notifier ships disabled. `dev-release.yaml` and `release.yml` stay in step.
- The addon now posts only notifications that carry a sender; everything else goes through the shared `createElectronNotification`, so turning `push-avatar-sender` off restores Electron as the delivery path without a new build.
- `CATEGORY_ACTIONS` and `createElectronNotification` are exported from `@vellumai/electron-desktop/notifications`; the macOS startup category list is derived from `NOTIFICATION_CATEGORIES` instead of a hand-copied label array, and the test imports the shared constants.
- The addon's lazy re-registration at post time is gone (it could never apply in the same runloop turn); an unregistered category id now posts without a category and names the reason on the `shown` event.
- `ApplyCategories()` is serialized with an in-flight flag plus a coalesced re-run, so overlapping applications cannot drop a category.
- `EmitEvent` holds `g_mutex` across `BlockingCall` so a concurrent eviction cannot release the thread-safe function mid-call.
- `isNotifierSupported()` wraps the probe in try/catch (false on throw) and is used at boot and in the permissions service; a loaded-but-unsupported addon now falls back to the Electron probe instead of reporting `restricted`, and the native path posts the same "Notifications are enabled." confirmation banner the Electron path leaves behind.
- `"dismiss"` is back in `NotifierEvent["kind"]` with a documented no-op branch, so the test no longer launders the event through `as unknown`.
- `// @ts-check` restored on `electron-builder.config.cjs` and added to `derive-communication-entitlements.js`; dropped the redundant `settled` flags, the unreachable `deriveCommunicationEntitlements()` fallback in `afterSign.js`, and the unused `NotifierSender` / `DERIVED_PLIST_PATH` exports.
- `build-notifier.sh` defaults to `ELECTRON_TARGET_ARCH` (arm64, matching `pack.sh` and the builder config) and asserts the compiled slice with `lipo -archs`; `afterSign.js` fails the build when the packed addon is not the architecture being packaged.

Round-2 self-review fixes for the notification avatar feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1