### PR TITLE
fix(android): close the foreground handler gap, bound the read overshoot, skip the shortcut on self-hosted origins

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -400,7 +400,10 @@ failures retry on resume.
 `AndroidPushRegistration.getCapabilities` advertises
 `native-notification-render` on token registration. The platform sends
 data-only pushes only to tokens that claim it, so a build that cannot render
-one natively must never claim it.
+one natively must never claim it. The claim is deliberately not gated on
+`push-avatar-sender`: that flag is the platform's own switch for the data-only
+shape, while the capability says which tokens could render one, so a shell that
+can render natively says so whether the flag is on or off.
 
 `SafeMessagingService` routes each push to exactly one renderer. A push whose
 payload carries a Firebase notification block, or a data-only push the web
@@ -420,33 +423,43 @@ name is the message line, and the conversation title is the header. Without a
 sender it matches what Firebase would have rendered. `vellum-alerts` is the only
 channel a payload may name: it is created if it is missing, because from API 26
 posting to a channel that does not exist is a silent no-op, and any other name
-falls back to it. Existing is not enough, since the voice session channel and
-Firebase's own fallback both exist and both post silently. The notification id
-walks the same seed chain the web layer hashes, the delivery id then the
-Firebase message id then the source event with the copy, so a delivery both
-paths see collapses onto one entry.
+posts here anyway and is logged once. Existing is not enough, since the voice
+session channel and Firebase's own fallback both exist and both post silently.
+The notification id walks the same seed chain the web layer hashes: the
+`delivery_id`, then the Firebase message id, then the composite of the source
+event with the copy. Every rung is trimmed on both sides, so padded copy cannot
+split one delivery in two. A payload carrying no `delivery_id` therefore keys on
+the Firebase message id, which is per-delivery, so it does not collapse onto the
+conversation either.
 
 Each conversation notification also publishes a long-lived dynamic shortcut,
 which is what gives Android the conversation treatment. The shortcut intent is
 the conversation's own app link, never the push's identifiers, so a tap opens
 the thread from a cold or a warm start and a week-old shortcut cannot replay a
-stale delivery. Two conversations keep a shortcut at a time: a product cap on
-how much of the launcher's list a notification may claim, not a budget shared
-with the static New chat and Start voice entries, which are manifest shortcuts
-a dynamic push can never evict. The shortcuts leave with the token on
-`AndroidPushRegistration.unregister`, so the next account does not inherit the
-previous one's conversation titles and avatars.
+stale delivery. That link names the baked cloud host, and `MainActivity` refuses
+an app link while a self-hosted origin is configured, so a self-hosted install
+publishes no shortcut at all rather than one that only foregrounds the app. Two
+conversations keep a shortcut at a time: a product cap on how much of the
+launcher's list a notification may claim. The launcher's own budget counts the
+static New chat and Start voice entries towards the same total, but they are
+manifest shortcuts, so a dynamic push can only ever evict another dynamic one.
+The shortcuts leave with the token on `AndroidPushRegistration.unregister`, once
+that unregister has actually reached the push plugin, so the next account does
+not inherit the previous one's conversation titles and avatars.
 
 `AvatarCache` keeps the sender avatars on disk under the cache directory, eight
 at a time, evicted least-recently-used, each file re-hashed against the name it
-is filed under before it is drawn. The avatar is resolved once the renderer
+is filed under before it is drawn, and deleted when it no longer hashes to that
+name or has grown past the 512 KB cap. The avatar is resolved once the renderer
 confirms a notification can be posted at all, and before it is posted: the cache
 first, then an HTTPS download verified against the pushed sha256. The download
-runs inside `onMessageReceived` with 3 s connect and read timeouts plus a 4 s
-total budget for the body, since the per-read timeout restarts on every chunk.
-All of that is deliberately shorter than the 8 s an iOS notification-service
-extension gets, because the Firebase callback window is much tighter. A miss
-just posts without an avatar.
+runs inside `onMessageReceived` with a 3 s connect timeout, a 2 s read timeout,
+and a 3 s total budget for the body, since the per-read timeout restarts on
+every chunk. The budget is only read between chunks and Android fixes the socket
+timeout when the connection is made, so the read that crosses the budget still
+runs its own timeout out: a connect, the budget, and that last read bound a
+responding host at 8 s. The local cache read carries the cap but no deadline,
+having no host to trickle it. A miss just posts without an avatar.
 
 ### Device QA checklist
 
@@ -469,6 +482,8 @@ push from a lower environment. Verify:
   New chat or Start voice.
 - Signing out clears our conversation shortcuts and leaves New chat and Start
   voice in place.
+- A push arriving while a self-hosted origin is configured posts its banner and
+  publishes no launcher shortcut.
 - On API 24 or 25 the notification plays the default sound.
 - A push naming an unknown channel still arrives, on `vellum-alerts`.
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidNotificationChannelsPlugin.java
@@ -6,10 +6,13 @@ import android.content.Context;
 import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import java.util.HashSet;
+import java.util.Set;
 
 @CapacitorPlugin(name = "AndroidNotificationChannels")
 public class AndroidNotificationChannelsPlugin extends Plugin {
@@ -18,6 +21,14 @@ public class AndroidNotificationChannelsPlugin extends Plugin {
     private static final String ALERTS_CHANNEL_NAME = "Alerts";
     private static final String FAILURE_CODE = "NOTIFICATION_CHANNEL_FAILED";
     private static final String FAILURE_MESSAGE = "Android notification channels are unavailable";
+    /**
+     * A payload picks the channel id, so the warned set is capped: an unknown
+     * name is a platform bug worth one line, never a growing map keyed by
+     * whatever arrives.
+     */
+    private static final int MAX_WARNED_CHANNEL_IDS = 16;
+
+    private static final Set<String> warnedChannelIds = new HashSet<>();
 
     @PluginMethod
     public void ensureAlertsChannel(PluginCall call) {
@@ -35,33 +46,31 @@ public class AndroidNotificationChannelsPlugin extends Plugin {
     }
 
     /**
-     * The channel a natively rendered push posts on. A push can arrive before
-     * the web runtime has ever asked for the alerts channel, and from API 26
-     * posting to a channel that does not exist is a silent no-op, so the
-     * channel is created here and stands in for any channel a payload names
-     * that is not one of ours to alert on.
+     * Creates the channel a natively rendered push posts on. A push can arrive
+     * before the web runtime has ever asked for the alerts channel, and from
+     * API 26 posting to a channel that does not exist is a silent no-op.
+     *
+     * <p>{@link #ALERTS_CHANNEL_ID} is also the only channel a payload may
+     * name, so a push naming another still posts here. Existing is not enough:
+     * the voice session channel and Firebase's own fallback both exist and both
+     * post silently and without a badge.
      */
-    public static String resolveChannelId(Context context, String requestedChannelId) {
+    public static void ensureAlertsChannel(Context context, @Nullable String requestedChannelId) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             createAlertsChannel(context);
         }
-        if (isAlertChannelId(requestedChannelId)) {
-            return requestedChannelId;
+        if (firstWarningFor(requestedChannelId)) {
+            Logger.warn("Android push named a channel that does not alert: " + requestedChannelId);
         }
-        NativeFailureGuard.record(
-            "Android push named a channel that does not alert",
-            new IllegalStateException(requestedChannelId)
-        );
-        return ALERTS_CHANNEL_ID;
     }
 
-    /**
-     * Existing is not enough: the voice session channel and Firebase's own
-     * fallback both exist and both post silently and without a badge, so a
-     * payload can only name a channel this app alerts on.
-     */
-    static boolean isAlertChannelId(@Nullable String channelId) {
-        return ALERTS_CHANNEL_ID.equals(channelId);
+    /** One line per unrecognized channel id, which is a platform bug, not a user's problem. */
+    static synchronized boolean firstWarningFor(@Nullable String channelId) {
+        if (ALERTS_CHANNEL_ID.equals(channelId)) {
+            return false;
+        }
+        return warnedChannelIds.size() < MAX_WARNED_CHANNEL_IDS
+            && warnedChannelIds.add(String.valueOf(channelId));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AndroidPushRegistrationPlugin.java
@@ -33,13 +33,16 @@ public class AndroidPushRegistrationPlugin extends Plugin {
 
     @PluginMethod
     public void unregister(PluginCall call) {
-        // The conversation shortcuts carry the previous account's titles and
-        // avatars, so they leave with its token.
-        NativeFailureGuard.run(
-            "Unable to remove the Android conversation shortcuts",
-            () -> NativePushRenderer.clearConversationShortcuts(getContext())
-        );
-        invokeSafely(call, plugin -> plugin.unregister(call));
+        invokeSafely(call, plugin -> {
+            plugin.unregister(call);
+            // The conversation shortcuts carry the previous account's titles
+            // and avatars, so they leave with its token, and only once the
+            // token is actually on its way out.
+            NativeFailureGuard.run(
+                "Unable to remove the Android conversation shortcuts",
+                () -> NativePushRenderer.clearConversationShortcuts(getContext())
+            );
+        });
     }
 
     @PluginMethod
@@ -49,8 +52,12 @@ public class AndroidPushRegistrationPlugin extends Plugin {
 
     @PluginMethod
     public void setForegroundHandler(PluginCall call) {
-        foregroundHandler = Boolean.TRUE.equals(call.getBoolean("active", false));
+        setForegroundHandler(Boolean.TRUE.equals(call.getBoolean("active", false)));
         call.resolve();
+    }
+
+    static void setForegroundHandler(boolean active) {
+        foregroundHandler = active;
     }
 
     public static boolean hasForegroundHandler() {

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -20,7 +20,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-final class SelfHostedServer {
+public final class SelfHostedServer {
     private static final String CONFIG_DIRECTORY = "capacitor-self-hosted";
     private static final String CONFIG_FILE = "capacitor.config.json";
     private static final String PREFERENCES_NAME = "self_hosted_server";
@@ -65,7 +65,7 @@ final class SelfHostedServer {
 
     private SelfHostedServer() {}
 
-    static URI configured(Context context) {
+    public static URI configured(Context context) {
         return configured(new PreferencesStore(context));
     }
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
@@ -34,10 +34,17 @@ public final class AvatarCache {
     // than the 8 s an iOS notification-service extension gets, and a cached
     // avatar is a handful of kilobytes, so a stalled host has to give up fast.
     private static final int CONNECT_TIMEOUT_MILLIS = 3_000;
-    private static final int READ_TIMEOUT_MILLIS = 3_000;
+    // Bounds the response head and each body read alike.
+    private static final int READ_TIMEOUT_MILLIS = 2_000;
     // The read timeout restarts on every chunk, so the body also gets a total
     // deadline: a host trickling bytes must not cost the whole notification.
-    private static final long READ_BUDGET_MILLIS = 4_000;
+    // The deadline is only read between chunks, and Android fixes the socket
+    // timeout when the connection is made, so the read that crosses it still
+    // runs its full timeout out: a connect, the budget, and that last read
+    // bound a responding host at 8 s.
+    private static final long READ_BUDGET_MILLIS = 3_000;
+    // A local file has no host trickling it, so its read carries no deadline.
+    private static final long NO_DEADLINE = 0;
     private static final int MAX_FILES = 8;
     // A write that never finished belongs to a call that is long gone.
     private static final long TEMPORARY_MAX_AGE_MILLIS = 60_000;
@@ -86,8 +93,8 @@ public final class AvatarCache {
 
     /**
      * Cached bytes whose digest still matches the name they are filed under, so
-     * a truncated or tampered file is dropped rather than drawn. A hit is also
-     * an eviction touch.
+     * an oversized, truncated, or tampered file is deleted rather than drawn. A
+     * hit is also an eviction touch.
      */
     @Nullable
     byte[] verified(@Nullable String hash) {
@@ -96,6 +103,12 @@ public final class AvatarCache {
             return null;
         }
         File file = new File(directory, name + EXTENSION);
+        if (file.length() > MAX_BYTES) {
+            // Too big to have been one of ours. Left in place it would sit in
+            // the eviction list forever, re-read and refused on every push.
+            file.delete();
+            return null;
+        }
         byte[] bytes = read(file);
         if (bytes == null) {
             return null;
@@ -186,7 +199,7 @@ public final class AvatarCache {
     @Nullable
     private static byte[] read(File file) {
         try (FileInputStream input = new FileInputStream(file)) {
-            return readCapped(input, READ_BUDGET_MILLIS);
+            return readCapped(input, NO_DEADLINE);
         } catch (IOException exception) {
             return null;
         }
@@ -218,14 +231,23 @@ public final class AvatarCache {
         }
     }
 
+    /**
+     * Bytes up to {@link #MAX_BYTES}, or null once the payload passes the cap
+     * or the budget runs out. A budget of {@link #NO_DEADLINE} reads to the end
+     * of the stream. Package-private so a test can burn a budget quickly.
+     */
     @Nullable
     static byte[] readCapped(InputStream stream, long budgetMillis) throws IOException {
+        boolean deadlined = budgetMillis > NO_DEADLINE;
         long deadline = System.nanoTime() + budgetMillis * 1_000_000L;
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         byte[] chunk = new byte[8192];
         int read = stream.read(chunk);
         while (read != -1) {
-            if (buffer.size() + read > MAX_BYTES || System.nanoTime() - deadline >= 0) {
+            if (
+                buffer.size() + read > MAX_BYTES
+                    || (deadlined && System.nanoTime() - deadline >= 0)
+            ) {
                 return null;
             }
             buffer.write(chunk, 0, read);

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/NativePushRenderer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/NativePushRenderer.java
@@ -3,6 +3,7 @@ package ai.vellum.assistant.push;
 import ai.vellum.assistant.AndroidNotificationChannelsPlugin;
 import ai.vellum.assistant.NativeFailureGuard;
 import ai.vellum.assistant.R;
+import ai.vellum.assistant.SelfHostedServer;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.PendingIntent;
@@ -20,6 +21,7 @@ import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.content.pm.ShortcutManagerCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import com.google.firebase.messaging.RemoteMessage;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -36,9 +38,10 @@ import java.util.List;
 public final class NativePushRenderer {
     /**
      * How many conversations keep a launcher shortcut. Two is a product choice
-     * about how much of the launcher's shortcut list a notification may claim,
-     * not a budget the static New chat and Start voice entries share: those are
-     * manifest shortcuts, which a dynamic push can never evict.
+     * about how much of the launcher's shortcut list a notification may claim.
+     * The launcher's own budget counts the static New chat and Start voice
+     * entries towards the same total, but they are manifest shortcuts, so a
+     * dynamic push can only ever evict another dynamic one.
      */
     private static final int MAX_CONVERSATION_SHORTCUTS = 2;
 
@@ -60,8 +63,11 @@ public final class NativePushRenderer {
         return NotificationManagerCompat.from(context).areNotificationsEnabled();
     }
 
-    // canPost is the POST_NOTIFICATIONS check, which lint cannot follow across
-    // a method boundary.
+    /**
+     * Posts the notification. The caller checks {@link #canPost} first, which
+     * is the POST_NOTIFICATIONS check lint cannot follow across a method
+     * boundary.
+     */
     @SuppressLint("MissingPermission")
     public static void show(
         Context context,
@@ -69,9 +75,7 @@ public final class NativePushRenderer {
         PushDataMessage message,
         @Nullable Bitmap avatar
     ) {
-        if (!canPost(context)) {
-            return;
-        }
+        AndroidNotificationChannelsPlugin.ensureAlertsChannel(context, message.channelId);
         NotificationManagerCompat manager = NotificationManagerCompat.from(context);
 
         int notificationId = message.notificationId();
@@ -83,7 +87,7 @@ public final class NativePushRenderer {
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(
             context,
-            AndroidNotificationChannelsPlugin.resolveChannelId(context, message.channelId)
+            AndroidNotificationChannelsPlugin.ALERTS_CHANNEL_ID
         )
             .setSmallIcon(R.drawable.ic_stat_notification)
             .setColor(ContextCompat.getColor(context, R.color.notification_icon_color))
@@ -156,11 +160,17 @@ public final class NativePushRenderer {
         Person person,
         @Nullable IconCompat icon
     ) {
-        Intent intent = PushTapIntents.shortcutIntent(context, message.conversationId);
+        String conversationId = message.conversationId;
+        if (
+            !publishesConversationShortcut(conversationId, SelfHostedServer.configured(context))
+        ) {
+            return null;
+        }
+        Intent intent = PushTapIntents.shortcutIntent(context, conversationId);
         if (intent == null) {
             return null;
         }
-        String shortcutId = PushDataMessage.shortcutId(sender.id, message.conversationId);
+        String shortcutId = PushDataMessage.shortcutId(sender.id, conversationId);
         // Trimming is housekeeping: a failure there must not cost this
         // notification the shortcut that gives it the conversation treatment.
         NativeFailureGuard.run(
@@ -184,6 +194,20 @@ public final class NativePushRenderer {
             false
         );
         return pushed ? shortcutId : null;
+    }
+
+    /**
+     * Whether this push earns a launcher shortcut. It needs a conversation to
+     * point at, and the install must not be self-hosted: the tap target is the
+     * app link for the baked cloud host, which MainActivity refuses while a
+     * self-hosted origin is configured, so the shortcut would only foreground
+     * the app and hand its VIEW intent to the bridge as an appUrlOpen.
+     */
+    static boolean publishesConversationShortcut(
+        @Nullable String conversationId,
+        @Nullable URI selfHostedServer
+    ) {
+        return conversationId != null && selfHostedServer == null;
     }
 
     /** Drops our oldest conversation shortcuts so the new one fits within the cap. */

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/PushDataMessage.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/PushDataMessage.java
@@ -42,6 +42,7 @@ public final class PushDataMessage {
         }
     }
 
+    /** Never null on a natively rendered push: {@link #isDataOnly} requires it. */
     @Nullable
     public final String title;
     @Nullable
@@ -123,9 +124,8 @@ public final class PushDataMessage {
      * share a sender id, so the conversation id keeps their shortcuts, ranking,
      * and per-conversation settings apart.
      */
-    static String shortcutId(String senderId, @Nullable String conversationId) {
-        String suffix = conversationId == null ? senderId : senderId + ":" + conversationId;
-        return SHORTCUT_ID_PREFIX + suffix;
+    static String shortcutId(String senderId, String conversationId) {
+        return SHORTCUT_ID_PREFIX + senderId + ":" + conversationId;
     }
 
     /** Stable per-delivery id so a redelivery replaces its own notification. */
@@ -149,7 +149,8 @@ public final class PushDataMessage {
      * The seed chain {@code postForegroundRemotePush} walks: the delivery id,
      * then the Firebase message id it reads as {@code notification.id}, then
      * the source event with the copy. Hashing nothing would collapse unrelated
-     * deliveries onto a single notification id.
+     * deliveries onto a single notification id. Every rung is trimmed on both
+     * sides, so padded copy hashes to the same id here and there.
      */
     private String seed() {
         if (deliveryId != null) {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AndroidNotificationChannelsPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AndroidNotificationChannelsPluginTest.java
@@ -9,17 +9,31 @@ public class AndroidNotificationChannelsPluginTest {
     /**
      * A channel that merely exists is not a channel to alert on: the voice
      * session channel is IMPORTANCE_LOW with no badge, and Firebase's fallback
-     * channel is whatever the OS made of it.
+     * channel is whatever the OS made of it. Naming one is a platform bug, so
+     * it earns a log line rather than a user-visible failure report, and one
+     * line rather than one per push.
      */
     @Test
-    public void onlyTheAlertsChannelIsOneAPayloadMayName() {
-        assertTrue(
-            AndroidNotificationChannelsPlugin.isAlertChannelId(
+    public void warnsOncePerChannelIdAndNeverForTheAlertsChannel() {
+        assertFalse(
+            AndroidNotificationChannelsPlugin.firstWarningFor(
                 AndroidNotificationChannelsPlugin.ALERTS_CHANNEL_ID
             )
         );
-        assertFalse(AndroidNotificationChannelsPlugin.isAlertChannelId("voice_session_status"));
-        assertFalse(AndroidNotificationChannelsPlugin.isAlertChannelId("fcm_fallback_notification_channel"));
-        assertFalse(AndroidNotificationChannelsPlugin.isAlertChannelId(null));
+        assertTrue(AndroidNotificationChannelsPlugin.firstWarningFor("voice_session_status"));
+        assertFalse(
+            "already warned",
+            AndroidNotificationChannelsPlugin.firstWarningFor("voice_session_status")
+        );
+        assertTrue(
+            AndroidNotificationChannelsPlugin.firstWarningFor(
+                "fcm_fallback_notification_channel"
+            )
+        );
+        assertTrue("unnamed", AndroidNotificationChannelsPlugin.firstWarningFor(null));
+        assertFalse(
+            "already warned",
+            AndroidNotificationChannelsPlugin.firstWarningFor(null)
+        );
     }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AndroidPushRegistrationPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AndroidPushRegistrationPluginTest.java
@@ -1,6 +1,8 @@
 package ai.vellum.assistant;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.getcapacitor.JSObject;
 import org.json.JSONArray;
@@ -15,5 +17,26 @@ public class AndroidPushRegistrationPluginTest {
         JSONArray capabilities = payload.getJSONArray("capabilities");
         assertEquals(1, capabilities.length());
         assertEquals("native-notification-render", capabilities.getString(0));
+    }
+
+    /**
+     * The renderer asks this instead of holding the web runtime's handler,
+     * which the plugin instance outlives. A stale true would hand a push to a
+     * torn-down handler and lose it.
+     */
+    @Test
+    public void tracksWhetherTheWebRuntimeHoldsAForegroundHandler() {
+        AndroidPushRegistrationPlugin.clearForegroundHandler();
+        assertFalse(AndroidPushRegistrationPlugin.hasForegroundHandler());
+
+        AndroidPushRegistrationPlugin.setForegroundHandler(true);
+        assertTrue(AndroidPushRegistrationPlugin.hasForegroundHandler());
+
+        AndroidPushRegistrationPlugin.setForegroundHandler(false);
+        assertFalse(AndroidPushRegistrationPlugin.hasForegroundHandler());
+
+        AndroidPushRegistrationPlugin.setForegroundHandler(true);
+        AndroidPushRegistrationPlugin.clearForegroundHandler();
+        assertFalse("a page load takes it", AndroidPushRegistrationPlugin.hasForegroundHandler());
     }
 }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
@@ -22,7 +22,7 @@ import org.junit.rules.TemporaryFolder;
 public class AvatarCacheTest {
     private static final String VELLUM_SHA256 =
         "2fc2a6dd013e7ab41c5a54ab8a254031ff329aa42c5815ac420f1facfe2542d1";
-    private static final long BUDGET_MILLIS = 4_000;
+    private static final long NO_DEADLINE = 0;
 
     @Rule
     public final TemporaryFolder folder = new TemporaryFolder();
@@ -32,7 +32,7 @@ public class AvatarCacheTest {
         byte[] bytes = new byte[512 * 1024];
         bytes[bytes.length - 1] = 7;
 
-        byte[] read = AvatarCache.readCapped(new ByteArrayInputStream(bytes), BUDGET_MILLIS);
+        byte[] read = AvatarCache.readCapped(new ByteArrayInputStream(bytes), NO_DEADLINE);
 
         assertEquals(bytes.length, read.length);
         assertEquals(7, read[read.length - 1]);
@@ -42,7 +42,7 @@ public class AvatarCacheTest {
     public void rejectsAPayloadOverTheCap() throws IOException {
         byte[] bytes = new byte[512 * 1024 + 1];
 
-        assertNull(AvatarCache.readCapped(new ByteArrayInputStream(bytes), BUDGET_MILLIS));
+        assertNull(AvatarCache.readCapped(new ByteArrayInputStream(bytes), NO_DEADLINE));
     }
 
     /**
@@ -53,6 +53,14 @@ public class AvatarCacheTest {
     @Test
     public void givesUpOnAHostThatTricklesPastTheTotalBudget() throws IOException {
         assertNull(AvatarCache.readCapped(tricklingStream(10), 50));
+    }
+
+    /** A local file has no host to trickle it, so its read runs to the end. */
+    @Test
+    public void readsToTheEndWithoutADeadline() throws IOException {
+        byte[] read = AvatarCache.readCapped(tricklingStream(10, 5), NO_DEADLINE);
+
+        assertEquals(5, read.length);
     }
 
     @Test
@@ -115,6 +123,18 @@ public class AvatarCacheTest {
         assertNull(cache.verified(VELLUM_SHA256));
     }
 
+    /** An over-cap file is never served, so leaving it filed wastes the slot forever. */
+    @Test
+    public void dropsACachedAvatarBiggerThanTheCap() throws IOException {
+        File directory = folder.newFolder("oversized");
+        AvatarCache cache = new AvatarCache(directory);
+        File file = new File(directory, VELLUM_SHA256 + ".png");
+        Files.write(file.toPath(), new byte[512 * 1024 + 1]);
+
+        assertNull(cache.verified(VELLUM_SHA256));
+        assertFalse("deleted", file.exists());
+    }
+
     @Test
     public void keepsTheEightNewestAvatarsAndSweepsAbandonedWrites() throws IOException {
         File directory = folder.newFolder("prune");
@@ -148,7 +168,13 @@ public class AvatarCacheTest {
 
     /** A host answering one byte per call, slowly enough to burn the budget. */
     private static InputStream tricklingStream(long millisPerRead) {
+        return tricklingStream(millisPerRead, Integer.MAX_VALUE);
+    }
+
+    private static InputStream tricklingStream(long millisPerRead, int bytes) {
         return new InputStream() {
+            private int served;
+
             @Override
             public int read() {
                 return 0;
@@ -162,6 +188,10 @@ public class AvatarCacheTest {
                     Thread.currentThread().interrupt();
                     throw new IOException(exception);
                 }
+                if (served == bytes) {
+                    return -1;
+                }
+                served++;
                 buffer[offset] = 1;
                 return 1;
             }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/NativePushRendererTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/NativePushRendererTest.java
@@ -1,7 +1,10 @@
 package ai.vellum.assistant.push;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +53,26 @@ public class NativePushRendererTest {
         );
 
         assertEquals(Collections.singletonList(MIDDLE), stale);
+    }
+
+    /**
+     * A shortcut's tap target is the baked cloud app link, which MainActivity
+     * refuses while a self-hosted origin is configured, so the notification
+     * claims no shortcut at all rather than one that only foregrounds the app.
+     */
+    @Test
+    public void publishesNoConversationShortcutAgainstASelfHostedOrigin() {
+        URI selfHosted = URI.create("https://vellum.internal.example.com");
+
+        assertTrue(NativePushRenderer.publishesConversationShortcut("conversation-1", null));
+        assertFalse(
+            "self-hosted",
+            NativePushRenderer.publishesConversationShortcut("conversation-1", selfHosted)
+        );
+        assertFalse(
+            "no conversation to point at",
+            NativePushRenderer.publishesConversationShortcut(null, null)
+        );
     }
 
     /** The launcher's own entries are not ours to remove on logout. */

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/PushDataMessageTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/PushDataMessageTest.java
@@ -132,20 +132,6 @@ public class PushDataMessageTest {
         );
     }
 
-    @Test
-    public void theShortcutIdFallsBackToTheAssistantWithoutAConversation() {
-        Map<String, String> data = alertData();
-        data.remove("conversationId");
-
-        PushDataMessage message = message(data);
-
-        assertNull(message.conversationId);
-        assertEquals(
-            "vellum-conversation:assistant-1",
-            PushDataMessage.shortcutId("assistant-1", message.conversationId)
-        );
-    }
-
     /** Pruning has to tell our conversation shortcuts from the launcher's own. */
     @Test
     public void everyShortcutIdCarriesTheOwnershipPrefix() {
@@ -217,6 +203,24 @@ public class PushDataMessageTest {
                 "chat.assistant_turn_complete:Weekly review:Ready when you are."
             ),
             message(data).notificationId()
+        );
+    }
+
+    /**
+     * Both sides trim every rung before hashing, so padding in the payload
+     * cannot split one delivery across a native and a web notification.
+     */
+    @Test
+    public void theFallbackSeedIgnoresPaddingTheWayTheWebLayerDoes() {
+        Map<String, String> padded = alertData();
+        padded.remove("delivery_id");
+        padded.put("title", "  Weekly review  ");
+        padded.put("body", "\tReady when you are.\n");
+        padded.put("source_event_name", " remote_push ");
+
+        assertEquals(
+            126856326,
+            PushDataMessage.of(padded, false, "   ").notificationId()
         );
     }
 }

--- a/clients/web/src/hooks/use-push-registration.test.tsx
+++ b/clients/web/src/hooks/use-push-registration.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The effect that owns the Android shell's foreground-handler flag. The shell
+ * renders a data-only push itself whenever the flag says the web layer holds no
+ * handler, so a mount that forgets to raise it double-renders and an unmount
+ * that forgets to lower it drops the push entirely.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+const realPushRegistration = await import("@/runtime/push-registration");
+
+type Handler = ((push: unknown) => void) | null;
+
+const handlerCalls: Handler[] = [];
+const setForegroundPushHandlerMock = mock((handler: Handler) => {
+  handlerCalls.push(handler);
+});
+const registerCalls: string[] = [];
+const registerForRemotePushMock = mock(async (assistantId: string) => {
+  registerCalls.push(assistantId);
+});
+mock.module("@/runtime/push-registration", () => ({
+  ...realPushRegistration,
+  registerForRemotePush: registerForRemotePushMock,
+  setForegroundPushHandler: setForegroundPushHandlerMock,
+}));
+
+const foregroundPushHandler = () => {};
+mock.module("@/runtime/notifications", () => ({
+  postForegroundRemotePush: foregroundPushHandler,
+}));
+
+const { usePushRegistration } = await import("@/hooks/use-push-registration");
+
+beforeEach(() => {
+  handlerCalls.length = 0;
+  registerCalls.length = 0;
+  setForegroundPushHandlerMock.mockClear();
+  registerForRemotePushMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("usePushRegistration", () => {
+  test("installs the handler and registers while an assistant is active", () => {
+    renderHook(() => usePushRegistration("assistant-1"));
+
+    expect(handlerCalls).toEqual([foregroundPushHandler]);
+    expect(registerCalls).toEqual(["assistant-1"]);
+  });
+
+  test("clears the handler on unmount so the shell takes the push back", () => {
+    const { unmount } = renderHook(() => usePushRegistration("assistant-1"));
+    unmount();
+
+    expect(handlerCalls).toEqual([foregroundPushHandler, null]);
+  });
+
+  /**
+   * The early exit is what makes the previous cleanup's clear stick: touching
+   * the handler here would re-install it for an assistant that is gone.
+   */
+  test("leaves the previous cleanup's clear in place when the assistant goes away", () => {
+    const { rerender } = renderHook(
+      ({ assistantId }: { assistantId: string | null }) =>
+        usePushRegistration(assistantId),
+      { initialProps: { assistantId: "assistant-1" as string | null } },
+    );
+
+    rerender({ assistantId: null });
+
+    expect(handlerCalls).toEqual([foregroundPushHandler, null]);
+    expect(registerCalls).toEqual(["assistant-1"]);
+  });
+});

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -318,6 +318,29 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     expect(scheduled?.body).toBe("Standup notes are up");
   });
 
+  /**
+   * The Android shell trims every field it hashes into a notification id, so
+   * padded copy must not seed a second id and show the delivery twice. The
+   * expected id is the one PushDataMessageTest pins for the same push.
+   */
+  test("a padded data-only push hashes to the id the Android shell derives", async () => {
+    nativeAndroid = true;
+    postForegroundRemotePush({
+      id: "   ",
+      data: {
+        title: "  Weekly review  ",
+        body: "\tReady when you are.\n",
+        source_event_name: " remote_push ",
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const scheduled = scheduleMock.mock.calls[0]?.[0].notifications[0];
+    expect(scheduled?.title).toBe("Weekly review");
+    expect(scheduled?.body).toBe("Ready when you are.");
+    expect(scheduled?.id).toBe(126856326);
+  });
+
   test("a concurrent waiter retries after scheduling fails", async () => {
     nativeAndroid = true;
     let rejectFirst!: (error: Error) => void;

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -678,17 +678,22 @@ export function postForegroundRemotePush(
     typeof notification.data === "object" && notification.data !== null
       ? (notification.data as Record<string, unknown>)
       : {};
-  const text = (value: unknown): string | undefined =>
-    typeof value === "string" ? value : undefined;
-  const deliveryId = text(data.delivery_id) ?? notification.id;
+  // Trimmed, and blank read as absent, because the Android shell trims every
+  // field it hashes into a notification id (PushDataMessage.trimmed): padded
+  // copy that seeded two different ids would show the same delivery twice.
+  const text = (value: unknown): string | undefined => {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    return trimmed === "" ? undefined : trimmed;
+  };
+  const deliveryId = text(data.delivery_id) ?? text(notification.id);
   const sourceEventName = text(data.source_event_name) ?? "remote_push";
   const conversationId = extractPushConversationId(data);
 
   void postLocalNotification({
     // A data-only push carries no notification block, so the copy the OS
     // would have rendered lives in `data`.
-    title: notification.title ?? text(data.title) ?? "Vellum",
-    body: notification.body ?? text(data.body) ?? "",
+    title: text(notification.title) ?? text(data.title) ?? "Vellum",
+    body: text(notification.body) ?? text(data.body) ?? "",
     sourceEventName,
     deliveryId,
     correlationId: deliveryId,

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -19,8 +19,11 @@ let androidCapabilities: unknown = {
 const androidGetCapabilitiesMock = mock(async () => androidCapabilities);
 let androidSetForegroundHandlerError: Error | null = null;
 const foregroundHandlerStates: boolean[] = [];
+/** Whether the web layer held a handler at the moment the shell was told. */
+const handlerHeldWhenTold: boolean[] = [];
 const androidSetForegroundHandlerMock = mock(
   async ({ active }: { active: boolean }) => {
+    handlerHeldWhenTold.push(hasForegroundPushHandlerForTests());
     if (androidSetForegroundHandlerError) {
       throw androidSetForegroundHandlerError;
     }
@@ -201,6 +204,7 @@ const {
   registerForRemotePush,
   setForegroundPushHandler,
   unregisterFromRemotePush,
+  __hasForegroundPushHandlerForTests: hasForegroundPushHandlerForTests,
   __resetPushRegistrationStateForTests,
 } = await import("@/runtime/push-registration");
 
@@ -257,6 +261,7 @@ beforeEach(() => {
   androidSetForegroundHandlerMock.mockClear();
   androidSetForegroundHandlerError = null;
   foregroundHandlerStates.length = 0;
+  handlerHeldWhenTold.length = 0;
   ensureAndroidAlertsChannelMock.mockClear();
   callOrder.length = 0;
   getInfoMock.mockClear();
@@ -742,37 +747,64 @@ describe("unregisterFromRemotePush", () => {
 });
 
 describe("setForegroundPushHandler", () => {
-  test("tells the Android shell when a handler is live and when it is gone", () => {
+  test("tells the Android shell when a handler is live and when it is gone", async () => {
     platform = "android";
 
     setForegroundPushHandler(() => {});
     setForegroundPushHandler(null);
+    await flushMicrotasks(2);
 
     expect(foregroundHandlerStates).toEqual([true, false]);
   });
 
-  test("says nothing on iOS, which has no native renderer to hand back to", () => {
-    setForegroundPushHandler(() => {});
+  /**
+   * A push landing between the two states has to reach a renderer. The handler
+   * goes in before the shell hears one is live, and the shell hears one is gone
+   * before it comes out, so the only overlap is the shell rendering natively
+   * while the web still holds an idle handler.
+   */
+  test("installs the handler before the shell hears of it, and drops it after", async () => {
+    platform = "android";
 
-    expect(androidSetForegroundHandlerMock).not.toHaveBeenCalled();
+    setForegroundPushHandler(() => {});
+    setForegroundPushHandler(null);
+    await flushMicrotasks(2);
+
+    expect(handlerHeldWhenTold).toEqual([true, true]);
+    expect(hasForegroundPushHandlerForTests()).toBe(false);
   });
 
-  test("says nothing to an Android shell without the guarded plugin", () => {
+  test("says nothing on iOS, which has no native renderer to hand back to", async () => {
+    setForegroundPushHandler(() => {});
+    await flushMicrotasks(2);
+
+    expect(androidSetForegroundHandlerMock).not.toHaveBeenCalled();
+    expect(hasForegroundPushHandlerForTests()).toBe(true);
+  });
+
+  test("says nothing to an Android shell without the guarded plugin", async () => {
     platform = "android";
     androidPushRegistrationAvailable = false;
 
     setForegroundPushHandler(() => {});
+    await flushMicrotasks(2);
 
     expect(androidSetForegroundHandlerMock).not.toHaveBeenCalled();
+    expect(hasForegroundPushHandlerForTests()).toBe(true);
   });
 
-  test("swallows a rejection from a shell whose plugin lacks the method", async () => {
+  test("reports a rejection once and keeps the handler the shell cannot hear about", async () => {
     platform = "android";
     androidSetForegroundHandlerError = new Error("not implemented");
 
     setForegroundPushHandler(() => {});
+    setForegroundPushHandler(null);
     await flushMicrotasks(2);
 
-    expect(androidSetForegroundHandlerMock).toHaveBeenCalledTimes(1);
+    expect(androidSetForegroundHandlerMock).toHaveBeenCalledTimes(2);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    // A shell still believing the web renders must not be paired with a web
+    // layer that no longer does.
+    expect(hasForegroundPushHandlerForTests()).toBe(true);
   });
 });

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -123,6 +123,8 @@ let currentAssistantId: string | null = null;
 let lastRegistered: RegisteredToken | null = null;
 let foregroundPushHandler: ((push: PushNotificationSchema) => void) | null =
   null;
+let foregroundHandlerQueue = Promise.resolve();
+let foregroundHandlerFailureReported = false;
 const pendingUpserts = new Set<Promise<void>>();
 let androidUpsertQueue = Promise.resolve();
 
@@ -173,6 +175,11 @@ export function isRemotePushSupported(): boolean {
  * The platform sends data-only FCM messages only to tokens claiming
  * `native-notification-render`, so an older shell whose plugin lacks the
  * method must report nothing and keep receiving notification-block pushes.
+ *
+ * The claim is deliberately not gated on `push-avatar-sender`: that flag is the
+ * platform's own switch for the data-only shape, while this says which tokens
+ * could render one. A shell that can render natively says so whether the flag
+ * is on or off.
  */
 async function readAndroidCapabilities(): Promise<string[]> {
   if (!Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)) {
@@ -318,26 +325,60 @@ async function deleteRegisteredToken(
 }
 
 /**
- * Install or clear the handler for pushes that arrive while the app is on
- * screen, and tell the Android shell which it is. The native renderer posts a
- * data-only push itself whenever no handler is live, so a push arriving on a
- * route that has torn this down reaches the user instead of a no-op.
+ * Tell the Android shell whether the web layer holds a foreground handler.
+ *
+ * @returns false only when the shell rejected, and so still believes whatever
+ *   it believed before.
  */
-export function setForegroundPushHandler(
-  handler: ((push: PushNotificationSchema) => void) | null,
-): void {
-  foregroundPushHandler = handler;
+async function announceForegroundHandler(active: boolean): Promise<boolean> {
   if (
     Capacitor.getPlatform() !== "android" ||
     !Capacitor.isPluginAvailable(ANDROID_PUSH_REGISTRATION_PLUGIN)
   ) {
-    return;
+    return true;
   }
-  void AndroidPushRegistration.setForegroundHandler({
-    active: handler !== null,
-  }).catch(() => {
-    // An older shell has no such method, and its renderer already treats every
-    // data-only push as its own.
+  try {
+    await AndroidPushRegistration.setForegroundHandler({ active });
+    return true;
+  } catch (err) {
+    if (!foregroundHandlerFailureReported) {
+      // An older shell has no such method, and its renderer already treats
+      // every data-only push as its own. Once is enough to say so.
+      foregroundHandlerFailureReported = true;
+      captureError(err, {
+        context: "push_foreground_handler",
+        level: "warning",
+        bestEffort: true,
+      });
+    }
+    return false;
+  }
+}
+
+/**
+ * Install or clear the handler for pushes that arrive while the app is on
+ * screen, and tell the Android shell which it is. The native renderer posts a
+ * data-only push itself whenever no handler is live, so a push arriving on a
+ * route that has torn this down reaches the user instead of a no-op.
+ *
+ * The two moves are serialized, and each is ordered so a push landing part-way
+ * through still finds a renderer: the handler goes in before the shell hears
+ * one is live, and the shell hears one is gone before the handler comes out.
+ * A rejected call keeps the handler, since a shell that believes the web
+ * renders while the web does not is the one pairing that drops a push.
+ */
+export function setForegroundPushHandler(
+  handler: ((push: PushNotificationSchema) => void) | null,
+): void {
+  foregroundHandlerQueue = foregroundHandlerQueue.then(async () => {
+    if (handler !== null) {
+      foregroundPushHandler = handler;
+      await announceForegroundHandler(true);
+      return;
+    }
+    if (await announceForegroundHandler(false)) {
+      foregroundPushHandler = null;
+    }
   });
 }
 
@@ -536,12 +577,19 @@ export function hasSessionConfirmedRemotePushRegistration(
   );
 }
 
+/** Test-only: whether a foreground handler is currently installed. */
+export function __hasForegroundPushHandlerForTests(): boolean {
+  return foregroundPushHandler !== null;
+}
+
 /** Test-only: reset module + persisted state between cases. */
 export function __resetPushRegistrationStateForTests(): void {
   listenersRegistered = false;
   currentAssistantId = null;
   lastRegistered = null;
   foregroundPushHandler = null;
+  foregroundHandlerQueue = Promise.resolve();
+  foregroundHandlerFailureReported = false;
   pendingUpserts.clear();
   androidUpsertQueue = Promise.resolve();
   persistedRegistration.remove();


### PR DESCRIPTION
## Summary

- `setForegroundPushHandler` now serializes its two moves and orders each so a push landing mid-change still finds a renderer: the JS handler goes in before the shell hears one is live, and the shell hears one is gone before the handler comes out. A rejected native call keeps the handler and is reported once.
- `AvatarCache` read timeout drops to 2 s and the body budget to 3 s, so a connect plus the budget plus the read that crosses it bound a responding host at 8 s. The local cache-file read carries the cap but no deadline.
- A cached avatar over the 512 KB cap is now deleted instead of being refused on every push while holding an eviction slot.
- `NativePushRenderer` publishes no conversation shortcut while a self-hosted origin is configured, since `MainActivity` refuses the baked cloud app link there and the shortcut would only foreground the app.
- `resolveChannelId` becomes `ensureAlertsChannel(context, requestedChannelId)`: an unrecognized channel id is a bounded, once-per-id log line rather than a user-visible failure report on every push.
- `postForegroundRemotePush` trims every field it feeds the notification-id seed, matching `PushDataMessage.trimmed`, so padded copy cannot show one delivery twice.
- Cleanups: unreachable `shortcutId` fallback removed, duplicate `canPost` check dropped, shortcuts cleared only once the unregister reaches the push plugin, corrected shortcut-cap comment, and new tests for the foreground-handler effect, the handler flag, the warn-once behavior, the self-hosted guard, the over-cap eviction, and the trimmed seed parity.

Round-3 self-review fixes for the notification avatar feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1