### PR TITLE
Fix Windows release metadata and Microsoft catalog verification

### DIFF
--- a/.github/workflows/pr-windows.yaml
+++ b/.github/workflows/pr-windows.yaml
@@ -19,6 +19,7 @@ on:
       - 'skills/**'
       - 'packages/**'
       - '.github/workflows/pr-windows.yaml'
+      - '.github/workflows/release-windows.yaml'
 
 concurrency:
   group: pr-windows-${{ github.event.pull_request.number }}
@@ -110,6 +111,10 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --filter=@vellumai/native-sidecar --filter=@vellumai/windows
+
+      - name: Test release signature verification
+        shell: pwsh
+        run: ./scripts/verify-release.tests.ps1
 
       - name: Test and publish helper
         run: bun scripts/build-native-helper.ts --arch all --test

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -230,25 +230,9 @@ jobs:
           AZURE_TRUSTED_SIGNING_PROFILE: vellum-assistant
         run: bunx electron-builder --win --config electron-builder.config.cjs --publish never
 
-      # Azure rotates certificates; verify the publisher instead of a thumbprint.
       - name: Verify signatures
         shell: pwsh
-        run: |
-          $arch = "${{ matrix.arch }}"
-          $manifest = Get-Content "dist/signing-manifest-$arch.json" | ConvertFrom-Json
-          $appOutDir = if ($arch -eq "x64") { "dist/win-unpacked" } else { "dist/win-$arch-unpacked" }
-          $targets = @($manifest.files | ForEach-Object { Join-Path $appOutDir $_.path }) + @($manifest.installers | ForEach-Object { Join-Path "dist" $_.path })
-          if ($manifest.installers.Count -lt 1) { throw "signing manifest lists no installer" }
-          $bad = @()
-          foreach ($file in $targets) {
-            $sig = Get-AuthenticodeSignature -FilePath $file
-            if ($sig.Status -ne "Valid") { $bad += "$file ($($sig.Status))"; continue }
-            $publisher = $sig.SignerCertificate.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
-            if ($publisher -cne $env:WINDOWS_SIGNING_PUBLISHER_NAME) { $bad += "$file (unexpected publisher '$publisher')" }
-          }
-          if ($bad.Count -gt 0) { throw "Unsigned or invalid signatures:`n$($bad -join "`n")" }
-          Write-Host "Verified $($targets.Count) signatures from $env:WINDOWS_SIGNING_PUBLISHER_NAME"
-          if (-not (Test-Path "dist/latest.yml")) { throw "electron-builder did not write dist/latest.yml" }
+        run: ./scripts/verify-release.ps1 -Arch $env:ELECTRON_TARGET_ARCH -PublisherName $env:WINDOWS_SIGNING_PUBLISHER_NAME
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -159,10 +159,15 @@ for packaging and signing through `electron-builder`, because
 [Azure Artifact Signing does not support Windows ARM runners](https://github.com/Azure/artifact-signing-action#runner-requirements).
 The workflow verifies every manifest binary and the installer with
 `Get-AuthenticodeSignature`, requiring valid signatures from the configured
-publisher while allowing Azure certificate rotation, and publishes to the
+publisher while allowing Azure certificate rotation. Three bundled Microsoft
+runtime DLL paths also accept valid Microsoft Windows catalog signatures,
+which PowerShell prefers over embedded signatures. The workflow publishes to the
 `vellum-ai-<env>-releases/win-electron/<arch>/` feed: installer and blockmap
 first, then the `<env>.yml` channel manifest. Dev also publishes the installer
 as `vellum-assistant-dev-<arch>.exe` for stable download-page links.
+
+The builder always writes `latest.yml`, including for prerelease versions;
+CD uploads it under the environment's `<env>.yml` channel name.
 
 The executable, installer, and uninstaller use the environment-specific icon
 from `build-resources/icons/<environment>/icon.ico`, matching the local, dev,

--- a/clients/windows/electron-builder.config.cjs
+++ b/clients/windows/electron-builder.config.cjs
@@ -134,6 +134,8 @@ module.exports = {
   },
   publish: {
     provider: "generic",
+    // CD publishes latest.yml under the environment's channel name.
+    channel: "latest",
     url: `https://storage.googleapis.com/vellum-ai-${bucketEnv}-releases/win-electron/${targetArch}/`,
   },
   directories: {

--- a/clients/windows/scripts/verify-release.ps1
+++ b/clients/windows/scripts/verify-release.ps1
@@ -1,0 +1,34 @@
+param(
+  [Parameter(Mandatory)][ValidateSet("x64", "arm64")][string]$Arch,
+  [Parameter(Mandatory)][string]$PublisherName
+)
+
+$ErrorActionPreference = "Stop"
+$manifest = Get-Content "dist/signing-manifest-$Arch.json" | ConvertFrom-Json
+$appOutDir = if ($Arch -eq "x64") { "dist/win-unpacked" } else { "dist/win-$Arch-unpacked" }
+$targets = @($manifest.files | ForEach-Object { Join-Path $appOutDir $_.path }) + @($manifest.installers | ForEach-Object { Join-Path "dist" $_.path })
+if ($manifest.installers.Count -lt 1) { throw "signing manifest lists no installer" }
+
+# PowerShell prefers Windows catalog signatures over embedded signatures.
+$microsoftCatalogFiles = @(
+  "d3dcompiler_47.dll"
+  "dxil.dll"
+  "resources/native-helper/$Arch/D3DCompiler_47_cor3.dll"
+) | ForEach-Object { Join-Path $appOutDir $_ }
+
+$bad = @()
+$catalogCount = 0
+foreach ($file in $targets) {
+  $sig = Get-AuthenticodeSignature -FilePath $file
+  if ($sig.Status -ne "Valid") { $bad += "$file ($($sig.Status))"; continue }
+  $publisher = $sig.SignerCertificate.GetNameInfo([System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
+  if ($publisher -ceq $PublisherName) { continue }
+  if ($sig.SignatureType -eq "Catalog" -and $publisher -ceq "Microsoft Windows" -and $microsoftCatalogFiles -contains $file) {
+    $catalogCount++
+    continue
+  }
+  $bad += "$file (unexpected publisher '$publisher', signature type '$($sig.SignatureType)')"
+}
+if ($bad.Count -gt 0) { throw "Unsigned or invalid signatures:`n$($bad -join "`n")" }
+Write-Host "Verified $($targets.Count) signatures ($PublisherName; $catalogCount Microsoft catalog DLLs)"
+if (-not (Test-Path "dist/latest.yml")) { throw "electron-builder did not write dist/latest.yml" }

--- a/clients/windows/scripts/verify-release.tests.ps1
+++ b/clients/windows/scripts/verify-release.tests.ps1
@@ -1,0 +1,88 @@
+$ErrorActionPreference = "Stop"
+$verifier = Join-Path $PSScriptRoot "verify-release.ps1"
+$fixture = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString())
+$testCount = 0
+
+function New-Signature($Publisher = "Example Publisher", $Type = "Authenticode") {
+  $certificate = [pscustomobject]@{ Publisher = $Publisher; Thumbprint = [guid]::NewGuid().ToString() }
+  $certificate | Add-Member ScriptMethod GetNameInfo { param($NameType, $ForIssuer) $this.Publisher }
+  return [pscustomobject]@{ Status = "Valid"; SignatureType = $Type; SignerCertificate = $certificate }
+}
+
+function Get-AuthenticodeSignature([string]$FilePath) {
+  $signature = $signatures[[IO.Path]::GetFullPath($FilePath)]
+  if ($null -eq $signature) { throw "Missing signature fixture: $FilePath" }
+  return $signature
+}
+
+function Assert-Verification([string]$FailurePattern) {
+  $failure = $null
+  try { & $verifier -Arch $arch -PublisherName "Example Publisher" }
+  catch { $failure = $_.Exception.Message }
+  if ($FailurePattern) {
+    if (-not $failure -or $failure -notlike $FailurePattern) { throw "Expected '$FailurePattern', got '$failure'" }
+  } elseif ($failure) { throw $failure }
+  $script:testCount++
+}
+
+New-Item -ItemType Directory -Path (Join-Path $fixture "dist") -Force | Out-Null
+Push-Location $fixture
+try {
+  foreach ($arch in @("x64", "arm64")) {
+    $appOutDir = if ($arch -eq "x64") { "dist/win-unpacked" } else { "dist/win-$arch-unpacked" }
+    $vendorPaths = @("d3dcompiler_47.dll", "dxil.dll", "resources/native-helper/$arch/D3DCompiler_47_cor3.dll")
+    $manifest = @{
+      files = @(@{ path = "app.exe" }) + @($vendorPaths | ForEach-Object { @{ path = $_ } })
+      installers = @(@{ path = "setup.exe" })
+    }
+    $manifestPath = "dist/signing-manifest-$arch.json"
+    $manifest | ConvertTo-Json -Depth 4 | Set-Content $manifestPath
+    Set-Content "dist/latest.yml" "version: 1.0.0"
+    $signatures = @{}
+    $appPath = [IO.Path]::GetFullPath((Join-Path $appOutDir "app.exe"))
+    $installerPath = [IO.Path]::GetFullPath("dist/setup.exe")
+    $signatures[$appPath] = New-Signature
+    $signatures[$installerPath] = New-Signature
+    foreach ($relative in $vendorPaths) {
+      $signatures[[IO.Path]::GetFullPath((Join-Path $appOutDir $relative))] = New-Signature "Microsoft Windows" "Catalog"
+    }
+    Assert-Verification
+
+    foreach ($relative in $vendorPaths) {
+      $vendorPath = [IO.Path]::GetFullPath((Join-Path $appOutDir $relative))
+      $signatures[$vendorPath].Status = "HashMismatch"
+      Assert-Verification "*HashMismatch*"
+      $signatures[$vendorPath].Status = "Valid"
+      $signatures[$vendorPath].SignatureType = "Authenticode"
+      Assert-Verification "*unexpected publisher*"
+      $signatures[$vendorPath] = New-Signature "Other Publisher" "Catalog"
+      Assert-Verification "*unexpected publisher*"
+      $signatures[$vendorPath] = New-Signature "Microsoft Windows" "Catalog"
+    }
+
+    foreach ($ownedPath in @($appPath, $installerPath)) {
+      $signatures[$ownedPath].Status = "NotSigned"
+      Assert-Verification "*NotSigned*"
+      $signatures[$ownedPath] = New-Signature "Microsoft Windows" "Catalog"
+      Assert-Verification "*unexpected publisher*"
+      $signatures[$ownedPath] = New-Signature
+    }
+
+    $manifest.files += @{ path = "resources/other/dxil.dll" }
+    $manifest | ConvertTo-Json -Depth 4 | Set-Content $manifestPath
+    $signatures[[IO.Path]::GetFullPath((Join-Path $appOutDir "resources/other/dxil.dll"))] = New-Signature "Microsoft Windows" "Catalog"
+    Assert-Verification "*unexpected publisher*"
+    $manifest.files = @($manifest.files | Where-Object { $_.path -ne "resources/other/dxil.dll" })
+    $manifest | ConvertTo-Json -Depth 4 | Set-Content $manifestPath
+
+    Remove-Item "dist/latest.yml"
+    Assert-Verification "*did not write dist/latest.yml*"
+    $manifest.installers = @()
+    $manifest | ConvertTo-Json -Depth 4 | Set-Content $manifestPath
+    Assert-Verification "*lists no installer*"
+  }
+  Write-Host "Passed $testCount release verification cases"
+} finally {
+  Pop-Location
+  Remove-Item $fixture -Recurse -Force
+}


### PR DESCRIPTION
## Summary

- Set electron-builder's generic publish channel to `latest` so prerelease builds generate the `latest.yml` required by verification and artifact publishing. CD continues uploading that file under the environment's channel name.
- Accept valid `Microsoft Windows` catalog signatures only at the three bundled Direct3D/DXIL DLL paths. PowerShell prioritizes catalog signatures over embedded signatures. Every other file still requires the configured release publisher, and all files must pass Windows signature validation.
- Extract the release verifier into a PowerShell script and exercise 34 acceptance/rejection cases on Windows PR CI, including both architectures, invalid signatures, wrong publishers, misplaced DLLs, missing metadata, and missing installers.

## Validation

- Ran the installed electron-builder metadata generator through 12 cases: dev/staging/production versions, x64/ARM64, and old/new channel behavior. Reproduced the old filenames and verified the corrected filename, installer URL, version, and SHA-512.
- `actionlint` passes, excluding only its outdated warning for the existing ARM runner label. `git diff --check` passes.
- PowerShell behavior tests run in the Windows CI job. A complete signed release remains the end-to-end validation.
- [Microsoft documents catalog signature precedence](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/get-authenticodesignature).

## Original prompt

Fix the next Windows release failures in the Verify signatures step. ARM successfully verified 28 signatures but failed because `dist/latest.yml` was absent. The x64 job rejected three valid Microsoft-signed runtime DLLs because their reported publisher was Microsoft Windows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->