### PR TITLE
feat(web): the Assets control opens the Chat Info panel

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -13,8 +13,9 @@
  * is the same ghost icon-only `Button` with the same glyph, which is all this
  * story needs it to be. It exists to occupy the cluster, not to be exercised.
  *
- * Three states are covered: the composition is what this file protects, not a
- * per-component matrix.
+ * The states covered are the composition's, not a per-component matrix: the
+ * desktop and mobile baselines, a channel-bound header, and each viewport with
+ * the Chat Info panel open, where the Assets trigger reads as selected.
  */
 
 import { useEffect, useState } from "react";
@@ -32,6 +33,7 @@ import { ChannelSourceLinkPill } from "@/domains/chat/components/channel-source-
 import { ChatLayoutHeader } from "@/domains/chat/chat-layout-header";
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
 import { MOBILE_MEDIA_QUERY } from "@/hooks/use-is-mobile";
+import { useViewerStore } from "@/stores/viewer-store";
 
 const ASSISTANT_ID = "asst-story";
 const CONVERSATION_ID = "conv-story";
@@ -185,6 +187,28 @@ function ForceMobile({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
+/**
+ * Opens the Chat Info panel for the story's conversation, so the Assets
+ * trigger renders the selected state it holds while the panel is on screen.
+ *
+ * Opened from a `useState` initializer, which runs during this component's
+ * render, i.e. before the trigger below it first samples the store.
+ */
+function ChatInfoOpen({ children }: { children: React.ReactNode }) {
+  const [opened] = useState(() => {
+    useViewerStore.getState().openChatInfo({
+      assistantId: ASSISTANT_ID,
+      conversationId: CONVERSATION_ID,
+    });
+    return true;
+  });
+  void opened;
+  useEffect(() => {
+    return () => useViewerStore.getState().closeChatInfo();
+  }, []);
+  return <>{children}</>;
+}
+
 const meta: Meta<typeof Harness> = {
   title: "Chat/ChatLayoutHeader",
   component: Harness,
@@ -223,6 +247,39 @@ export const MobileBaseline: Story = {
     (Story) => (
       <ForceMobile>
         <Story />
+      </ForceMobile>
+    ),
+  ],
+};
+
+/**
+ * The Chat Info panel is open on this conversation, so the Assets glyph carries
+ * the `active` fill that marks it as the selected view.
+ */
+export const AssetsPanelOpen: Story = {
+  args: { isMobile: false },
+  decorators: [
+    (Story) => (
+      <ChatInfoOpen>
+        <Story />
+      </ChatInfoOpen>
+    ),
+  ],
+};
+
+/**
+ * The same open state on the narrow header, where the trigger is the filled
+ * icon button.
+ */
+export const AssetsPanelOpenMobile: Story = {
+  args: { isMobile: true },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+  decorators: [
+    (Story) => (
+      <ForceMobile>
+        <ChatInfoOpen>
+          <Story />
+        </ChatInfoOpen>
       </ForceMobile>
     ),
   ],

--- a/clients/web/src/domains/chat/components/adaptive-popover.tsx
+++ b/clients/web/src/domains/chat/components/adaptive-popover.tsx
@@ -4,9 +4,8 @@
  *
  * The split is not a style preference. A popover anchored near the bottom of a
  * phone screen opens into the thumb's own reach and lands under the soft
- * keyboard, which is why every existing chat control that opens a panel
- * (Assets, and the activity pill before it) hand-rolled this same branch. This
- * exists so they stop hand-rolling it: three surfaces now share one
+ * keyboard, which is why the activity pill hand-rolled this same branch. This
+ * exists so chat controls stop hand-rolling it: every surface shares one
  * implementation, so a fix to the touch path cannot land on one and miss the
  * others.
  *

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -1,9 +1,10 @@
 /**
- * Tests for `ConversationAssetsPill`'s unseen-document-changes affordance.
+ * Tests for `ConversationAssetsPill`: the Chat Info trigger it registers in the
+ * viewer store, and its unseen-document-changes affordance.
  *
- * The pill's asset list comes from two TanStack queries, so the suite seeds
- * the cache with `staleTime: Infinity` instead of mocking the SDK: nothing
- * refetches on mount and the rendered list is exactly what a test asks for.
+ * The pill's asset count comes from TanStack queries, so the suite seeds the
+ * cache with `staleTime: Infinity` instead of mocking the SDK: nothing
+ * refetches on mount and the count is exactly what a test asks for.
  *
  * Class strings are deliberately not asserted (happy-dom makes those brittle);
  * the dot is located by its `data-testid` and the state it communicates is
@@ -18,13 +19,6 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as motionReact from "motion/react";
 
 import type { DocumentSummary } from "@/types/document-types";
-
-const isTouchMobileRef = { value: false };
-
-mock.module("@/hooks/use-touch-mobile", () => ({
-  useTouchMobile: () => isTouchMobileRef.value,
-  TOUCH_MOBILE_MEDIA_QUERY: "(width < 48rem) and (pointer: coarse)",
-}));
 
 const isMobileRef = { value: false };
 
@@ -49,6 +43,7 @@ const {
 } = await import("@/domains/chat/components/conversation-assets-pill");
 const { useUnseenDocumentChangesStore } =
   await import("@/domains/chat/unseen-document-changes-store");
+const { useViewerStore } = await import("@/stores/viewer-store");
 const { appsGetOptions, documentsGetOptions } =
   await import("@/generated/daemon/@tanstack/react-query.gen");
 
@@ -59,7 +54,6 @@ const OTHER_CONVERSATION_ID = "conv-2";
 const OTHER_SURFACE_ID = "surface-2";
 
 const DOC_TITLE = "Roadmap";
-const OTHER_DOC_TITLE = "Backlog";
 
 // Singular: these fixtures seed one asset, and the ICU `plural` in
 // `conversationAssets.ariaLabel` agrees with the count.
@@ -69,12 +63,11 @@ const UNSEEN_LABEL = "Conversation assets, 1 item (unseen changes)";
 function makeDocument(
   conversationId = CONVERSATION_ID,
   surfaceId = SURFACE_ID,
-  title = DOC_TITLE,
 ): DocumentSummary {
   return {
     surfaceId,
     conversationId,
-    title,
+    title: DOC_TITLE,
     wordCount: 12,
     createdAt: 1_700_000_000_000,
     updatedAt: 1_700_000_000_001,
@@ -111,7 +104,7 @@ function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
   seedConversation(client, withAssets ? [makeDocument()] : [], CONVERSATION_ID);
   seedConversation(
     client,
-    [makeDocument(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID, OTHER_DOC_TITLE)],
+    [makeDocument(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID)],
     OTHER_CONVERSATION_ID,
   );
 
@@ -144,16 +137,22 @@ function unseenConversations(): string[] {
   return Object.keys(useUnseenDocumentChangesStore.getState().changedDocuments);
 }
 
+function chatInfoState() {
+  const { mainView, activeChatInfo } = useViewerStore.getState();
+  return { mainView, activeChatInfo };
+}
+
 beforeEach(() => {
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+  useViewerStore.getState().reset();
 });
 
 afterEach(() => {
   cleanup();
-  isTouchMobileRef.value = false;
   isMobileRef.value = false;
   reducedMotion = false;
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+  useViewerStore.getState().reset();
 });
 
 function dotHasPulse(): boolean {
@@ -178,21 +177,52 @@ describe("desktop pill", () => {
     expect(screen.getByRole("button", { name: SEEN_LABEL })).toBeTruthy();
   });
 
-  test("opening the popover clears the conversation", () => {
+  test("opening the panel clears the conversation and sets mainView to chat-info", () => {
     markUnseen();
     renderPill();
 
     fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
 
+    expect(chatInfoState()).toEqual({
+      mainView: "chat-info",
+      activeChatInfo: {
+        assistantId: ASSISTANT_ID,
+        conversationId: CONVERSATION_ID,
+        category: null,
+      },
+    });
     expect(unseenConversations()).toEqual([]);
     expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+  });
+
+  test("clicking while open closes the panel", () => {
+    renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(chatInfoState().mainView).toBe("chat-info");
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+
+    expect(chatInfoState()).toEqual({
+      mainView: "chat",
+      activeChatInfo: null,
+    });
+  });
+
+  test("aria-expanded reflects the store", () => {
+    renderPill();
+
+    const trigger = screen.getByRole("button", { name: SEEN_LABEL });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
   });
 });
 
 describe("narrow window with a mouse", () => {
-  // Room decides whether the count fits in the header cluster, and pointer
-  // decides whether the disclosure is a sheet: a narrow mouse-driven window
-  // gets the compact trigger and still opens the anchored popover.
+  // Room decides whether the count fits in the header cluster: a narrow window
+  // gets the compact trigger and the same panel.
   beforeEach(() => {
     isMobileRef.value = true;
   });
@@ -205,82 +235,38 @@ describe("narrow window with a mouse", () => {
     );
   });
 
-  test("opening the popover clears the conversation", () => {
+  test("opening the panel clears the conversation", () => {
     markUnseen();
     renderPill();
 
     fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
 
+    expect(chatInfoState().mainView).toBe("chat-info");
     expect(unseenConversations()).toEqual([]);
   });
 });
 
-describe("mobile trigger", () => {
-  beforeEach(() => {
-    isTouchMobileRef.value = true;
-    isMobileRef.value = true;
-  });
-
-  test("shows the dot and names the state when a change is unseen", () => {
-    markUnseen();
-    renderPill();
-
-    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
-    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
-  });
-
-  test("shows no dot and the plain name when nothing is unseen", () => {
-    renderPill();
-
-    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
-    expect(screen.getByRole("button", { name: SEEN_LABEL })).toBeTruthy();
-  });
-
-  test("opening the sheet clears the conversation", () => {
-    markUnseen();
-    renderPill();
-
-    fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
-
-    expect(unseenConversations()).toEqual([]);
-    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
-  });
-});
-
-describe("conversation switch while the disclosure is open", () => {
+describe("conversation switch while the panel is open", () => {
   /**
    * The chat header renders one unkeyed pill and swaps `conversationId` on it,
-   * so `open` survives the switch and `onOpenChange` never fires for it. The
-   * pill closes its own disclosure on that swap: the incoming conversation's
-   * assets are never put on screen unasked, and its changes stay marked unseen
-   * until the user opens the list.
+   * so the open panel would otherwise survive the switch. The pill settles the
+   * store on that swap: the incoming conversation's assets are never put on
+   * screen unasked, and its changes stay marked unseen until the user opens
+   * the panel.
    */
-  test("closes the popover and keeps the incoming dot", () => {
+  test("closes the panel and keeps the incoming dot", () => {
     markUnseen(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID);
     const { switchConversation } = renderPill();
 
     fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
-    expect(screen.getByText(DOC_TITLE)).toBeTruthy();
+    expect(chatInfoState().mainView).toBe("chat-info");
 
     switchConversation(OTHER_CONVERSATION_ID);
 
-    expect(screen.queryByText(OTHER_DOC_TITLE)).toBeNull();
-    expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
-    expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
-    expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
-  });
-
-  test("closes the sheet and keeps the incoming dot on mobile", () => {
-    isTouchMobileRef.value = true;
-    markUnseen(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID);
-    const { switchConversation } = renderPill();
-
-    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
-    expect(screen.getByText(DOC_TITLE)).toBeTruthy();
-
-    switchConversation(OTHER_CONVERSATION_ID);
-
-    expect(screen.queryByText(OTHER_DOC_TITLE)).toBeNull();
+    expect(chatInfoState()).toEqual({
+      mainView: "chat",
+      activeChatInfo: null,
+    });
     expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
     expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
     expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
@@ -313,7 +299,7 @@ describe("empty asset list", () => {
    * assets, so there is no Layers icon to carry a dot. An unseen change in
    * that window stays recorded in the store and the dot appears as soon as
    * the documents query reports the asset, rather than the pill being forced
-   * to render an empty disclosure.
+   * to render a trigger for an empty panel.
    */
   test("renders nothing even when a change is unseen", () => {
     markUnseen();

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -120,6 +120,7 @@ function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
   const view = render(pill(CONVERSATION_ID));
 
   return {
+    unmount: () => view.unmount(),
     /** Swap the prop on the already-mounted pill, as the chat header does. */
     switchConversation: (conversationId: string) => {
       view.rerender(pill(conversationId));
@@ -270,6 +271,19 @@ describe("conversation switch while the panel is open", () => {
     expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
     expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
     expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
+  });
+});
+
+describe("pill unmount while the panel is open", () => {
+  test("closes the panel it owns", () => {
+    const { unmount } = renderPill();
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(useViewerStore.getState().mainView).toBe("chat-info");
+
+    unmount();
+
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(useViewerStore.getState().activeChatInfo).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -71,6 +71,19 @@ export function ConversationAssetsPill({
     ) {
       state.closeChatInfo();
     }
+    // The pill leaving (an assistant switch clears the conversation before
+    // the next one resolves) must take its panel with it, or the store keeps
+    // showing a target no control owns.
+    return () => {
+      const current = useViewerStore.getState();
+      if (
+        current.mainView === "chat-info" &&
+        current.activeChatInfo !== null &&
+        chatInfoTargetKey(current.activeChatInfo) === targetKey
+      ) {
+        current.closeChatInfo();
+      }
+    };
   }, [targetKey]);
 
   // The header cluster only has room for a labelled pill on a roomy window.

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -1,43 +1,27 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { AppWindow, FileText, Layers } from "lucide-react";
+/**
+ * The chat header's Layers control: the trigger for the Chat Info panel.
+ *
+ * Clicking it toggles the viewer store's `chat-info` view, which the drawer
+ * renders beside the chat on a roomy window and the mobile overlay renders
+ * full-screen under a thumb. The control itself only reports the conversation's
+ * asset count, carries the unseen-changes dot, and reflects whether the panel
+ * is currently showing this conversation.
+ */
+
+import { Layers } from "lucide-react";
 import { useReducedMotion } from "motion/react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from "react";
+import { useCallback, useLayoutEffect } from "react";
 
-import {
-  BottomSheet,
-  Button,
-  PanelItem,
-  Popover,
-  Typography,
-} from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library";
 
-import {
-  appsGetOptions,
-  appsGetQueryKey,
-  documentsGetOptions,
-  documentsGetQueryKey,
-} from "@/generated/daemon/@tanstack/react-query.gen";
-import { DeleteAppDialog } from "@/components/delete-app-dialog";
-import {
-  AppAssetActions,
-  DocumentAssetActions,
-} from "@/domains/chat/components/conversation-asset-actions";
+import { useConversationAssets } from "@/domains/chat/hooks/use-conversation-assets";
 import {
   useHasUnseenDocumentChanges,
   useUnseenDocumentChangesStore,
 } from "@/domains/chat/unseen-document-changes-store";
-import { useAppDelete } from "@/hooks/use-app-delete";
 import { useIsMobile } from "@/hooks/use-is-mobile";
-import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { useTranslation } from "@/i18n";
-import type { AppSummary } from "@/types/app-types";
-import type { DocumentSummary } from "@/types/document-types";
+import { chatInfoTargetKey, useViewerStore } from "@/stores/viewer-store";
 import { cn } from "@/utils/misc";
 
 export const ASSETS_PILL_UNSEEN_DOT_TESTID = "assets-pill-unseen-dot";
@@ -45,146 +29,68 @@ export const ASSETS_PILL_UNSEEN_DOT_TESTID = "assets-pill-unseen-dot";
 /** Bounded attention pulse defined in `src/index.css`. */
 export const ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS = "unseen-dot-pulse";
 
-interface ConversationAsset {
-  id: string;
-  title: string;
-  type: "app" | "document";
-  appId?: string;
-  surfaceId?: string;
-  app?: AppSummary;
-  doc?: DocumentSummary;
-}
-
 export interface ConversationAssetsPillProps {
   assistantId: string;
   conversationId: string;
   /** Bumped externally to trigger a refetch (e.g. on ui_surface_show). */
   refreshKey?: number;
-  onOpenApp?: (appId: string) => void;
-  onOpenDocument?: (surfaceId: string) => void;
-}
-
-function toAssets(
-  apps: AppSummary[],
-  docs: DocumentSummary[],
-): ConversationAsset[] {
-  const assets: ConversationAsset[] = [];
-  for (const app of apps) {
-    assets.push({
-      id: `app-${app.id}`,
-      title: app.name,
-      type: "app",
-      appId: app.id,
-      app,
-    });
-  }
-  for (const doc of docs) {
-    assets.push({
-      id: `doc-${doc.surfaceId}`,
-      title: doc.title,
-      type: "document",
-      surfaceId: doc.surfaceId,
-      doc,
-    });
-  }
-  return assets;
 }
 
 export function ConversationAssetsPill({
   assistantId,
   conversationId,
   refreshKey,
-  onOpenApp,
-  onOpenDocument,
 }: ConversationAssetsPillProps) {
-  const queryClient = useQueryClient();
-  const appsQueryOpts = appsGetOptions({
-    path: { assistant_id: assistantId },
-    query: { conversationId },
-  });
-  const docsQueryOpts = documentsGetOptions({
-    path: { assistant_id: assistantId },
-    query: { conversationId },
+  const { count } = useConversationAssets({
+    assistantId,
+    conversationId,
+    refreshKey,
   });
 
-  const { data: apps = [] } = useQuery({
-    ...appsQueryOpts,
-    select: (data) => data.apps,
-  });
-  const { data: docs = [] } = useQuery({
-    ...docsQueryOpts,
-    select: (data) => data.documents,
-  });
-
-  useEffect(() => {
-    if (refreshKey === undefined) {
-      return;
-    }
-    void queryClient.invalidateQueries({
-      queryKey: appsGetQueryKey({
-        path: { assistant_id: assistantId },
-        query: { conversationId },
-      }),
-    });
-    void queryClient.invalidateQueries({
-      queryKey: documentsGetQueryKey({
-        path: { assistant_id: assistantId },
-        query: { conversationId },
-      }),
-    });
-  }, [refreshKey, queryClient, assistantId, conversationId]);
-
-  const assets = useMemo(() => toAssets(apps, docs), [apps, docs]);
-
-  const [open, setOpen] = useState(false);
+  const targetKey = chatInfoTargetKey({ assistantId, conversationId });
+  const mainView = useViewerStore.use.mainView();
+  const activeChatInfo = useViewerStore.use.activeChatInfo();
+  const isOpen =
+    mainView === "chat-info" &&
+    activeChatInfo !== null &&
+    chatInfoTargetKey(activeChatInfo) === targetKey;
 
   // The chat header swaps `conversationId` on this same mounted pill, so an
-  // open disclosure would otherwise carry over and list the incoming
-  // conversation's assets without the user asking to see them, leaving that
-  // conversation's changes marked unseen behind a sheet that is already open.
-  // Layout effect: the outgoing conversation's disclosure must never paint
-  // over the incoming conversation, not even for one frame.
+  // open panel would otherwise carry over and list the incoming conversation's
+  // assets without the user asking to see them, leaving that conversation's
+  // changes marked unseen behind a panel that is already open.
+  // `clearTranscriptPanelPayloads` drops the payload on a switch; this settles
+  // `mainView` too. Layout effect: the outgoing conversation's panel must never
+  // paint over the incoming conversation, not even for one frame.
   useLayoutEffect(() => {
-    setOpen(false);
-  }, [conversationId]);
+    const state = useViewerStore.getState();
+    if (
+      state.mainView === "chat-info" &&
+      state.activeChatInfo !== null &&
+      chatInfoTargetKey(state.activeChatInfo) !== targetKey
+    ) {
+      state.closeChatInfo();
+    }
+  }, [targetKey]);
 
-  // Two independent questions: the header cluster only has room for a labelled
-  // pill on a roomy window, and the disclosure is a sheet only under a thumb.
+  // The header cluster only has room for a labelled pill on a roomy window.
   const isMobile = useIsMobile();
-  const isTouchMobile = useTouchMobile();
   const { t } = useTranslation("chat");
   const reduceMotion = useReducedMotion();
   const hasUnseenChanges = useHasUnseenDocumentChanges(conversationId);
   const clearConversation =
     useUnseenDocumentChangesStore.use.clearConversation();
 
-  // Opening the disclosure is the user looking at the asset list, so whatever
-  // changed is no longer unseen.
-  const handleOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      setOpen(nextOpen);
-      if (nextOpen) {
-        clearConversation(conversationId);
-      }
-    },
-    [clearConversation, conversationId],
-  );
+  // Opening the panel is the user looking at the assets, so whatever changed
+  // is no longer unseen.
+  const handleClick = useCallback(() => {
+    if (!isOpen) {
+      clearConversation(conversationId);
+    }
+    useViewerStore.getState().toggleChatInfo({ assistantId, conversationId });
+  }, [assistantId, clearConversation, conversationId, isOpen]);
 
-  const handleSelect = useCallback(
-    (asset: ConversationAsset) => {
-      setOpen(false);
-      if (asset.type === "app" && asset.appId) {
-        onOpenApp?.(asset.appId);
-      } else if (asset.type === "document" && asset.surfaceId) {
-        onOpenDocument?.(asset.surfaceId);
-      }
-    },
-    [onOpenApp, onOpenDocument],
-  );
-
-  const appDelete = useAppDelete(assistantId);
-
-  if (assets.length === 0) {
+  if (count === 0) {
     return null;
   }
 
@@ -194,10 +100,10 @@ export function ConversationAssetsPill({
   // `select` branch appended to the base one: translators get a whole sentence
   // to work with, and languages that place the qualifier somewhere other than
   // the end are free to move it.
-  const label = t("conversationAssets.label", { count: assets.length });
+  const label = t("conversationAssets.label", { count });
   const ariaLabel = hasUnseenChanges
-    ? t("conversationAssets.ariaLabelUnseen", { count: assets.length })
-    : t("conversationAssets.ariaLabel", { count: assets.length });
+    ? t("conversationAssets.ariaLabelUnseen", { count })
+    : t("conversationAssets.ariaLabel", { count });
 
   // Same dot as the notifications bell in this header cluster: ringed in the
   // color of the surface behind it so the ring reads as a gap carved out of
@@ -230,107 +136,34 @@ export function ConversationAssetsPill({
     </span>
   );
 
-  const assetItems = assets.map((asset) => (
-    <PanelItem
-      key={asset.id}
-      icon={asset.type === "app" ? AppWindow : FileText}
-      label={asset.title}
-      onSelect={() => handleSelect(asset)}
-      trailingAction={
-        asset.type === "app" && asset.app ? (
-          <AppAssetActions
-            assistantId={assistantId}
-            app={asset.app}
-            onRequestDelete={appDelete.requestDelete}
-          />
-        ) : asset.type === "document" && asset.doc ? (
-          <DocumentAssetActions
-            assistantId={assistantId}
-            doc={asset.doc}
-            onOpen={() => handleSelect(asset)}
-          />
-        ) : undefined
-      }
-    />
-  ));
-
-  const trigger = isMobile ? (
-    <Button
-      variant="ghost"
-      active
-      iconOnly={layersIcon}
-      tintColor="var(--content-default)"
-      aria-label={ariaLabel}
-    />
-  ) : (
-    // Desktop: a bare glyph, matching the notifications bell it shares the
-    // header cluster with: same `ghost` + `iconOnly` Button, no `active` fill
-    // and no pill. The count moves to the tooltip and the accessible name,
-    // which is where the bell keeps its own unread count too.
-    <Button
-      variant="ghost"
-      iconOnly={layersIcon}
-      aria-label={ariaLabel}
-      tooltip={label}
-    />
-  );
-
-  if (isTouchMobile) {
+  if (isMobile) {
     return (
-      <>
-        <BottomSheet.Root open={open} onOpenChange={handleOpenChange}>
-          <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
-          <BottomSheet.Content>
-            <BottomSheet.Header>
-              <BottomSheet.Title>{t("conversationAssets.heading")}</BottomSheet.Title>
-            </BottomSheet.Header>
-            <BottomSheet.Body className="pt-0">{assetItems}</BottomSheet.Body>
-          </BottomSheet.Content>
-        </BottomSheet.Root>
-        <DeleteAppDialog
-          app={appDelete.pendingDelete}
-          isDeleting={appDelete.isDeleting}
-          onConfirm={appDelete.confirmDelete}
-          onCancel={appDelete.cancelDelete}
-        />
-      </>
+      <Button
+        variant="ghost"
+        active
+        iconOnly={layersIcon}
+        tintColor="var(--content-default)"
+        aria-label={ariaLabel}
+        aria-expanded={isOpen}
+        onClick={handleClick}
+      />
     );
   }
 
+  // Desktop: a bare glyph, matching the notifications bell it shares the
+  // header cluster with: same `ghost` + `iconOnly` Button and no pill. The
+  // `active` fill marks the panel as the selected view. The count moves to the
+  // tooltip and the accessible name, which is where the bell keeps its own
+  // unread count too.
   return (
-    <>
-      <Popover.Root open={open} onOpenChange={handleOpenChange}>
-        <Popover.Trigger asChild>{trigger}</Popover.Trigger>
-        {/*
-          The popover keeps its own `p-2` inset and the heading sits at
-          `px-2`, which is the column the rows' icons start from. Its own
-          vertical padding is only what separates it from the first row: the
-          label is 10px on a `line-height: 1`, and the popover's inset above
-          and the row's 8px of padding below already carry the rest.
-        */}
-        <Popover.Content
-          side="bottom"
-          align="center"
-          sideOffset={8}
-          className="w-60"
-        >
-          <div className="px-2 pb-1">
-            <Typography
-              variant="label-small-default"
-              className="text-[var(--content-tertiary)]"
-            >
-              {t("conversationAssets.heading")}
-            </Typography>
-          </div>
-          <div className="max-h-[240px] overflow-y-auto">{assetItems}</div>
-        </Popover.Content>
-      </Popover.Root>
-      <DeleteAppDialog
-        app={appDelete.pendingDelete}
-        isDeleting={appDelete.isDeleting}
-        onConfirm={appDelete.confirmDelete}
-        onCancel={appDelete.cancelDelete}
-      />
-    </>
+    <Button
+      variant="ghost"
+      active={isOpen}
+      iconOnly={layersIcon}
+      aria-label={ariaLabel}
+      aria-expanded={isOpen}
+      tooltip={label}
+      onClick={handleClick}
+    />
   );
 }

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.tsx
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.tsx
@@ -26,9 +26,9 @@ export interface InChatPluginPillProps {
 /**
  * Top-right chat pill summarizing the conversation's active plugins. Clicking it
  * opens a read-only list of those plugins plus a "Manage" shortcut to the
- * plugins page — editing the set happens there, not in this menu. Mirrors
- * `ConversationAssetsPill`'s top-right placement and desktop-popover /
- * touch-bottom-sheet split.
+ * plugins page: editing the set happens there, not in this menu. Sits in the
+ * header's top-right cluster, and splits its disclosure between a desktop
+ * popover and a touch bottom sheet.
  */
 export function InChatPluginPill({
   assistantId,

--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.test.tsx
@@ -52,10 +52,6 @@ mock.module("@/domains/chat/hooks/use-slack-conversation-display", () => ({
   useSlackConversationDisplay: () => slackDisplayRef.value,
 }));
 
-mock.module("@/domains/chat/hooks/use-open-app-from-chat", () => ({
-  useOpenAppFromChat: () => () => {},
-}));
-
 const supportsRef = { value: true };
 mock.module("@/lib/backwards-compat/use-supports-inchat-plugin-edit", () => ({
   useSupportsInchatPluginEdit: () => supportsRef.value,

--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
@@ -6,14 +6,15 @@
  * Owns:
  * - `headerSupplements` computation and slot registration
  * - `topBarRightSlot` (ChannelThreadControl or ChannelSourceLinkPill, plus
- *   ConversationAssetsPill + InChatPluginPill) computation and registration
+ *   the ConversationAssetsPill Chat Info trigger + InChatPluginPill)
+ *   computation and registration
  * - Slack conversation display derivation for the header label and the
  *   source-thread link
  * - Settling the channel drawer when the sidecar target changes, so a
  *   conversation switch or a lost binding never leaves a stale thread open
  */
 
-import { useCallback, useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
 import type { ChatHeaderSupplements } from "@/components/layout/chat-layout-slots-store";
@@ -33,9 +34,7 @@ import { useChannelSidecar } from "@/domains/chat/channel-sidecar/use-channel-si
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
 import { InChatPluginPill } from "@/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill";
 import { useSupportsInchatPluginEdit } from "@/lib/backwards-compat/use-supports-inchat-plugin-edit";
-import { useOpenAppFromChat } from "@/domains/chat/hooks/use-open-app-from-chat";
 import { useViewerStore } from "@/stores/viewer-store";
-import { haptic } from "@/utils/haptics";
 import type { Conversation } from "@/types/conversation-types";
 
 export interface UseChatHeaderRegistrationOptions {
@@ -186,18 +185,7 @@ export function useChatHeaderRegistration({
     };
   }, [headerSupplements, setHeaderSupplements]);
 
-  // Top bar right slot — ConversationAssetsPill
-  const handleOpenAppFromChat = useOpenAppFromChat();
-  const handleOpenDocument = useCallback(
-    (surfaceId: string) => {
-      haptic.light();
-      if (assistantId) {
-        void useViewerStore.getState().loadDocument(assistantId, surfaceId);
-      }
-    },
-    [assistantId],
-  );
-
+  // Top bar right slot - ConversationAssetsPill
   const topBarRightContent = useMemo(() => {
     if (!activeConversation?.conversationId || !assistantId) {
       return null;
@@ -216,8 +204,6 @@ export function useChatHeaderRegistration({
           assistantId={assistantId}
           conversationId={activeConversation.conversationId}
           refreshKey={assetsRefreshKey}
-          onOpenApp={handleOpenAppFromChat}
-          onOpenDocument={handleOpenDocument}
         />
         {supportsPluginPill ? (
           <InChatPluginPill
@@ -231,8 +217,6 @@ export function useChatHeaderRegistration({
     activeConversation?.conversationId,
     assistantId,
     assetsRefreshKey,
-    handleOpenAppFromChat,
-    handleOpenDocument,
     supportsPluginPill,
     channelSourceLinkHref,
     channelHeaderChannelId,

--- a/clients/web/src/domains/chat/unseen-document-changes-store.ts
+++ b/clients/web/src/domains/chat/unseen-document-changes-store.ts
@@ -43,7 +43,7 @@ export interface UnseenDocumentChangesActions {
    * the one the edit was recorded against.
    */
   clearDocumentEverywhere: (surfaceId: string) => void;
-  /** Clear a whole conversation, for "the user opened the assets sheet". */
+  /** Clear a whole conversation, for "the user opened the Chat Info panel". */
   clearConversation: (conversationId: string) => void;
 }
 

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -635,7 +635,6 @@
   "conversationAssets": {
     "ariaLabel": "Conversation assets, {count, plural, one {# item} other {# items}}",
     "ariaLabelUnseen": "Conversation assets, {count, plural, one {# item} other {# items}} (unseen changes)",
-    "heading": "Assets",
     "label": "{count, plural, one {# asset} other {# assets}}"
   },
   "conversationRow": {

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -631,7 +631,6 @@
   "conversationAssets": {
     "ariaLabel": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}}",
     "ariaLabelUnseen": "Recursos de la conversación, {count, plural, one {# elemento} other {# elementos}} (cambios sin ver)",
-    "heading": "Recursos",
     "label": "{count, plural, one {# recurso} other {# recursos}}"
   },
   "conversationRow": {

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -355,7 +355,6 @@
   "conversationAssets": {
     "ariaLabel": "Ресурсы диалога, {count, plural, one {# элемент} few {# элемента} many {# элементов} other {# элемента}}",
     "ariaLabelUnseen": "Ресурсы диалога, {count, plural, one {# элемент} few {# элемента} many {# элементов} other {# элемента}} (есть невидимые изменения)",
-    "heading": "Ресурсы",
     "label": "{count, plural, one {# ресурс} few {# ресурса} many {# ресурсов} other {# ресурса}}"
   },
   "conversationStarterDock": {

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -613,7 +613,6 @@
   "conversationAssets": {
     "ariaLabel": "對話資產，{count, plural, one {# 個項目} other {# 個項目}}",
     "ariaLabelUnseen": "對話資產，{count, plural, one {# 個項目} other {# 個項目}} (未檢視的變更)",
-    "heading": "資產",
     "label": "{count, plural, one {# 個資產} other {# 個資產}}"
   },
   "conversationRow": {

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -613,7 +613,6 @@
   "conversationAssets": {
     "ariaLabel": "对话资产，{count, plural, one {# 个项目} other {# 个项目}}",
     "ariaLabelUnseen": "对话资产，{count, plural, one {# 个项目} other {# 个项目}}（未查看的更改）",
-    "heading": "资产",
     "label": "{count, plural, one {# 个资产} other {# 个资产}}"
   },
   "conversationRow": {


### PR DESCRIPTION
## Summary
- The header Layers control toggles the Chat Info view in the viewer store instead of opening a popover or bottom sheet; the panel opens in the drawer on desktop and as an overlay on mobile
- The pill reads its count from the shared assets hook, keeps the unseen dot, and settles the panel on a conversation switch
- Header stories gain the open-trigger state on both viewports; the retired `conversationAssets.heading` key is removed

Part of plan: chat-info-assets-panel.md (PR 9 of 12)