### PR TITLE
fix(ios): bound the avatar download, refuse symlinked cache entries, cancel on early expiry, check every profile in the preflight

### DIFF
--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -163,7 +163,18 @@ jobs:
           security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          echo "$CERT_P12" | base64 -D > /tmp/ios-certificate.p12
+          if [ -z "$CERT_P12" ]; then
+            echo "::error::DIST_CERTIFICATE_P12 is empty. Export the Apple Distribution certificate as a .p12, encode it with 'base64 -i <file>', and set the secret."
+            exit 1
+          fi
+          # Without this the decode writes an empty or truncated file and
+          # 'security import' fails on the file rather than on the secret,
+          # which sends the operator to the keychain for a fault that is in
+          # the secret.
+          if ! echo "$CERT_P12" | base64 -D > /tmp/ios-certificate.p12; then
+            echo "::error::DIST_CERTIFICATE_P12 is not valid base64. Re-encode the .p12 with 'base64 -i <file>' and replace the secret."
+            exit 1
+          fi
           security import /tmp/ios-certificate.p12 \
             -k "$KEYCHAIN_PATH" \
             -P "$CERT_PASSWORD" \
@@ -223,28 +234,55 @@ jobs:
             echo "Provisioning profile installed from $key"
           }
 
-          # Fails the run when an installed profile does not grant $key.
+          # Decodes an installed profile into a plist for the checks below.
           #
           # Decoding and checking are separate steps on purpose: a profile that
           # is not CMS-signed at all (a mis-encoded secret, a truncated
-          # download) fails the decode, and folding that into the entitlement
+          # download) fails the decode, and folding that into an entitlement
           # test would report a missing capability and send the operator to the
-          # portal for a fault that is in the secret. The decoded plist is read
-          # by key path rather than grepped, so the check is anchored to
-          # Entitlements and asserts the value is true.
-          require_entitlement() {
-            local filename="$1" key="$2" secret="$3" remedy="$4"
-            local plist="$RUNNER_TEMP/$filename.plist"
+          # portal for a fault that is in the secret.
+          decode_profile() {
+            local filename="$1" plist="$2" secret="$3"
             if ! security cms -D -i "$PROFILE_DIR/$filename" > "$plist"; then
               echo "::error::Could not decode the profile installed from $secret with 'security cms -D'. The secret does not hold a CMS-signed .mobileprovision: re-download the profile from the Apple Developer portal, re-encode it with 'base64 -i <file>', and replace $secret."
               exit 1
             fi
+          }
+
+          # Fails the run when the profile does not grant $key as true. The
+          # plist is read by key path rather than grepped, so the check is
+          # anchored to Entitlements and asserts the value.
+          require_entitlement_true() {
+            local plist="$1" key="$2" remedy="$3"
             local granted
             granted=$(/usr/libexec/PlistBuddy -c "Print :Entitlements:$key" "$plist" 2>/dev/null || true)
             if [ "$granted" != "true" ]; then
               echo "::error::$remedy"
               exit 1
             fi
+          }
+
+          # Fails the run when the profile carries no $key at all. An
+          # entitlement whose value is an array has no "true" to compare
+          # against, so presence is the whole of the assertion.
+          require_entitlement_present() {
+            local plist="$1" key="$2" remedy="$3"
+            if ! /usr/libexec/PlistBuddy -c "Print :Entitlements:$key" "$plist" > /dev/null 2>&1; then
+              echo "::error::$remedy"
+              exit 1
+            fi
+          }
+
+          # Every signed bundle declares the App Group: the app through
+          # App/App.entitlements and App/App-Dev.entitlements, all three
+          # appexes through App/Extension.entitlements. A profile issued before
+          # the group was assigned to its App ID does not grant it, and the
+          # build fails at Archive with an error that names neither the
+          # entitlement nor the fix.
+          require_app_group() {
+            local plist="$1" secret="$2" target="$3"
+            require_entitlement_present "$plist" com.apple.security.application-groups \
+              "Provisioning profile $secret does not grant com.apple.security.application-groups, which $target declares. Archive would fail while signing $target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md for this environment's row: assign the App Group to this App ID (steps 1 and 2), reissue its distribution profile under the identical name (steps 3 and 4), then replace $secret."
           }
 
           # The app profile is non-negotiable: without it there is no build to
@@ -262,11 +300,13 @@ jobs:
           # build has started, with an error that names neither the entitlement
           # nor the fix, so the profile is decoded and checked here instead.
           # The appexes carry no entitlement of their own beyond the App Group,
-          # so this check belongs to the app profile alone.
-          require_entitlement ios_distribution.mobileprovision \
+          # so the communication check belongs to the app profile alone.
+          APP_PLIST="$RUNNER_TEMP/app_profile.plist"
+          decode_profile ios_distribution.mobileprovision "$APP_PLIST" "$APP_PROFILE_KEY"
+          require_entitlement_true "$APP_PLIST" \
             com.apple.developer.usernotifications.communication \
-            "$APP_PROFILE_KEY" \
             "Provisioning profile $APP_PROFILE_KEY does not grant com.apple.developer.usernotifications.communication, which App.entitlements and App-Dev.entitlements declare. Archive would fail while signing the app target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md, steps 2 and 4 for this environment's app row: tick Communication Notifications on the app App ID, reissue its distribution profile under the identical name, then replace $APP_PROFILE_KEY."
+          require_app_group "$APP_PLIST" "$APP_PROFILE_KEY" "the app target"
 
           # A missing extension profile is tolerated: the App IDs and profiles
           # behind IOS_PROVISIONING_PROFILE_EXT* do not exist in the Apple
@@ -277,6 +317,9 @@ jobs:
           EXT_PROFILE_KEY="${{ steps.config.outputs.ext_profile_key }}"
           if install_profile "$EXT_PROFILE_KEY" ios_distribution_ext.mobileprovision; then
             echo "ext_profile_installed=true" >> "$GITHUB_OUTPUT"
+            EXT_PLIST="$RUNNER_TEMP/ext_profile.plist"
+            decode_profile ios_distribution_ext.mobileprovision "$EXT_PLIST" "$EXT_PROFILE_KEY"
+            require_app_group "$EXT_PLIST" "$EXT_PROFILE_KEY" "the VoiceActivity extension"
           else
             echo "ext_profile_installed=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Provisioning profile secret $EXT_PROFILE_KEY is empty, so the VoiceActivity extension profile was not installed and is omitted from ExportOptions.plist. THIS RELEASE WILL STILL FAIL: every app target embeds the extension, so 'xcodebuild archive' stops at signing with \"No profile for team ... matching '${{ steps.config.outputs.ext_profile_name }}' found ... (in target 'VoiceActivity ...')\". No iOS release of any environment can be produced until the portal setup lands. Fix: follow 'Manual Apple Developer portal setup' in clients/ios/README.md to create the App ID and profile, then add $EXT_PROFILE_KEY."
@@ -285,6 +328,9 @@ jobs:
           SHARE_PROFILE_KEY="${{ steps.config.outputs.share_profile_key }}"
           if install_profile "$SHARE_PROFILE_KEY" ios_distribution_share.mobileprovision; then
             echo "share_profile_installed=true" >> "$GITHUB_OUTPUT"
+            SHARE_PLIST="$RUNNER_TEMP/share_profile.plist"
+            decode_profile ios_distribution_share.mobileprovision "$SHARE_PLIST" "$SHARE_PROFILE_KEY"
+            require_app_group "$SHARE_PLIST" "$SHARE_PROFILE_KEY" "the Share extension"
           else
             echo "share_profile_installed=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Provisioning profile secret $SHARE_PROFILE_KEY is empty, so the Share extension profile was not installed and is omitted from ExportOptions.plist. THIS RELEASE WILL STILL FAIL: every app target embeds the extension, so 'xcodebuild archive' stops at signing with \"No profile for team ... matching '${{ steps.config.outputs.share_profile_name }}' found ... (in target 'Share ...')\". No iOS release of any environment can be produced until the portal setup lands. Fix: follow 'Manual Apple Developer portal setup' in clients/ios/README.md to create the App ID and profile, then add $SHARE_PROFILE_KEY."
@@ -293,6 +339,9 @@ jobs:
           NSE_PROFILE_KEY="${{ steps.config.outputs.nse_profile_key }}"
           if install_profile "$NSE_PROFILE_KEY" ios_distribution_nse.mobileprovision; then
             echo "nse_profile_installed=true" >> "$GITHUB_OUTPUT"
+            NSE_PLIST="$RUNNER_TEMP/nse_profile.plist"
+            decode_profile ios_distribution_nse.mobileprovision "$NSE_PLIST" "$NSE_PROFILE_KEY"
+            require_app_group "$NSE_PLIST" "$NSE_PROFILE_KEY" "the NotificationService extension"
           else
             echo "nse_profile_installed=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Provisioning profile secret $NSE_PROFILE_KEY is empty, so the NotificationService extension profile was not installed and is omitted from ExportOptions.plist. THIS RELEASE WILL STILL FAIL: every app target embeds the extension, so 'xcodebuild archive' stops at signing with \"No profile for team ... matching '${{ steps.config.outputs.nse_profile_name }}' found ... (in target 'NotificationService ...')\". No iOS release of any environment can be produced until the portal setup lands. Fix: follow 'Manual Apple Developer portal setup' in clients/ios/README.md to create the App ID and profile, then add $NSE_PROFILE_KEY."

--- a/clients/ios/App/AppTests/AvatarCacheTests.swift
+++ b/clients/ios/App/AppTests/AvatarCacheTests.swift
@@ -115,6 +115,26 @@ final class AvatarCacheTests: XCTestCase {
         XCTAssertEqual(storedFileCount(), 0)
     }
 
+    /// `attributesOfItem` reports a symlink's own size while `Data(contentsOf:)`
+    /// follows it, so a link is measured against the wrong file and the byte cap
+    /// bounds nothing. The target here holds the very bytes the name promises,
+    /// which leaves the entry's type as the only thing that can reject it.
+    func testDropsACachedEntryThatIsASymlink() throws {
+        let bytes = avatar(1)
+        let hash = AvatarCache.sha256Hex(bytes)
+        let link = try XCTUnwrap(cache.fileURL(forHash: hash))
+        let target = root.appendingPathComponent("elsewhere.png", isDirectory: false)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try bytes.write(to: target)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertNil(cache.data(forHash: hash))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: link.path))
+        // Only the link is removed: the container is shared with the app, whose
+        // own files a cache read has no business deleting.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target.path))
+    }
+
     func testDropsACachedFileWhoseBytesNoLongerMatchItsName() throws {
         let hash = AvatarCache.sha256Hex(avatar(1))
         let url = try XCTUnwrap(cache.fileURL(forHash: hash))
@@ -152,6 +172,25 @@ final class AvatarCacheTests: XCTestCase {
         // rest of the response is never pulled into memory, buffered chunk or
         // not.
         XCTAssertEqual(feed.produced, 17)
+    }
+
+    /// The request's idle timeout only bounds a stall, so a body arriving
+    /// steadily but far too slowly needs a deadline of its own.
+    func testStopsReadingOnceTheDeadlineHasPassed() async throws {
+        let feed = ByteFeed(count: 4_096)
+        do {
+            _ = try await AvatarCache.readAtMost(
+                AvatarCache.maxBytes,
+                from: feed.stream(),
+                before: .distantPast
+            )
+            XCTFail("expected the read to give up on the deadline")
+        } catch let reason as AvatarCache.UnavailableReason {
+            XCTAssertEqual(reason, .timedOut)
+        }
+        // The deadline is checked once per stride rather than per byte, so the
+        // read stops at the first check instead of the first byte.
+        XCTAssertEqual(feed.produced, AvatarCache.deadlineCheckStride)
     }
 
     func testFetchRefusesANonHttpsURL() async throws {
@@ -204,6 +243,29 @@ final class AvatarCacheTests: XCTestCase {
         XCTAssertEqual(storedFileCount(), 0)
     }
 
+    /// A response that declares no length is read under the streaming cap
+    /// alone, which is the only thing standing between a lying host and the
+    /// extension's memory budget.
+    func testFetchRejectsAnUndeclaredBodyPastTheByteCap() async throws {
+        let oversized = Data(repeating: 0x41, count: AvatarCache.maxBytes + 1)
+        stubbedResponse.set(headerFields: [:], body: oversized)
+
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
+        let result = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(oversized))
+        XCTAssertEqual(result.reason, .bodyTooLarge)
+        XCTAssertEqual(storedFileCount(), 0)
+    }
+
+    func testFetchRejectsANonOkStatus() async throws {
+        let bytes = avatar(1)
+        stubbedResponse.set(statusCode: 404, headerFields: [:], body: bytes)
+
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
+        let result = await cache.fetch(url: url, hash: AvatarCache.sha256Hex(bytes))
+        XCTAssertEqual(result.reason, .badStatus)
+        XCTAssertEqual(storedFileCount(), 0)
+    }
+
     func testFetchRejectsBytesThatDoNotMatchTheHash() async throws {
         stubbedResponse.set(headerFields: [:], body: avatar(2))
 
@@ -243,7 +305,7 @@ private final class CountingURLProtocol: URLProtocol {
               let stub = stubbedResponse.current,
               let response = HTTPURLResponse(
                   url: url,
-                  statusCode: 200,
+                  statusCode: stub.statusCode,
                   httpVersion: "HTTP/1.1",
                   headerFields: stub.headerFields
               )
@@ -264,6 +326,7 @@ private let stubbedResponse = StubbedResponse()
 
 private final class StubbedResponse: @unchecked Sendable {
     struct Stub {
+        let statusCode: Int
         let headerFields: [String: String]
         let body: Data
     }
@@ -275,8 +338,10 @@ private final class StubbedResponse: @unchecked Sendable {
 
     /// Headers with no `Content-Length` are what a chunked response looks like
     /// to `URLSession`: `expectedContentLength` comes back as -1.
-    func set(headerFields: [String: String], body: Data) {
-        lock.withLock { stub = Stub(headerFields: headerFields, body: body) }
+    func set(statusCode: Int = 200, headerFields: [String: String], body: Data) {
+        lock.withLock {
+            stub = Stub(statusCode: statusCode, headerFields: headerFields, body: body)
+        }
     }
 
     func clear() {

--- a/clients/ios/App/AppTests/SenderPayloadTests.swift
+++ b/clients/ios/App/AppTests/SenderPayloadTests.swift
@@ -11,7 +11,7 @@ final class SenderPayloadTests: XCTestCase {
         return info
     }
 
-    func testParsesACompleteSenderBlock() {
+    func testParsesACompleteSenderBlock() throws {
         let parsed = SenderPayload.parse(
             userInfo: userInfo(sender: [
                 "id": "asst-123",
@@ -20,12 +20,13 @@ final class SenderPayloadTests: XCTestCase {
                 "avatar_hash": avatarHash,
             ])
         )
+        let url = try XCTUnwrap(URL(string: "https://storage.example.com/avatar.png"))
         XCTAssertEqual(
             parsed,
             SenderPayload(
                 id: "asst-123",
                 name: "Vellum",
-                avatarURL: URL(string: "https://storage.example.com/avatar.png"),
+                avatarURL: .url(url),
                 avatarHash: avatarHash
             )
         )
@@ -39,8 +40,24 @@ final class SenderPayloadTests: XCTestCase {
                 "avatar_hash": avatarHash,
             ])
         )
-        XCTAssertNil(parsed?.avatarURL)
+        XCTAssertEqual(parsed?.avatarURL, .absent)
         XCTAssertEqual(parsed?.avatarHash, avatarHash)
+    }
+
+    /// An unterminated IPv6 literal is invalid in a way percent-encoding cannot
+    /// rescue, so `URL(string:)` returns nil for it. A trimmed payload and a
+    /// URL the platform mangled both leave the push without an avatar, and the
+    /// two get their own reason tokens rather than sharing `no_url`.
+    func testSeparatesAnUnparseableAvatarUrlFromAnAbsentOne() {
+        let parsed = SenderPayload.parse(
+            userInfo: userInfo(sender: [
+                "id": "asst-123",
+                "name": "Vellum",
+                "avatar_url": "https://[::1",
+                "avatar_hash": avatarHash,
+            ])
+        )
+        XCTAssertEqual(parsed?.avatarURL, .malformed)
     }
 
     func testReturnsNilWithoutASenderBlock() {

--- a/clients/ios/App/NotificationService/AvatarCache.swift
+++ b/clients/ios/App/NotificationService/AvatarCache.swift
@@ -21,13 +21,23 @@ struct AvatarCache {
     static let maxEntries = 8
     static let maxBytes = 512 * 1024
     static let requestTimeout: TimeInterval = 8
+    /// The total wall-clock bound on one download. ``requestTimeout`` bounds
+    /// only how long a transfer may stall without new bytes, so without this a
+    /// host trickling a byte at a time would run until the extension's own
+    /// budget expired.
+    static let downloadBudget: TimeInterval = 6
     static let readChunkSize = 16 * 1024
+    /// Bytes between deadline checks. Reading the clock costs more than copying
+    /// the byte it guards, so it is amortized rather than paid per byte while
+    /// staying frequent enough to catch a body arriving one byte at a time.
+    static let deadlineCheckStride = 512
 
     /// Why no avatar reached the notification. Every cause has its own stable
     /// token, so the Console line names which one it was instead of standing
     /// for any of them.
     enum UnavailableReason: String, Error {
         case missingURL = "no_url"
+        case invalidURL = "invalid_url"
         case badHash = "bad_hash"
         case insecureURL = "insecure_url"
         case requestFailed = "request_failed"
@@ -35,6 +45,7 @@ struct AvatarCache {
         case declaredTooLarge = "declared_too_large"
         case bodyTooLarge = "body_too_large"
         case readFailed = "read_failed"
+        case timedOut = "timed_out"
         case digestMismatch = "digest_mismatch"
     }
 
@@ -59,21 +70,26 @@ struct AvatarCache {
     /// The cached bytes for `hash`, or `nil` when nothing is stored under it.
     ///
     /// The container is shared with the app, so a stored file is held to the
-    /// same bounds a download is: its size is read before its bytes, anything
-    /// past ``maxBytes`` is deleted unread, and a file that no longer matches
-    /// its own name is deleted rather than rendered.
+    /// same bounds a download is: only a regular file is read, its size is read
+    /// before its bytes, anything past ``maxBytes`` is deleted unread, and a
+    /// file that no longer matches its own name is deleted rather than
+    /// rendered.
     ///
     /// A hit stamps the file with the current time so eviction, which ranks by
     /// modification date, treats a recently used avatar as recent.
     func data(forHash hash: String) -> Data? {
-        guard let url = fileURL(forHash: hash) else {
+        guard let url = fileURL(forHash: hash),
+              let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        else {
             return nil
         }
-        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
-        guard let size = attributes?[.size] as? Int else {
-            return nil
-        }
-        guard size <= Self.maxBytes else {
+        // `attributesOfItem` describes a symlink itself while `Data(contentsOf:)`
+        // follows it, so a link reports the wrong size and the cap bounds
+        // nothing. Anything that is not a regular file is poisoned.
+        guard attributes[.type] as? FileAttributeType == .typeRegular,
+              let size = attributes[.size] as? Int,
+              size <= Self.maxBytes
+        else {
             try? FileManager.default.removeItem(at: url)
             return nil
         }
@@ -123,8 +139,8 @@ struct AvatarCache {
     ///
     /// ``requestTimeout`` is the request's idle timeout: it bounds how long the
     /// transfer may stall without new bytes, not how long it may run in total.
-    /// The total bound is the extension's own budget, whose expiry cancels the
-    /// task this runs in.
+    /// ``downloadBudget`` is the total bound, which a body arriving slowly
+    /// enough crosses without ever going idle; it surfaces as `timed_out`.
     func fetch(url: URL, hash: String) async -> Result<Data, UnavailableReason> {
         guard Self.isValidHash(hash) else {
             return .failure(.badHash)
@@ -159,6 +175,9 @@ struct AvatarCache {
                 from: bytes,
                 expecting: declared >= 0 ? Int(declared) : nil
             )
+        } catch let reason as UnavailableReason {
+            bytes.task.cancel()
+            return .failure(reason)
         } catch {
             bytes.task.cancel()
             return .failure(.readFailed)
@@ -183,18 +202,30 @@ struct AvatarCache {
     /// at a time: appending each byte to `Data` on its own costs a bounds check
     /// and a possible reallocation per byte, which is the whole of the
     /// extension's CPU budget on a 512 KB avatar.
+    ///
+    /// Throws ``UnavailableReason/timedOut`` once `deadline` passes, so a body
+    /// that keeps arriving too slowly to go idle is still bounded.
     static func readAtMost<Bytes: AsyncSequence>(
         _ limit: Int,
         from bytes: Bytes,
-        expecting expectedCount: Int? = nil
+        expecting expectedCount: Int? = nil,
+        before deadline: Date = Date().addingTimeInterval(downloadBudget)
     ) async throws -> Data? where Bytes.Element == UInt8 {
         var data = Data()
         data.reserveCapacity(min(limit, expectedCount ?? readChunkSize))
         var chunk = [UInt8](repeating: 0, count: min(limit, readChunkSize))
         var filled = 0
+        var sinceDeadlineCheck = 0
         for try await byte in bytes {
             if data.count + filled >= limit {
                 return nil
+            }
+            sinceDeadlineCheck += 1
+            if sinceDeadlineCheck == deadlineCheckStride {
+                sinceDeadlineCheck = 0
+                guard Date() < deadline else {
+                    throw UnavailableReason.timedOut
+                }
             }
             chunk[filled] = byte
             filled += 1

--- a/clients/ios/App/NotificationService/NotificationService.swift
+++ b/clients/ios/App/NotificationService/NotificationService.swift
@@ -29,6 +29,7 @@ final class NotificationService: UNNotificationServiceExtension {
     private var contentHandler: ((UNNotificationContent) -> Void)?
     private var unchangedContent: UNNotificationContent?
     private var rewrite: Task<Void, Never>?
+    private var expired = false
 
     override func didReceive(
         _ request: UNNotificationRequest,
@@ -55,8 +56,15 @@ final class NotificationService: UNNotificationServiceExtension {
             if let cached = cache.data(forHash: sender.avatarHash) {
                 avatar = cached
             } else {
-                guard let url = sender.avatarURL else {
+                let url: URL
+                switch sender.avatarURL {
+                case .url(let resolved):
+                    url = resolved
+                case .absent:
                     self.deliverWithoutAvatar(.missingURL, content: request.content)
+                    return
+                case .malformed:
+                    self.deliverWithoutAvatar(.invalidURL, content: request.content)
                     return
                 }
                 switch await cache.fetch(url: url, hash: sender.avatarHash) {
@@ -84,13 +92,21 @@ final class NotificationService: UNNotificationServiceExtension {
         }
         lock.lock()
         rewrite = task
+        let alreadyExpired = expired
         lock.unlock()
+        // The task is built before it can be stored, so an expiry landing in
+        // between finds nothing to cancel and the download outlives the
+        // notification it was for.
+        if alreadyExpired {
+            task.cancel()
+        }
     }
 
     /// Called when the extension runs out of its budget. Delivering the push as
     /// it arrived is the only alternative to the system dropping it silently.
     override func serviceExtensionTimeWillExpire() {
         lock.lock()
+        expired = true
         let content = unchangedContent
         let pending = rewrite
         rewrite = nil
@@ -98,32 +114,42 @@ final class NotificationService: UNNotificationServiceExtension {
         // Cancelling propagates into the avatar download, whose only bound
         // otherwise is an idle timeout the system has already outlasted.
         pending?.cancel()
-        if let content {
-            Self.logger.info("nse.expired: budget ran out before the rewrite finished")
-            deliver(content)
+        guard let content, deliver(content) else {
+            return
         }
+        Self.logger.info("nse.expired: budget ran out before the rewrite finished")
     }
 
-    /// Logs why the notification has no avatar, then delivers the push as it
-    /// arrived.
+    /// Delivers the push as it arrived, and logs why it has no avatar when this
+    /// is the delivery that reached the system. A cancelled download reports a
+    /// reason after the expiry callback has already delivered, and that reason
+    /// describes the cancellation rather than the notification the user saw.
     private func deliverWithoutAvatar(
         _ reason: AvatarCache.UnavailableReason,
         content: UNNotificationContent
     ) {
+        guard deliver(content) else {
+            return
+        }
         Self.logger.info(
             "nse.avatar_unavailable reason=\(reason.rawValue, privacy: .public)"
         )
-        deliver(content)
     }
 
-    /// Hands `content` to the system once. Later calls are dropped: iOS accepts
-    /// a single delivery per push, and the rewrite can finish just as the
-    /// expiry callback fires.
-    private func deliver(_ content: UNNotificationContent) {
+    /// Hands `content` to the system once and reports whether it did. Later
+    /// calls are dropped: iOS accepts a single delivery per push, and the
+    /// rewrite can finish just as the expiry callback fires.
+    @discardableResult
+    private func deliver(_ content: UNNotificationContent) -> Bool {
         lock.lock()
         let handler = contentHandler
         contentHandler = nil
+        unchangedContent = nil
         lock.unlock()
-        handler?(content)
+        guard let handler else {
+            return false
+        }
+        handler(content)
+        return true
     }
 }

--- a/clients/ios/App/NotificationService/SenderPayload.swift
+++ b/clients/ios/App/NotificationService/SenderPayload.swift
@@ -11,8 +11,19 @@ import Foundation
 struct SenderPayload: Equatable {
     let id: String
     let name: String
-    let avatarURL: URL?
+    let avatarURL: AvatarURL
     let avatarHash: String
+
+    /// Where the avatar can be fetched from, or why it cannot be.
+    ///
+    /// An absent `avatar_url` is routine, and a warm cache serves the push
+    /// anyway. A present one that `URL(string:)` cannot read is a platform
+    /// fault. Keeping them apart is what lets one Console line say which.
+    enum AvatarURL: Equatable {
+        case url(URL)
+        case absent
+        case malformed
+    }
 
     static func parse(userInfo: [AnyHashable: Any]) -> SenderPayload? {
         guard let sender = userInfo["sender"] as? [AnyHashable: Any],
@@ -25,9 +36,19 @@ struct SenderPayload: Equatable {
         return SenderPayload(
             id: id,
             name: name,
-            avatarURL: nonEmptyString(sender["avatar_url"]).flatMap { URL(string: $0) },
+            avatarURL: parseAvatarURL(sender["avatar_url"]),
             avatarHash: avatarHash
         )
+    }
+
+    private static func parseAvatarURL(_ value: Any?) -> AvatarURL {
+        guard let text = nonEmptyString(value) else {
+            return .absent
+        }
+        guard let url = URL(string: text) else {
+            return .malformed
+        }
+        return .url(url)
     }
 
     private static func nonEmptyString(_ value: Any?) -> String? {

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -735,12 +735,8 @@ says to "Enable the Communication Notifications capability in your app target",
 and [WWDC21 session 10091](https://developer.apple.com/videos/play/wwdc2021/10091/)
 splits the two halves the same way: "enable the communication capability via
 Xcode for your application" against "start donating incoming StartCall and
-SendMessage intents in your service extension". Vendor integration guides that
-walk the same setup, such as [Smartsupp's Communication
-Notifications](https://docs.smartsupp.com/mobile-sdk/ios/communication-notifications/)
-page, add the capability once at the project's app target and give the
-extension only its Info.plist and code. Do not add the entitlement to the appex
-speculatively: a target declaring an entitlement its profile does not grant
+SendMessage intents in your service extension". Do not add the entitlement to
+the appex speculatively: a target declaring an entitlement its profile does not grant
 fails to sign, so it would break every environment's release until the NSE App
 IDs carried the capability too.
 
@@ -931,6 +927,7 @@ line is enough to tell a trimmed payload from a rejected download:
 | `reason=` | What it means |
 |-----------|---------------|
 | `no_url` | Cache miss and the payload carried no `avatar_url` (usually a payload trimmed for size). |
+| `invalid_url` | `avatar_url` was present but `URL(string:)` could not read it. |
 | `bad_hash` | `avatar_hash` is not 64 lowercase hex characters. |
 | `insecure_url` | `avatar_url` is not `https`. |
 | `request_failed` | The request never produced a response (offline, DNS, TLS). |
@@ -938,7 +935,18 @@ line is enough to tell a trimmed payload from a rejected download:
 | `declared_too_large` | The response declared a `Content-Length` past 512 KB. |
 | `body_too_large` | The body crossed 512 KB while streaming, declared or not. |
 | `read_failed` | The body stopped mid-transfer, including on extension expiry. |
+| `timed_out` | The body kept arriving, too slowly to go idle, past the download's total budget. |
 | `digest_mismatch` | The bytes did not hash to `avatar_hash`. |
+
+`declared_too_large`, `body_too_large` and `timed_out` are the download's own
+bounds: 512 KB whether the response declares a length or streams one, and six
+seconds of wall clock on top of the request's idle timeout, which bounds only a
+stall. Android bounds the same download the same way, reading 8 KB chunks under
+the same 512 KB cap against a four-second budget (`READ_BUDGET_MILLIS` in
+`clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java`).
+iOS buffers 16 KB chunks out of a per-byte `URLSession.AsyncBytes` sequence and
+checks the deadline once per 512 bytes, because reading the clock costs more
+than copying the byte it guards.
 
 A banner with no avatar and no `nse.` line at all is the entitlement and
 profile case rather than a code one. `updating(from:)` may throw, which lands

--- a/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
+++ b/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
@@ -6,6 +6,21 @@ import { readSetting } from "./xcconfig-fixtures";
 
 const APP_DIR = join(import.meta.dir, "../../App/App");
 const NSE_DIR = join(import.meta.dir, "../../App/NotificationService");
+const REPO_ROOT = join(import.meta.dir, "../../../..");
+
+const RELEASE_WORKFLOW = readFileSync(
+  join(REPO_ROOT, ".github/workflows/release-ios.yaml"),
+  "utf8",
+);
+
+function workflowOutputs(key: string): string[] {
+  return RELEASE_WORKFLOW.split("\n")
+    .flatMap((line) => {
+      const match = line.match(new RegExp(`${key}=(.+?)"`));
+      return match ? [match[1]] : [];
+    })
+    .sort();
+}
 
 const PAIRS = [
   { app: "App.xcconfig", nse: "NotificationService.xcconfig" },
@@ -66,17 +81,7 @@ describe("NSE profile names agree with release-ios.yaml", () => {
   // be checked from here, but a drift between the other two fails the archive
   // with "No profile for team ... matching '<name>' found", which names
   // neither file.
-  const workflow = readFileSync(
-    join(import.meta.dir, "../../../../.github/workflows/release-ios.yaml"),
-    "utf8",
-  );
-  const workflowNames = workflow
-    .split("\n")
-    .flatMap((line) => {
-      const match = line.match(/nse_profile_name=(.+?)"/);
-      return match ? [match[1]] : [];
-    })
-    .sort();
+  const workflowNames = workflowOutputs("nse_profile_name");
 
   test("the workflow names one profile per environment", () => {
     expect(workflowNames).toHaveLength(PAIRS.length);
@@ -88,4 +93,44 @@ describe("NSE profile names agree with release-ios.yaml", () => {
     ).sort();
     expect(configNames).toEqual(workflowNames);
   });
+});
+
+describe("NSE bundle ids agree with release-ios.yaml", () => {
+  // The workflow writes one ExportOptions.plist entry per signed bundle, and
+  // `-exportArchive` fails on an entry that names a bundle the archive does
+  // not contain, with an error that names neither.
+  const workflowIds = workflowOutputs("nse_bundle_id");
+
+  test("the workflow names one bundle id per environment", () => {
+    expect(workflowIds).toHaveLength(PAIRS.length);
+  });
+
+  test("every xcconfig bundle id appears in the workflow", () => {
+    const configIds = PAIRS.map(({ nse }) =>
+      readSetting(nse, "PRODUCT_BUNDLE_IDENTIFIER"),
+    ).sort();
+    expect(configIds).toEqual(workflowIds);
+  });
+});
+
+describe("every avatar failure token is documented", () => {
+  // The README's `reason=` table is the only place a `nse.avatar_unavailable`
+  // line can be decoded, so a token that reaches Console without a row there
+  // is a dead end for whoever is holding the device.
+  const source = readFileSync(join(NSE_DIR, "AvatarCache.swift"), "utf8");
+  const body = source.split("enum UnavailableReason")[1] ?? "";
+  const tokens = [...body.split("}")[0].matchAll(/case \w+ = "(\w+)"/g)].map(
+    (match) => match[1],
+  );
+  const readme = readFileSync(join(import.meta.dir, "../../README.md"), "utf8");
+
+  test("the enum parses", () => {
+    expect(tokens.length).toBeGreaterThan(0);
+  });
+
+  for (const token of tokens) {
+    test(`${token} has a row in the README table`, () => {
+      expect(readme).toContain(`| \`${token}\` |`);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

- The cache refuses any entry that is not a regular file. `attributesOfItem` reports a symlink's own size while `Data(contentsOf:)` follows it, so a link was measured against the wrong file and the 512 KB cap bounded nothing; a non-regular entry is now deleted unread.
- The download gets a total wall-clock budget (6 s), checked once per 512 bytes inside the read loop. `requestTimeout` is idle-only, so a body arriving steadily but far too slowly never went idle and ran until the extension's own budget expired. It surfaces as a new `timed_out` reason token.
- `deliver` returns whether it consumed the handler and clears `unchangedContent`, and both `nse.expired` and `nse.avatar_unavailable` are gated on that result. A rewrite that delivered no longer produces an `nse.expired` line, and a cancelled read no longer logs `reason=read_failed` after the plain notification already went out.
- An expiry landing between building the rewrite task and storing it under the lock now cancels it: the callback sets an `expired` flag, and `didReceive` cancels immediately when it finds the flag already set.
- A present-but-unparseable `avatar_url` reports `invalid_url` instead of sharing `no_url` with a payload trimmed for size. `SenderPayload.avatarURL` becomes a three-case enum rather than an optional.
- The release preflight splits into `decode_profile`, `require_entitlement_true` and `require_entitlement_present`, decodes all four profiles, and asserts `com.apple.security.application-groups` on each (an array, so `!= "true"` could never have checked it). The certificate import guards its own base64 decode and an empty secret.
- Tests: a symlinked cache entry, a past deadline, a non-200 status, and an undeclared body past the cap (the only producer of `body_too_large`). The bundle-id guard also pins the three `nse_bundle_id=` workflow values against the xcconfigs and asserts every `UnavailableReason` raw value has a README row.
- README: `invalid_url` and `timed_out` rows, a note that Android reads 8 KB chunks under a four-second budget and the same 512 KB cap, and the third-party vendor citation dropped from the capability paragraph.

Round-3 self-review fixes for the notification avatar feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1