### PR TITLE
fix(macos): keep the addon delegate in front of Electron's presenter, read the macOS profile app id, share the avatar path helper

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -121,7 +121,7 @@ jobs:
           cat > "$RUNNER_TEMP/smoke-notifier.js" <<'JS'
           const addon = { exports: {} };
           process.dlopen(addon, process.argv[2]);
-          const exported = ["isSupported", "requestAuthorization", "registerCategories", "restoreDelegate", "show"];
+          const exported = ["isSupported", "requestAuthorization", "registerCategories", "ensureDelegate", "restoreDelegate", "show"];
           for (const name of exported) {
             if (typeof addon.exports[name] !== "function") {
               console.error(`vellum-notifier: missing export ${name}`);
@@ -133,8 +133,15 @@ jobs:
           JS
           # build-notifier.sh writes one architecture and clears the rest, so
           # the addon is whatever it left behind. Resolving it that way keeps
-          # the smoke load honest about the arch the build actually produced.
-          ADDON="$(ls resources/notifier/*/vellum-notifier.node)"
+          # the smoke load honest about the arch the build actually produced,
+          # and a second arch directory has to fail here rather than be smoke
+          # loaded as a two-line path.
+          ADDONS=(resources/notifier/*/vellum-notifier.node)
+          if [ "${#ADDONS[@]}" -ne 1 ] || [ ! -f "${ADDONS[0]}" ]; then
+            echo "::error::expected exactly one built notifier addon under resources/notifier, found: ${ADDONS[*]}"
+            exit 1
+          fi
+          ADDON="${ADDONS[0]}"
           ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron \
             "$RUNNER_TEMP/smoke-notifier.js" \
             "$ADDON"

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1773,7 +1773,17 @@ jobs:
             echo "::error::The provisioning profile does not grant com.apple.developer.usernotifications.communication. Enable Communication Notifications on the $EXPECTED_BUNDLE_ID App ID in the Apple Developer portal, regenerate the profile, and update the MAC_PROVISIONING_PROFILE secret."
             exit 1
           fi
-          APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          # A macOS profile carries the app id under
+          # com.apple.application-identifier; the bare key is the iOS shape,
+          # which some older exports still use.
+          APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          if [ -z "$APPLICATION_ID" ]; then
+            APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          fi
+          if [ -z "$APPLICATION_ID" ]; then
+            echo "::error::The provisioning profile carries no application-identifier entitlement, so the bundle id it authorizes cannot be read. Re-export the .provisionprofile for the $EXPECTED_BUNDLE_ID App ID and update the MAC_PROVISIONING_PROFILE secret."
+            exit 1
+          fi
           case "$APPLICATION_ID" in
             *".$EXPECTED_BUNDLE_ID") ;;
             *)

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -121,7 +121,7 @@ jobs:
           cat > "$RUNNER_TEMP/smoke-notifier.js" <<'JS'
           const addon = { exports: {} };
           process.dlopen(addon, process.argv[2]);
-          const exported = ["isSupported", "requestAuthorization", "registerCategories", "restoreDelegate", "show"];
+          const exported = ["isSupported", "requestAuthorization", "registerCategories", "ensureDelegate", "restoreDelegate", "show"];
           for (const name of exported) {
             if (typeof addon.exports[name] !== "function") {
               console.error(`vellum-notifier: missing export ${name}`);
@@ -133,8 +133,15 @@ jobs:
           JS
           # build-notifier.sh writes one architecture and clears the rest, so
           # the addon is whatever it left behind. Resolving it that way keeps
-          # the smoke load honest about the arch the build actually produced.
-          ADDON="$(ls resources/notifier/*/vellum-notifier.node)"
+          # the smoke load honest about the arch the build actually produced,
+          # and a second arch directory has to fail here rather than be smoke
+          # loaded as a two-line path.
+          ADDONS=(resources/notifier/*/vellum-notifier.node)
+          if [ "${#ADDONS[@]}" -ne 1 ] || [ ! -f "${ADDONS[0]}" ]; then
+            echo "::error::expected exactly one built notifier addon under resources/notifier, found: ${ADDONS[*]}"
+            exit 1
+          fi
+          ADDON="${ADDONS[0]}"
           ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron \
             "$RUNNER_TEMP/smoke-notifier.js" \
             "$ADDON"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2159,7 +2159,17 @@ jobs:
             echo "::error::The provisioning profile does not grant com.apple.developer.usernotifications.communication. Enable Communication Notifications on the $EXPECTED_BUNDLE_ID App ID in the Apple Developer portal, regenerate the profile, and update the MAC_PROVISIONING_PROFILE secret."
             exit 1
           fi
-          APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          # A macOS profile carries the app id under
+          # com.apple.application-identifier; the bare key is the iOS shape,
+          # which some older exports still use.
+          APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          if [ -z "$APPLICATION_ID" ]; then
+            APPLICATION_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$DECODED_PATH" 2>/dev/null || true)"
+          fi
+          if [ -z "$APPLICATION_ID" ]; then
+            echo "::error::The provisioning profile carries no application-identifier entitlement, so the bundle id it authorizes cannot be read. Re-export the .provisionprofile for the $EXPECTED_BUNDLE_ID App ID and update the MAC_PROVISIONING_PROFILE secret."
+            exit 1
+          fi
           case "$APPLICATION_ID" in
             *".$EXPECTED_BUNDLE_ID") ;;
             *)

--- a/clients/linux/src/main/features/notifications.ts
+++ b/clients/linux/src/main/features/notifications.ts
@@ -8,7 +8,7 @@ import type {
   CapabilityModule,
   DesktopCapabilityRegistry,
 } from "@vellumai/electron-desktop/capability-registry";
-import { ensureNotificationAvatarFile } from "@vellumai/electron-desktop/notification-avatar-file";
+import { resolveNotificationAvatarPath } from "@vellumai/electron-desktop/notification-avatar-path";
 import {
   configureNotifications,
   installNotifications,
@@ -105,32 +105,6 @@ export const createHelperToastFactory = (
     return client;
   };
 
-  /**
-   * The toast's image, or null when there is no sender or the file could not
-   * be written. A cache failure must not cost the user the notification, so it
-   * falls back to the app-icon toast.
-   */
-  const resolveAvatarPath = (
-    options: NotificationCreateOptions,
-  ): string | null => {
-    if (!options.sender) {
-      return null;
-    }
-    try {
-      return ensureNotificationAvatarFile(
-        app.getPath("userData"),
-        options.sender.avatarPng,
-        options.sender.avatarHash,
-      );
-    } catch (error) {
-      log.warn(
-        "[notifications] Could not store the notification avatar:",
-        error,
-      );
-      return null;
-    }
-  };
-
   return (options) => {
     const token = `toast-${nextToken++}`;
     const listeners: Record<string, ToastListener> = {};
@@ -153,7 +127,11 @@ export const createHelperToastFactory = (
           const actions = options.actions.map((action) => ({
             text: action.text,
           }));
-          const avatarPath = resolveAvatarPath(options);
+          const avatarPath = resolveNotificationAvatarPath(
+            options.sender,
+            app.getPath("userData"),
+            log,
+          );
           // With an avatar in the image slot the assistant is the sender, so
           // its name is the toast title and the conversation title drops to
           // the subtitle.

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -222,7 +222,10 @@ buttons never render. `src/main/index.ts` registers every action set through
 `registerCategories` at startup instead, deriving the set from the shared
 `NOTIFICATION_CATEGORIES` and `CATEGORY_ACTIONS` pair so it covers every set
 the app can post, and the addon unions its own set with whatever the
-notification center already holds rather than replacing it. An identifier that
+notification center already holds rather than replacing it. That union is a
+read-modify-write, and Electron's own post path does the same one under no
+shared lock, so the addon re-reads what landed and re-applies once when its
+categories were written over. An identifier that
 is still unregistered when a notification is posted cannot be repaired in that
 same runloop turn, so the notification goes out with no category and the
 `shown` event carries the reason.
@@ -235,18 +238,21 @@ renderer's Web Notification API all do. Three consequences:
 - The client must pass `isSupported` to `configureNotifications` alongside
   `create`. The shared module otherwise falls back to
   `electron.Notification.isSupported()`, and that call alone builds the
-  presenter.
+  presenter, at whatever moment the first notification arrives.
 - The notifications permission probe in `src/main/permissions-service.ts` goes
   through the addon's `requestAuthorization()` whenever the addon is loaded.
   Constructing an `electron.Notification` there hands the presenter the
   delegate and strands clicks on notifications already on screen.
 - The addon installs its own delegate, holds a strong reference to the one it
-  displaced, forwards every response it does not own there, and re-asserts
-  itself on the way into `show` and `requestAuthorization`. Electron builds its
-  presenter at most once, so a sender-less notification moves the delegate a
-  single time and the addon's next post takes it back, keeping Electron's
-  presenter as the delegate it forwards to. `restoreDelegate()` hands the seat
-  back at `before-quit`.
+  displaced, and forwards every response it does not own there. Electron's
+  presenter discards responses for identifiers it does not own, so the addon
+  has to be in front of it before anything the addon posted can be clicked:
+  `src/main/index.ts` builds Electron's presenter deliberately at startup, with
+  nothing on screen, then calls the addon's `ensureDelegate()`, which leaves the
+  addon's proxy in front and Electron's presenter as the delegate it forwards
+  to for the life of the process. `show`, `requestAuthorization`, and every
+  sender-less post through Electron re-assert it too. `restoreDelegate()` hands
+  the seat back at `before-quit`.
 
 **Rebuild:**
 
@@ -257,9 +263,12 @@ bash scripts/build-notifier.sh   # also runs as part of `bun run setup` and `bun
 It compiles against the headers for the Electron version pinned in
 `package.json` and writes `resources/notifier/<arch>/vellum-notifier.node`,
 which `electron-builder` packs to `bin/notifier/` and `scripts/afterSign.js`
-re-signs with `inherit.plist`. `ELECTRON_TARGET_ARCH` picks the architecture
-(arm64 by default, the same default `pack.sh` and
-`electron-builder.config.cjs` use). The script fails when the compiled slice is
+re-signs with `inherit.plist`. `ELECTRON_TARGET_ARCH` picks the architecture,
+defaulting to the host's so a local `bun run setup` on any Mac builds an addon
+that machine's Electron can load. `pack.sh` exports the variable (arm64 unless
+it is already set, the same default `electron-builder.config.cjs` uses), so a
+pack builds the addon for the app it is packaging rather than for the builder.
+The script fails when the compiled slice is
 not the one that was asked for, and `afterSign.js` fails again when the packed
 addon is not the architecture being packaged, because a mismatched addon does
 not load and the app quietly falls back to plain notifications.

--- a/clients/macos/native/notifier/notifier.mm
+++ b/clients/macos/native/notifier/notifier.mm
@@ -12,13 +12,14 @@
 // NotificationPresenterMac claims
 // `UNUserNotificationCenter.currentNotificationCenter.delegate` the moment it
 // is constructed (by `new Notification()`, by `Notification.isSupported()`, or
-// by the renderer's Web Notification API). This addon installs its own
-// delegate, holds a strong reference to whichever delegate it displaced, and
-// forwards every response it does not own to that delegate. `Show` and
-// `RequestAuthorization` re-assert the delegate on the way in, and the JS side
-// routes its notification permission probe through `requestAuthorization`
-// rather than `electron.Notification`, so no path in the app can build the
-// presenter without the addon taking the seat straight back.
+// by the renderer's Web Notification API), and it drops responses for
+// identifiers it does not own. This addon installs its own delegate, holds a
+// strong reference to whichever delegate it displaced, and forwards every
+// response it does not own to that delegate. `Show` and `RequestAuthorization`
+// re-assert the delegate on the way in, and `EnsureDelegate` exposes the same
+// re-assertion to JavaScript: the app builds Electron's presenter once at
+// startup, with nothing on screen, and calls it, so the addon's proxy sits in
+// front of the presenter for the life of the process.
 
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
@@ -284,12 +285,31 @@ void RestoreDelegate() {
 bool g_applyingCategories = false;
 bool g_categoriesDirty = false;
 
+// `verify` re-reads the written set once and re-applies when the addon's
+// categories are missing from it, and is false on that repair pass so a center
+// that keeps dropping them cannot spin.
+void ApplyCategories(bool verify = true);
+
+// Ends one application, re-running it for a request that arrived mid-flight or,
+// failing that, for a write that did not land.
+void FinishApplyingCategories(bool repair) {
+  g_applyingCategories = false;
+  if (g_categoriesDirty) {
+    g_categoriesDirty = false;
+    ApplyCategories();
+  } else if (repair) {
+    ApplyCategories(false);
+  }
+}
+
 // Hands the notification center the union of what it already holds and every
 // category this addon has registered. Replacing the set instead would drop
 // categories registered by anything else in the process. The union is a
-// read-modify-write straddling an asynchronous fetch, so two applications that
-// overlapped could each write back a set missing the other's categories.
-void ApplyCategories() {
+// read-modify-write straddling an asynchronous fetch, and Electron's own
+// `CocoaNotification::Show` does the same read-modify-write under no shared
+// lock, so an application that interleaves with one of those can be written
+// back over. The verification pass below is what catches that.
+void ApplyCategories(bool verify) {
   if (g_applyingCategories) {
     g_categoriesDirty = true;
     return;
@@ -310,13 +330,29 @@ void ApplyCategories() {
     // ordered action set, so a collision means the same buttons either way.
     [merged addEntriesFromDictionary:ours];
     [center setNotificationCategories:[NSSet setWithArray:merged.allValues]];
-    dispatch_async(dispatch_get_main_queue(), ^{
-      g_applyingCategories = false;
-      if (g_categoriesDirty) {
-        g_categoriesDirty = false;
-        ApplyCategories();
+    if (!verify) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        FinishApplyingCategories(false);
+      });
+      return;
+    }
+    [center getNotificationCategoriesWithCompletionHandler:^(
+                NSSet<UNNotificationCategory *> *written) {
+      NSMutableSet<NSString *> *writtenIds = [NSMutableSet set];
+      for (UNNotificationCategory *category in written) {
+        [writtenIds addObject:category.identifier];
       }
-    });
+      BOOL dropped = NO;
+      for (NSString *identifier in ours) {
+        if (![writtenIds containsObject:identifier]) {
+          dropped = YES;
+          break;
+        }
+      }
+      dispatch_async(dispatch_get_main_queue(), ^{
+        FinishApplyingCategories(dropped);
+      });
+    }];
   }];
 }
 
@@ -522,6 +558,19 @@ Napi::Value IsSupported(const Napi::CallbackInfo &info) {
   // an unbundled run (a bare `electron main.js`) reports unsupported rather
   // than taking the whole app down on the first post.
   return Napi::Boolean::New(info.Env(), IsBundled());
+}
+
+// Puts this addon's delegate back in front of whoever holds the notification
+// center's seat. The app calls this once at startup, after deliberately
+// building Electron's presenter, and again after every notification Electron
+// posts, so a response to a notification this addon posted is never routed to
+// a presenter that discards it.
+Napi::Value EnsureDelegate(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (IsBundled()) {
+    EnsureDelegateInstalled();
+  }
+  return env.Undefined();
 }
 
 // Returns the notification center's delegate to whoever held it before this
@@ -754,6 +803,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
               Napi::Function::New(env, RequestAuthorization));
   exports.Set("registerCategories",
               Napi::Function::New(env, RegisterCategories));
+  exports.Set("ensureDelegate", Napi::Function::New(env, EnsureDelegate));
   exports.Set("restoreDelegate",
               Napi::Function::New(env, RestoreDelegateBinding));
   exports.Set("show", Napi::Function::New(env, Show));

--- a/clients/macos/scripts/build-notifier.sh
+++ b/clients/macos/scripts/build-notifier.sh
@@ -15,18 +15,20 @@ if ! command -v xcrun >/dev/null 2>&1; then
   exit 1
 fi
 
-# The packaged app's architecture comes from ELECTRON_TARGET_ARCH, defaulting
-# to arm64 in pack.sh and electron-builder.config.cjs. The addon follows the
-# same variable rather than the host's architecture: electron-builder packs
-# whatever is under resources/notifier, so a host-shaped addon in an arm64 pack
-# ships an app that quietly falls back to plain notifications.
-# `lipo -archs` names the x64 slice x86_64.
-ARCH="${ELECTRON_TARGET_ARCH:-arm64}"
-case "$ARCH" in
-  arm64) EXPECTED_SLICE=arm64 ;;
-  x64)   EXPECTED_SLICE=x86_64 ;;
+# The packaged app's architecture comes from ELECTRON_TARGET_ARCH, which pack.sh
+# exports so a pack always builds the addon for the app it is packing:
+# electron-builder packs whatever is under resources/notifier, so a host-shaped
+# addon in an arm64 pack ships an app that quietly falls back to plain
+# notifications. Unset, the architecture is the host's, because a local
+# `bun run setup` builds an addon for the Electron running on this machine.
+# `uname -m` reports x86_64 on Intel, which is also what `lipo -archs` calls
+# the x64 slice.
+REQUESTED_ARCH="${ELECTRON_TARGET_ARCH:-$(uname -m)}"
+case "$REQUESTED_ARCH" in
+  arm64)      ARCH=arm64; EXPECTED_SLICE=arm64 ;;
+  x64|x86_64) ARCH=x64;   EXPECTED_SLICE=x86_64 ;;
   *)
-    echo "build-notifier: unsupported ELECTRON_TARGET_ARCH: $ARCH (use arm64 or x64)" >&2
+    echo "build-notifier: unsupported architecture: $REQUESTED_ARCH (use arm64 or x64)" >&2
     exit 1
     ;;
 esac

--- a/clients/macos/scripts/pack.sh
+++ b/clients/macos/scripts/pack.sh
@@ -51,7 +51,10 @@ done
 
 export VELLUM_ENVIRONMENT="${VELLUM_ENVIRONMENT:-local}"
 
-ARCH="${ELECTRON_TARGET_ARCH:-arm64}"
+# Exported rather than only read: build-notifier.sh defaults to the host's
+# architecture, and a pack has to get the one it is packaging.
+export ELECTRON_TARGET_ARCH="${ELECTRON_TARGET_ARCH:-arm64}"
+ARCH="$ELECTRON_TARGET_ARCH"
 case "$ARCH" in
   arm64) BUN_ARCH=aarch64 ;;
   x64)   BUN_ARCH=x64 ;;

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -1,5 +1,5 @@
 import "./env-seed";
-import { app, net, protocol, session, shell } from "electron";
+import { app, net, Notification, protocol, session, shell } from "electron";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 
@@ -110,7 +110,11 @@ import {
   createNativeNotificationFactory,
   registerNativeNotificationCategories,
 } from "./native-notifications";
-import { isNotifierSupported, restoreNotifierDelegate } from "./notifier";
+import {
+  ensureNotifierDelegate,
+  isNotifierSupported,
+  restoreNotifierDelegate,
+} from "./notifier";
 import { installPermissionsService } from "./permissions-service";
 import {
   installCompanionWindow,
@@ -477,6 +481,16 @@ app
       ...(nativeNotifications ?? {}),
     });
     if (nativeNotifications) {
+      // Electron builds its notification presenter lazily, on the first
+      // `Notification.isSupported()` or `new Notification()`, and the presenter
+      // claims the notification center's delegate and discards responses for
+      // identifiers it does not own. Building it here, with nothing on screen,
+      // and re-asserting the addon's delegate straight after leaves the addon
+      // in front of it for the life of the process, forwarding what it does not
+      // own. The categories are then written after the presenter exists, so
+      // Electron's own category read-modify-write cannot land on top of them.
+      Notification.isSupported();
+      ensureNotifierDelegate();
       registerNativeNotificationCategories();
       app.on("before-quit", restoreNotifierDelegate);
     }

--- a/clients/macos/src/main/native-notifications.test.ts
+++ b/clients/macos/src/main/native-notifications.test.ts
@@ -59,6 +59,7 @@ interface Call {
 
 const calls: Call[] = [];
 const registered: NotifierCategory[][] = [];
+let delegateReassertions = 0;
 let notifierSupported = true;
 let notifierPresent = true;
 let showThrows = false;
@@ -66,6 +67,9 @@ let showThrows = false;
 mock.module("./notifier", () => ({
   registerNotifierCategories: (categories: NotifierCategory[]) => {
     registered.push(categories);
+  },
+  ensureNotifierDelegate: () => {
+    delegateReassertions += 1;
   },
   isNotifierSupported: () => notifierPresent && notifierSupported,
   getNotifier: () =>
@@ -130,6 +134,7 @@ beforeEach(() => {
   registered.length = 0;
   warnings.length = 0;
   electronNotifications.length = 0;
+  delegateReassertions = 0;
   notifierSupported = true;
   notifierPresent = true;
   showThrows = false;
@@ -197,6 +202,27 @@ describe("createNativeNotificationFactory", () => {
         ],
       },
     ]);
+  });
+
+  // Electron's presenter claims the notification center's delegate and drops
+  // responses for identifiers it does not own, so a post through it that left
+  // the seat there would strand clicks on notifications the addon posted.
+  test("puts the addon's delegate back in front after Electron posts", () => {
+    const notification = createNativeNotificationFactory().create(
+      options({ sender: undefined }),
+    );
+    expect(delegateReassertions).toBe(0);
+
+    notification.show();
+
+    expect(electronNotifications.length).toBe(1);
+    expect(delegateReassertions).toBe(1);
+  });
+
+  test("leaves the delegate alone for a notification the addon posts", () => {
+    createNativeNotificationFactory().create(options()).show();
+
+    expect(delegateReassertions).toBe(0);
   });
 
   test("keeps a sender-less notification off the addon even when the addon is gone", () => {

--- a/clients/macos/src/main/native-notifications.ts
+++ b/clients/macos/src/main/native-notifications.ts
@@ -21,7 +21,7 @@ import { createHash, randomUUID } from "node:crypto";
 
 import { app } from "electron";
 
-import { ensureNotificationAvatarFile } from "@vellumai/electron-desktop/notification-avatar-file";
+import { resolveNotificationAvatarPath } from "@vellumai/electron-desktop/notification-avatar-path";
 import {
   CATEGORY_ACTIONS,
   createElectronNotification,
@@ -33,6 +33,7 @@ import {
 
 import log from "./logger";
 import {
+  ensureNotifierDelegate,
   getNotifier,
   isNotifierSupported,
   registerNotifierCategories,
@@ -78,13 +79,15 @@ const categoryIdForActions = (actions: readonly CategoryAction[]): string =>
  * category needs no second edit here.
  */
 export const registerNativeNotificationCategories = (): void => {
-  const categories: NotifierCategory[] = NOTIFICATION_CATEGORIES.map(
-    (category) => {
-      const actions = CATEGORY_ACTIONS[category].map((action) => action.text);
-      return { categoryId: categoryIdForLabels(actions), actions };
-    },
-  );
-  registerNotifierCategories(categories);
+  // Keyed by identifier: two categories with the same ordered labels mint the
+  // same one, and the same definition with it, so they register once.
+  const byId = new Map<string, NotifierCategory>();
+  for (const category of NOTIFICATION_CATEGORIES) {
+    const actions = CATEGORY_ACTIONS[category].map((action) => action.text);
+    const categoryId = categoryIdForLabels(actions);
+    byId.set(categoryId, { categoryId, actions });
+  }
+  registerNotifierCategories([...byId.values()]);
 };
 
 export const createNativeNotificationFactory = (): {
@@ -97,9 +100,19 @@ export const createNativeNotificationFactory = (): {
     // avatar as the icon. A notification with no sender has nothing to gain
     // from it, so Electron's presenter takes it, which is also what makes the
     // `push-avatar-sender` flag a kill switch.
-    const senderImage = options.sender;
-    if (!senderImage) {
-      return createElectronNotification(options);
+    const sender = options.sender;
+    if (!sender) {
+      const notification = createElectronNotification(options);
+      return {
+        on: notification.on.bind(notification) as NotificationLike["on"],
+        show: () => {
+          notification.show();
+          // Electron's presenter takes the notification center's delegate when
+          // it is built and drops responses for identifiers it does not own,
+          // so the addon's proxy goes straight back in front of it.
+          ensureNotifierDelegate();
+        },
+      };
     }
 
     const listeners: Listeners = {};
@@ -108,25 +121,24 @@ export const createNativeNotificationFactory = (): {
     }) as NotificationLike["on"];
 
     const resolveSender = (): NotifierRequest["sender"] => {
-      try {
-        return {
-          id: senderImage.id,
-          name: senderImage.name,
-          // The addon reads the avatar from disk: Intents takes image data,
-          // not a buffer over IPC.
-          avatarPngPath: ensureNotificationAvatarFile(
-            app.getPath("userData"),
-            senderImage.avatarPng,
-            senderImage.avatarHash,
-          ),
-          // Groups every notification from one assistant into a single
-          // conversation in Notification Center.
-          conversationId: senderImage.id,
-        };
-      } catch (error) {
-        log.warn("[notifications] could not stage the sender avatar:", error);
+      // The addon reads the avatar from disk: Intents takes image data, not a
+      // buffer over IPC.
+      const avatarPngPath = resolveNotificationAvatarPath(
+        sender,
+        app.getPath("userData"),
+        log,
+      );
+      if (!avatarPngPath) {
         return undefined;
       }
+      return {
+        id: sender.id,
+        name: sender.name,
+        avatarPngPath,
+        // Groups every notification from one assistant into a single
+        // conversation in Notification Center.
+        conversationId: sender.id,
+      };
     };
 
     const show = (): void => {
@@ -135,15 +147,15 @@ export const createNativeNotificationFactory = (): {
         listeners.failed?.(undefined, "Native notifier unavailable");
         return;
       }
-      const sender = resolveSender();
+      const resolved = resolveSender();
       const request: NotifierRequest = {
         id: randomUUID(),
-        title: sender ? sender.name : options.title,
-        ...(sender ? { subtitle: options.title } : {}),
+        title: resolved ? resolved.name : options.title,
+        ...(resolved ? { subtitle: options.title } : {}),
         body: options.body,
         categoryId: categoryIdForActions(options.actions),
         actions: options.actions.map((action) => action.text),
-        ...(sender ? { sender } : {}),
+        ...(resolved ? { sender: resolved } : {}),
       };
       try {
         notifier.show(request, (event) => {
@@ -169,10 +181,6 @@ export const createNativeNotificationFactory = (): {
             // An action without a readable index is dropped: defaulting could
             // route an ambiguous press as e.g. a tool-call "Allow".
             listeners.action?.(undefined, event.actionIndex);
-          } else if (event.kind === "dismiss") {
-            // The addon emits `dismiss` as a notification's final event so it
-            // can release the callback. Nothing downstream acts on one, and
-            // Electron has no matching event to map it onto.
           }
         });
       } catch (error) {

--- a/clients/macos/src/main/notifier.test.ts
+++ b/clients/macos/src/main/notifier.test.ts
@@ -38,6 +38,7 @@ mock.module("./logger", () => ({
 const {
   __resetNotifierForTesting,
   __setNotifierForTesting,
+  ensureNotifierDelegate,
   getNotifier,
   isNotifierSupported,
   registerNotifierCategories,
@@ -47,6 +48,7 @@ const {
 
 interface FakeNotifier extends Notifier {
   authorizationCalls: number;
+  ensureCalls: number;
   restoreCalls: number;
   registered: NotifierCategory[][];
 }
@@ -54,6 +56,7 @@ interface FakeNotifier extends Notifier {
 const fakeNotifier = (overrides: Partial<Notifier> = {}): FakeNotifier => {
   const fake: FakeNotifier = {
     authorizationCalls: 0,
+    ensureCalls: 0,
     restoreCalls: 0,
     registered: [],
     isSupported: () => true,
@@ -63,6 +66,9 @@ const fakeNotifier = (overrides: Partial<Notifier> = {}): FakeNotifier => {
     },
     registerCategories: (categories) => {
       fake.registered.push(categories);
+    },
+    ensureDelegate: () => {
+      fake.ensureCalls += 1;
     },
     restoreDelegate: () => {
       fake.restoreCalls += 1;
@@ -292,7 +298,7 @@ describe("isNotifierSupported", () => {
   });
 });
 
-describe("notifier categories and delegate handback", () => {
+describe("notifier categories and delegate seat", () => {
   beforeEach(() => {
     __resetNotifierForTesting();
     warnings.length = 0;
@@ -301,6 +307,7 @@ describe("notifier categories and delegate handback", () => {
   test("do nothing when the addon is unavailable", () => {
     expect(() => {
       registerNotifierCategories([{ categoryId: "a", actions: [] }]);
+      ensureNotifierDelegate();
       restoreNotifierDelegate();
     }).not.toThrow();
   });
@@ -310,18 +317,34 @@ describe("notifier categories and delegate handback", () => {
     __setNotifierForTesting(notifier);
 
     registerNotifierCategories([{ categoryId: "a", actions: ["Allow"] }]);
+    ensureNotifierDelegate();
     restoreNotifierDelegate();
 
     expect(notifier.registered).toEqual([
       [{ categoryId: "a", actions: ["Allow"] }],
     ]);
+    expect(notifier.ensureCalls).toBe(1);
     expect(notifier.restoreCalls).toBe(1);
+  });
+
+  // A packed addon built before the export loads fine and simply has no
+  // re-assertion to make, so the call is a no-op rather than a throw.
+  test("skip the re-assertion on an addon without the export", () => {
+    const notifier = fakeNotifier();
+    delete notifier.ensureDelegate;
+    __setNotifierForTesting(notifier);
+
+    expect(() => ensureNotifierDelegate()).not.toThrow();
+    expect(warnings.length).toBe(0);
   });
 
   test("swallow an addon that throws", () => {
     __setNotifierForTesting(
       fakeNotifier({
         registerCategories: () => {
+          throw new Error("addon exploded");
+        },
+        ensureDelegate: () => {
           throw new Error("addon exploded");
         },
         restoreDelegate: () => {
@@ -331,7 +354,8 @@ describe("notifier categories and delegate handback", () => {
     );
 
     registerNotifierCategories([]);
+    ensureNotifierDelegate();
     restoreNotifierDelegate();
-    expect(warnings.length).toBe(2);
+    expect(warnings.length).toBe(3);
   });
 });

--- a/clients/macos/src/main/notifier.ts
+++ b/clients/macos/src/main/notifier.ts
@@ -77,6 +77,13 @@ export interface Notifier {
    * with whatever is already registered.
    */
   registerCategories(categories: NotifierCategory[]): void;
+  /**
+   * Puts the addon's delegate back in front of whoever holds the notification
+   * center's seat, forwarding to them what the addon does not own. Optional
+   * because a packed addon built without the export still satisfies the rest
+   * of this interface.
+   */
+  ensureDelegate?(): void;
   /** Hands the notification center's delegate back to whoever held it. */
   restoreDelegate(): void;
   show(
@@ -195,6 +202,25 @@ export const registerNotifierCategories = (
     notifier.registerCategories(categories);
   } catch (error) {
     log.warn("[notifier] registerCategories failed:", error);
+  }
+};
+
+/**
+ * Puts the addon's delegate back in front of whatever holds the notification
+ * center's seat. Electron's presenter takes that seat when it is built and
+ * drops responses for identifiers it does not own, so anything that can build
+ * it calls this afterwards. An addon built without the export has nothing to
+ * call, and the delegate then moves back on the addon's next post.
+ */
+export const ensureNotifierDelegate = (): void => {
+  const notifier = loadNotifier();
+  if (!notifier?.ensureDelegate) {
+    return;
+  }
+  try {
+    notifier.ensureDelegate();
+  } catch (error) {
+    log.warn("[notifier] ensureDelegate failed:", error);
   }
 };
 

--- a/clients/macos/src/main/permissions-service.ts
+++ b/clients/macos/src/main/permissions-service.ts
@@ -133,6 +133,10 @@ const settingsPaneUrl = (kind: PermissionKind): string => {
 // the outcome is called unknown.
 const NOTIFICATION_PROMPT_TIMEOUT_MS = 30_000;
 
+// The probe posts a real notification, so the user reads this on whichever
+// path delivered it.
+const NOTIFICATION_CONFIRMATION_BODY = "Notifications are enabled.";
+
 /**
  * Runs `probe` and resolves whatever it settles on, or `null` once `timeoutMs`
  * passes with no answer. The first settle wins, so a probe that answers twice
@@ -169,7 +173,7 @@ const postNativeNotificationConfirmation = (): void => {
       {
         id: randomUUID(),
         title: "Vellum",
-        body: "Notifications are enabled.",
+        body: NOTIFICATION_CONFIRMATION_BODY,
         categoryId: "",
         actions: [],
       },
@@ -393,7 +397,7 @@ export class PermissionsService {
       (settle) => {
         const notification = new Notification({
           title: "Vellum",
-          body: "Notifications are enabled.",
+          body: NOTIFICATION_CONFIRMATION_BODY,
           silent: false,
         });
         notification.once("show", () => settle("granted"));

--- a/clients/windows/src/main/features/notifications.ts
+++ b/clients/windows/src/main/features/notifications.ts
@@ -8,7 +8,7 @@ import type {
   CapabilityModule,
   DesktopCapabilityRegistry,
 } from "@vellumai/electron-desktop/capability-registry";
-import { ensureNotificationAvatarFile } from "@vellumai/electron-desktop/notification-avatar-file";
+import { resolveNotificationAvatarPath } from "@vellumai/electron-desktop/notification-avatar-path";
 import {
   configureNotifications,
   installNotifications,
@@ -108,32 +108,6 @@ export const createHelperToastFactory = (
     return client;
   };
 
-  /**
-   * The toast's `appLogoOverride` image, or null when there is no sender or
-   * the file could not be written. A cache failure must not cost the user the
-   * notification, so it falls back to the app-logo toast.
-   */
-  const resolveAvatarPath = (
-    options: NotificationCreateOptions,
-  ): string | null => {
-    if (!options.sender) {
-      return null;
-    }
-    try {
-      return ensureNotificationAvatarFile(
-        app.getPath("userData"),
-        options.sender.avatarPng,
-        options.sender.avatarHash,
-      );
-    } catch (error) {
-      log.warn(
-        "[notifications] Could not store the notification avatar:",
-        error,
-      );
-      return null;
-    }
-  };
-
   return (options) => {
     const token = `toast-${nextToken++}`;
     const listeners: Record<string, ToastListener> = {};
@@ -156,7 +130,11 @@ export const createHelperToastFactory = (
           const actions = options.actions.map((action) => ({
             text: action.text,
           }));
-          const avatarPath = resolveAvatarPath(options);
+          const avatarPath = resolveNotificationAvatarPath(
+            options.sender,
+            app.getPath("userData"),
+            log,
+          );
           // With an avatar in the logo slot the assistant is the sender, so
           // its name is the toast title and the conversation title drops to
           // the subtitle. Windows keeps the app name in the attribution line.

--- a/packages/electron-desktop/package.json
+++ b/packages/electron-desktop/package.json
@@ -62,6 +62,7 @@
     "./module-configuration": "./src/module-configuration.ts",
     "./native-auth": "./src/native-auth.ts",
     "./notification-avatar-file": "./src/notification-avatar-file.ts",
+    "./notification-avatar-path": "./src/notification-avatar-path.ts",
     "./notifications": "./src/notifications.ts",
     "./paired-gateway-request-guard": "./src/paired-gateway-request-guard.ts",
     "./permissions": "./src/permissions.ts",

--- a/packages/electron-desktop/src/notification-avatar-path.test.ts
+++ b/packages/electron-desktop/src/notification-avatar-path.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { resolveNotificationAvatarPath } from "./notification-avatar-path";
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const HASH = new Bun.CryptoHasher("sha256").update(PNG).digest("hex");
+
+const sender = {
+  id: "assistant-1",
+  name: "Ada",
+  avatarPng: PNG,
+  avatarHash: HASH,
+};
+
+let userDataDir: string;
+let warnings: unknown[][];
+
+const logger = { warn: (...args: unknown[]) => warnings.push(args) };
+
+beforeEach(() => {
+  userDataDir = mkdtempSync(path.join(tmpdir(), "vellum-avatar-path-"));
+  warnings = [];
+});
+
+afterEach(() => {
+  rmSync(userDataDir, { recursive: true, force: true });
+});
+
+describe("resolveNotificationAvatarPath", () => {
+  test("stages the avatar and returns its path", () => {
+    const file = resolveNotificationAvatarPath(sender, userDataDir, logger);
+
+    expect(file).toBe(
+      path.join(userDataDir, "notification-avatars", `${HASH}.png`),
+    );
+    expect(readFileSync(file!)).toEqual(PNG);
+    expect(warnings).toEqual([]);
+  });
+
+  test("returns null without touching disk when there is no sender", () => {
+    expect(
+      resolveNotificationAvatarPath(undefined, userDataDir, logger),
+    ).toBeNull();
+    expect(warnings).toEqual([]);
+  });
+
+  test("logs and returns null when the avatar cannot be staged", () => {
+    const file = resolveNotificationAvatarPath(
+      { ...sender, avatarHash: "../../escape" },
+      userDataDir,
+      logger,
+    );
+
+    expect(file).toBeNull();
+    expect(warnings.length).toBe(1);
+    expect(String(warnings[0]?.[0])).toContain("notification avatar");
+  });
+});

--- a/packages/electron-desktop/src/notification-avatar-path.ts
+++ b/packages/electron-desktop/src/notification-avatar-path.ts
@@ -1,0 +1,35 @@
+import { ensureNotificationAvatarFile } from "./notification-avatar-file";
+import type { NotificationSenderImage } from "./notifications";
+
+/**
+ * The sender avatar's path on disk, or null when the notification carries no
+ * sender or the file could not be written.
+ *
+ * Every OS draws a notification's sender image from a file, so each platform's
+ * factory stages the bytes through the shared cache before it posts. A cache
+ * failure must not cost the user the notification, so a throw is logged and
+ * reported as "no avatar", which each caller renders as its plain app-icon
+ * layout.
+ */
+export const resolveNotificationAvatarPath = (
+  sender: NotificationSenderImage | undefined,
+  userDataDir: string,
+  logger: { warn: (...args: unknown[]) => void },
+): string | null => {
+  if (!sender) {
+    return null;
+  }
+  try {
+    return ensureNotificationAvatarFile(
+      userDataDir,
+      sender.avatarPng,
+      sender.avatarHash,
+    );
+  } catch (error) {
+    logger.warn(
+      "[notifications] Could not store the notification avatar:",
+      error,
+    );
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary

- Startup builds Electron's notification presenter deliberately, with nothing on screen, then re-asserts the addon's delegate through a new `ensureDelegate` export, so a click on an addon-posted notification is never routed to a presenter that discards it. Every sender-less post through Electron re-asserts it again.
- Categories are registered after that warm-up, and `ApplyCategories` now re-reads what landed and re-applies once when Electron's own category read-modify-write wrote over the addon's set.
- The release gates read the macOS provisioning profile's app id from `com.apple.application-identifier`, falling back to the iOS-shaped `application-identifier`, and fail with an `::error::` when neither is present.
- `resolveNotificationAvatarPath` in `@vellumai/electron-desktop` replaces the three copies of the same guard in the macOS, Windows, and Linux notification factories.
- The CI smoke step globs the built addon into an array and asserts exactly one match instead of joining two arch directories into one string, and checks the new export.
- `build-notifier.sh` defaults to the host architecture so a local `bun run setup` on an Intel Mac builds a loadable addon; `pack.sh` exports `ELECTRON_TARGET_ARCH` so packaging keeps its arm64 default.
- Small cleanups: the empty `dismiss` branch is gone, the startup category list is deduped by identifier, and the permission confirmation copy is one constant.

Round-3 self-review fixes for the notification avatar feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1