### PR TITLE
fix(web): chat-info attachments scoping, object-URL lifecycle, and frame labels

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -21,6 +21,7 @@ import {
   classifyAttachment,
   formatAttachmentSize,
 } from "@/domains/chat/components/chat-attachments/utils";
+import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import { useGallerySwipe } from "@/domains/chat/components/chat-attachments/use-gallery-swipe";
 import { baseMimeType, extensionOf } from "@/domains/chat/utils/mime-sniff";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
@@ -130,9 +131,10 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     !isRehydrated;
 
   const { data: blob, isError } = useQuery({
-    // The attachment id is stable and unique, so it is the cache key — reopening
-    // the same attachment reuses the fetched blob instead of refetching.
-    queryKey: ["attachmentContent", assistantId, attachment.id],
+    // The attachment id is stable and unique, so it is the cache key. Reopening
+    // the same attachment, or opening one a thumbnail already fetched, reuses
+    // that blob instead of refetching.
+    queryKey: attachmentContentQueryKey(assistantId, attachment.id),
     queryFn: async () => {
       const data = await fetchAttachmentContentBlob(
         assistantId!,

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
@@ -128,7 +128,10 @@ describe("ToolResultImages referenced media", () => {
     };
     renderStrip([toolCall], { assistantId: null });
 
-    expect(screen.getByTestId("tool-result-image-placeholder")).toBeDefined();
+    const placeholder = screen.getByTestId("tool-result-image-placeholder");
+    expect(placeholder).toBeDefined();
+    // Nothing is on its way, so the box stays empty rather than spinning.
+    expect(placeholder.querySelector(".animate-spin")).toBeNull();
     expect(screen.queryByTestId("tool-result-image")).toBeNull();
     expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
   });

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -330,8 +330,10 @@ const ToolResultImageThumb: FC<{
 /**
  * Renders a workspace-referenced tool-result image from the object URL
  * {@link useAttachmentObjectUrl} fetches for it, which shares its cache entry
- * with the preview modal. Until that resolves (or when no assistant id is
- * available to fetch with), a spinner placeholder holds the slot.
+ * with the preview modal. A spinner placeholder holds the slot while that
+ * resolves; with nothing to fetch with (no assistant id, or an id that can
+ * never resolve) the placeholder box stays empty, because there is nothing
+ * left to wait for.
  */
 const ReferencedToolResultImage: FC<{
   attachment: DisplayAttachment;

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
@@ -4,10 +4,14 @@
  * An attachment that already carries its content inline resolves to that URL
  * with no daemon round trip. A metadata-only attachment (a real id and a null
  * `previewUrl`) fetches its bytes once and holds them as an object URL, revoked
- * when the blob changes or the caller unmounts.
+ * when the blob changes or the caller unmounts. A null attachment resolves to
+ * nothing at all, so a caller with an optional attachment still calls this
+ * unconditionally.
  *
- * The cache key is the one `AttachmentPreviewModal` reads, so a thumbnail that
- * has already loaded hands the modal a cache hit instead of a second request.
+ * The fetch runs under {@link attachmentContentQueryKey}, which
+ * `AttachmentPreviewModal` fetches under too: the modal keeps its own query so
+ * it can tell a legacy row apart from a failed fetch, but a thumbnail that has
+ * already loaded hands it a cache hit instead of a second request.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -15,6 +19,14 @@ import { useEffect, useState } from "react";
 
 import { fetchAttachmentContentBlob } from "@/domains/chat/components/chat-attachments/download-attachment";
 import type { DisplayAttachment } from "@/types/attachment-types";
+
+/** Cache entry for one attachment's fetched bytes, shared by every reader. */
+export function attachmentContentQueryKey(
+  assistantId: string | null | undefined,
+  attachmentId: string,
+) {
+  return ["attachmentContent", assistantId, attachmentId] as const;
+}
 
 export interface AttachmentObjectUrl {
   /** The inline preview URL, the fetched object URL, or null until one exists. */
@@ -25,21 +37,22 @@ export interface AttachmentObjectUrl {
 
 export function useAttachmentObjectUrl(
   assistantId: string | null | undefined,
-  attachment: Pick<DisplayAttachment, "id" | "previewUrl">,
+  attachment: Pick<DisplayAttachment, "id" | "previewUrl"> | null,
   /** Fetch only while true (the tile is on screen). */
   enabled: boolean,
 ): AttachmentObjectUrl {
-  const { id, previewUrl } = attachment;
+  const id = attachment?.id ?? "";
+  const previewUrl = attachment?.previewUrl ?? null;
   // Synthetic `rehydrated:` ids from the text-parsing history fallback can
   // never resolve against the content endpoint, so they are never fetched.
   const canFetch = !!assistantId && !!id && !id.startsWith("rehydrated:");
   const shouldFetch = enabled && !previewUrl && canFetch;
   // No inline bytes and no way to fetch them is a settled answer, not a
   // pending one, so callers can fall back instead of waiting.
-  const unavailable = !previewUrl && !canFetch;
+  const unavailable = !!attachment && !previewUrl && !canFetch;
 
   const { data: blob, isError } = useQuery({
-    queryKey: ["attachmentContent", assistantId, id],
+    queryKey: attachmentContentQueryKey(assistantId, id),
     queryFn: async () => {
       const data = await fetchAttachmentContentBlob(assistantId!, id);
       if (!data) {
@@ -52,19 +65,24 @@ export function useAttachmentObjectUrl(
     retry: false,
   });
 
+  // The cache answers whoever asks, so a blob another reader already fetched
+  // arrives even here; hold it only while this caller would draw it, or the
+  // object URL is minted for a picture nothing renders.
+  const shownBlob = !previewUrl && enabled ? (blob ?? null) : null;
+
   const [objectUrl, setObjectUrl] = useState<string | null>(null);
   useEffect(() => {
-    if (!blob) {
+    if (!shownBlob) {
       setObjectUrl(null);
       return;
     }
-    const url = URL.createObjectURL(blob);
+    const url = URL.createObjectURL(shownBlob);
     setObjectUrl(url);
     return () => {
       URL.revokeObjectURL(url);
       setObjectUrl(null);
     };
-  }, [blob]);
+  }, [shownBlob]);
 
   return { url: previewUrl ?? objectUrl, isError: isError || unavailable };
 }

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
@@ -42,6 +42,7 @@ export function ChatInfoAppTile({
 
   return (
     <div
+      data-slot="chat-info-app-tile"
       data-reveal-row=""
       className={cn(
         "relative flex flex-col gap-1",

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
@@ -4,9 +4,9 @@
  * cannot get, a non-image glyph, a video poster, and a camera frame labelled
  * with when it was captured.
  *
- * `LazyImage` seeds the shared `attachmentContent` cache entry the tile reads,
- * which is the same entry the preview modal uses, so the story shows the
- * fetched path without a daemon behind it.
+ * `LazyImage` seeds the cache entry the tile reads, under the same
+ * `attachmentContentQueryKey` the preview modal fetches with, so the story
+ * shows the fetched path without a daemon behind it.
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -18,8 +18,10 @@ import {
   makeSamplePreview,
   SAMPLE_PREVIEWS,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
 import type { DocumentSummary } from "@/types/document-types";
+import { decodeBase64Payload } from "@/utils/base64";
 
 import { ChatInfoFileTile } from "./chat-info-file-tile";
 
@@ -69,9 +71,10 @@ const LAZY_IMAGE_ATTACHMENT = makeDisplayAttachment({
 });
 const LAZY_IMAGE = attachmentFile(LAZY_IMAGE_ATTACHMENT);
 
+/** A legacy row: a synthetic id the content endpoint can never resolve. */
 const LAZY_IMAGE_UNAVAILABLE = attachmentFile(
   makeDisplayAttachment({
-    id: "gulls-at-dusk",
+    id: "rehydrated:0",
     filename: "gulls-at-dusk.png",
     sizeBytes: 176_128,
   }),
@@ -110,25 +113,13 @@ const FRAME_FILE: ConversationFileAsset = {
   capturedAt: Date.UTC(2026, 4, 27, 9, 41),
 };
 
-/** The bytes the daemon would return, decoded from a sample preview data URL. */
-function blobFromDataUrl(dataUrl: string): Blob {
-  const [prefix, payload] = dataUrl.split(",");
-  const binary = atob(payload!);
-  const bytes = new Uint8Array(binary.length);
-  for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
-  }
-  return new Blob([bytes], {
-    type: prefix!.slice("data:".length).replace(";base64", ""),
-  });
-}
-
 const storyClient = new QueryClient({
   defaultOptions: { queries: { retry: false, staleTime: Infinity } },
 });
+// The bytes the daemon would return, decoded from a sample preview data URL.
 storyClient.setQueryData(
-  ["attachmentContent", ASSISTANT_ID, LAZY_IMAGE_ATTACHMENT.id],
-  blobFromDataUrl(SAMPLE_PREVIEWS[2]!),
+  attachmentContentQueryKey(ASSISTANT_ID, LAZY_IMAGE_ATTACHMENT.id),
+  new Blob([decodeBase64Payload(SAMPLE_PREVIEWS[2]!)!], { type: "image/png" }),
 );
 
 const withSeededBytes: Decorator = (Story) => (
@@ -165,7 +156,7 @@ export const LazyImage: Story = {
   args: { file: LAZY_IMAGE },
 };
 
-/** The same path with nothing to fetch: the tile settles on the image glyph. */
+/** A legacy image with no bytes to fetch: the tile settles straight on the glyph. */
 export const LazyImageUnavailable: Story = {
   args: { file: LAZY_IMAGE_UNAVAILABLE },
 };
@@ -180,7 +171,7 @@ export const VideoPoster: Story = {
   args: { file: VIDEO_FILE },
 };
 
-/** A camera frame, labelled with when it was captured rather than its filename. */
+/** A camera frame, labelled by capture time: the time of day for today's, the date for an older one. */
 export const Frame: Story = {
   args: { file: FRAME_FILE },
 };

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Loader2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
 
@@ -16,14 +16,12 @@ import {
   classifyAttachment,
 } from "@/domains/chat/components/chat-attachments/utils";
 import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
+import { useInView } from "@/hooks/use-in-view";
 import { useTranslation } from "@/i18n";
-import { formatFriendlyDate } from "@/utils/format-date";
+import { formatCaptureTime } from "@/utils/format-date";
 
 /** Fixed tile width, and what the section fits a row of them to. Kept in step with `w-[135px]` below. */
 export const CHAT_INFO_FILE_TILE_WIDTH_PX = 135;
-
-/** Stands in for a document's absent attachment so the bytes hook stays unconditional. */
-const NO_ATTACHMENT = { id: "", previewUrl: null };
 
 export interface ChatInfoFileTileProps {
   file: ConversationFileAsset;
@@ -36,31 +34,13 @@ export function ChatInfoFileTile({
   assistantId,
   onOpen,
 }: ChatInfoFileTileProps) {
-  const { t } = useTranslation("chat");
+  const { t, i18n } = useTranslation("chat");
   const boxRef = useRef<HTMLButtonElement>(null);
 
+  const hasSeenTile = useInView(boxRef, { rootMargin: "200px", once: true });
   // A browser without IntersectionObserver loads every tile rather than none:
   // the picture is the tile's content here, not an enhancement of it.
-  const [isVisible, setIsVisible] = useState(
-    () => typeof IntersectionObserver === "undefined",
-  );
-  useEffect(() => {
-    const el = boxRef.current;
-    if (!el || typeof IntersectionObserver === "undefined") {
-      return;
-    }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          setIsVisible(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: "200px" },
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+  const isVisible = hasSeenTile || typeof IntersectionObserver === "undefined";
 
   const attachment = file.kind === "document" ? null : file.attachment;
   // A document's own glyph is the `document` kind's, so the three kinds of tile
@@ -72,7 +52,7 @@ export function ChatInfoFileTile({
   const [previewFailed, setPreviewFailed] = useState(false);
   const { url, isError } = useAttachmentObjectUrl(
     assistantId,
-    attachment ?? NO_ATTACHMENT,
+    attachment,
     isVisible && kind === "image",
   );
 
@@ -96,7 +76,7 @@ export function ChatInfoFileTile({
 
   const label =
     file.kind === "frame" && file.capturedAt !== null
-      ? formatFriendlyDate(new Date(file.capturedAt))
+      ? formatCaptureTime(file.capturedAt, i18n.resolvedLanguage)
       : file.title;
 
   const renderBoxContent = () => {
@@ -127,6 +107,7 @@ export function ChatInfoFileTile({
 
   return (
     <div
+      data-slot="chat-info-file-tile"
       data-reveal-row=""
       className="relative flex w-[135px] shrink-0 flex-col gap-1"
     >

--- a/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
@@ -6,7 +6,15 @@
  * asserted through accessible names and the rendered image source.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
@@ -81,7 +89,7 @@ const { makeDisplayAttachment, SAMPLE_PREVIEWS } =
   await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
 const { appsGetQueryKey } =
   await import("@/generated/daemon/@tanstack/react-query.gen");
-const { formatFriendlyDate } = await import("@/utils/format-date");
+const { formatCaptureTime } = await import("@/utils/format-date");
 type ConversationFileAsset =
   import("@/domains/chat/hooks/use-conversation-assets").ConversationFileAsset;
 
@@ -147,6 +155,10 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("ChatInfoAppTile", () => {
@@ -318,9 +330,11 @@ describe("ChatInfoFileTile attachments", () => {
 });
 
 describe("ChatInfoFileTile camera frames", () => {
-  test("labels itself with the capture time and names itself a frame", () => {
-    const capturedAt = new Date(2026, 4, 27, 10, 30).getTime();
-    const file: ConversationFileAsset = {
+  // The suite pins i18next to English, which is the locale the tile formats in.
+  const LOCALE = "en";
+
+  function frameAsset(capturedAt: number): ConversationFileAsset {
+    return {
       kind: "frame",
       id: "frame-1",
       title: "frame-01.jpg",
@@ -332,9 +346,15 @@ describe("ChatInfoFileTile camera frames", () => {
       }),
       capturedAt,
     };
+  }
+
+  test("labels a frame from today with its time of day", () => {
+    // Frames from one Live session share a date, so the time is what tells
+    // them apart.
+    const capturedAt = new Date().setHours(10, 30, 0, 0);
     renderTile(
       <ChatInfoFileTile
-        file={file}
+        file={frameAsset(capturedAt)}
         assistantId={ASSISTANT_ID}
         onOpen={() => {}}
       />,
@@ -342,7 +362,23 @@ describe("ChatInfoFileTile camera frames", () => {
 
     expect(screen.getByLabelText("Preview camera frame")).toBeDefined();
     expect(
-      screen.getByText(formatFriendlyDate(new Date(capturedAt))),
+      screen.getByText(formatCaptureTime(capturedAt, LOCALE)),
     ).toBeDefined();
+  });
+
+  test("labels an older frame with its date", () => {
+    const capturedAt = new Date(2001, 4, 27, 10, 30).getTime();
+    renderTile(
+      <ChatInfoFileTile
+        file={frameAsset(capturedAt)}
+        assistantId={ASSISTANT_ID}
+        onOpen={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText(formatCaptureTime(capturedAt, LOCALE)),
+    ).toBeDefined();
+    expect(screen.getByText(/2001/)).toBeDefined();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -5,9 +5,10 @@
  * everything asserted here is the walk over those rows.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
+import type * as ConversationStore from "@/stores/conversation-store";
 import type * as TranscriptMessages from "@/domains/chat/transcript/use-transcript-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
@@ -16,7 +17,20 @@ const messagesRef: { value: DisplayMessage[] } = { value: [] };
 mock.module(
   "@/domains/chat/transcript/use-transcript-messages",
   (): Partial<typeof TranscriptMessages> => ({
-    useTranscriptMessages: () => messagesRef.value,
+    // A fresh array each render, the way the real selector behaves when the
+    // snapshot churns, so the memo is actually exercised.
+    useTranscriptMessages: () => [...messagesRef.value],
+  }),
+);
+
+const openConversationRef: { value: string | null } = { value: "conv-1" };
+
+mock.module(
+  "@/stores/conversation-store",
+  (): Partial<typeof ConversationStore> => ({
+    useConversationStore: {
+      use: { activeConversationId: () => openConversationRef.value },
+    } as unknown as typeof ConversationStore.useConversationStore,
   }),
 );
 
@@ -34,6 +48,11 @@ function makeMessage(overrides: Partial<DisplayMessage>): DisplayMessage {
 afterEach(() => {
   cleanup();
   messagesRef.value = [];
+  openConversationRef.value = "conv-1";
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("useConversationAttachments", () => {
@@ -127,6 +146,7 @@ describe("useConversationAttachments", () => {
       makeMessage({
         id: "msg-folded",
         role: "assistant",
+        mergedMessageIds: ["msg-donor"],
         attachments: [
           makeDisplayAttachment({ id: "rehydrated:0", filename: "a.pdf" }),
           makeDisplayAttachment({ id: "rehydrated:0", filename: "b.pdf" }),
@@ -144,6 +164,24 @@ describe("useConversationAttachments", () => {
     expect(
       result.current.entries.map((entry) => entry.attachment.filename),
     ).toEqual(["b.pdf", "a.pdf"]);
+  });
+
+  test("keeps one row's uploads in the order they were sent", () => {
+    messagesRef.value = [
+      makeMessage({
+        id: "msg-upload",
+        attachments: [
+          makeDisplayAttachment({ id: "first", filename: "first.pdf" }),
+          makeDisplayAttachment({ id: "second", filename: "second.pdf" }),
+        ],
+      }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(
+      result.current.entries.map((entry) => entry.attachment.filename),
+    ).toEqual(["first.pdf", "second.pdf"]);
   });
 
   test("skips a channel-deleted row's files", () => {
@@ -191,6 +229,45 @@ describe("useConversationAttachments", () => {
 
     expect(result.current.entries).toHaveLength(0);
     expect(result.current.entries).toBe(first);
+  });
+
+  test("lists the loaded transcript when it is the target conversation's", () => {
+    openConversationRef.value = "conv-1";
+    messagesRef.value = [
+      makeMessage({ attachments: [makeDisplayAttachment({ id: "mine" })] }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
+      "mine",
+    ]);
+  });
+
+  test("lists nothing when the loaded transcript is another conversation's", () => {
+    openConversationRef.value = "conv-2";
+    messagesRef.value = [
+      makeMessage({ attachments: [makeDisplayAttachment({ id: "theirs" })] }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries).toHaveLength(0);
+    expect(result.current.totalFiles).toBe(0);
+  });
+
+  test("lists the transcript when no conversation is named as open", () => {
+    // Nothing open is nothing to confuse these rows with, so the rows stand.
+    openConversationRef.value = null;
+    messagesRef.value = [
+      makeMessage({ attachments: [makeDisplayAttachment({ id: "draft" })] }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
+      "draft",
+    ]);
   });
 
   test("keeps the load-more callbacks stable", () => {

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -11,10 +11,8 @@
 import { useMemo } from "react";
 
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
+import { useConversationStore } from "@/stores/conversation-store";
 import type { DisplayAttachment } from "@/types/attachment-types";
-
-/** Page size for a paged attachment listing. */
-export const ATTACHMENT_PAGE_SIZE = 200;
 
 export interface ConversationAttachmentEntry {
   /**
@@ -64,13 +62,21 @@ export function useConversationAttachments(target: {
   assistantId: string;
   conversationId: string;
 }): ConversationAttachments {
-  // The transcript is already the open conversation's, so this source has
-  // nothing to scope by; `target` names the conversation the entries belong to.
-  void target;
+  // The transcript holds whichever conversation is open and its snapshot names
+  // no conversation of its own, so a caller asking about a different one is
+  // answered with nothing rather than with the open conversation's files. With
+  // none open there is no other conversation to mistake these rows for.
+  const activeConversationId = useConversationStore.use.activeConversationId();
+  const isOtherConversation =
+    activeConversationId !== null &&
+    activeConversationId !== target.conversationId;
 
   const messages = useTranscriptMessages();
 
   const entries = useMemo(() => {
+    if (isOtherConversation) {
+      return NO_ENTRIES;
+    }
     const collected: ConversationAttachmentEntry[] = [];
     const seen = new Set<string>();
     // Newest first, and an optimistic row plus its confirmed echo carry the
@@ -83,13 +89,12 @@ export function useConversationAttachments(target: {
         continue;
       }
       const attachments = message.attachments ?? [];
-      // Folded assistant rows append the newer donor's files after the
-      // survivor's, so a row is walked from its end as well.
-      for (
-        let position = attachments.length - 1;
-        position >= 0;
-        position -= 1
-      ) {
+      // A folded row appends the newer donor's files after the survivor's, so
+      // only those are walked from the end; one upload keeps the order it was
+      // sent in.
+      const folded = (message.mergedMessageIds?.length ?? 0) > 0;
+      for (let step = 0; step < attachments.length; step += 1) {
+        const position = folded ? attachments.length - 1 - step : step;
         const attachment = attachments[position]!;
         const key = entryKey(message.id, attachment.id, position);
         if (seen.has(key)) {
@@ -106,7 +111,7 @@ export function useConversationAttachments(target: {
       }
     }
     return collected.length === 0 ? NO_ENTRIES : collected;
-  }, [messages]);
+  }, [messages, isOtherConversation]);
 
   return useMemo(
     () => ({

--- a/clients/web/src/hooks/use-in-view.ts
+++ b/clients/web/src/hooks/use-in-view.ts
@@ -3,24 +3,35 @@
  *
  * A thin `IntersectionObserver` wrapper, added because the codebase had three
  * hand-rolled copies (the app card's lazy preview, the PDF page renderer, the
- * transcript's load-more sentinel) and this is a fourth caller that wants the
- * plain "is it visible" answer rather than a one-shot trigger. Those three are
- * left alone; they each fold extra behaviour into their observer.
+ * transcript's load-more sentinel). Those three are left alone; they each fold
+ * extra behaviour into their observer.
  *
  * Reports `false` before the first observation and wherever the API is missing,
- * so callers get the conservative answer while the browser catches up.
+ * so callers get the conservative answer while the browser catches up. A caller
+ * for which "not observable" means "show it" (a lazily loaded picture that is
+ * the content, not an enhancement of it) checks for the API itself.
  */
 
 import { useEffect, useState, type RefObject } from "react";
 
 export function useInView(
   ref: RefObject<Element | null>,
-  /**
-   * Fraction of the element that must be showing to count as visible. The
-   * default asks for any sliver, which is the right test for "the user can
-   * already see this, so don't show them a second copy of it".
-   */
-  { threshold = 0 }: { threshold?: number } = {},
+  {
+    threshold = 0,
+    rootMargin,
+    once = false,
+  }: {
+    /**
+     * Fraction of the element that must be showing to count as visible. The
+     * default asks for any sliver, which is the right test for "the user can
+     * already see this, so don't show them a second copy of it".
+     */
+    threshold?: number;
+    /** Grows the viewport the element is tested against, e.g. `"200px"` to start loading just before it scrolls in. */
+    rootMargin?: string;
+    /** Latch on the first sighting and stop observing, for work that only needs doing once. */
+    once?: boolean;
+  } = {},
 ): boolean {
   const [inView, setInView] = useState(false);
 
@@ -32,21 +43,29 @@ export function useInView(
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
-        if (entry) {
-          setInView(entry.isIntersecting);
+        if (!entry || (once && !entry.isIntersecting)) {
+          return;
+        }
+        setInView(entry.isIntersecting);
+        if (once) {
+          observer.disconnect();
         }
       },
-      { threshold },
+      { threshold, rootMargin },
     );
     observer.observe(el);
     return () => {
       observer.disconnect();
-      // An unmounting element is not on screen. Without this a control that
-      // scrolls out of the virtualised transcript would leave its last
-      // "visible" answer behind and suppress the floating copy forever.
-      setInView(false);
+      if (!once) {
+        // An unmounting element is not on screen. Without this a control that
+        // scrolls out of the virtualised transcript would leave its last
+        // "visible" answer behind and suppress the floating copy forever. A
+        // latched caller keeps its answer: it asked for one sighting, not for
+        // the live state.
+        setInView(false);
+      }
     };
-  }, [ref, threshold]);
+  }, [ref, threshold, rootMargin, once]);
 
   return inView;
 }

--- a/clients/web/src/utils/format-date.test.ts
+++ b/clients/web/src/utils/format-date.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  formatCaptureTime,
   formatCompactLocalDate,
   formatFriendlyDate,
   formatFullLocalDate,
@@ -54,5 +55,44 @@ describe("formatCompactLocalDate", () => {
     expect(formatCompactLocalDate(null)).toBe("");
     expect(formatCompactLocalDate(undefined)).toBe("");
     expect(formatCompactLocalDate("")).toBe("");
+  });
+});
+
+describe("formatCaptureTime", () => {
+  test("gives the time of day for a capture made today", () => {
+    const capturedAt = new Date().setHours(9, 41, 0, 0);
+
+    expect(formatCaptureTime(capturedAt, "en")).toBe(
+      new Date(capturedAt).toLocaleTimeString("en", {
+        hour: "numeric",
+        minute: "2-digit",
+      }),
+    );
+  });
+
+  test("tells two captures from one session apart", () => {
+    const morning = new Date().setHours(9, 41, 0, 0);
+    const evening = new Date().setHours(18, 12, 0, 0);
+
+    expect(formatCaptureTime(morning, "en")).not.toBe(
+      formatCaptureTime(evening, "en"),
+    );
+  });
+
+  test("falls back to the friendly date for an older capture", () => {
+    const capturedAt = new Date(2001, 0, 15, 9, 14).getTime();
+
+    expect(formatCaptureTime(capturedAt, "en")).toBe(
+      formatFriendlyDate(new Date(capturedAt), { locale: "en" }),
+    );
+    expect(formatCaptureTime(capturedAt, "en")).toContain("2001");
+  });
+
+  test("formats in the locale it is given", () => {
+    const capturedAt = new Date(2001, 0, 15, 9, 14).getTime();
+
+    expect(formatCaptureTime(capturedAt, "ru")).not.toBe(
+      formatCaptureTime(capturedAt, "en"),
+    );
   });
 });

--- a/clients/web/src/utils/format-date.ts
+++ b/clients/web/src/utils/format-date.ts
@@ -1,12 +1,13 @@
 /**
  * Format a date as a short, human-readable string (e.g., "27 May" or "27 May 2025").
  * Omits the year when it matches the current year, unless `alwaysShowYear` is set.
+ * `locale` defaults to the browser's; pass the app's where the two can differ.
  */
 export function formatFriendlyDate(
   date: Date,
-  opts?: { alwaysShowYear?: boolean },
+  opts?: { alwaysShowYear?: boolean; locale?: string },
 ): string {
-  return date.toLocaleDateString(undefined, {
+  return date.toLocaleDateString(opts?.locale, {
     day: "numeric",
     month: "short",
     year:
@@ -14,6 +15,31 @@ export function formatFriendlyDate(
         ? "numeric"
         : undefined,
   });
+}
+
+/** Hour and minute, the shape every inline timestamp here shows. */
+function formatTimeOfDay(date: Date, locale?: string): string {
+  return date.toLocaleTimeString(locale, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Label for when something was captured: the time of day for a capture made
+ * today, the friendly date for an older one. A run of captures from a single
+ * session all fall on one date, so the date alone would label them identically.
+ */
+export function formatCaptureTime(ms: number, locale?: string): string {
+  const date = new Date(ms);
+  const now = new Date();
+  const isToday =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  return isToday
+    ? formatTimeOfDay(date, locale)
+    : formatFriendlyDate(date, { locale });
 }
 
 /**
@@ -80,11 +106,7 @@ export function formatCompactLocalDate(
     return "";
   }
   const date = new Date(dateStr);
-  const time = date.toLocaleTimeString(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  });
-  return `${formatFriendlyDate(date)}, ${time}`;
+  return `${formatFriendlyDate(date)}, ${formatTimeOfDay(date)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for chat-info-assets-panel.md.

- The attachments hook scopes to its conversation and keeps user-upload order, reversing only folded rows
- The object-URL hook holds a blob only while it is shown, accepts a missing attachment, and shares its query key with the preview modal
- Camera frames are labelled by capture time in the app locale; tiles carry data-slot; tests restore their module mocks