### PR TITLE
refactor(web): one DetailShell title cluster and body inset for the chat-side panels

### DIFF
--- a/clients/web/src/components/detail-shell.tsx
+++ b/clients/web/src/components/detail-shell.tsx
@@ -9,7 +9,9 @@
  * alone, exported for hosts whose body/footer can't fit the default
  * scrollable-body wrapper (e.g. `AcpRunChatView`, which owns its own inner
  * scroll container and a sticky composer) but still need a pixel-identical
- * header.
+ * header. `DetailShellTitleWithCount` is the "title · N" header cluster,
+ * exported with its midline dot and the body's inset so every panel draws
+ * them from one place.
  */
 
 import type { LucideIcon } from "lucide-react";
@@ -17,6 +19,51 @@ import { X } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Button, Typography } from "@vellumai/design-library";
+
+import { cn } from "@/utils/misc";
+
+/** Horizontal inset of the scrollable body, in px. */
+export const DETAIL_SHELL_BODY_INSET_PX = 20;
+
+/** The 3px midline dot between a title and the count beside it. */
+export function DetailShellMidlineDot({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]",
+        className,
+      )}
+    />
+  );
+}
+
+/** Header title cluster: title · count, inline at the same size. */
+export function DetailShellTitleWithCount({
+  title,
+  count,
+}: {
+  title: ReactNode;
+  count: ReactNode;
+}) {
+  return (
+    <span className="flex min-w-0 items-center gap-1.5 py-0.5">
+      <Typography
+        variant="title-medium"
+        className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
+      >
+        {title}
+      </Typography>
+      <DetailShellMidlineDot />
+      <Typography
+        variant="title-medium"
+        className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"
+      >
+        {count}
+      </Typography>
+    </span>
+  );
+}
 
 export interface DetailShellHeaderProps {
   /** Lucide icon rendered with default sizing/color. Ignored when `icon` is set. */
@@ -139,7 +186,12 @@ export function DetailShell({
       <DetailShellHeader {...headerProps} />
 
       {/* Scrollable body */}
-      <div className="flex-1 overflow-y-auto px-5 py-5">{children}</div>
+      <div
+        className="flex-1 overflow-y-auto py-5"
+        style={{ paddingInline: DETAIL_SHELL_BODY_INSET_PX }}
+      >
+        {children}
+      </div>
 
       {/* Pinned footer. Divider uses `--border-hover`, matching the header:
           `--border-base` equals the drawer's `--surface-lift` in dark mode

--- a/clients/web/src/domains/chat/components/activity-steps-panel.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.tsx
@@ -25,7 +25,10 @@ import { useState } from "react";
 import { Button, Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
-import { DetailShell } from "@/components/detail-shell";
+import {
+  DetailShell,
+  DetailShellTitleWithCount,
+} from "@/components/detail-shell";
 import { useTranslation } from "@/i18n";
 import { StreamingShimmerText } from "@/domains/chat/components/streaming-shimmer-text";
 import {
@@ -148,34 +151,16 @@ export function ActivityStepsPanel({
             {stepDetailTitle}
           </Typography>
         ) : (
-          // Timeline level, per Figma: title · N steps — inline at the same
-          // size, separated by a 3px midline dot, count in the secondary tone.
-          <span className="flex min-w-0 items-center gap-1.5 py-0.5">
-            <Typography
-              variant="title-medium"
-              className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
-            >
-              {isRunning ? (
+          <DetailShellTitleWithCount
+            title={
+              isRunning ? (
                 <StreamingShimmerText>{title}</StreamingShimmerText>
               ) : (
                 title
-              )}
-            </Typography>
-            {cardData.stepCount ? (
-              <>
-                <span
-                  aria-hidden
-                  className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
-                />
-                <Typography
-                  variant="title-medium"
-                  className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"
-                >
-                  {cardData.stepCount}
-                </Typography>
-              </>
-            ) : null}
-          </span>
+              )
+            }
+            count={cardData.stepCount}
+          />
         )
       }
       closeLabel={t("activityStepsPanel.closeSteps")}

--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -13,12 +13,13 @@ import { ChevronLeft, Layers } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo } from "react";
 
-import { Button, Typography } from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library";
 
 import { DeleteAppDialog } from "@/components/delete-app-dialog";
 import {
   DetailShell,
   type DetailShellHeaderProps,
+  DetailShellTitleWithCount,
 } from "@/components/detail-shell";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
 import {
@@ -49,30 +50,6 @@ export interface ChatInfoPanelProps {
   onClose: () => void;
   /** See All drills in with a category; the back control passes `null`. */
   onSelectCategory: (category: ChatInfoCategory | null) => void;
-}
-
-/** The drilled-in header's title cluster: title · N, as every detail panel draws it. */
-function TitleWithCount({ title, count }: { title: string; count: number }) {
-  return (
-    <span className="flex min-w-0 items-center gap-1.5 py-0.5">
-      <Typography
-        variant="title-medium"
-        className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
-      >
-        {title}
-      </Typography>
-      <span
-        aria-hidden
-        className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
-      />
-      <Typography
-        variant="title-medium"
-        className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"
-      >
-        {count}
-      </Typography>
-    </span>
-  );
 }
 
 export function ChatInfoPanel({
@@ -297,7 +274,7 @@ export function ChatInfoPanel({
             />
           ),
           titleNode: (
-            <TitleWithCount
+            <DetailShellTitleWithCount
               title={categoryTitles[level]}
               count={counts[level]}
             />

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -8,9 +8,20 @@
  * never inspects a tile, so the real Chat Info tiles would only add mocks.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
+import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
+import { CHAT_INFO_APP_TILE_WIDTH_PX } from "@/domains/chat/components/chat-info-app-tile";
+import { CHAT_INFO_FILE_TILE_WIDTH_PX } from "@/domains/chat/components/chat-info-file-tile";
 import type * as ElementSizeModule from "@/hooks/use-element-size";
 import type * as IsMobileModule from "@/hooks/use-is-mobile";
 
@@ -38,11 +49,10 @@ mock.module(
 const { ChatInfoSection, fitTileCount } =
   await import("@/domains/chat/components/chat-info-section");
 
-/** The mock's tile widths: apps and files or camera frames. */
-const APP_TILE_WIDTH = 184;
-const FILE_TILE_WIDTH = 135;
 /** The drawer's body width on the desktop mock. */
 const DRAWER_WIDTH = 569;
+/** What a 402px phone leaves once the body takes its inset off both edges. */
+const NARROW_COLUMN_WIDTH = 402 - DETAIL_SHELL_BODY_INSET_PX * 2;
 
 const SEE_ALL_ARIA = "See all apps";
 const TILE_TESTID = "section-tile";
@@ -102,26 +112,33 @@ afterEach(() => {
   cleanup();
 });
 
+afterAll(() => {
+  mock.restore();
+});
+
 describe("fitTileCount", () => {
   test.each([
-    [DRAWER_WIDTH, APP_TILE_WIDTH, 3],
-    [DRAWER_WIDTH, FILE_TILE_WIDTH, 4],
-    [378, APP_TILE_WIDTH, 2],
-    [378, FILE_TILE_WIDTH, 2],
-    [0, FILE_TILE_WIDTH, 1],
-    [100, FILE_TILE_WIDTH, 1],
+    [DRAWER_WIDTH, CHAT_INFO_APP_TILE_WIDTH_PX, 3],
+    [DRAWER_WIDTH, CHAT_INFO_FILE_TILE_WIDTH_PX, 4],
+    [378, CHAT_INFO_APP_TILE_WIDTH_PX, 2],
+    [378, CHAT_INFO_FILE_TILE_WIDTH_PX, 2],
+    [0, CHAT_INFO_FILE_TILE_WIDTH_PX, 1],
+    [100, CHAT_INFO_FILE_TILE_WIDTH_PX, 1],
   ])("fits %p / %p tiles on one line", (rowWidth, tileWidth, expected) => {
     expect(fitTileCount(rowWidth, tileWidth)).toBe(expected);
   });
 
   test("a wider gutter fits fewer tiles on the same row", () => {
-    expect(fitTileCount(DRAWER_WIDTH, APP_TILE_WIDTH, 40)).toBe(2);
+    expect(fitTileCount(DRAWER_WIDTH, CHAT_INFO_APP_TILE_WIDTH_PX, 40)).toBe(2);
   });
 });
 
 describe("ChatInfoSection", () => {
   test("truncates a roomy row to the tiles that fit and offers See All", () => {
-    renderSection({ items: makeItems(5), tileWidth: APP_TILE_WIDTH });
+    renderSection({
+      items: makeItems(5),
+      tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
+    });
 
     expect(tiles()).toHaveLength(3);
     expect(tiles()[0]?.getAttribute("data-layout")).toBe("fitted");
@@ -129,7 +146,10 @@ describe("ChatInfoSection", () => {
   });
 
   test("shows every tile and no See All when the category fits", () => {
-    renderSection({ items: makeItems(4), tileWidth: FILE_TILE_WIDTH });
+    renderSection({
+      items: makeItems(4),
+      tileWidth: CHAT_INFO_FILE_TILE_WIDTH_PX,
+    });
 
     expect(tiles()).toHaveLength(4);
     expect(seeAll()).toBeNull();
@@ -139,7 +159,7 @@ describe("ChatInfoSection", () => {
     renderSection({
       items: makeItems(4),
       count: 12,
-      tileWidth: FILE_TILE_WIDTH,
+      tileWidth: CHAT_INFO_FILE_TILE_WIDTH_PX,
     });
 
     expect(tiles()).toHaveLength(4);
@@ -150,7 +170,7 @@ describe("ChatInfoSection", () => {
     isMobileRef.value = true;
     const { container } = renderSection({
       items: makeItems(5),
-      tileWidth: APP_TILE_WIDTH,
+      tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
     });
 
     const strip = container.querySelector(
@@ -165,14 +185,14 @@ describe("ChatInfoSection", () => {
   });
 
   test("counts the strip's reclaimed right inset toward the narrow-window fit", () => {
-    // A 402px phone leaves a 362px column; the strip shows 382px of tiles.
+    // The strip shows the column plus the inset it reclaims on the right.
     isMobileRef.value = true;
-    widthRef.value = 362;
+    widthRef.value = NARROW_COLUMN_WIDTH;
 
     const fitted = renderSection({
       items: makeItems(2),
       count: 2,
-      tileWidth: APP_TILE_WIDTH,
+      tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
     });
     expect(seeAll()).toBeNull();
     // Nothing runs past the edge, so the strip claims no trailing inset.
@@ -182,7 +202,7 @@ describe("ChatInfoSection", () => {
     const overflowing = renderSection({
       items: makeItems(3),
       count: 3,
-      tileWidth: APP_TILE_WIDTH,
+      tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
     });
     expect(seeAll()).not.toBeNull();
     expect(
@@ -194,7 +214,7 @@ describe("ChatInfoSection", () => {
     let seeAllCalls = 0;
     renderSection({
       items: makeItems(5),
-      tileWidth: APP_TILE_WIDTH,
+      tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
       onSeeAll: () => {
         seeAllCalls += 1;
       },
@@ -209,7 +229,7 @@ describe("ChatInfoSection", () => {
     renderSection({
       items: makeItems(4),
       count: 12,
-      tileWidth: FILE_TILE_WIDTH,
+      tileWidth: CHAT_INFO_FILE_TILE_WIDTH_PX,
     });
 
     expect(screen.getByText("Apps")).not.toBeNull();

--- a/clients/web/src/domains/chat/components/chat-info-section.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.tsx
@@ -7,10 +7,14 @@
  * fit rule.
  */
 
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { Button, ScrollShadow, Typography } from "@vellumai/design-library";
 
+import {
+  DETAIL_SHELL_BODY_INSET_PX,
+  DetailShellMidlineDot,
+} from "@/components/detail-shell";
 import { useElementSize } from "@/hooks/use-element-size";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTranslation } from "@/i18n";
@@ -19,11 +23,10 @@ import { cn } from "@/utils/misc";
 /** Gutter between tiles, the pixel value behind the rows' `gap-2`. */
 export const CHAT_INFO_TILE_GAP_PX = 8;
 
-/**
- * How far the narrow-window strip runs past the measured column on the right:
- * `DetailShell`'s 20px body inset, which the strip's `-mx-5 px-5` reclaims.
- */
-const MOBILE_STRIP_BLEED_PX = 20;
+/** Feeds the strip's own margin and padding classes below. */
+const STRIP_BLEED_STYLE = {
+  "--chat-info-strip-bleed": `${DETAIL_SHELL_BODY_INSET_PX}px`,
+} as CSSProperties;
 
 /** Whole tiles that fit on one line of `rowWidth`, never fewer than one. */
 export function fitTileCount(
@@ -68,7 +71,7 @@ export function ChatInfoSection<T>({
   const isMobile = useIsMobile();
   // The strip runs through the body's right inset, so that width counts too.
   const fit = fitTileCount(
-    isMobile ? size.w + MOBILE_STRIP_BLEED_PX : size.w,
+    isMobile ? size.w + DETAIL_SHELL_BODY_INSET_PX : size.w,
     tileWidth,
   );
   const showSeeAll = count > fit;
@@ -77,7 +80,7 @@ export function ChatInfoSection<T>({
   const stripOverflows = items.length > fit;
 
   return (
-    <section className="flex flex-col gap-3">
+    <section className="flex flex-col gap-3" style={STRIP_BLEED_STYLE}>
       <div className="flex items-center justify-between gap-3">
         <span className="flex min-w-0 items-center gap-1">
           <Typography
@@ -86,10 +89,7 @@ export function ChatInfoSection<T>({
           >
             {title}
           </Typography>
-          <span
-            aria-hidden
-            className="size-[3px] shrink-0 rounded-full bg-[var(--content-disabled)]"
-          />
+          <DetailShellMidlineDot className="bg-[var(--content-disabled)]" />
           <Typography
             variant="title-small"
             className="shrink-0 text-[var(--content-disabled)]"
@@ -116,13 +116,16 @@ export function ChatInfoSection<T>({
           measured width, so See All and the visible tiles can never disagree:
           a roomy window truncates the line to what fits, a narrow one scrolls
           the whole fetched set past the same edge. The strip cancels
-          `DetailShell`'s 20px body inset so tiles run to the viewport edge. */}
+          `DetailShell`'s body inset so tiles run to the viewport edge. */}
       <div ref={ref} className="w-full">
         {isMobile ? (
           <ScrollShadow
             orientation="horizontal"
             hideScrollBar
-            className={cn("-mx-5 pl-5", stripOverflows && "pr-5")}
+            className={cn(
+              "-mx-[var(--chat-info-strip-bleed)] pl-[var(--chat-info-strip-bleed)]",
+              stripOverflows && "pr-[var(--chat-info-strip-bleed)]",
+            )}
           >
             <div
               className="flex w-max gap-2"

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -1,4 +1,3 @@
-
 import { useTranslation } from "@/i18n";
 /**
  * Side-drawer panel listing every attachment on one transcript message.
@@ -17,7 +16,10 @@ import { Paperclip } from "lucide-react";
 
 import { Typography } from "@vellumai/design-library";
 
-import { DetailShell } from "@/components/detail-shell";
+import {
+  DetailShell,
+  DetailShellTitleWithCount,
+} from "@/components/detail-shell";
 import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 import { useLiveMessageAttachments } from "@/domains/chat/hooks/use-live-message-attachments";
 import type { MessageFilesPayload } from "@/stores/viewer-store";
@@ -43,27 +45,11 @@ export function MessageFilesPanel({
   return (
     <DetailShell
       Glyph={Paperclip}
-      // Matches the activity-steps panel header: title · N inline at the same
-      // size, separated by a 3px midline dot, count in the secondary tone.
       titleNode={
-        <span className="flex min-w-0 items-center gap-1.5 py-0.5">
-          <Typography
-            variant="title-medium"
-            className="min-w-0 shrink truncate leading-snug text-[var(--content-default)]"
-          >
-            {t("messageFilesPanel.title")}
-          </Typography>
-          <span
-            aria-hidden
-            className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
-          />
-          <Typography
-            variant="title-medium"
-            className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"
-          >
-            {displayAttachments.length}
-          </Typography>
-        </span>
+        <DetailShellTitleWithCount
+          title={t("messageFilesPanel.title")}
+          count={displayAttachments.length}
+        />
       }
       closeLabel={t("messageFilesPanel.closeAria")}
       onClose={onClose}


### PR DESCRIPTION
## Summary
- export DetailShellTitleWithCount, DetailShellMidlineDot, and DETAIL_SHELL_BODY_INSET_PX from detail-shell
- chat-info, message-files, and activity-steps panels consume the shared cluster; chat-info section derives its strip bleed from the inset constant
- section test imports the tile width constants and restores mocks

Part of plan: chat-info-assets-panel.md (remediation round 2)