### PR TITLE
fix(web): chat-info lifecycle owned by the store and the panel

### DIFF
--- a/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
@@ -9,7 +9,15 @@
  * level renders, and the sequence each tile runs when it is opened.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
@@ -24,7 +32,6 @@ import * as appHtmlCache from "@/utils/app-html-cache";
 import type * as ConversationAssetsModule from "@/domains/chat/hooks/use-conversation-assets";
 import type * as ElementSizeModule from "@/hooks/use-element-size";
 import type * as IsMobileModule from "@/hooks/use-is-mobile";
-import type * as OpenAppModule from "@/domains/chat/hooks/use-open-app-from-chat";
 import type { AppSummary } from "@/types/app-types";
 import type { ChatInfoCategory } from "@/stores/viewer-store";
 import type { DocumentSummary } from "@/types/document-types";
@@ -88,27 +95,24 @@ mock.module(
 );
 
 const assetsRef = { value: null as ConversationAssets | null };
+const assetsTargets: ConversationAssetsModule.ConversationAssetsTarget[] = [];
 mock.module(
   "@/domains/chat/hooks/use-conversation-assets",
   (): Partial<typeof ConversationAssetsModule> => ({
-    useConversationAssets: () => assetsRef.value!,
+    useConversationAssets: (target) => {
+      assetsTargets.push(target);
+      return assetsRef.value!;
+    },
   }),
 );
 
 const calls: string[] = [];
-const openApp = mock(async (_appId: string): Promise<void> => {
-  calls.push("openApp");
-});
-mock.module(
-  "@/domains/chat/hooks/use-open-app-from-chat",
-  (): Partial<typeof OpenAppModule> => ({
-    useOpenAppFromChat: () => openApp,
-  }),
-);
 
 const { ChatInfoPanel } =
   await import("@/domains/chat/components/chat-info-panel");
 const { useViewerStore } = await import("@/stores/viewer-store");
+const { useUnseenDocumentChangesStore } =
+  await import("@/domains/chat/unseen-document-changes-store");
 const { appsGetQueryKey } =
   await import("@/generated/daemon/@tanstack/react-query.gen");
 const { makeDisplayAttachment, SAMPLE_PREVIEWS } =
@@ -223,6 +227,11 @@ function makeAssets(
 const closeChatInfo = mock((): void => {
   calls.push("closeChatInfo");
 });
+const loadApp = mock(
+  async (_assistantId: string, _appId: string): Promise<void> => {
+    calls.push("loadApp");
+  },
+);
 const loadDocument = mock(
   async (_assistantId: string, _surfaceId: string): Promise<void> => {
     calls.push("loadDocument");
@@ -270,18 +279,27 @@ async function renderChatInfo(
 beforeEach(() => {
   assetsRef.value = makeAssets();
   calls.length = 0;
-  openApp.mockClear();
+  assetsTargets.length = 0;
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+  loadApp.mockClear();
   closeChatInfo.mockClear();
   loadDocument.mockClear();
   loadMoreFiles.mockClear();
   loadMoreFrames.mockClear();
   onClose.mockClear();
   onSelectCategory.mockClear();
-  useViewerStore.setState({ closeChatInfo, loadDocument });
+  useViewerStore.setState({ closeChatInfo, loadApp, loadDocument });
 });
 
 afterEach(() => {
   cleanup();
+  useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
+});
+
+// `mock.module` is process-global in this runner, so the module graph is put
+// back before the next file loads.
+afterAll(() => {
+  mock.restore();
 });
 
 // ---------------------------------------------------------------------------
@@ -323,13 +341,48 @@ describe("ChatInfoPanel top level", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  test("leaves the panel before opening an app", async () => {
+  test("leaves the panel before opening an app, under the payload's assistant", async () => {
     await renderChatInfo();
 
     fireEvent.click(screen.getByLabelText("Open App 1"));
 
-    expect(calls).toEqual(["closeChatInfo", "openApp"]);
-    expect(openApp).toHaveBeenCalledWith("app-1");
+    expect(calls).toEqual(["closeChatInfo", "loadApp"]);
+    expect(loadApp).toHaveBeenCalledWith(ASSISTANT_ID, "app-1");
+  });
+
+  test("reads the assets of the conversation its payload names", async () => {
+    await renderChatInfo();
+
+    expect(assetsTargets[0]).toEqual({
+      assistantId: ASSISTANT_ID,
+      conversationId: CONVERSATION_ID,
+    });
+  });
+
+  test("clears the conversation's unseen dot while it is open", async () => {
+    useUnseenDocumentChangesStore
+      .getState()
+      .markDocumentChanged(CONVERSATION_ID, TRIP_NOTES.surfaceId);
+
+    await renderChatInfo();
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toEqual(
+      {},
+    );
+  });
+
+  test("clears a change that lands while it is already open", async () => {
+    await renderChatInfo();
+
+    await act(async () => {
+      useUnseenDocumentChangesStore
+        .getState()
+        .markDocumentChanged(CONVERSATION_ID, PACKING_LIST.surfaceId);
+    });
+
+    expect(useUnseenDocumentChangesStore.getState().changedDocuments).toEqual(
+      {},
+    );
   });
 
   test("leaves the panel before opening a document", async () => {
@@ -386,5 +439,8 @@ describe("ChatInfoPanel See All level", () => {
 
     expect(screen.getByText("Chat Info")).toBeDefined();
     expect(screen.queryByLabelText("Back to chat info")).toBeNull();
+    // Settled in the store too, so a refilled category cannot drill back in
+    // on its own and See All on it is not a silent no-op.
+    expect(onSelectCategory).toHaveBeenCalledWith(null);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -11,7 +11,7 @@
 
 import { ChevronLeft, Layers } from "lucide-react";
 import type { ReactNode } from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { Button, Typography } from "@vellumai/design-library";
 
@@ -34,7 +34,7 @@ import {
   type ConversationFileAsset,
   useConversationAssets,
 } from "@/domains/chat/hooks/use-conversation-assets";
-import { useOpenAppFromChat } from "@/domains/chat/hooks/use-open-app-from-chat";
+import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useAppDelete } from "@/hooks/use-app-delete";
 import { useTranslation } from "@/i18n";
 import {
@@ -110,16 +110,31 @@ export function ChatInfoPanel({
   );
 
   const appDelete = useAppDelete(assistantId);
-  const openApp = useOpenAppFromChat();
+
+  // The panel showing a conversation's assets is the user looking at them, so
+  // a change that lands while it is open is seen the moment it arrives. It
+  // clears here rather than at the header trigger because every entry point
+  // into the panel passes through this component.
+  const unseenDocuments =
+    useUnseenDocumentChangesStore.use.changedDocuments()[conversationId];
+  const clearConversation =
+    useUnseenDocumentChangesStore.use.clearConversation();
+  useEffect(() => {
+    if (unseenDocuments !== undefined) {
+      clearConversation(conversationId);
+    }
+  }, [clearConversation, conversationId, unseenDocuments]);
 
   // Closing first returns the viewer to whatever the panel was opened from,
-  // so the asset lands there rather than behind the panel.
+  // so the asset lands there rather than behind the panel. The app opens
+  // under the panel's own assistant, which need not be the active one.
   const handleOpenApp = useCallback(
     (appId: string) => {
+      haptic.light();
       useViewerStore.getState().closeChatInfo();
-      void openApp(appId);
+      void useViewerStore.getState().loadApp(assistantId, appId);
     },
-    [openApp],
+    [assistantId],
   );
 
   const handleOpenFile = useCallback(
@@ -147,10 +162,18 @@ export function ChatInfoPanel({
 
   // A category emptied while drilled in (the last app deleted) falls back to
   // the top level rather than rendering an empty page.
-  const level =
-    payload.category !== null && categoryLists[payload.category].length > 0
-      ? payload.category
-      : null;
+  const emptiedCategory =
+    payload.category !== null && categoryLists[payload.category].length === 0;
+  const level = emptiedCategory ? null : payload.category;
+
+  // The fallback above is what this frame renders; the store still holds the
+  // category, so it is settled too. Otherwise a refilled category would drill
+  // back in on its own, and See All on that same category would no-op.
+  useEffect(() => {
+    if (emptiedCategory) {
+      onSelectCategory(null);
+    }
+  }, [emptiedCategory, onSelectCategory]);
 
   const renderFileSection = (category: "files" | "frames") => {
     const items = categoryLists[category];
@@ -184,7 +207,12 @@ export function ChatInfoPanel({
   let body: ReactNode;
   if (level === "apps") {
     body = (
-      <div className="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(184px,1fr))]">
+      <div
+        className="grid gap-2"
+        style={{
+          gridTemplateColumns: `repeat(auto-fill, minmax(${CHAT_INFO_APP_TILE_WIDTH_PX}px, 1fr))`,
+        }}
+      >
         {apps.map((app) => (
           <ChatInfoAppTile
             key={app.id}

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -15,7 +15,14 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import * as motionReact from "motion/react";
 
 import type { DocumentSummary } from "@/types/document-types";
@@ -123,7 +130,16 @@ function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
     unmount: () => view.unmount(),
     /** Swap the prop on the already-mounted pill, as the chat header does. */
     switchConversation: (conversationId: string) => {
+      // Every real switch drops the transcript panel payloads before the
+      // header re-renders; the store settles the view from there.
+      act(() => {
+        useViewerStore.getState().clearTranscriptPanelPayloads();
+      });
       view.rerender(pill(conversationId));
+    },
+    /** Drop the conversation's last asset, as a delete would. */
+    emptyAssets: () => {
+      seedConversation(client, [], CONVERSATION_ID);
     },
   };
 }
@@ -178,7 +194,9 @@ describe("desktop pill", () => {
     expect(screen.getByRole("button", { name: SEEN_LABEL })).toBeTruthy();
   });
 
-  test("opening the panel clears the conversation and sets mainView to chat-info", () => {
+  // The dot survives the click here: the panel is what clears it, and this
+  // suite renders the trigger alone.
+  test("opening the panel sets mainView to chat-info", () => {
     markUnseen();
     renderPill();
 
@@ -192,8 +210,7 @@ describe("desktop pill", () => {
         category: null,
       },
     });
-    expect(unseenConversations()).toEqual([]);
-    expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
+    expect(unseenConversations()).toEqual([CONVERSATION_ID]);
   });
 
   test("clicking while open closes the panel", () => {
@@ -216,8 +233,20 @@ describe("desktop pill", () => {
     const trigger = screen.getByRole("button", { name: SEEN_LABEL });
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
 
-    fireEvent.click(trigger);
+    // Store-first, so the attribute tracks the view however it was opened,
+    // not just the trigger's own click.
+    act(() => {
+      useViewerStore.getState().openChatInfo({
+        assistantId: ASSISTANT_ID,
+        conversationId: CONVERSATION_ID,
+      });
+    });
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    act(() => {
+      useViewerStore.getState().closeChatInfo();
+    });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
   });
 });
 
@@ -236,24 +265,23 @@ describe("narrow window with a mouse", () => {
     );
   });
 
-  test("opening the panel clears the conversation", () => {
+  test("opening the panel sets mainView to chat-info", () => {
     markUnseen();
     renderPill();
 
     fireEvent.click(screen.getByRole("button", { name: UNSEEN_LABEL }));
 
     expect(chatInfoState().mainView).toBe("chat-info");
-    expect(unseenConversations()).toEqual([]);
   });
 });
 
 describe("conversation switch while the panel is open", () => {
   /**
    * The chat header renders one unkeyed pill and swaps `conversationId` on it,
-   * so the open panel would otherwise survive the switch. The pill settles the
-   * store on that swap: the incoming conversation's assets are never put on
-   * screen unasked, and its changes stay marked unseen until the user opens
-   * the panel.
+   * so the open panel would otherwise survive the switch. The store settles it
+   * from `clearTranscriptPanelPayloads`, which every switch runs: the incoming
+   * conversation's assets are never put on screen unasked, and its changes
+   * stay marked unseen until the user opens the panel.
    */
   test("closes the panel and keeps the incoming dot", () => {
     markUnseen(OTHER_CONVERSATION_ID, OTHER_SURFACE_ID);
@@ -271,6 +299,25 @@ describe("conversation switch while the panel is open", () => {
     expect(screen.getByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeTruthy();
     expect(screen.getByRole("button", { name: UNSEEN_LABEL })).toBeTruthy();
     expect(unseenConversations()).toEqual([OTHER_CONVERSATION_ID]);
+  });
+});
+
+describe("the last asset leaving while the panel is open", () => {
+  test("hides the trigger and takes the panel with it", async () => {
+    const { emptyAssets } = renderPill();
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(chatInfoState().mainView).toBe("chat-info");
+
+    emptyAssets();
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button")).toBeNull();
+    });
+    expect(chatInfoState()).toEqual({
+      mainView: "chat",
+      activeChatInfo: null,
+    });
   });
 });
 

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -10,15 +10,12 @@
 
 import { Layers } from "lucide-react";
 import { useReducedMotion } from "motion/react";
-import { useCallback, useLayoutEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect } from "react";
 
 import { Button } from "@vellumai/design-library";
 
-import { useConversationAssets } from "@/domains/chat/hooks/use-conversation-assets";
-import {
-  useHasUnseenDocumentChanges,
-  useUnseenDocumentChangesStore,
-} from "@/domains/chat/unseen-document-changes-store";
+import { useConversationAssetCounts } from "@/domains/chat/hooks/use-conversation-assets";
+import { useHasUnseenDocumentChanges } from "@/domains/chat/unseen-document-changes-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTranslation } from "@/i18n";
 import { chatInfoTargetKey, useViewerStore } from "@/stores/viewer-store";
@@ -28,6 +25,18 @@ export const ASSETS_PILL_UNSEEN_DOT_TESTID = "assets-pill-unseen-dot";
 
 /** Bounded attention pulse defined in `src/index.css`. */
 export const ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS = "unseen-dot-pulse";
+
+/** Dismiss the chat-info panel when it is the one this trigger owns. */
+function closeOwnedChatInfo(targetKey: string): void {
+  const state = useViewerStore.getState();
+  if (
+    state.mainView === "chat-info" &&
+    state.activeChatInfo !== null &&
+    chatInfoTargetKey(state.activeChatInfo) === targetKey
+  ) {
+    state.closeChatInfo();
+  }
+}
 
 export interface ConversationAssetsPillProps {
   assistantId: string;
@@ -41,7 +50,7 @@ export function ConversationAssetsPill({
   conversationId,
   refreshKey,
 }: ConversationAssetsPillProps) {
-  const { count } = useConversationAssets({
+  const { count } = useConversationAssetCounts({
     assistantId,
     conversationId,
     refreshKey,
@@ -55,53 +64,37 @@ export function ConversationAssetsPill({
     activeChatInfo !== null &&
     chatInfoTargetKey(activeChatInfo) === targetKey;
 
-  // The chat header swaps `conversationId` on this same mounted pill, so an
-  // open panel would otherwise carry over and list the incoming conversation's
-  // assets without the user asking to see them, leaving that conversation's
-  // changes marked unseen behind a panel that is already open.
-  // `clearTranscriptPanelPayloads` drops the payload on a switch; this settles
-  // `mainView` too. Layout effect: the outgoing conversation's panel must never
-  // paint over the incoming conversation, not even for one frame.
+  // The panel this pill opened must not outlive the pill's target: the chat
+  // header swaps `conversationId` on this same mounted pill, and an assistant
+  // switch unmounts it. `clearTranscriptPanelPayloads` settles the store on a
+  // conversation switch, so this covers the paths that do not run it. Layout
+  // effect: the outgoing panel must never paint over the incoming
+  // conversation, not even for one frame.
   useLayoutEffect(() => {
-    const state = useViewerStore.getState();
-    if (
-      state.mainView === "chat-info" &&
-      state.activeChatInfo !== null &&
-      chatInfoTargetKey(state.activeChatInfo) !== targetKey
-    ) {
-      state.closeChatInfo();
-    }
-    // The pill leaving (an assistant switch clears the conversation before
-    // the next one resolves) must take its panel with it, or the store keeps
-    // showing a target no control owns.
     return () => {
-      const current = useViewerStore.getState();
-      if (
-        current.mainView === "chat-info" &&
-        current.activeChatInfo !== null &&
-        chatInfoTargetKey(current.activeChatInfo) === targetKey
-      ) {
-        current.closeChatInfo();
-      }
+      closeOwnedChatInfo(targetKey);
     };
   }, [targetKey]);
+
+  // Zero assets hides the trigger, and a panel with no control to dismiss it
+  // is a trap; the last asset leaving takes the panel with it.
+  useEffect(() => {
+    if (count === 0) {
+      closeOwnedChatInfo(targetKey);
+    }
+  }, [count, targetKey]);
 
   // The header cluster only has room for a labelled pill on a roomy window.
   const isMobile = useIsMobile();
   const { t } = useTranslation("chat");
   const reduceMotion = useReducedMotion();
   const hasUnseenChanges = useHasUnseenDocumentChanges(conversationId);
-  const clearConversation =
-    useUnseenDocumentChangesStore.use.clearConversation();
 
-  // Opening the panel is the user looking at the assets, so whatever changed
-  // is no longer unseen.
+  // The panel clears the unseen dot, since it is the surface that shows what
+  // changed and it opens from other entry points too.
   const handleClick = useCallback(() => {
-    if (!isOpen) {
-      clearConversation(conversationId);
-    }
     useViewerStore.getState().toggleChatInfo({ assistantId, conversationId });
-  }, [assistantId, clearConversation, conversationId, isOpen]);
+  }, [assistantId, conversationId]);
 
   if (count === 0) {
     return null;

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
@@ -8,7 +8,7 @@
  * suite mocks it.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook } from "@testing-library/react";
 
@@ -26,8 +26,11 @@ mock.module(
   }),
 );
 
-const { useConversationAssets, toConversationFileAssets } =
-  await import("@/domains/chat/hooks/use-conversation-assets");
+const {
+  useConversationAssetCounts,
+  useConversationAssets,
+  toConversationFileAssets,
+} = await import("@/domains/chat/hooks/use-conversation-assets");
 const { makeDisplayAttachment } =
   await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
 const {
@@ -118,9 +121,69 @@ function renderAssets({
   return { ...view, client };
 }
 
+function renderCounts({
+  apps = [],
+  documents = [],
+}: {
+  apps?: AppSummary[];
+  documents?: DocumentSummary[];
+} = {}) {
+  const client = makeQueryClient();
+  seedConversation(client, apps, documents);
+
+  return renderHook(
+    () =>
+      useConversationAssetCounts({
+        assistantId: ASSISTANT_ID,
+        conversationId: CONVERSATION_ID,
+      }),
+    {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    },
+  );
+}
+
 afterEach(() => {
   cleanup();
   messagesRef.value = [];
+});
+
+// `mock.module` is process-global in this runner, so the module graph is put
+// back before the next file loads.
+afterAll(() => {
+  mock.restore();
+});
+
+describe("useConversationAssetCounts", () => {
+  test("totals every category without building the tile model", () => {
+    messagesRef.value = [
+      {
+        id: "msg-1",
+        role: "user",
+        attachments: [
+          makeDisplayAttachment({ id: "att-1" }),
+          makeDisplayAttachment({ id: "att-2" }),
+        ],
+      },
+    ];
+
+    const { result } = renderCounts({
+      apps: [makeApp("a", 1_000), makeApp("b", 2_000)],
+      documents: [makeDocument("doc-1", 1_000)],
+    });
+
+    expect(result.current.counts).toEqual({ apps: 2, files: 3, frames: 0 });
+    expect(result.current.count).toBe(5);
+    expect(result.current).not.toHaveProperty("files");
+  });
+
+  test("counts nothing for a conversation with no assets", () => {
+    const { result } = renderCounts();
+
+    expect(result.current.count).toBe(0);
+  });
 });
 
 describe("useConversationAssets", () => {

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
@@ -3,6 +3,9 @@
  * apps, files (daemon documents plus the attachments that are not camera
  * frames), and camera frames. Frames stay empty while attachments come from
  * the transcript, which cannot see the camera-frame tag.
+ *
+ * `useConversationAssetCounts` is the totals alone, over the same sources, for
+ * the header trigger that shows a number rather than the tiles.
  */
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -16,6 +19,7 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
   type ConversationAttachmentEntry,
+  type ConversationAttachments,
   useConversationAttachments,
 } from "@/domains/chat/hooks/use-conversation-attachments";
 import type { AppSummary } from "@/types/app-types";
@@ -38,18 +42,28 @@ export type ConversationFileAsset =
       capturedAt: number | null;
     };
 
-export interface ConversationAssets {
+export interface ConversationAssetCounts {
+  counts: { apps: number; files: number; frames: number };
+  /** Sum of `counts`: what the header pill shows, and hides on when zero. */
+  count: number;
+}
+
+export interface ConversationAssets extends ConversationAssetCounts {
   apps: AppSummary[];
   /** Documents, newest first, then the attachments that are not frames. */
   files: ConversationFileAsset[];
   frames: ConversationFileAsset[];
-  counts: { apps: number; files: number; frames: number };
-  /** Sum of `counts`: what the header pill shows, and hides on when zero. */
-  count: number;
   hasMoreFiles: boolean;
   hasMoreFrames: boolean;
   loadMoreFiles: () => void;
   loadMoreFrames: () => void;
+}
+
+export interface ConversationAssetsTarget {
+  assistantId: string;
+  conversationId: string;
+  /** Bumped externally to trigger a refetch (e.g. on ui_surface_show). Only one mounted caller should pass it. */
+  refreshKey?: number;
 }
 
 /**
@@ -92,16 +106,15 @@ export function toConversationFileAssets(
   return { files, frames };
 }
 
-export function useConversationAssets({
+/**
+ * The two queries and the transcript attachments every asset reader shares,
+ * plus the refresh invalidation, so the queries and their keys live once.
+ */
+function useConversationAssetSources({
   assistantId,
   conversationId,
   refreshKey,
-}: {
-  assistantId: string;
-  conversationId: string;
-  /** Bumped externally to trigger a refetch (e.g. on ui_surface_show). Only one mounted caller should pass it. */
-  refreshKey?: number;
-}): ConversationAssets {
+}: ConversationAssetsTarget) {
   const queryClient = useQueryClient();
   const appsQueryOpts = appsGetOptions({
     path: { assistant_id: assistantId },
@@ -144,6 +157,43 @@ export function useConversationAssets({
     conversationId,
   });
 
+  return { apps, docs, attachments };
+}
+
+function toAssetCounts(
+  appCount: number,
+  docCount: number,
+  attachments: ConversationAttachments,
+): ConversationAssetCounts {
+  const counts = {
+    apps: appCount,
+    files: docCount + attachments.totalFiles,
+    frames: attachments.totalFrames,
+  };
+  return { counts, count: counts.apps + counts.files + counts.frames };
+}
+
+/**
+ * How many assets a conversation holds, per category and in total, without
+ * building the tile model. The header trigger reads only the number, so it
+ * pays for the shared queries and nothing more.
+ */
+export function useConversationAssetCounts(
+  target: ConversationAssetsTarget,
+): ConversationAssetCounts {
+  const { apps, docs, attachments } = useConversationAssetSources(target);
+
+  return useMemo(
+    () => toAssetCounts(apps.length, docs.length, attachments),
+    [apps.length, docs.length, attachments],
+  );
+}
+
+export function useConversationAssets(
+  target: ConversationAssetsTarget,
+): ConversationAssets {
+  const { apps, docs, attachments } = useConversationAssetSources(target);
+
   const sortedApps = useMemo(
     () => [...apps].sort((a, b) => b.updatedAt - a.updatedAt),
     [apps],
@@ -154,22 +204,17 @@ export function useConversationAssets({
     [docs, attachments.entries],
   );
 
-  return useMemo(() => {
-    const counts = {
-      apps: sortedApps.length,
-      files: docs.length + attachments.totalFiles,
-      frames: attachments.totalFrames,
-    };
-    return {
+  return useMemo(
+    () => ({
       apps: sortedApps,
       files,
       frames,
-      counts,
-      count: counts.apps + counts.files + counts.frames,
+      ...toAssetCounts(sortedApps.length, docs.length, attachments),
       hasMoreFiles: attachments.hasMoreFiles,
       hasMoreFrames: attachments.hasMoreFrames,
       loadMoreFiles: attachments.loadMoreFiles,
       loadMoreFrames: attachments.loadMoreFrames,
-    };
-  }, [sortedApps, files, frames, docs.length, attachments]);
+    }),
+    [sortedApps, files, frames, docs.length, attachments],
+  );
 }

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
@@ -5,9 +5,8 @@ import { useViewerStore } from "@/stores/viewer-store";
 import { haptic } from "@/utils/haptics";
 
 /**
- * Open an app in the viewer panel from inside the chat surface — sidebar
- * pinned-app click, transcript "Open App" affordance, conversation assets
- * pill.
+ * Open an app in the viewer panel from inside the chat surface: the sidebar's
+ * pinned-app click and the transcript's "Open App" affordance.
  *
  * Opening an app is a *view* action, so the app lands full-width:
  * `loadApp` sets `mainView` to `"app"` and nothing here upgrades it. That
@@ -30,9 +29,11 @@ import { haptic } from "@/utils/haptics";
  * Returns a stable async callback `(appId: string) => Promise<void>` safe
  * to drop into deps arrays.
  *
- * Single source of truth, used by `chat-layout.tsx` (sidebar),
- * `chat-route-content.tsx` (transcript) and
- * `use-chat-header-registration.tsx` (assets pill). Don't inline a copy.
+ * Single source of truth for the active assistant's apps, used by
+ * `chat-layout.tsx` (sidebar) and `chat-route-content.tsx` (transcript).
+ * Don't inline a copy. A surface that opens an app for some other assistant
+ * (the chat-info panel opens the one its payload names) calls `loadApp`
+ * directly instead.
  */
 export function useOpenAppFromChat(): (appId: string) => Promise<void> {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -589,6 +589,8 @@ describe("openProcessDetail", () => {
   });
 });
 
+const SAMPLE_CHAT_INFO = { assistantId: "a1", conversationId: "c1" };
+
 describe("closeActiveOverlay", () => {
   it("closes a tool detail overlay and restores its prior view", () => {
     getState().openToolDetail(SAMPLE_TOOL);
@@ -620,6 +622,18 @@ describe("closeActiveOverlay", () => {
 
     expect(getState().closeActiveOverlay()).toBe(true);
     expect(getState().mainView).toBe("app");
+    expect(getState().activeChatInfo).toBeNull();
+  });
+
+  it("pops the chat-info drill-in before closing the panel", () => {
+    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+
+    expect(getState().closeActiveOverlay()).toBe(true);
+    expect(getState().mainView).toBe("chat-info");
+    expect(getState().activeChatInfo?.category).toBeNull();
+
+    expect(getState().closeActiveOverlay()).toBe(true);
+    expect(getState().mainView).toBe("chat");
     expect(getState().activeChatInfo).toBeNull();
   });
 
@@ -886,8 +900,6 @@ describe("openMessageFiles / toggleMessageFiles / closeMessageFiles", () => {
 // Chat info panel
 // ---------------------------------------------------------------------------
 
-const SAMPLE_CHAT_INFO = { assistantId: "a1", conversationId: "c1" };
-
 describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", () => {
   it("opens the panel at the top level and records the prior view", () => {
     getState().openChatInfo(SAMPLE_CHAT_INFO);
@@ -935,10 +947,25 @@ describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", 
     });
   });
 
-  it("clearTranscriptPanelPayloads drops the chat-info payload on a conversation switch", () => {
+  it("clearTranscriptPanelPayloads settles the chat-info view on a conversation switch", () => {
+    useViewerStore.setState({ mainView: "app" });
     getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+
     getState().clearTranscriptPanelPayloads();
-    expect(getState().activeChatInfo).toBeNull();
+
+    const state = getState();
+    expect(state.activeChatInfo).toBeNull();
+    expect(state.mainView).toBe("app");
+  });
+
+  it("toggling to another conversation keeps the view the panel was opened from", () => {
+    useViewerStore.setState({ mainView: "app" });
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().toggleChatInfo({ ...SAMPLE_CHAT_INFO, conversationId: "c2" });
+
+    expect(getState().viewBeforeChatInfo).toBe("app");
+    getState().closeChatInfo();
+    expect(getState().mainView).toBe("app");
   });
 
   it("toggle treats the same conversation id under another assistant as a new target", () => {

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -677,7 +677,12 @@ export interface ViewerActions {
    * panels are dismissed when the viewer returns to chat, and holding
    * their payloads keeps the previous conversation's data alive -
    * `activeMessageFiles` in particular retains decoded attachment blob/data
-   * URLs. Leaves `mainView` alone; this is a memory concern, not navigation.
+   * URLs.
+   *
+   * Leaves `mainView` alone except for `"chat-info"`, which it restores to
+   * the view the panel was opened from: that panel is the conversation's own,
+   * so a switch that takes its payload has to take the view with it rather
+   * than leave an empty panel on screen.
    */
   clearTranscriptPanelPayloads: () => void;
 
@@ -1066,7 +1071,13 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
         get().closeChannelTranscript();
         return true;
       case "chat-info":
-        get().closeChatInfo();
+        // Alone among the overlays, this one's second level lives in the
+        // store, so Escape and Android Back pop the drill-in before the panel.
+        if (get().activeChatInfo?.category != null) {
+          get().setChatInfoCategory(null);
+        } else {
+          get().closeChatInfo();
+        }
         return true;
       default:
         return false;
@@ -1313,11 +1324,16 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
   },
 
   clearTranscriptPanelPayloads: () => {
+    const { mainView, viewBeforeChatInfo } = get();
     set({
       activeMessageFiles: null,
       activeActivitySteps: null,
       activeToolDetail: null,
       activeChatInfo: null,
+      // The chat-info panel is about the conversation itself, so the switch
+      // that drops its payload has to settle its view too. The other three
+      // are reached from a transcript row and are already off screen.
+      mainView: mainView === "chat-info" ? viewBeforeChatInfo : mainView,
     });
   },
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for chat-info-assets-panel.md.

- `clearTranscriptPanelPayloads` restores `mainView` for chat-info, and Escape / Android Back pop the See All level before closing
- The panel owns the unseen-dot clear and settles an emptied drilled-in category; the trigger closes the panel at zero assets and opens apps for the panel's own assistant
- A counts-only hook for the header trigger; store and pill tests exercise the app's real switch sequence