### PR TITLE
fix(android): bound the avatar download, open the conversation from its shortcut, align the notification id seed

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -406,33 +406,47 @@ one natively must never claim it.
 payload carries a Firebase notification block, or a data-only push the web
 layer can render right now, goes to `PushNotificationsPlugin`. Everything else
 is rendered natively, including a data-only push that arrives while the app is
-on screen but the bridge is not up yet, so a cold start never drops one. The
-two paths never both run: the web handler posts its own banner from either a
-live `pushNotificationReceived` or the message it stashes for the next load.
+on screen but the bridge is not up yet, so a cold start never drops one. "Right
+now" means an activity of ours is resumed and the web runtime holds a foreground
+push handler, which it asserts through
+`AndroidPushRegistration.setForegroundHandler` for exactly as long as it holds
+one. Those foreground pushes are drawn by the web layer and carry no avatar
+treatment, an accepted scope cut. A native render that throws falls through to
+`PushNotificationsPlugin` rather than losing the push.
 
 `NativePushRenderer` posts the native notification. With a sender it is a
 `MessagingStyle` conversation: the avatar is the large icon, the assistant's
 name is the message line, and the conversation title is the header. Without a
-sender it matches what Firebase would have rendered. The channel the payload
-names is created if it is missing and falls back to `vellum-alerts` if it is
-not one of ours, because from API 26 posting to a channel that does not exist
-is a silent no-op. The notification id is the same hash of the delivery id the
-web layer derives, so a delivery both paths see collapses onto one entry.
+sender it matches what Firebase would have rendered. `vellum-alerts` is the only
+channel a payload may name: it is created if it is missing, because from API 26
+posting to a channel that does not exist is a silent no-op, and any other name
+falls back to it. Existing is not enough, since the voice session channel and
+Firebase's own fallback both exist and both post silently. The notification id
+walks the same seed chain the web layer hashes, the delivery id then the
+Firebase message id then the source event with the copy, so a delivery both
+paths see collapses onto one entry.
 
 Each conversation notification also publishes a long-lived dynamic shortcut,
-which is what gives Android the conversation treatment. The shortcut intent
-carries only the conversation id, never the push's identifiers, so a tap on a
-week-old shortcut cannot replay a stale delivery. At most two of our shortcuts
-are kept; the oldest is removed before a new one is pushed, so the static New
-chat and Start voice entries keep their places.
+which is what gives Android the conversation treatment. The shortcut intent is
+the conversation's own app link, never the push's identifiers, so a tap opens
+the thread from a cold or a warm start and a week-old shortcut cannot replay a
+stale delivery. Two conversations keep a shortcut at a time: a product cap on
+how much of the launcher's list a notification may claim, not a budget shared
+with the static New chat and Start voice entries, which are manifest shortcuts
+a dynamic push can never evict. The shortcuts leave with the token on
+`AndroidPushRegistration.unregister`, so the next account does not inherit the
+previous one's conversation titles and avatars.
 
 `AvatarCache` keeps the sender avatars on disk under the cache directory, eight
-at a time, evicted least-recently-used. The avatar is resolved before the
-notification is posted: the cache first, then an HTTPS download verified
-against the pushed sha256. The download runs inside `onMessageReceived` with
-3 s connect and read timeouts, deliberately shorter than the 8 s an iOS
-notification-service extension gets, because the Firebase callback window is
-much tighter. A miss just posts without an avatar.
+at a time, evicted least-recently-used, each file re-hashed against the name it
+is filed under before it is drawn. The avatar is resolved once the renderer
+confirms a notification can be posted at all, and before it is posted: the cache
+first, then an HTTPS download verified against the pushed sha256. The download
+runs inside `onMessageReceived` with 3 s connect and read timeouts plus a 4 s
+total budget for the body, since the per-read timeout restarts on every chunk.
+All of that is deliberately shorter than the 8 s an iOS notification-service
+extension gets, because the Firebase callback window is much tighter. A miss
+just posts without an avatar.
 
 ### Device QA checklist
 
@@ -443,13 +457,18 @@ push from a lower environment. Verify:
   never two.
 - Foreground delivery during a cold start, before the web layer has loaded,
   still posts.
+- A push arriving right after a WebView reload, while the web runtime has no
+  handler yet, still posts exactly one banner.
 - The first push for a new avatar hash downloads and shows the avatar; the
   next push for the same hash shows it from the cache with no visible delay.
 - A push whose `sender_avatar_url` is missing posts without an avatar.
 - Tapping a notification opens the conversation it came from.
-- The conversation appears as a launcher shortcut, tapping it opens that
-  conversation rather than replaying the push, and a third conversation
-  evicts the oldest of ours without disturbing New chat or Start voice.
+- The conversation appears as a launcher shortcut; tapping it opens that
+  conversation from both a cold and a warm start rather than replaying the
+  push, and a third conversation evicts the oldest of ours without disturbing
+  New chat or Start voice.
+- Signing out clears our conversation shortcuts and leaves New chat and Start
+  voice in place.
 - On API 24 or 25 the notification plays the default sound.
 - A push naming an unknown channel still arrives, on `vellum-alerts`.
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidAppLink.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidAppLink.java
@@ -1,10 +1,25 @@
 package ai.vellum.assistant;
 
+import androidx.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-final class AndroidAppLink {
+public final class AndroidAppLink {
+    private static final String CONVERSATION_PATH = "/assistant/conversations/";
+    // A conversation id that survives both ownsPath and the normalization
+    // check: no escaping, no relative segment, nothing that rewrites the route.
+    private static final String CONVERSATION_ID_PATTERN = "[A-Za-z0-9_-]{1,128}";
+
     private AndroidAppLink() {}
+
+    /** The link {@link #parse} accepts back for a conversation. */
+    @Nullable
+    public static String conversationUrl(String host, @Nullable String conversationId) {
+        if (conversationId == null || !conversationId.matches(CONVERSATION_ID_PATTERN)) {
+            return null;
+        }
+        return "https://" + host + CONVERSATION_PATH + conversationId;
+    }
 
     static URI parse(String raw, String expectedHost) {
         if (raw == null || expectedHost == null) {
@@ -50,7 +65,7 @@ final class AndroidAppLink {
             case "/assistant/settings/usage":
                 return true;
             default:
-                return path.startsWith("/assistant/conversations/")
+                return path.startsWith(CONVERSATION_PATH)
                     || path.startsWith("/assistant/settings/billing/");
         }
     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
@@ -38,25 +38,30 @@ public class AndroidNotificationChannelsPlugin extends Plugin {
      * The channel a natively rendered push posts on. A push can arrive before
      * the web runtime has ever asked for the alerts channel, and from API 26
      * posting to a channel that does not exist is a silent no-op, so the
-     * channel is created here and stands in for any other channel a payload
-     * names.
+     * channel is created here and stands in for any channel a payload names
+     * that is not one of ours to alert on.
      */
     public static String resolveChannelId(Context context, String requestedChannelId) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return requestedChannelId;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createAlertsChannel(context);
         }
-        createAlertsChannel(context);
-        if (
-            ALERTS_CHANNEL_ID.equals(requestedChannelId)
-                || channelExists(context, requestedChannelId)
-        ) {
+        if (isAlertChannelId(requestedChannelId)) {
             return requestedChannelId;
         }
         NativeFailureGuard.record(
-            "Android push named a notification channel that does not exist",
+            "Android push named a channel that does not alert",
             new IllegalStateException(requestedChannelId)
         );
         return ALERTS_CHANNEL_ID;
+    }
+
+    /**
+     * Existing is not enough: the voice session channel and Firebase's own
+     * fallback both exist and both post silently and without a badge, so a
+     * payload can only name a channel this app alerts on.
+     */
+    static boolean isAlertChannelId(@Nullable String channelId) {
+        return ALERTS_CHANNEL_ID.equals(channelId);
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
@@ -73,12 +78,6 @@ public class AndroidNotificationChannelsPlugin extends Plugin {
             )
         );
         return true;
-    }
-
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private static boolean channelExists(Context context, String channelId) {
-        NotificationManager manager = manager(context);
-        return manager != null && manager.getNotificationChannel(channelId) != null;
     }
 
     @Nullable

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
@@ -1,5 +1,6 @@
 package ai.vellum.assistant;
 
+import ai.vellum.assistant.push.NativePushRenderer;
 import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
@@ -18,6 +19,13 @@ public class AndroidPushRegistrationPlugin extends Plugin {
      */
     static final String NATIVE_NOTIFICATION_RENDER = "native-notification-render";
 
+    /**
+     * Whether the web runtime currently holds a handler for foreground pushes.
+     * The plugin instance outlives that handler, so the renderer asks this
+     * instead: a push handed to a torn-down handler is simply lost.
+     */
+    private static volatile boolean foregroundHandler;
+
     @PluginMethod
     public void register(PluginCall call) {
         invokeSafely(call, plugin -> plugin.register(call));
@@ -25,12 +33,33 @@ public class AndroidPushRegistrationPlugin extends Plugin {
 
     @PluginMethod
     public void unregister(PluginCall call) {
+        // The conversation shortcuts carry the previous account's titles and
+        // avatars, so they leave with its token.
+        NativeFailureGuard.run(
+            "Unable to remove the Android conversation shortcuts",
+            () -> NativePushRenderer.clearConversationShortcuts(getContext())
+        );
         invokeSafely(call, plugin -> plugin.unregister(call));
     }
 
     @PluginMethod
     public void getCapabilities(PluginCall call) {
         call.resolve(capabilitiesPayload());
+    }
+
+    @PluginMethod
+    public void setForegroundHandler(PluginCall call) {
+        foregroundHandler = Boolean.TRUE.equals(call.getBoolean("active", false));
+        call.resolve();
+    }
+
+    public static boolean hasForegroundHandler() {
+        return foregroundHandler;
+    }
+
+    /** A page load takes the handler with it without running its own teardown. */
+    public static void clearForegroundHandler() {
+        foregroundHandler = false;
     }
 
     static JSObject capabilitiesPayload() {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -45,6 +45,7 @@ public class MainActivity extends BridgeActivity {
 
     private static ConnectDeepLink recreationConnect;
     private static String recreationRoutePath;
+    private static volatile boolean activityResumed;
 
     private final Handler launchScreenHandler = new Handler(Looper.getMainLooper());
     private AlertDialog unreachableDialog;
@@ -191,6 +192,28 @@ public class MainActivity extends BridgeActivity {
         }
         launchScreenHandler.removeCallbacksAndMessages(null);
         launchScreenHandler.postDelayed(this::hideLaunchScreen, delayMs);
+    }
+
+    /**
+     * True while an activity of ours is in front of the user, which is what the
+     * push renderer asks before leaving a notification to the web layer.
+     * Process importance cannot answer that: it also reads as visible while the
+     * Quick Settings tile service is bound and no window is shown.
+     */
+    public static boolean isResumed() {
+        return activityResumed;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        activityResumed = true;
+    }
+
+    @Override
+    public void onPause() {
+        activityResumed = false;
+        super.onPause();
     }
 
     @Override
@@ -542,6 +565,7 @@ public class MainActivity extends BridgeActivity {
         @Override
         public void onPageStarted(WebView view, String url, android.graphics.Bitmap favicon) {
             VoiceAudioSessionPlugin.releaseForPageLoad(activity);
+            AndroidPushRegistrationPlugin.clearForegroundHandler();
             activity.scheduleLaunchScreenFallback(LAUNCH_SCREEN_TIMEOUT_MS);
             mainFrameUrl = url;
             mainFrameFailed = false;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeFailureGuard.java
@@ -44,6 +44,20 @@ public final class NativeFailureGuard {
         }
     }
 
+    /**
+     * {@link #get} widened to {@link Throwable} for work that can exhaust the
+     * heap, such as decoding a bitmap: the fallback is a notification without
+     * an avatar, while an escaping OutOfMemoryError loses the push entirely.
+     */
+    public static <T> T getAllocating(String logMessage, Supplier<T> operation, T fallback) {
+        try {
+            return operation.get();
+        } catch (Throwable throwable) {
+            record(logMessage, throwable);
+            return fallback;
+        }
+    }
+
     public static void record(String logMessage, Throwable exception) {
         Logger.error(logMessage, exception);
         Context context = applicationContext;

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SafeMessagingService.java
@@ -3,17 +3,19 @@ package ai.vellum.assistant;
 import ai.vellum.assistant.push.AvatarCache;
 import ai.vellum.assistant.push.NativePushRenderer;
 import ai.vellum.assistant.push.PushDataMessage;
-import android.app.ActivityManager;
-import android.content.Context;
 import android.graphics.Bitmap;
-import android.os.Process;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
-import java.util.List;
 
+/**
+ * Routes each push to exactly one renderer. A data-only push this process owns
+ * gets the conversation treatment with the sender's avatar; everything else,
+ * including a data-only push the web layer will render while the app is on
+ * screen, goes to the Capacitor plugin and shows without an avatar.
+ */
 public class SafeMessagingService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(@NonNull RemoteMessage remoteMessage) {
@@ -28,8 +30,7 @@ public class SafeMessagingService extends FirebaseMessagingService {
                 // pushNotificationReceived at a live bridge or stash the
                 // message for replay on the next load, and the web handler
                 // posts its own banner from either.
-                if (message.rendersNatively(webWillRender())) {
-                    render(remoteMessage, message);
+                if (message.rendersNatively(webWillRender()) && render(remoteMessage, message)) {
                     return;
                 }
                 PushNotificationsPlugin.sendRemoteMessage(remoteMessage);
@@ -50,12 +51,25 @@ public class SafeMessagingService extends FirebaseMessagingService {
      * Resolves the avatar before posting rather than posting twice: a second
      * post on the same id flickers the banner and can land after the user has
      * already dismissed the first. The download runs on the Firebase message
-     * thread inside onMessageReceived, so {@link AvatarCache}'s timeouts are
-     * the whole budget it gets.
+     * thread inside onMessageReceived under {@link AvatarCache}'s own total
+     * deadline, and only once the renderer says a notification can be posted at
+     * all.
+     *
+     * @return false only when this path threw, leaving the push for the web
+     *     layer rather than dropping it.
      */
-    private void render(RemoteMessage remoteMessage, PushDataMessage message) {
-        AvatarCache cache = new AvatarCache(this);
-        NativePushRenderer.show(this, remoteMessage, message, avatar(message, cache));
+    private boolean render(RemoteMessage remoteMessage, PushDataMessage message) {
+        return NativeFailureGuard.getAllocating(
+            "Unable to render the Android push notification",
+            () -> {
+                if (NativePushRenderer.canPost(this)) {
+                    AvatarCache cache = new AvatarCache(this);
+                    NativePushRenderer.show(this, remoteMessage, message, avatar(message, cache));
+                }
+                return true;
+            },
+            false
+        );
     }
 
     /** Runs on the Firebase message thread, so the cache read and fetch may block. */
@@ -65,7 +79,7 @@ public class SafeMessagingService extends FirebaseMessagingService {
         if (sender == null) {
             return null;
         }
-        return NativeFailureGuard.get(
+        return NativeFailureGuard.getAllocating(
             "Unable to load the Android push notification avatar",
             () -> {
                 Bitmap cached = cache.load(sender.avatarHash);
@@ -76,35 +90,13 @@ public class SafeMessagingService extends FirebaseMessagingService {
     }
 
     /**
-     * The web layer renders only a push it can actually receive, which takes a
-     * screen in front of the user and a bridge that is already up. A push
-     * arriving during a cold start, or while the app sits on a route that has
-     * not registered the handler, is rendered natively instead of lost.
+     * The web layer renders only a push it can actually receive, which takes an
+     * activity in front of the user and a foreground handler the web runtime
+     * asserts for as long as it is registered. A push arriving during a cold
+     * start, on a route that has torn the handler down, or while only the Quick
+     * Settings tile holds the process up, is rendered natively instead of lost.
      */
     private boolean webWillRender() {
-        return isOnScreen() && PushNotificationsPlugin.getPushNotificationsInstance() != null;
-    }
-
-    private boolean isOnScreen() {
-        ActivityManager manager = (ActivityManager) getSystemService(Context.ACTIVITY_SERVICE);
-        if (manager == null) {
-            return false;
-        }
-        List<ActivityManager.RunningAppProcessInfo> processes = manager.getRunningAppProcesses();
-        if (processes == null) {
-            return false;
-        }
-        int pid = Process.myPid();
-        for (ActivityManager.RunningAppProcessInfo process : processes) {
-            if (process.pid != pid) {
-                continue;
-            }
-            // A partly covered activity still shows the web layer's own banner.
-            return process.importance
-                == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-                || process.importance
-                    == ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE;
-        }
-        return false;
+        return MainActivity.isResumed() && AndroidPushRegistrationPlugin.hasForegroundHandler();
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
@@ -6,15 +6,16 @@ import android.graphics.BitmapFactory;
 import androidx.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Locale;
+import java.util.List;
 import java.util.function.Function;
 import javax.net.ssl.HttpsURLConnection;
 
@@ -27,47 +28,50 @@ import javax.net.ssl.HttpsURLConnection;
 public final class AvatarCache {
     private static final String DIRECTORY = "notification-avatars";
     private static final String EXTENSION = ".png";
+    private static final String TEMPORARY_EXTENSION = ".tmp";
     private static final int MAX_BYTES = 512 * 1024;
     // The timeouts run inside onMessageReceived, whose window is far shorter
     // than the 8 s an iOS notification-service extension gets, and a cached
     // avatar is a handful of kilobytes, so a stalled host has to give up fast.
     private static final int CONNECT_TIMEOUT_MILLIS = 3_000;
     private static final int READ_TIMEOUT_MILLIS = 3_000;
+    // The read timeout restarts on every chunk, so the body also gets a total
+    // deadline: a host trickling bytes must not cost the whole notification.
+    private static final long READ_BUDGET_MILLIS = 4_000;
     private static final int MAX_FILES = 8;
+    // A write that never finished belongs to a call that is long gone.
+    private static final long TEMPORARY_MAX_AGE_MILLIS = 60_000;
     // A notification large icon is displayed at well under 512 px, and a
     // decoded bitmap this size costs a megabyte of the Firebase callback's heap.
     private static final int MAX_PIXELS = 512;
-    private static final int MAX_BITMAP_BYTES = 4 * 1024 * 1024;
 
     private final File directory;
 
     public AvatarCache(Context context) {
-        directory = new File(context.getCacheDir(), DIRECTORY);
+        this(new File(context.getCacheDir(), DIRECTORY));
+    }
+
+    AvatarCache(File directory) {
+        this.directory = directory;
     }
 
     @Nullable
     public Bitmap load(@Nullable String hash) {
-        String normalized = normalized(hash);
-        if (normalized == null) {
+        byte[] bytes = verified(hash);
+        if (bytes == null) {
             return null;
         }
-        File file = new File(directory, normalized + EXTENSION);
-        Bitmap bitmap = decode(options -> BitmapFactory.decodeFile(file.getPath(), options));
-        if (bitmap != null) {
-            // Eviction reads the modified time, so a hit is also a touch.
-            file.setLastModified(System.currentTimeMillis());
-        }
-        return bitmap;
+        return decode(options -> BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options));
     }
 
     @Nullable
     public Bitmap fetch(@Nullable String url, @Nullable String hash) {
-        String normalized = normalized(hash);
-        if (normalized == null || url == null || url.isEmpty()) {
+        String name = validated(hash);
+        if (name == null || url == null || url.isEmpty()) {
             return null;
         }
         byte[] bytes = download(url);
-        if (bytes == null || !normalized.equals(sha256Hex(bytes))) {
+        if (bytes == null || !name.equals(sha256Hex(bytes))) {
             return null;
         }
         Bitmap bitmap = decode(options ->
@@ -76,8 +80,32 @@ public final class AvatarCache {
         if (bitmap == null) {
             return null;
         }
-        store(normalized, bytes);
+        store(name, bytes);
         return bitmap;
+    }
+
+    /**
+     * Cached bytes whose digest still matches the name they are filed under, so
+     * a truncated or tampered file is dropped rather than drawn. A hit is also
+     * an eviction touch.
+     */
+    @Nullable
+    byte[] verified(@Nullable String hash) {
+        String name = validated(hash);
+        if (name == null) {
+            return null;
+        }
+        File file = new File(directory, name + EXTENSION);
+        byte[] bytes = read(file);
+        if (bytes == null) {
+            return null;
+        }
+        if (!name.equals(sha256Hex(bytes))) {
+            file.delete();
+            return null;
+        }
+        file.setLastModified(System.currentTimeMillis());
+        return bytes;
     }
 
     /**
@@ -91,7 +119,7 @@ public final class AvatarCache {
         decoder.apply(bounds);
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inSampleSize = sampleSize(bounds.outWidth, bounds.outHeight);
-        return bounded(decoder.apply(options));
+        return decoder.apply(options);
     }
 
     /** Halvings that bring the longest edge down to {@link #MAX_PIXELS}. */
@@ -104,44 +132,63 @@ public final class AvatarCache {
         return size;
     }
 
-    /** Downsampling alone still leaves room for an allocation the callback cannot afford. */
-    @Nullable
-    private static Bitmap bounded(@Nullable Bitmap bitmap) {
-        if (bitmap == null) {
-            return null;
-        }
-        if (bitmap.getByteCount() > MAX_BITMAP_BYTES) {
-            bitmap.recycle();
-            return null;
-        }
-        return bitmap;
-    }
-
-    private void store(String hash, byte[] bytes) {
+    private void store(String name, byte[] bytes) {
         directory.mkdirs();
-        File temporary = new File(directory, hash + EXTENSION + ".tmp");
+        // A unique staging name so two callers writing one hash cannot truncate
+        // each other's file mid-write.
+        File temporary = new File(
+            directory,
+            name + "." + System.nanoTime() + TEMPORARY_EXTENSION
+        );
         try (FileOutputStream output = new FileOutputStream(temporary)) {
             output.write(bytes);
         } catch (IOException exception) {
             temporary.delete();
             return;
         }
-        if (!temporary.renameTo(new File(directory, hash + EXTENSION))) {
+        if (!temporary.renameTo(new File(directory, name + EXTENSION))) {
             temporary.delete();
             return;
         }
         prune();
     }
 
-    /** Keeps the {@link #MAX_FILES} most recently used avatars. */
-    private void prune() {
-        File[] files = directory.listFiles((unused, name) -> name.endsWith(EXTENSION));
-        if (files == null || files.length <= MAX_FILES) {
+    /**
+     * Keeps the {@link #MAX_FILES} most recently used avatars and sweeps the
+     * staging files left behind by a write that never reached its rename.
+     */
+    void prune() {
+        File[] files = directory.listFiles();
+        if (files == null) {
             return;
         }
-        Arrays.sort(files, Comparator.comparingLong(File::lastModified).reversed());
-        for (int index = MAX_FILES; index < files.length; index++) {
-            files[index].delete();
+        long abandonedBefore = System.currentTimeMillis() - TEMPORARY_MAX_AGE_MILLIS;
+        List<File> cached = new ArrayList<>();
+        for (File file : files) {
+            String name = file.getName();
+            if (name.endsWith(EXTENSION)) {
+                cached.add(file);
+            } else if (
+                name.endsWith(TEMPORARY_EXTENSION) && file.lastModified() < abandonedBefore
+            ) {
+                file.delete();
+            }
+        }
+        if (cached.size() <= MAX_FILES) {
+            return;
+        }
+        cached.sort(Comparator.comparingLong(File::lastModified).reversed());
+        for (File file : cached.subList(MAX_FILES, cached.size())) {
+            file.delete();
+        }
+    }
+
+    @Nullable
+    private static byte[] read(File file) {
+        try (FileInputStream input = new FileInputStream(file)) {
+            return readCapped(input, READ_BUDGET_MILLIS);
+        } catch (IOException exception) {
+            return null;
         }
     }
 
@@ -160,7 +207,7 @@ public final class AvatarCache {
                 return null;
             }
             try (InputStream stream = connection.getInputStream()) {
-                return readCapped(stream);
+                return readCapped(stream, READ_BUDGET_MILLIS);
             }
         } catch (IOException | RuntimeException exception) {
             return null;
@@ -172,12 +219,13 @@ public final class AvatarCache {
     }
 
     @Nullable
-    static byte[] readCapped(InputStream stream) throws IOException {
+    static byte[] readCapped(InputStream stream, long budgetMillis) throws IOException {
+        long deadline = System.nanoTime() + budgetMillis * 1_000_000L;
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         byte[] chunk = new byte[8192];
         int read = stream.read(chunk);
         while (read != -1) {
-            if (buffer.size() + read > MAX_BYTES) {
+            if (buffer.size() + read > MAX_BYTES || System.nanoTime() - deadline >= 0) {
                 return null;
             }
             buffer.write(chunk, 0, read);
@@ -201,12 +249,13 @@ public final class AvatarCache {
         return hex.toString();
     }
 
-    /** Lowercased sha256 hex, which is also a filename that cannot escape the cache. */
+    /**
+     * Lowercase sha256 hex, which is also a filename that cannot escape the
+     * cache. Uppercase is rejected rather than folded so one avatar has one
+     * name here, on iOS, and on the desktop.
+     */
     @Nullable
-    static String normalized(@Nullable String hash) {
-        if (hash == null || !hash.matches("[0-9a-fA-F]{64}")) {
-            return null;
-        }
-        return hash.toLowerCase(Locale.ROOT);
+    static String validated(@Nullable String hash) {
+        return hash != null && hash.matches("[0-9a-f]{64}") ? hash : null;
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/NativePushRenderer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/NativePushRenderer.java
@@ -4,6 +4,7 @@ import ai.vellum.assistant.AndroidNotificationChannelsPlugin;
 import ai.vellum.assistant.NativeFailureGuard;
 import ai.vellum.assistant.R;
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -20,6 +21,7 @@ import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -33,31 +35,44 @@ import java.util.List;
  */
 public final class NativePushRenderer {
     /**
-     * The launcher gives one app a small shortcut budget shared with the static
-     * New chat and Start voice entries, so only the two most recent
-     * conversations keep a shortcut.
+     * How many conversations keep a launcher shortcut. Two is a product choice
+     * about how much of the launcher's shortcut list a notification may claim,
+     * not a budget the static New chat and Start voice entries share: those are
+     * manifest shortcuts, which a dynamic push can never evict.
      */
     private static final int MAX_CONVERSATION_SHORTCUTS = 2;
 
     private NativePushRenderer() {}
 
+    /**
+     * Whether a notification would reach the user at all. Checked before the
+     * avatar is resolved so a device that denied notifications pays for no
+     * download.
+     */
+    public static boolean canPost(Context context) {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+                    != PackageManager.PERMISSION_GRANTED
+        ) {
+            return false;
+        }
+        return NotificationManagerCompat.from(context).areNotificationsEnabled();
+    }
+
+    // canPost is the POST_NOTIFICATIONS check, which lint cannot follow across
+    // a method boundary.
+    @SuppressLint("MissingPermission")
     public static void show(
         Context context,
         RemoteMessage remoteMessage,
         PushDataMessage message,
         @Nullable Bitmap avatar
     ) {
-        if (
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
-                && ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
-                    != PackageManager.PERMISSION_GRANTED
-        ) {
+        if (!canPost(context)) {
             return;
         }
         NotificationManagerCompat manager = NotificationManagerCompat.from(context);
-        if (!manager.areNotificationsEnabled()) {
-            return;
-        }
 
         int notificationId = message.notificationId();
         Intent launchIntent = PushTapIntents.launchIntent(context, remoteMessage);
@@ -73,7 +88,8 @@ public final class NativePushRenderer {
             .setSmallIcon(R.drawable.ic_stat_notification)
             .setColor(ContextCompat.getColor(context, R.color.notification_icon_color))
             .setContentIntent(contentIntent)
-            .setAutoCancel(true);
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true);
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             // From API 26 the channel owns the sound. Before it, a notification
             // that asks for nothing arrives silently.
@@ -105,7 +121,6 @@ public final class NativePushRenderer {
         Person person = personBuilder.build();
         builder
             .setCategory(NotificationCompat.CATEGORY_MESSAGE)
-            .setOnlyAlertOnce(true)
             .setStyle(
                 new NotificationCompat.MessagingStyle(
                     new Person.Builder()
@@ -124,6 +139,14 @@ public final class NativePushRenderer {
         manager.notify(notificationId, builder.build());
     }
 
+    /** Forgets every conversation shortcut this renderer owns. */
+    public static void clearConversationShortcuts(Context context) {
+        List<String> ours = ownedShortcutIds(dynamicShortcutIds(context), null);
+        if (!ours.isEmpty()) {
+            ShortcutManagerCompat.removeLongLivedShortcuts(context, ours);
+        }
+    }
+
     /** The shortcut id once it is live, which is what lets the notification claim it. */
     @Nullable
     private static String pushShortcut(
@@ -138,15 +161,20 @@ public final class NativePushRenderer {
             return null;
         }
         String shortcutId = PushDataMessage.shortcutId(sender.id, message.conversationId);
+        // Trimming is housekeeping: a failure there must not cost this
+        // notification the shortcut that gives it the conversation treatment.
+        NativeFailureGuard.run(
+            "Unable to trim the Android conversation shortcuts",
+            () -> trimConversationShortcuts(context, shortcutId)
+        );
         boolean pushed = NativeFailureGuard.get(
             "Unable to publish the Android conversation shortcut",
             () -> {
-                trimConversationShortcuts(context, shortcutId);
                 ShortcutInfoCompat.Builder shortcut =
                     new ShortcutInfoCompat.Builder(context, shortcutId)
                         .setLongLived(true)
                         .setPerson(person)
-                        .setShortLabel(PushDataMessage.shortcutLabel(message.title, sender.name))
+                        .setShortLabel(message.title)
                         .setIntent(intent);
                 if (icon != null) {
                     shortcut.setIcon(icon);
@@ -160,22 +188,39 @@ public final class NativePushRenderer {
 
     /** Drops our oldest conversation shortcuts so the new one fits within the cap. */
     private static void trimConversationShortcuts(Context context, String keptId) {
-        List<ShortcutInfoCompat> ours = new ArrayList<>();
-        for (ShortcutInfoCompat shortcut : ShortcutManagerCompat.getDynamicShortcuts(context)) {
-            String id = shortcut.getId();
+        List<String> stale = staleShortcutIds(dynamicShortcutIds(context), keptId);
+        if (!stale.isEmpty()) {
+            ShortcutManagerCompat.removeLongLivedShortcuts(context, stale);
+        }
+    }
+
+    private static List<String> dynamicShortcutIds(Context context) {
+        List<ShortcutInfoCompat> shortcuts = new ArrayList<>(
+            ShortcutManagerCompat.getDynamicShortcuts(context)
+        );
+        shortcuts.sort(Comparator.comparingLong(ShortcutInfoCompat::getLastChangedTimestamp));
+        List<String> ids = new ArrayList<>();
+        for (ShortcutInfoCompat shortcut : shortcuts) {
+            ids.add(shortcut.getId());
+        }
+        return ids;
+    }
+
+    /** Ours out of the launcher's, oldest first, minus the one being claimed. */
+    static List<String> ownedShortcutIds(List<String> oldestFirst, @Nullable String keptId) {
+        List<String> ours = new ArrayList<>();
+        for (String id : oldestFirst) {
             if (id.startsWith(PushDataMessage.SHORTCUT_ID_PREFIX) && !id.equals(keptId)) {
-                ours.add(shortcut);
+                ours.add(id);
             }
         }
+        return ours;
+    }
+
+    /** The oldest of ours to drop so the claimed id lands within the cap. */
+    static List<String> staleShortcutIds(List<String> oldestFirst, String keptId) {
+        List<String> ours = ownedShortcutIds(oldestFirst, keptId);
         int surplus = ours.size() - (MAX_CONVERSATION_SHORTCUTS - 1);
-        if (surplus <= 0) {
-            return;
-        }
-        ours.sort(Comparator.comparingLong(ShortcutInfoCompat::getLastChangedTimestamp));
-        List<String> stale = new ArrayList<>();
-        for (ShortcutInfoCompat oldest : ours.subList(0, surplus)) {
-            stale.add(oldest.getId());
-        }
-        ShortcutManagerCompat.removeLongLivedShortcuts(context, stale);
+        return surplus <= 0 ? Collections.emptyList() : ours.subList(0, surplus);
     }
 }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/PushDataMessage.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/PushDataMessage.java
@@ -8,14 +8,16 @@ import java.util.Map;
 
 /** The Vellum fields of a push, read from the FCM {@code data} block. */
 public final class PushDataMessage {
-    static final String DEFAULT_CHANNEL_ID = AndroidNotificationChannelsPlugin.ALERTS_CHANNEL_ID;
-
     /** Marks the shortcuts this renderer owns so pruning leaves the launcher's alone. */
     static final String SHORTCUT_ID_PREFIX = "vellum-conversation:";
+
+    private static final String DEFAULT_SOURCE_EVENT_NAME = "remote_push";
+    private static final String DEFAULT_TITLE = "Vellum";
 
     private static final String KEY_TITLE = "title";
     private static final String KEY_BODY = "body";
     private static final String KEY_CHANNEL_ID = "channel_id";
+    private static final String KEY_SOURCE_EVENT_NAME = "source_event_name";
     static final String KEY_DELIVERY_ID = "delivery_id";
     static final String KEY_CONVERSATION_ID = "conversationId";
     private static final String KEY_UNREAD_COUNT = "unread_count";
@@ -46,14 +48,15 @@ public final class PushDataMessage {
     public final String body;
     public final String channelId;
     @Nullable
-    public final String deliveryId;
-    @Nullable
     public final String conversationId;
     @Nullable
     public final Integer unreadCount;
     @Nullable
     public final Sender sender;
 
+    @Nullable
+    private final String deliveryId;
+    private final String sourceEventName;
     @Nullable
     private final String messageId;
     private final boolean hasNotificationBlock;
@@ -68,7 +71,11 @@ public final class PushDataMessage {
         title = trimmed(data.get(KEY_TITLE));
         body = trimmed(data.get(KEY_BODY));
         String channel = trimmed(data.get(KEY_CHANNEL_ID));
-        channelId = channel == null ? DEFAULT_CHANNEL_ID : channel;
+        channelId = channel == null
+            ? AndroidNotificationChannelsPlugin.ALERTS_CHANNEL_ID
+            : channel;
+        String source = trimmed(data.get(KEY_SOURCE_EVENT_NAME));
+        sourceEventName = source == null ? DEFAULT_SOURCE_EVENT_NAME : source;
         deliveryId = trimmed(data.get(KEY_DELIVERY_ID));
         conversationId = trimmed(data.get(KEY_CONVERSATION_ID));
         unreadCount = count(data.get(KEY_UNREAD_COUNT));
@@ -81,10 +88,6 @@ public final class PushDataMessage {
             remoteMessage.getNotification() != null,
             remoteMessage.getMessageId()
         );
-    }
-
-    static PushDataMessage of(@Nullable Map<String, String> data, boolean hasNotificationBlock) {
-        return of(data, hasNotificationBlock, null);
     }
 
     static PushDataMessage of(
@@ -125,12 +128,6 @@ public final class PushDataMessage {
         return SHORTCUT_ID_PREFIX + suffix;
     }
 
-    /** The conversation the shortcut opens, named by its title where there is one. */
-    static String shortcutLabel(@Nullable String title, String senderName) {
-        String trimmed = trimmed(title);
-        return trimmed == null ? senderName : trimmed;
-    }
-
     /** Stable per-delivery id so a redelivery replaces its own notification. */
     public int notificationId() {
         return notificationId(seed());
@@ -138,9 +135,9 @@ public final class PushDataMessage {
 
     /**
      * The same id the web layer derives in {@code toNotificationId}
-     * (clients/web/src/runtime/notifications.ts) from the same seed, so a
-     * delivery rendered by both paths lands on one notification rather than
-     * two. {@code String.hashCode} is JavaScript's {@code (hash << 5) - hash +
+     * (clients/web/src/runtime/notifications.ts), so a delivery rendered by
+     * both paths lands on one notification rather than two.
+     * {@code String.hashCode} is JavaScript's {@code (hash << 5) - hash +
      * charCode | 0} loop, and the widening to {@code long} keeps
      * {@code Integer.MIN_VALUE} positive the way {@code Math.abs} does there.
      */
@@ -149,17 +146,23 @@ public final class PushDataMessage {
     }
 
     /**
-     * Every push carries at least one of these. Hashing nothing would collapse
-     * unrelated deliveries onto a single notification id.
+     * The seed chain {@code postForegroundRemotePush} walks: the delivery id,
+     * then the Firebase message id it reads as {@code notification.id}, then
+     * the source event with the copy. Hashing nothing would collapse unrelated
+     * deliveries onto a single notification id.
      */
     private String seed() {
         if (deliveryId != null) {
             return deliveryId;
         }
-        if (conversationId != null) {
-            return conversationId;
+        if (messageId != null) {
+            return messageId;
         }
-        return messageId == null ? "" : messageId;
+        return sourceEventName
+            + ":"
+            + (title == null ? DEFAULT_TITLE : title)
+            + ":"
+            + (body == null ? "" : body);
     }
 
     @Nullable

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/PushTapIntents.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/PushTapIntents.java
@@ -1,8 +1,12 @@
 package ai.vellum.assistant.push;
 
+import ai.vellum.assistant.AndroidAppLink;
+import ai.vellum.assistant.MainActivity;
+import ai.vellum.assistant.R;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import androidx.annotation.Nullable;
 import com.google.firebase.messaging.RemoteMessage;
 import java.util.LinkedHashMap;
@@ -36,20 +40,28 @@ public final class PushTapIntents {
 
     /**
      * Tap target for a conversation shortcut, which outlives the push that
-     * created it. It names the conversation and nothing else: carrying the
-     * push's identifiers would make a shortcut tap replay a delivery the user
-     * has already read.
+     * created it. It is the conversation's own app link, the same URL a browser
+     * hands {@link MainActivity}, so the tap opens the thread from a cold or a
+     * warm start. Carrying the push's identifiers instead would make a shortcut
+     * tap replay a delivery the user has already read.
      */
     @Nullable
     public static Intent shortcutIntent(Context context, @Nullable String conversationId) {
-        Intent intent = launcherIntent(context);
-        if (intent == null) {
+        String url = AndroidAppLink.conversationUrl(
+            context.getString(R.string.vellum_auth_host),
+            conversationId
+        );
+        if (url == null) {
             return null;
         }
-        if (conversationId != null) {
-            intent.putExtra(PushDataMessage.KEY_CONVERSATION_ID, conversationId);
-        }
-        return intent;
+        return new Intent(context, MainActivity.class)
+            .setAction(Intent.ACTION_VIEW)
+            .setData(Uri.parse(url))
+            .addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK
+                    | Intent.FLAG_ACTIVITY_SINGLE_TOP
+                    | Intent.FLAG_ACTIVITY_CLEAR_TOP
+            );
     }
 
     public static PendingIntent pendingIntent(Context context, Intent intent, int requestCode) {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AndroidAppLinkTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AndroidAppLinkTest.java
@@ -70,4 +70,26 @@ public class AndroidAppLinkTest {
             )
         );
     }
+
+    /**
+     * The conversation shortcut's tap target is built here and parsed here, so
+     * a shortcut tap always lands on the conversation route.
+     */
+    @Test
+    public void buildsAConversationLinkItParsesBack() {
+        String url = AndroidAppLink.conversationUrl(HOST, "conv-xyz");
+
+        assertEquals("https://dev-assistant.vellum.ai/assistant/conversations/conv-xyz", url);
+        assertEquals(url, AndroidAppLink.parse(url, HOST).toASCIIString());
+    }
+
+    @Test
+    public void buildsNoConversationLinkForAnIdThatCannotSitInAPathSegment() {
+        assertNull(AndroidAppLink.conversationUrl(HOST, null));
+        assertNull(AndroidAppLink.conversationUrl(HOST, ""));
+        assertNull("traversal", AndroidAppLink.conversationUrl(HOST, "../pair"));
+        assertNull("escaped", AndroidAppLink.conversationUrl(HOST, "a%2Fb"));
+        assertNull("separator", AndroidAppLink.conversationUrl(HOST, "a/b"));
+        assertNull("query", AndroidAppLink.conversationUrl(HOST, "a?b=c"));
+    }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AndroidNotificationChannelsPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AndroidNotificationChannelsPluginTest.java
@@ -1,0 +1,25 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class AndroidNotificationChannelsPluginTest {
+    /**
+     * A channel that merely exists is not a channel to alert on: the voice
+     * session channel is IMPORTANCE_LOW with no badge, and Firebase's fallback
+     * channel is whatever the OS made of it.
+     */
+    @Test
+    public void onlyTheAlertsChannelIsOneAPayloadMayName() {
+        assertTrue(
+            AndroidNotificationChannelsPlugin.isAlertChannelId(
+                AndroidNotificationChannelsPlugin.ALERTS_CHANNEL_ID
+            )
+        );
+        assertFalse(AndroidNotificationChannelsPlugin.isAlertChannelId("voice_session_status"));
+        assertFalse(AndroidNotificationChannelsPlugin.isAlertChannelId("fcm_fallback_notification_channel"));
+        assertFalse(AndroidNotificationChannelsPlugin.isAlertChannelId(null));
+    }
+}

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
@@ -1,24 +1,38 @@
 package ai.vellum.assistant.push;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class AvatarCacheTest {
     private static final String VELLUM_SHA256 =
         "2fc2a6dd013e7ab41c5a54ab8a254031ff329aa42c5815ac420f1facfe2542d1";
+    private static final long BUDGET_MILLIS = 4_000;
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void readsAPayloadUpToTheCap() throws IOException {
         byte[] bytes = new byte[512 * 1024];
         bytes[bytes.length - 1] = 7;
 
-        byte[] read = AvatarCache.readCapped(new ByteArrayInputStream(bytes));
+        byte[] read = AvatarCache.readCapped(new ByteArrayInputStream(bytes), BUDGET_MILLIS);
 
         assertEquals(bytes.length, read.length);
         assertEquals(7, read[read.length - 1]);
@@ -28,16 +42,27 @@ public class AvatarCacheTest {
     public void rejectsAPayloadOverTheCap() throws IOException {
         byte[] bytes = new byte[512 * 1024 + 1];
 
-        assertNull(AvatarCache.readCapped(new ByteArrayInputStream(bytes)));
+        assertNull(AvatarCache.readCapped(new ByteArrayInputStream(bytes), BUDGET_MILLIS));
+    }
+
+    /**
+     * The read timeout restarts on every chunk, so a host that answers a byte
+     * at a time would otherwise hold the Firebase callback for as many timeouts
+     * as the cap allows chunks.
+     */
+    @Test
+    public void givesUpOnAHostThatTricklesPastTheTotalBudget() throws IOException {
+        assertNull(AvatarCache.readCapped(tricklingStream(10), 50));
     }
 
     @Test
-    public void lowercasesAHashAndRejectsAnythingThatIsNotSha256Hex() {
-        assertEquals(VELLUM_SHA256, AvatarCache.normalized(VELLUM_SHA256.toUpperCase()));
-        assertNull(AvatarCache.normalized(null));
-        assertNull("too short", AvatarCache.normalized(VELLUM_SHA256.substring(1)));
-        assertNull("not hex", AvatarCache.normalized(VELLUM_SHA256.replace('0', 'z')));
-        assertNull("path traversal", AvatarCache.normalized("../../etc/passwd"));
+    public void acceptsLowercaseSha256HexAndNothingElseAsAFilename() {
+        assertEquals(VELLUM_SHA256, AvatarCache.validated(VELLUM_SHA256));
+        assertNull(AvatarCache.validated(null));
+        assertNull("uppercase", AvatarCache.validated(VELLUM_SHA256.toUpperCase()));
+        assertNull("too short", AvatarCache.validated(VELLUM_SHA256.substring(1)));
+        assertNull("not hex", AvatarCache.validated(VELLUM_SHA256.replace('0', 'z')));
+        assertNull("path traversal", AvatarCache.validated("../../etc/passwd"));
     }
 
     /** A payload whose digest does not match the pushed hash is never cached. */
@@ -56,5 +81,90 @@ public class AvatarCacheTest {
         assertEquals(2, AvatarCache.sampleSize(1024, 512));
         assertEquals(4, AvatarCache.sampleSize(512, 2048));
         assertEquals("undecodable bounds", 1, AvatarCache.sampleSize(-1, -1));
+    }
+
+    @Test
+    public void servesACachedAvatarAndTouchesItSoEvictionSeesTheUse() throws IOException {
+        File directory = folder.newFolder("hit");
+        AvatarCache cache = new AvatarCache(directory);
+        byte[] bytes = "vellum".getBytes(StandardCharsets.UTF_8);
+        File file = new File(directory, VELLUM_SHA256 + ".png");
+        Files.write(file.toPath(), bytes);
+        file.setLastModified(1_000_000);
+
+        assertArrayEquals(bytes, cache.verified(VELLUM_SHA256));
+        assertTrue("touched", file.lastModified() > 1_000_000);
+    }
+
+    @Test
+    public void dropsACachedAvatarWhoseBytesNoLongerHashToItsName() throws IOException {
+        File directory = folder.newFolder("tampered");
+        AvatarCache cache = new AvatarCache(directory);
+        File file = new File(directory, VELLUM_SHA256 + ".png");
+        Files.write(file.toPath(), "tampered".getBytes(StandardCharsets.UTF_8));
+
+        assertNull(cache.verified(VELLUM_SHA256));
+        assertFalse("deleted", file.exists());
+    }
+
+    @Test
+    public void readsNothingForAnUnusableHashOrAnAbsentFile() throws IOException {
+        AvatarCache cache = new AvatarCache(folder.newFolder("empty"));
+
+        assertNull(cache.verified(null));
+        assertNull(cache.verified(VELLUM_SHA256));
+    }
+
+    @Test
+    public void keepsTheEightNewestAvatarsAndSweepsAbandonedWrites() throws IOException {
+        File directory = folder.newFolder("prune");
+        long now = System.currentTimeMillis();
+        for (int index = 0; index < 10; index++) {
+            touched(new File(directory, "avatar-" + index + ".png"), now - index * 1_000L);
+        }
+        File abandoned = touched(new File(directory, "avatar.1.tmp"), now - 120_000);
+        File inFlight = touched(new File(directory, "avatar.2.tmp"), now);
+
+        new AvatarCache(directory).prune();
+
+        List<String> remaining = new ArrayList<>();
+        for (File file : directory.listFiles()) {
+            remaining.add(file.getName());
+        }
+        assertEquals(9, remaining.size());
+        assertTrue("newest kept", remaining.contains("avatar-0.png"));
+        assertTrue("eighth newest kept", remaining.contains("avatar-7.png"));
+        assertFalse("ninth newest evicted", remaining.contains("avatar-8.png"));
+        assertFalse("oldest evicted", remaining.contains("avatar-9.png"));
+        assertFalse("abandoned write swept", abandoned.exists());
+        assertTrue("write still in flight kept", inFlight.exists());
+    }
+
+    private static File touched(File file, long modified) throws IOException {
+        Files.write(file.toPath(), new byte[] { 1 });
+        file.setLastModified(modified);
+        return file;
+    }
+
+    /** A host answering one byte per call, slowly enough to burn the budget. */
+    private static InputStream tricklingStream(long millisPerRead) {
+        return new InputStream() {
+            @Override
+            public int read() {
+                return 0;
+            }
+
+            @Override
+            public int read(byte[] buffer, int offset, int length) throws IOException {
+                try {
+                    Thread.sleep(millisPerRead);
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(exception);
+                }
+                buffer[offset] = 1;
+                return 1;
+            }
+        };
     }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/NativePushRendererTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/NativePushRendererTest.java
@@ -1,0 +1,66 @@
+package ai.vellum.assistant.push;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class NativePushRendererTest {
+    private static final String NEW_CHAT = "new_chat";
+    private static final String OLDEST = "vellum-conversation:assistant-1:conversation-1";
+    private static final String MIDDLE = "vellum-conversation:assistant-1:conversation-2";
+    private static final String NEWEST = "vellum-conversation:assistant-1:conversation-3";
+    private static final String CLAIMED = "vellum-conversation:assistant-1:conversation-4";
+
+    @Test
+    public void keepsTwoConversationsByDroppingTheOldestOfOurs() {
+        assertEquals(
+            Arrays.asList(OLDEST, MIDDLE),
+            NativePushRenderer.staleShortcutIds(
+                Arrays.asList(NEW_CHAT, OLDEST, MIDDLE, NEWEST),
+                CLAIMED
+            )
+        );
+        assertEquals(
+            Collections.singletonList(OLDEST),
+            NativePushRenderer.staleShortcutIds(Arrays.asList(OLDEST, NEWEST), CLAIMED)
+        );
+    }
+
+    @Test
+    public void dropsNothingWhileTheNewShortcutStillFits() {
+        assertEquals(
+            Collections.emptyList(),
+            NativePushRenderer.staleShortcutIds(Collections.singletonList(OLDEST), CLAIMED)
+        );
+        assertEquals(
+            Collections.emptyList(),
+            NativePushRenderer.staleShortcutIds(Collections.singletonList(NEW_CHAT), CLAIMED)
+        );
+    }
+
+    /** Re-posting a conversation must not evict the shortcut it is about to claim. */
+    @Test
+    public void neverDropsTheShortcutTheNotificationIsClaiming() {
+        List<String> stale = NativePushRenderer.staleShortcutIds(
+            Arrays.asList(OLDEST, MIDDLE, NEWEST),
+            OLDEST
+        );
+
+        assertEquals(Collections.singletonList(MIDDLE), stale);
+    }
+
+    /** The launcher's own entries are not ours to remove on logout. */
+    @Test
+    public void ownsOnlyThePrefixedConversationShortcuts() {
+        assertEquals(
+            Arrays.asList(OLDEST, NEWEST),
+            NativePushRenderer.ownedShortcutIds(
+                Arrays.asList(NEW_CHAT, OLDEST, "start_voice", NEWEST),
+                null
+            )
+        );
+    }
+}

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/PushDataMessageTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/PushDataMessageTest.java
@@ -35,14 +35,17 @@ public class PushDataMessageTest {
         return data;
     }
 
+    private static PushDataMessage message(Map<String, String> data) {
+        return PushDataMessage.of(data, false, null);
+    }
+
     @Test
     public void readsTheAlertFieldsFromTheDataBlock() {
-        PushDataMessage message = PushDataMessage.of(alertData(), false);
+        PushDataMessage message = message(alertData());
 
         assertEquals("Weekly review", message.title);
         assertEquals("Ready when you are.", message.body);
         assertEquals("vellum-alerts", message.channelId);
-        assertEquals("delivery-1", message.deliveryId);
         assertEquals("conversation-1", message.conversationId);
         assertEquals(Integer.valueOf(3), message.unreadCount);
         assertNull(message.sender);
@@ -50,7 +53,7 @@ public class PushDataMessageTest {
 
     @Test
     public void readsTheSenderWhenIdNameAndHashAreAllPresent() {
-        PushDataMessage.Sender sender = PushDataMessage.of(senderData(), false).sender;
+        PushDataMessage.Sender sender = message(senderData()).sender;
 
         assertNotNull(sender);
         assertEquals("assistant-1", sender.id);
@@ -65,7 +68,7 @@ public class PushDataMessageTest {
         Map<String, String> data = senderData();
         data.remove("sender_avatar_url");
 
-        PushDataMessage.Sender sender = PushDataMessage.of(data, false).sender;
+        PushDataMessage.Sender sender = message(data).sender;
 
         assertNotNull(sender);
         assertNull(sender.avatarUrl);
@@ -76,7 +79,7 @@ public class PushDataMessageTest {
         for (String key : new String[] { "sender_id", "sender_name", "sender_avatar_hash" }) {
             Map<String, String> data = senderData();
             data.put(key, "  ");
-            assertNull(key, PushDataMessage.of(data, false).sender);
+            assertNull(key, message(data).sender);
         }
     }
 
@@ -86,7 +89,7 @@ public class PushDataMessageTest {
         data.remove("channel_id");
         data.put("unread_count", "many");
 
-        PushDataMessage message = PushDataMessage.of(data, false);
+        PushDataMessage message = message(data);
 
         assertEquals("vellum-alerts", message.channelId);
         assertNull(message.unreadCount);
@@ -94,30 +97,27 @@ public class PushDataMessageTest {
 
     @Test
     public void onlyATitledPayloadWithoutANotificationBlockIsDataOnly() {
-        assertTrue(PushDataMessage.of(alertData(), false).isDataOnly());
-        assertFalse(PushDataMessage.of(alertData(), true).isDataOnly());
+        assertTrue(message(alertData()).isDataOnly());
+        assertFalse(PushDataMessage.of(alertData(), true, null).isDataOnly());
 
         Map<String, String> untitled = alertData();
         untitled.remove("title");
-        assertFalse(PushDataMessage.of(untitled, false).isDataOnly());
-        assertFalse(PushDataMessage.of(null, false).isDataOnly());
+        assertFalse(message(untitled).isDataOnly());
+        assertFalse(message(null).isDataOnly());
     }
 
     @Test
     public void onlyADataOnlyPushTheWebLayerCannotRenderIsRenderedNatively() {
-        assertTrue(PushDataMessage.of(alertData(), false).rendersNatively(false));
-        assertFalse(
-            "web layer renders it",
-            PushDataMessage.of(alertData(), false).rendersNatively(true)
-        );
+        assertTrue(message(alertData()).rendersNatively(false));
+        assertFalse("web layer renders it", message(alertData()).rendersNatively(true));
         assertFalse(
             "notification block",
-            PushDataMessage.of(alertData(), true).rendersNatively(false)
+            PushDataMessage.of(alertData(), true, null).rendersNatively(false)
         );
 
         Map<String, String> untitled = alertData();
         untitled.remove("title");
-        assertFalse("untitled", PushDataMessage.of(untitled, false).rendersNatively(false));
+        assertFalse("untitled", message(untitled).rendersNatively(false));
     }
 
     @Test
@@ -137,7 +137,7 @@ public class PushDataMessageTest {
         Map<String, String> data = alertData();
         data.remove("conversationId");
 
-        PushDataMessage message = PushDataMessage.of(data, false);
+        PushDataMessage message = message(data);
 
         assertNull(message.conversationId);
         assertEquals(
@@ -156,20 +156,13 @@ public class PushDataMessageTest {
     }
 
     @Test
-    public void theShortcutLabelPrefersTheConversationTitle() {
-        assertEquals("Weekly review", PushDataMessage.shortcutLabel("Weekly review", "Vellum"));
-        assertEquals("Vellum", PushDataMessage.shortcutLabel(null, "Vellum"));
-        assertEquals("Vellum", PushDataMessage.shortcutLabel("   ", "Vellum"));
-    }
-
-    @Test
     public void theNotificationIdIsStablePerDelivery() {
-        int first = PushDataMessage.of(alertData(), false).notificationId();
+        int first = message(alertData()).notificationId();
         Map<String, String> other = alertData();
         other.put("delivery_id", "delivery-2");
 
-        assertEquals(first, PushDataMessage.of(alertData(), false).notificationId());
-        assertNotEquals(first, PushDataMessage.of(other, false).notificationId());
+        assertEquals(first, message(alertData()).notificationId());
+        assertNotEquals(first, message(other).notificationId());
     }
 
     /**
@@ -182,21 +175,48 @@ public class PushDataMessageTest {
         assertEquals(1077802136, PushDataMessage.notificationId("delivery-1"));
         assertEquals("negative hash", 1676096153, PushDataMessage.notificationId("conversation-1"));
         assertEquals("Integer.MIN_VALUE", 1, PushDataMessage.notificationId("delivery-4b*42%$"));
+        assertEquals(1440014357, PushDataMessage.notificationId("message-1"));
+        assertEquals(
+            126856326,
+            PushDataMessage.notificationId("remote_push:Weekly review:Ready when you are.")
+        );
     }
 
+    /**
+     * postForegroundRemotePush seeds toNotificationId with the delivery id,
+     * then the Firebase message id it reads as notification.id, then the source
+     * event with the copy. The conversation id is not a rung of that chain.
+     */
     @Test
-    public void theNotificationIdSeedFallsBackThroughConversationToMessageId() {
+    public void theNotificationIdSeedWalksTheSameChainAsTheWebLayer() {
+        assertEquals(
+            PushDataMessage.notificationId("delivery-1"),
+            PushDataMessage.of(alertData(), false, "message-1").notificationId()
+        );
+
         Map<String, String> data = alertData();
         data.remove("delivery_id");
         assertEquals(
+            PushDataMessage.notificationId("message-1"),
+            PushDataMessage.of(data, false, "message-1").notificationId()
+        );
+        assertNotEquals(
+            "the conversation id is not a seed",
             PushDataMessage.notificationId("conversation-1"),
             PushDataMessage.of(data, false, "message-1").notificationId()
         );
 
-        data.remove("conversationId");
         assertEquals(
-            PushDataMessage.notificationId("message-1"),
-            PushDataMessage.of(data, false, "message-1").notificationId()
+            PushDataMessage.notificationId("remote_push:Weekly review:Ready when you are."),
+            message(data).notificationId()
+        );
+
+        data.put("source_event_name", "chat.assistant_turn_complete");
+        assertEquals(
+            PushDataMessage.notificationId(
+                "chat.assistant_turn_complete:Weekly review:Ready when you are."
+            ),
+            message(data).notificationId()
         );
     }
 }

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -17,6 +17,16 @@ let androidCapabilities: unknown = {
   capabilities: ["native-notification-render"],
 };
 const androidGetCapabilitiesMock = mock(async () => androidCapabilities);
+let androidSetForegroundHandlerError: Error | null = null;
+const foregroundHandlerStates: boolean[] = [];
+const androidSetForegroundHandlerMock = mock(
+  async ({ active }: { active: boolean }) => {
+    if (androidSetForegroundHandlerError) {
+      throw androidSetForegroundHandlerError;
+    }
+    foregroundHandlerStates.push(active);
+  },
+);
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNative,
@@ -36,6 +46,7 @@ mock.module("@capacitor/core", () => ({
       register: androidRegisterMock,
       unregister: androidUnregisterMock,
       getCapabilities: androidGetCapabilitiesMock,
+      setForegroundHandler: androidSetForegroundHandlerMock,
     };
   },
 }));
@@ -243,6 +254,9 @@ beforeEach(() => {
   androidUnregisterMock.mockClear();
   androidCapabilities = { capabilities: ["native-notification-render"] };
   androidGetCapabilitiesMock.mockClear();
+  androidSetForegroundHandlerMock.mockClear();
+  androidSetForegroundHandlerError = null;
+  foregroundHandlerStates.length = 0;
   ensureAndroidAlertsChannelMock.mockClear();
   callOrder.length = 0;
   getInfoMock.mockClear();
@@ -724,5 +738,41 @@ describe("unregisterFromRemotePush", () => {
   test("no-ops when no token was registered", async () => {
     await unregisterFromRemotePush();
     expect(deleteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("setForegroundPushHandler", () => {
+  test("tells the Android shell when a handler is live and when it is gone", () => {
+    platform = "android";
+
+    setForegroundPushHandler(() => {});
+    setForegroundPushHandler(null);
+
+    expect(foregroundHandlerStates).toEqual([true, false]);
+  });
+
+  test("says nothing on iOS, which has no native renderer to hand back to", () => {
+    setForegroundPushHandler(() => {});
+
+    expect(androidSetForegroundHandlerMock).not.toHaveBeenCalled();
+  });
+
+  test("says nothing to an Android shell without the guarded plugin", () => {
+    platform = "android";
+    androidPushRegistrationAvailable = false;
+
+    setForegroundPushHandler(() => {});
+
+    expect(androidSetForegroundHandlerMock).not.toHaveBeenCalled();
+  });
+
+  test("swallows a rejection from a shell whose plugin lacks the method", async () => {
+    platform = "android";
+    androidSetForegroundHandlerError = new Error("not implemented");
+
+    setForegroundPushHandler(() => {});
+    await flushMicrotasks(2);
+
+    expect(androidSetForegroundHandlerMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -68,6 +68,7 @@ interface AndroidPushRegistrationPlugin {
   register(): Promise<void>;
   unregister(): Promise<void>;
   getCapabilities(): Promise<{ capabilities: string[] }>;
+  setForegroundHandler(options: { active: boolean }): Promise<void>;
 }
 
 const ANDROID_PUSH_REGISTRATION_PLUGIN = "AndroidPushRegistration";
@@ -165,8 +166,9 @@ export function isRemotePushSupported(): boolean {
 }
 
 /**
- * What this Android build can do with a push, advertised on the token row as
- * `DevicePushToken.capabilities`, which the Android upsert serializer accepts.
+ * What this Android build can do with a push, sent on the Android upsert as
+ * `capabilities` and stored on the token row once the platform's schema
+ * carries the field; until then the platform drops it as an unknown field.
  *
  * The platform sends data-only FCM messages only to tokens claiming
  * `native-notification-render`, so an older shell whose plugin lacks the
@@ -207,8 +209,8 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
     const { id: bundleId } = await App.getInfo();
     const platform = Capacitor.getPlatform();
     // Annotated so a change to the generated contract is a compile error here.
-    // `capabilities` is not in it yet, and the assertion is what admits that
-    // one field without loosening the rest of the row.
+    // The generated Android body has no `capabilities` field, so the assertion
+    // is what admits that one field without loosening the rest of the row.
     const body: AssistantsPushTokensUpsertData["body"] =
       platform === "android"
         ? ({
@@ -315,10 +317,28 @@ async function deleteRegisteredToken(
   }
 }
 
+/**
+ * Install or clear the handler for pushes that arrive while the app is on
+ * screen, and tell the Android shell which it is. The native renderer posts a
+ * data-only push itself whenever no handler is live, so a push arriving on a
+ * route that has torn this down reaches the user instead of a no-op.
+ */
 export function setForegroundPushHandler(
   handler: ((push: PushNotificationSchema) => void) | null,
 ): void {
   foregroundPushHandler = handler;
+  if (
+    Capacitor.getPlatform() !== "android" ||
+    !Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)
+  ) {
+    return;
+  }
+  void AndroidPushRegistration.setForegroundHandler({
+    active: handler !== null,
+  }).catch(() => {
+    // An older shell has no such method, and its renderer already treats every
+    // data-only push as its own.
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- `AvatarCache` bounds the whole body read with a 4 s deadline, not just a per-chunk read timeout, so a trickling host cannot cost the notification; the fetch runs only after the renderer confirms a notification can be posted at all.
- The conversation shortcut's tap target is the conversation's own app link, which `MainActivity` already parses on both a cold and a warm start, so tapping it opens the thread instead of doing nothing. `AndroidAppLink` now owns both directions of that route.
- The notification id seed walks the web layer's chain (delivery id, then the Firebase message id it reads as `notification.id`, then `source_event_name` with the copy) instead of falling back through the conversation id, so one delivery lands on one notification whichever path renders it.
- Removed the unreachable bitmap byte-cap and shortcut-label fallbacks that downsampling and the data-only gate already make dead.
- The avatar decode and the native render are guarded against `Throwable`, so an `OutOfMemoryError` posts without an avatar or falls through to the JS path rather than losing the push.
- Shortcut trimming moved out of the guard that decides `setShortcutId`, and the cap's rationale is corrected: two owned conversation shortcuts is a product choice, not protection for the manifest New chat and Start voice entries.
- Unregistering removes every `vellum-conversation:` shortcut, so the next account does not inherit the previous one's titles and avatars.
- The avatar cache stages under a unique temp name, sweeps abandoned `.tmp` files, re-hashes a cached file against the name it is filed under, and rejects uppercase hex the way iOS and desktop do.
- `resolveChannelId` allowlists the alerts channel instead of checking mere existence, so a payload naming `voice_session_status` or Firebase's fallback cannot post a silent unbadged alert.
- The foreground handoff now takes a resumed activity plus a foreground-handler liveness flag the web runtime asserts alongside `foregroundPushHandler`, replacing a process-importance check that also reads as visible for the Quick Settings tile.
- `setOnlyAlertOnce(true)` moved back onto the base builder, and dead members on `PushDataMessage` were removed or narrowed.
- README and docblocks state the present contract, including that foreground pushes carry no avatar treatment.

Round-2 self-review fixes for the notification avatar feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1