### PR TITLE
test(web): chat-info stories and tests share one fixture layer

### DIFF
--- a/clients/web/docs/I18N.md
+++ b/clients/web/docs/I18N.md
@@ -43,8 +43,10 @@ component's own name with a lowercase first letter:
 ```jsonc
 // locales/en/chat.json
 {
+  "chatInfoPanel": {
+    "title": "Chat Info",
+  },
   "conversationAssets": {
-    "heading": "Assets",
     "label": "{count, plural, one {# asset} other {# assets}}",
   },
 }
@@ -75,7 +77,7 @@ is worded well, which is why the surrounding catalog is the reference.
 import { useTranslation } from "@/i18n";
 
 const { t } = useTranslation("chat");
-return <h2>{t("conversationAssets.heading")}</h2>;
+return <h2>{t("chatInfoPanel.title")}</h2>;
 ```
 
 Outside React (stores, event handlers, toasts) use the bound `t`:

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -291,6 +291,14 @@ const emDashEnforcedPaths = [
   // pre-existing em dashes that must not be swept retroactively.
   "src/domains/chat/components/surfaces/watch-retro-surface.tsx",
   "src/domains/chat/components/surfaces/watch-retro-surface.test.tsx",
+  // Chat Info: the panel and its rows, the tiles, the mobile host, the asset
+  // menus, the header trigger, and the hooks the three of them read.
+  "src/domains/chat/components/chat-info*.{ts,tsx}",
+  "src/domains/chat/components/mobile-chat-info-overlay*.tsx",
+  "src/domains/chat/components/conversation-asset*.{ts,tsx}",
+  "src/domains/chat/hooks/use-conversation-assets*.{ts,tsx}",
+  "src/domains/chat/hooks/use-conversation-attachments*.{ts,tsx}",
+  "src/domains/chat/chat-layout-header.stories.tsx",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -13,31 +13,32 @@
  * is the same ghost icon-only `Button` with the same glyph, which is all this
  * story needs it to be. It exists to occupy the cluster, not to be exercised.
  *
+ * The Assets pill's conversation is seeded by the shared Chat Info decorator,
+ * on ids of this file's own so a panel opened here can only be this header's.
+ *
  * The states covered are the composition's, not a per-component matrix: the
- * desktop and mobile baselines, a channel-bound header, and each viewport with
- * the Chat Info panel open, where the Assets trigger reads as selected.
+ * desktop and mobile baselines, a channel-bound header, and the desktop header
+ * with the Chat Info panel open, where the Assets trigger reads as selected.
+ * The mobile trigger carries the same `active` fill open or closed, so there is
+ * no second open state to show.
  */
 
 import { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 import { Bell } from "lucide-react";
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "@vellumai/design-library";
 
-import {
-  appsGetQueryKey,
-  documentsGetQueryKey,
-} from "@/generated/daemon/@tanstack/react-query.gen";
 import { ChannelSourceLinkPill } from "@/domains/chat/components/channel-source-link-pill";
 import { ChatLayoutHeader } from "@/domains/chat/chat-layout-header";
+import { inChatInfoConversation } from "@/domains/chat/components/chat-info-story-fixtures";
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
 import { MOBILE_MEDIA_QUERY } from "@/hooks/use-is-mobile";
 import { useViewerStore } from "@/stores/viewer-store";
 
+/** This header's own conversation, distinct from the panel stories' fixture ids. */
 const ASSISTANT_ID = "asst-story";
 const CONVERSATION_ID = "conv-story";
-const T0 = 1_700_000_000_000;
 
 const LONG_TITLE =
   "Investigating why the nightly ingestion job silently drops Slack threads " +
@@ -63,10 +64,6 @@ function NotificationsStandIn() {
 // Harness
 // ---------------------------------------------------------------------------
 
-/**
- * Seeds the assets query cache, so the Assets pill has something to show
- * without a daemon.
- */
 function Harness({
   isMobile,
   channelBound = false,
@@ -76,39 +73,6 @@ function Harness({
    *  way `useChatHeaderRegistration` composes it for channel-bound chats. */
   channelBound?: boolean;
 }) {
-  const queryClient = useQueryClient();
-  const [seeded] = useState(() => {
-    queryClient.setQueryData(
-      appsGetQueryKey({
-        path: { assistant_id: ASSISTANT_ID },
-        query: { conversationId: CONVERSATION_ID },
-      }),
-      {
-        apps: [
-          {
-            id: "app-1",
-            name: "Ingestion dashboard",
-            createdAt: T0,
-            updatedAt: T0,
-            version: "1",
-            contentId: "c1",
-            origin: "workspace",
-          },
-        ],
-      },
-    );
-    queryClient.setQueryData(
-      documentsGetQueryKey({
-        path: { assistant_id: ASSISTANT_ID },
-        query: { conversationId: CONVERSATION_ID },
-      }),
-      { documents: [] },
-    );
-    return true;
-  });
-  void seeded;
-
-
   return (
     <ChatLayoutHeader
       isMobile={isMobile}
@@ -155,9 +119,9 @@ function setMatchMedia(impl: typeof window.matchMedia) {
  * shows the mobile composition regardless of the viewport the docs page happens
  * to render at.
  */
-function ForceMobile({ children }: { children: React.ReactNode }) {
+const forceMobile: Decorator = function ForceMobile(Story) {
   // Installed from a `useState` initializer, which runs exactly once and during
-  // this component's render, i.e. before any child samples the query. An
+  // this decorator's render, i.e. before the story samples the query. An
   // identity check against the saved original would not work here: `bind`
   // returns a new function object, so it never compares equal to the global.
   const [original] = useState(() => {
@@ -184,35 +148,42 @@ function ForceMobile({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     return () => setMatchMedia(original);
   }, [original]);
-  return <>{children}</>;
-}
+  return <Story />;
+};
 
 /**
- * Opens the Chat Info panel for the story's conversation, so the Assets
+ * Opens the Chat Info panel for this header's conversation, so the Assets
  * trigger renders the selected state it holds while the panel is on screen.
- *
- * Opened from a `useState` initializer, which runs during this component's
- * render, i.e. before the trigger below it first samples the store.
  */
-function ChatInfoOpen({ children }: { children: React.ReactNode }) {
-  const [opened] = useState(() => {
+const withChatInfoOpen: Decorator = function WithChatInfoOpen(Story) {
+  // A `useState` initializer runs during this decorator's own render, i.e.
+  // before the trigger below it first samples the store.
+  useState(() => {
     useViewerStore.getState().openChatInfo({
       assistantId: ASSISTANT_ID,
       conversationId: CONVERSATION_ID,
     });
-    return true;
   });
-  void opened;
   useEffect(() => {
     return () => useViewerStore.getState().closeChatInfo();
   }, []);
-  return <>{children}</>;
-}
+  return <Story />;
+};
 
 const meta: Meta<typeof Harness> = {
   title: "Chat/ChatLayoutHeader",
   component: Harness,
-  parameters: { layout: "fullscreen" },
+  parameters: {
+    layout: "fullscreen",
+    chatInfo: {
+      assistantId: ASSISTANT_ID,
+      conversationId: CONVERSATION_ID,
+      appCount: 1,
+      documentCount: 0,
+      attachments: [],
+    },
+  },
+  decorators: [inChatInfoConversation],
 };
 
 export default meta;
@@ -243,13 +214,7 @@ export const DesktopChannelBound: Story = {
  */
 export const MobileBaseline: Story = {
   args: { isMobile: true },
-  decorators: [
-    (Story) => (
-      <ForceMobile>
-        <Story />
-      </ForceMobile>
-    ),
-  ],
+  decorators: [forceMobile],
 };
 
 /**
@@ -258,29 +223,5 @@ export const MobileBaseline: Story = {
  */
 export const AssetsPanelOpen: Story = {
   args: { isMobile: false },
-  decorators: [
-    (Story) => (
-      <ChatInfoOpen>
-        <Story />
-      </ChatInfoOpen>
-    ),
-  ],
-};
-
-/**
- * The same open state on the narrow header, where the trigger is the filled
- * icon button.
- */
-export const AssetsPanelOpenMobile: Story = {
-  args: { isMobile: true },
-  globals: { viewport: { value: "sbMobile", isRotated: false } },
-  decorators: [
-    (Story) => (
-      <ForceMobile>
-        <ChatInfoOpen>
-          <Story />
-        </ChatInfoOpen>
-      </ForceMobile>
-    ),
-  ],
+  decorators: [withChatInfoOpen],
 };

--- a/clients/web/src/domains/chat/components/adaptive-popover.tsx
+++ b/clients/web/src/domains/chat/components/adaptive-popover.tsx
@@ -4,10 +4,9 @@
  *
  * The split is not a style preference. A popover anchored near the bottom of a
  * phone screen opens into the thumb's own reach and lands under the soft
- * keyboard, which is why the activity pill hand-rolled this same branch. This
- * exists so chat controls stop hand-rolling it: every surface shares one
- * implementation, so a fix to the touch path cannot land on one and miss the
- * others.
+ * keyboard, so the touch path has to be a sheet. The chat controls that open a
+ * panel share this one implementation, so a fix to the touch path cannot land
+ * on one and miss the others.
  *
  * Branches on {@link useTouchMobile} (coarse pointer AND phone width), not on
  * width alone: a narrow desktop window still wants the popover, since a bottom

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
@@ -11,43 +11,42 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
+import {
+  CHAT_INFO_ASSISTANT_ID,
+  chatInfoPreviewHtml,
+} from "@/domains/chat/components/chat-info-story-fixtures";
+import { makeAppSummary } from "@/domains/chat/components/chat-info.test-helper";
 import { appsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { AppSummary } from "@/types/app-types";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 
 import { ChatInfoAppTile } from "./chat-info-app-tile";
 
-const ASSISTANT_ID = "story-assistant";
-
-function makeApp(id: string, name: string, icon: string): AppSummary {
-  return {
-    id,
-    name,
-    icon,
-    createdAt: 1_760_000_000_000,
-    updatedAt: 1_760_000_100_000,
-    version: "1.0.0",
-    contentId: `${id}-content`,
-    origin: "workspace",
-  };
-}
-
-const TRIP_PLANNER = makeApp("app-trip-planner", "Trip Planner", "🧭");
-const PACKING_LIST = makeApp("app-packing-list", "Packing List", "🧳");
-const FERRY_TIMES = makeApp("app-ferry-times", "Ferry Times", "⛴️");
-const LONG_NAME = makeApp(
-  "app-itinerary",
-  "Coastal Itinerary and Harbour Tour Booking Planner",
-  "🗺️",
-);
+const TRIP_PLANNER = makeAppSummary({
+  id: "app-trip-planner",
+  name: "Trip Planner",
+});
+const PACKING_LIST = makeAppSummary({
+  id: "app-packing-list",
+  name: "Packing List",
+  icon: "🧳",
+});
+const FERRY_TIMES = makeAppSummary({
+  id: "app-ferry-times",
+  name: "Ferry Times",
+  icon: "⛴️",
+});
+const LONG_NAME = makeAppSummary({
+  id: "app-itinerary",
+  name: "Coastal Itinerary and Harbour Tour Booking Planner",
+  icon: "🗺️",
+});
 /** Never primed, so its preview never resolves and the tile keeps the icon. */
-const NO_PREVIEW = makeApp("app-field-notes", "Field Notes", "📓");
-
-/** A small page for the preview iframe, using system colours so it reads in either theme. */
-function previewHtml(title: string, items: string[]): string {
-  const list = items.map((item) => `<li>${item}</li>`).join("");
-  return `<!doctype html><meta charset="utf-8"><title>${title}</title><style>body{margin:0;padding:24px;font-family:system-ui,sans-serif;background:Canvas;color:CanvasText}h1{margin:0 0 12px;font-size:28px}ul{margin:0;padding-left:22px;font-size:18px;line-height:1.7}</style><h1>${title}</h1><ul>${list}</ul>`;
-}
+const NO_PREVIEW = makeAppSummary({
+  id: "app-field-notes",
+  name: "Field Notes",
+  icon: "📓",
+});
 
 const PRIMED: Array<[AppSummary, string[]]> = [
   [TRIP_PLANNER, ["Book the ferry", "Pack a rain shell", "Confirm the tour"]],
@@ -57,7 +56,11 @@ const PRIMED: Array<[AppSummary, string[]]> = [
 ];
 
 for (const [app, items] of PRIMED) {
-  primeAppHtmlCache(ASSISTANT_ID, app.id, previewHtml(app.name, items));
+  primeAppHtmlCache(
+    CHAT_INFO_ASSISTANT_ID,
+    app.id,
+    chatInfoPreviewHtml(app.name, items),
+  );
 }
 
 const storyClient = new QueryClient({
@@ -65,7 +68,7 @@ const storyClient = new QueryClient({
 });
 // The options menu reads the app list to know whether the app is pinned.
 storyClient.setQueryData(
-  appsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+  appsGetQueryKey({ path: { assistant_id: CHAT_INFO_ASSISTANT_ID } }),
   {
     apps: [TRIP_PLANNER, PACKING_LIST, FERRY_TIMES, LONG_NAME, NO_PREVIEW],
   },
@@ -84,7 +87,7 @@ const meta: Meta<typeof ChatInfoAppTile> = {
   decorators: [withPrimedPreviews],
   args: {
     app: TRIP_PLANNER,
-    assistantId: ASSISTANT_ID,
+    assistantId: CHAT_INFO_ASSISTANT_ID,
     onOpen: fn(),
     onRequestDelete: fn(),
   },

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
@@ -19,42 +19,27 @@ import {
   SAMPLE_PREVIEWS,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
-import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
-import type { DocumentSummary } from "@/types/document-types";
+import { CHAT_INFO_ASSISTANT_ID } from "@/domains/chat/components/chat-info-story-fixtures";
+import {
+  CHAT_INFO_T0,
+  makeDocumentAsset,
+  makeDocumentSummary,
+  makeFileAsset,
+  makeFrameAsset,
+} from "@/domains/chat/components/chat-info.test-helper";
 import { decodeBase64Payload } from "@/utils/base64";
 
 import { ChatInfoFileTile } from "./chat-info-file-tile";
 
-const ASSISTANT_ID = "story-assistant";
+const DOCUMENT_FILE = makeDocumentAsset(
+  makeDocumentSummary({
+    surfaceId: "surface-trip-notes",
+    title: "Trip Notes",
+    wordCount: 842,
+  }),
+);
 
-const DOC: DocumentSummary = {
-  surfaceId: "surface-trip-notes",
-  conversationId: "conv-1",
-  title: "Trip Notes",
-  wordCount: 842,
-  createdAt: 1_760_000_000_000,
-  updatedAt: 1_760_000_100_000,
-};
-
-const DOCUMENT_FILE: ConversationFileAsset = {
-  kind: "document",
-  id: `doc-${DOC.surfaceId}`,
-  title: DOC.title,
-  doc: DOC,
-};
-
-function attachmentFile(
-  attachment: ReturnType<typeof makeDisplayAttachment>,
-): ConversationFileAsset {
-  return {
-    kind: "attachment",
-    id: `att-${attachment.id}`,
-    title: attachment.filename,
-    attachment,
-  };
-}
-
-const INLINE_IMAGE = attachmentFile(
+const INLINE_IMAGE = makeFileAsset(
   makeDisplayAttachment({
     id: "harbour-at-dawn",
     filename: "harbour-at-dawn.png",
@@ -69,10 +54,10 @@ const LAZY_IMAGE_ATTACHMENT = makeDisplayAttachment({
   filename: "ferry-deck.png",
   sizeBytes: 190_464,
 });
-const LAZY_IMAGE = attachmentFile(LAZY_IMAGE_ATTACHMENT);
+const LAZY_IMAGE = makeFileAsset(LAZY_IMAGE_ATTACHMENT);
 
 /** A legacy row: a synthetic id the content endpoint can never resolve. */
-const LAZY_IMAGE_UNAVAILABLE = attachmentFile(
+const LAZY_IMAGE_UNAVAILABLE = makeFileAsset(
   makeDisplayAttachment({
     id: "rehydrated:0",
     filename: "gulls-at-dusk.png",
@@ -80,7 +65,7 @@ const LAZY_IMAGE_UNAVAILABLE = attachmentFile(
   }),
 );
 
-const PDF_FILE = attachmentFile(
+const PDF_FILE = makeFileAsset(
   makeDisplayAttachment({
     id: "coast-guide",
     filename: "coast-guide.pdf",
@@ -89,7 +74,7 @@ const PDF_FILE = attachmentFile(
   }),
 );
 
-const VIDEO_FILE = attachmentFile(
+const VIDEO_FILE = makeFileAsset(
   makeDisplayAttachment({
     id: "harbour-tour",
     filename: "harbour-tour.mp4",
@@ -99,26 +84,23 @@ const VIDEO_FILE = attachmentFile(
   }),
 );
 
-const FRAME_FILE: ConversationFileAsset = {
-  kind: "frame",
-  id: "frame-capture-1",
-  title: "camera-frame-01.jpg",
-  attachment: makeDisplayAttachment({
+const FRAME_FILE = makeFrameAsset(
+  makeDisplayAttachment({
     id: "camera-frame-01",
     filename: "camera-frame-01.jpg",
     mimeType: "image/jpeg",
     sizeBytes: 98_304,
     previewUrl: SAMPLE_PREVIEWS[3]!,
   }),
-  capturedAt: Date.UTC(2026, 4, 27, 9, 41),
-};
+  CHAT_INFO_T0,
+);
 
 const storyClient = new QueryClient({
   defaultOptions: { queries: { retry: false, staleTime: Infinity } },
 });
 // The bytes the daemon would return, decoded from a sample preview data URL.
 storyClient.setQueryData(
-  attachmentContentQueryKey(ASSISTANT_ID, LAZY_IMAGE_ATTACHMENT.id),
+  attachmentContentQueryKey(CHAT_INFO_ASSISTANT_ID, LAZY_IMAGE_ATTACHMENT.id),
   new Blob([decodeBase64Payload(SAMPLE_PREVIEWS[2]!)!], { type: "image/png" }),
 );
 
@@ -135,7 +117,7 @@ const meta: Meta<typeof ChatInfoFileTile> = {
   decorators: [withSeededBytes],
   args: {
     file: DOCUMENT_FILE,
-    assistantId: ASSISTANT_ID,
+    assistantId: CHAT_INFO_ASSISTANT_ID,
     onOpen: fn(),
   },
 };

--- a/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
@@ -5,7 +5,9 @@
  * Nothing here is a stand-in. Every story seeds the two sources the panel's
  * real hooks read (the query cache for apps and documents, the chat-session
  * store for the transcript the attachments come from), so the rows are built
- * by the shipped code path and the app tiles render live previews.
+ * by the shipped code path and the app tiles render live previews. One
+ * decorator does that seeding for every story; a story that wants a different
+ * conversation names it in `parameters.chatInfo`.
  *
  * The frame is the shipped drawer, so a story opens at its 400px default and
  * the rows fit what that width holds. Drag the drawer's left edge to walk the
@@ -16,9 +18,7 @@
  */
 
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { fn, userEvent, within } from "storybook/test";
 
 import {
@@ -28,80 +28,40 @@ import {
 import {
   CHAT_INFO_ASSISTANT_ID,
   CHAT_INFO_CONVERSATION_ID,
-  chatInfoApps,
-  chatInfoDocuments,
-  chatInfoMessages,
-  resetChatInfoTranscript,
-  seedChatInfoQueries,
-  seedChatInfoTranscript,
+  type ChatInfoStoryConversation,
+  inChatInfoConversation,
 } from "@/domains/chat/components/chat-info-story-fixtures";
 import { DetailPanelStoryFrame } from "@/domains/chat/components/detail-panel-story-frame";
-import type { DisplayAttachment } from "@/domains/chat/types/types";
 import type { ChatInfoCategory } from "@/stores/viewer-store";
 
 import { ChatInfoPanel } from "./chat-info-panel";
 
-interface Conversation {
-  appCount: number;
-  documentCount: number;
-  attachments: DisplayAttachment[];
-}
-
-/** A worked-in trip conversation, the set most stories are shown against. */
-const SMALL_TRIP: Conversation = {
-  appCount: 12,
-  documentCount: 2,
-  attachments: makePreviewableImages(2),
-};
-
-/** A file-heavy conversation, so the Documents & Images grid is worth seeing. */
-const FILE_HEAVY: Conversation = {
+/**
+ * A file-heavy conversation, so the Documents & Images grid is worth seeing.
+ * The mixed set's leading image is dropped: it repeats `img-0` from the
+ * previewable set, and two entries sharing an attachment id collapse to one
+ * tile.
+ */
+const FILE_HEAVY: Partial<ChatInfoStoryConversation> = {
   appCount: 3,
   documentCount: 3,
-  attachments: [...makePreviewableImages(8), ...makeMixedAttachments()],
+  attachments: [
+    ...makePreviewableImages(8),
+    ...makeMixedAttachments().slice(1),
+  ],
 };
 
-function ChatInfoConversation({
-  appCount,
-  documentCount,
-  attachments,
-  children,
-}: Conversation & { children: ReactNode }) {
-  // Own client per story, so one story's conversation cannot leak into the
-  // next through the preview's shared one.
-  const [client] = useState(() => {
-    const created = new QueryClient({
-      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-    });
-    seedChatInfoQueries(created, {
-      apps: chatInfoApps(appCount),
-      documents: chatInfoDocuments(documentCount),
-    });
-    seedChatInfoTranscript(chatInfoMessages(attachments));
-    return created;
-  });
-  useEffect(() => resetChatInfoTranscript, []);
-
-  return (
-    <QueryClientProvider client={client}>
-      <DetailPanelStoryFrame>{children}</DetailPanelStoryFrame>
-    </QueryClientProvider>
-  );
-}
-
-function inConversation(conversation: Conversation): Decorator {
-  return (Story) => (
-    <ChatInfoConversation {...conversation}>
-      <Story />
-    </ChatInfoConversation>
-  );
-}
+const inDrawer: Decorator = (Story) => (
+  <DetailPanelStoryFrame>
+    <Story />
+  </DetailPanelStoryFrame>
+);
 
 const meta: Meta<typeof ChatInfoPanel> = {
   title: "Chat/ChatInfoPanel",
   component: ChatInfoPanel,
   parameters: { layout: "fullscreen" },
-  decorators: [inConversation(SMALL_TRIP)],
+  decorators: [inChatInfoConversation, inDrawer],
   args: {
     payload: {
       assistantId: CHAT_INFO_ASSISTANT_ID,
@@ -128,13 +88,9 @@ export const Default: Story = {};
  * so every tile is on show and neither header carries a See All.
  */
 export const FewAssets: Story = {
-  decorators: [
-    inConversation({
-      appCount: 1,
-      documentCount: 1,
-      attachments: [],
-    }),
-  ],
+  parameters: {
+    chatInfo: { appCount: 1, documentCount: 1, attachments: [] },
+  },
 };
 
 /**
@@ -153,7 +109,7 @@ export const AppsSeeAll: Story = {
 
 /** The same drill-in for Documents & Images, where the tiles wrap rather than grid. */
 export const FilesSeeAll: Story = {
-  decorators: [inConversation(FILE_HEAVY)],
+  parameters: { chatInfo: FILE_HEAVY },
   args: {
     payload: {
       assistantId: CHAT_INFO_ASSISTANT_ID,
@@ -178,8 +134,7 @@ export const NarrowPhone: Story = {
  * transition, because their `onSelectCategory` is a spy; this one owns the
  * category itself, so See All actually walks the panel to its second level.
  */
-export const LevelTwoInteraction: StoryObj = {
-  decorators: [inConversation(SMALL_TRIP)],
+export const LevelTwoInteraction: Story = {
   render: function LevelTwoInteraction() {
     const [category, setCategory] = useState<ChatInfoCategory | null>(null);
     return (

--- a/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
@@ -29,15 +29,23 @@ import {
 import type { ReactElement } from "react";
 
 import * as appHtmlCache from "@/utils/app-html-cache";
-import type * as ConversationAssetsModule from "@/domains/chat/hooks/use-conversation-assets";
+import * as conversationAssetsModule from "@/domains/chat/hooks/use-conversation-assets";
+import {
+  CHAT_INFO_T0,
+  makeAppSummary,
+  makeAttachmentEntry,
+  makeDocumentSummary,
+} from "@/domains/chat/components/chat-info.test-helper";
 import type * as ElementSizeModule from "@/hooks/use-element-size";
 import type * as IsMobileModule from "@/hooks/use-is-mobile";
 import type { AppSummary } from "@/types/app-types";
 import type { ChatInfoCategory } from "@/stores/viewer-store";
-import type { DocumentSummary } from "@/types/document-types";
 
-type ConversationAssets = ConversationAssetsModule.ConversationAssets;
-type ConversationFileAsset = ConversationAssetsModule.ConversationFileAsset;
+type ConversationAssets = conversationAssetsModule.ConversationAssets;
+
+// Captured before the module is replaced below, so the fixtures are built by
+// the real mapping the hook runs.
+const { toConversationFileAssets } = conversationAssetsModule;
 
 const ASSISTANT_ID = "asst-1";
 const CONVERSATION_ID = "conv-1";
@@ -95,10 +103,13 @@ mock.module(
 );
 
 const assetsRef = { value: null as ConversationAssets | null };
-const assetsTargets: ConversationAssetsModule.ConversationAssetsTarget[] = [];
+const assetsTargets: conversationAssetsModule.ConversationAssetsTarget[] = [];
+// Keeps the rest of the module real, so a file that reads another of its
+// exports is unaffected by this process-global replacement.
 mock.module(
   "@/domains/chat/hooks/use-conversation-assets",
-  (): Partial<typeof ConversationAssetsModule> => ({
+  (): Partial<typeof conversationAssetsModule> => ({
+    ...conversationAssetsModule,
     useConversationAssets: (target) => {
       assetsTargets.push(target);
       return assetsRef.value!;
@@ -122,80 +133,53 @@ const { makeDisplayAttachment, SAMPLE_PREVIEWS } =
 // Fixtures
 // ---------------------------------------------------------------------------
 
-const APPS: AppSummary[] = Array.from({ length: 12 }, (_, index) => ({
-  id: `app-${index + 1}`,
-  name: `App ${index + 1}`,
-  icon: "🧭",
-  createdAt: 1_700_000_000_000,
-  updatedAt: 1_700_000_000_000 + index,
-  version: "1.0.0",
-  contentId: `content-${index + 1}`,
-  origin: "workspace",
-}));
+const APPS: AppSummary[] = Array.from({ length: 12 }, (_, index) =>
+  makeAppSummary({
+    id: `app-${index + 1}`,
+    name: `App ${index + 1}`,
+    contentId: `content-${index + 1}`,
+    updatedAt: CHAT_INFO_T0 + index,
+  }),
+);
 
-function makeDoc(surfaceId: string, title: string): DocumentSummary {
-  return {
-    surfaceId,
-    conversationId: CONVERSATION_ID,
-    title,
-    wordCount: 120,
-    createdAt: 1_700_000_000_000,
-    updatedAt: 1_700_000_000_001,
-  };
+const TRIP_NOTES = makeDocumentSummary({
+  surfaceId: "surface-trip-notes",
+  conversationId: CONVERSATION_ID,
+  title: "Trip Notes",
+});
+const PACKING_LIST = makeDocumentSummary({
+  surfaceId: "surface-packing-list",
+  conversationId: CONVERSATION_ID,
+  title: "Packing List",
+});
+
+function imageEntry(index: number) {
+  return makeAttachmentEntry(
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `photo-${index}.png`,
+      previewUrl: SAMPLE_PREVIEWS[index]!,
+    }),
+  );
 }
 
-const TRIP_NOTES = makeDoc("surface-trip-notes", "Trip Notes");
-const PACKING_LIST = makeDoc("surface-packing-list", "Packing List");
-
-function documentAsset(doc: DocumentSummary): ConversationFileAsset {
-  return {
-    kind: "document",
-    id: `doc-${doc.surfaceId}`,
-    title: doc.title,
-    doc,
-  };
+function frameEntry(index: number) {
+  return makeAttachmentEntry(
+    makeDisplayAttachment({
+      id: `frame-${index}`,
+      filename: `frame-${index}.png`,
+      previewUrl: SAMPLE_PREVIEWS[index]!,
+    }),
+    { sightFrame: true },
+  );
 }
 
-function imageAsset(index: number): ConversationFileAsset {
-  const attachment = makeDisplayAttachment({
-    id: `img-${index}`,
-    filename: `photo-${index}.png`,
-    previewUrl: SAMPLE_PREVIEWS[index]!,
-  });
-  return {
-    kind: "attachment",
-    id: `att-${attachment.id}`,
-    title: attachment.filename,
-    attachment,
-  };
-}
-
-function frameAsset(index: number): ConversationFileAsset {
-  const attachment = makeDisplayAttachment({
-    id: `frame-${index}`,
-    filename: `frame-${index}.png`,
-    previewUrl: SAMPLE_PREVIEWS[index]!,
-  });
-  return {
-    kind: "frame",
-    id: `frame-${attachment.id}`,
-    title: attachment.filename,
-    attachment,
-    capturedAt: null,
-  };
-}
-
-const FILES: ConversationFileAsset[] = [
-  documentAsset(TRIP_NOTES),
-  documentAsset(PACKING_LIST),
-  imageAsset(0),
-  imageAsset(1),
-];
-const FRAMES: ConversationFileAsset[] = [
-  frameAsset(2),
-  frameAsset(3),
-  frameAsset(4),
-];
+// Built by the hook's own mapping, so these fixtures carry the ids and shapes
+// the panel is handed in the app rather than a hand-written copy of them.
+const { files: FILES, frames: FRAMES } = toConversationFileAssets(
+  [TRIP_NOTES, PACKING_LIST],
+  [imageEntry(0), imageEntry(1), frameEntry(2), frameEntry(3), frameEntry(4)],
+);
 
 const loadMoreFiles = mock((): void => undefined);
 const loadMoreFrames = mock((): void => undefined);
@@ -242,6 +226,14 @@ const onClose = mock((): void => undefined);
 const onSelectCategory = mock(
   (_category: ChatInfoCategory | null): void => undefined,
 );
+
+// The viewer store is a module singleton, so the real actions this suite
+// stands in for are put back before the next file loads.
+const {
+  closeChatInfo: realCloseChatInfo,
+  loadApp: realLoadApp,
+  loadDocument: realLoadDocument,
+} = useViewerStore.getState();
 
 function renderPanel(ui: ReactElement) {
   const client = new QueryClient({
@@ -299,6 +291,11 @@ afterEach(() => {
 // `mock.module` is process-global in this runner, so the module graph is put
 // back before the next file loads.
 afterAll(() => {
+  useViewerStore.setState({
+    closeChatInfo: realCloseChatInfo,
+    loadApp: realLoadApp,
+    loadDocument: realLoadDocument,
+  });
   mock.restore();
 });
 

--- a/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
@@ -11,7 +11,7 @@
  * it under a row that looks complete.
  *
  * Read the phone stories at the Mobile viewports: the frame draws
- * `DetailShell`'s 20px body inset, which the strip cancels.
+ * `DetailShell`'s lift surface and 20px body inset, which the strip cancels.
  */
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
@@ -40,9 +40,9 @@ const FITTING_SET: DisplayAttachment[] = [
   ...makeMixedAttachments().filter((file) => file.previewUrl === null),
 ];
 
-/** The drawer body's column on the desktop mock: 569px inside the shell's inset. */
+/** The drawer body's column on the desktop mock: 569px inside `DetailShell`'s lift surface and 20px inset. */
 const inDrawerColumn: Decorator = (Story) => (
-  <div className="bg-[var(--surface-base)] p-5">
+  <div className="bg-[var(--surface-lift)] p-5">
     <div className="w-[569px]">
       <Story />
     </div>
@@ -55,7 +55,7 @@ const inDrawerColumn: Decorator = (Story) => (
  * off, as in the mobile mock.
  */
 const inPhonePage: Decorator = (Story) => (
-  <div className="max-w-[402px] bg-[var(--surface-base)] p-5">
+  <div className="max-w-[402px] bg-[var(--surface-lift)] p-5">
     <Story />
   </div>
 );

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -1,19 +1,28 @@
 /**
- * Fixtures for the Chat Info stories.
+ * Fixtures and the seeded-conversation decorator for the Chat Info stories.
  *
  * The panel reads its assets through the real hooks, so a story has to fill
  * the two sources those hooks go to: the query cache holds the conversation's
  * apps and documents, and the chat-session store holds the transcript the
- * attachments are derived from. Everything here seeds one of those, so the
- * panel story and the mobile-overlay story can show the same conversation.
+ * attachments are derived from. {@link inChatInfoConversation} fills both, on a
+ * client of the story's own, before the story's first paint.
  *
- * No JSX and no test-runner import: this is data plus the calls that install
- * it, and the decorators that use it live in the story files.
+ * A story declares its conversation through `parameters.chatInfo` rather than
+ * by wrapping itself in a second decorator, so the panel, the mobile overlay,
+ * and the chat header each mount exactly one seeded conversation.
  */
 
-import type { QueryClient } from "@tanstack/react-query";
+import type { Decorator } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import {
+  CHAT_INFO_T0,
+  makeAppSummary,
+  makeDocumentSummary,
+} from "@/domains/chat/components/chat-info.test-helper";
 import type {
   DisplayAttachment,
   DisplayMessage,
@@ -28,8 +37,6 @@ import { primeAppHtmlCache } from "@/utils/app-html-cache";
 
 export const CHAT_INFO_ASSISTANT_ID = "story-assistant";
 export const CHAT_INFO_CONVERSATION_ID = "story-conversation";
-
-const T0 = 1_760_000_000_000;
 
 /** Name, icon, and preview lines for each app a story can ask for. */
 const APP_SEEDS: Array<{ name: string; icon: string; lines: string[] }> = [
@@ -96,23 +103,22 @@ const APP_SEEDS: Array<{ name: string; icon: string; lines: string[] }> = [
 ];
 
 /** A small page for the preview iframe, in system colours so it reads in either theme. */
-function previewHtml(title: string, lines: string[]): string {
+export function chatInfoPreviewHtml(title: string, lines: string[]): string {
   const items = lines.map((line) => `<li>${line}</li>`).join("");
   return `<!doctype html><meta charset="utf-8"><title>${title}</title><style>body{margin:0;padding:24px;font-family:system-ui,sans-serif;background:Canvas;color:CanvasText}h1{margin:0 0 12px;font-size:28px}ul{margin:0;padding-left:22px;font-size:18px;line-height:1.7}</style><h1>${title}</h1><ul>${items}</ul>`;
 }
 
 /** The first `count` fixture apps, newest first. */
-export function chatInfoApps(count: number): AppSummary[] {
-  return APP_SEEDS.slice(0, count).map((seed, index) => ({
-    id: `app-${index + 1}`,
-    name: seed.name,
-    icon: seed.icon,
-    createdAt: T0,
-    updatedAt: T0 + (count - index) * 1_000,
-    version: "1.0.0",
-    contentId: `content-${index + 1}`,
-    origin: "workspace",
-  }));
+function chatInfoApps(count: number): AppSummary[] {
+  return APP_SEEDS.slice(0, count).map((seed, index) =>
+    makeAppSummary({
+      id: `app-${index + 1}`,
+      name: seed.name,
+      icon: seed.icon,
+      updatedAt: CHAT_INFO_T0 + (count - index) * 1_000,
+      contentId: `content-${index + 1}`,
+    }),
+  );
 }
 
 const DOCUMENT_TITLES = [
@@ -122,15 +128,19 @@ const DOCUMENT_TITLES = [
 ];
 
 /** The first `count` fixture documents, newest first. */
-export function chatInfoDocuments(count: number): DocumentSummary[] {
-  return DOCUMENT_TITLES.slice(0, count).map((title, index) => ({
-    surfaceId: `surface-${index + 1}`,
-    conversationId: CHAT_INFO_CONVERSATION_ID,
-    title,
-    wordCount: 320 + index * 140,
-    createdAt: T0,
-    updatedAt: T0 + (count - index) * 1_000,
-  }));
+function chatInfoDocuments(
+  count: number,
+  conversationId: string,
+): DocumentSummary[] {
+  return DOCUMENT_TITLES.slice(0, count).map((title, index) =>
+    makeDocumentSummary({
+      surfaceId: `surface-${index + 1}`,
+      conversationId,
+      title,
+      wordCount: 320 + index * 140,
+      updatedAt: CHAT_INFO_T0 + (count - index) * 1_000,
+    }),
+  );
 }
 
 /**
@@ -138,15 +148,13 @@ export function chatInfoDocuments(count: number): DocumentSummary[] {
  * assistant's reply. This is the source `useConversationAttachments` reads,
  * so the panel's Documents & Images row lists exactly these files.
  */
-export function chatInfoMessages(
-  attachments: DisplayAttachment[],
-): DisplayMessage[] {
+function chatInfoMessages(attachments: DisplayAttachment[]): DisplayMessage[] {
   const half = Math.ceil(attachments.length / 2);
   return [
     {
       id: "msg-user",
       role: "user",
-      timestamp: T0,
+      timestamp: CHAT_INFO_T0,
       textSegments: ["Here are the shots from the harbour."],
       contentOrder: [{ type: "text", id: "0" }],
       attachments: attachments.slice(0, half),
@@ -154,7 +162,7 @@ export function chatInfoMessages(
     {
       id: "msg-assistant",
       role: "assistant",
-      timestamp: T0 + 1_000,
+      timestamp: CHAT_INFO_T0 + 1_000,
       textSegments: ["Added them to the trip notes."],
       contentOrder: [{ type: "text", id: "0" }],
       attachments: attachments.slice(half),
@@ -162,16 +170,41 @@ export function chatInfoMessages(
   ];
 }
 
+/** The conversation a story asks for through `parameters.chatInfo`. */
+export interface ChatInfoStoryConversation {
+  assistantId: string;
+  conversationId: string;
+  appCount: number;
+  documentCount: number;
+  attachments: DisplayAttachment[];
+}
+
+/** A worked-in trip conversation, the set most stories are shown against. */
+const DEFAULT_CONVERSATION: ChatInfoStoryConversation = {
+  assistantId: CHAT_INFO_ASSISTANT_ID,
+  conversationId: CHAT_INFO_CONVERSATION_ID,
+  appCount: 12,
+  documentCount: 2,
+  attachments: makePreviewableImages(2),
+};
+
 /**
  * Fills the query cache the way the daemon would, and primes each app's html
  * so the tiles render a live preview instead of the icon placeholder.
  */
-export function seedChatInfoQueries(
+function seedChatInfoQueries(
   client: QueryClient,
-  { apps, documents }: { apps: AppSummary[]; documents: DocumentSummary[] },
+  {
+    assistantId,
+    conversationId,
+    appCount,
+    documentCount,
+  }: ChatInfoStoryConversation,
 ): void {
-  const path = { assistant_id: CHAT_INFO_ASSISTANT_ID };
-  const query = { conversationId: CHAT_INFO_CONVERSATION_ID };
+  const apps = chatInfoApps(appCount);
+  const documents = chatInfoDocuments(documentCount, conversationId);
+  const path = { assistant_id: assistantId };
+  const query = { conversationId };
   client.setQueryData(appsGetQueryKey({ path, query }), { apps });
   // The app options menu reads the unscoped list to know whether a pin exists.
   client.setQueryData(appsGetQueryKey({ path }), { apps });
@@ -179,15 +212,15 @@ export function seedChatInfoQueries(
   for (const [index, app] of apps.entries()) {
     const seed = APP_SEEDS[index % APP_SEEDS.length]!;
     primeAppHtmlCache(
-      CHAT_INFO_ASSISTANT_ID,
+      assistantId,
       app.id,
-      previewHtml(app.name, seed.lines),
+      chatInfoPreviewHtml(app.name, seed.lines),
     );
   }
 }
 
 /** Installs `messages` as the rendered transcript. */
-export function seedChatInfoTranscript(messages: DisplayMessage[]): void {
+function seedChatInfoTranscript(messages: DisplayMessage[]): void {
   useChatSessionStore.getState().seedSnapshot(CHAT_INFO_CONVERSATION_ID, {
     messages,
     hasMore: false,
@@ -198,6 +231,40 @@ export function seedChatInfoTranscript(messages: DisplayMessage[]): void {
 }
 
 /** Drops the seeded transcript, so a story cannot leak into the next one. */
-export function resetChatInfoTranscript(): void {
+function resetChatInfoTranscript(): void {
   useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
 }
+
+/**
+ * Seeds the two sources the panel's hooks read, on a client of this story's
+ * own so one story's conversation cannot leak into the next through the
+ * preview's shared one.
+ *
+ * The seed runs in a `useState` initializer, which React calls during this
+ * decorator's own render, so the rows are in place for the story's first
+ * paint rather than one commit later.
+ */
+export const inChatInfoConversation: Decorator =
+  function InChatInfoConversation(Story, { parameters }) {
+    const [client] = useState(() => {
+      const conversation: ChatInfoStoryConversation = {
+        ...DEFAULT_CONVERSATION,
+        ...(parameters.chatInfo as
+          | Partial<ChatInfoStoryConversation>
+          | undefined),
+      };
+      const created = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+      });
+      seedChatInfoQueries(created, conversation);
+      seedChatInfoTranscript(chatInfoMessages(conversation.attachments));
+      return created;
+    });
+    useEffect(() => resetChatInfoTranscript, []);
+
+    return (
+      <QueryClientProvider client={client}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };

--- a/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
@@ -27,8 +27,14 @@ import type { ReactElement } from "react";
 
 import * as appHtmlCache from "@/utils/app-html-cache";
 import * as downloadAttachmentModule from "@/domains/chat/components/chat-attachments/download-attachment";
-import type { AppSummary } from "@/types/app-types";
-import type { DocumentSummary } from "@/types/document-types";
+import {
+  makeAppSummary,
+  makeDocumentAsset,
+  makeDocumentSummary,
+  makeFileAsset,
+  makeFrameAsset,
+} from "@/domains/chat/components/chat-info.test-helper";
+import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
 
 const OBJECT_URL = "blob:chat-info-tile";
 
@@ -90,48 +96,13 @@ const { makeDisplayAttachment, SAMPLE_PREVIEWS } =
 const { appsGetQueryKey } =
   await import("@/generated/daemon/@tanstack/react-query.gen");
 const { formatCaptureTime } = await import("@/utils/format-date");
-type ConversationFileAsset =
-  import("@/domains/chat/hooks/use-conversation-assets").ConversationFileAsset;
 
 const ASSISTANT_ID = "asst-1";
 
-const APP: AppSummary = {
-  id: "app-1",
-  name: "Trip Planner",
-  icon: "🧭",
-  createdAt: 1_700_000_000_000,
-  updatedAt: 1_700_000_000_001,
-  version: "1.0.0",
-  contentId: "content-1",
-  origin: "workspace",
-};
-
-const DOC: DocumentSummary = {
-  surfaceId: "surface-1",
-  conversationId: "conv-1",
-  title: "Trip Notes",
-  wordCount: 120,
-  createdAt: 1_700_000_000_000,
-  updatedAt: 1_700_000_000_001,
-};
-
-const DOCUMENT_ASSET: ConversationFileAsset = {
-  kind: "document",
-  id: "doc-surface-1",
-  title: DOC.title,
-  doc: DOC,
-};
-
-function attachmentAsset(
-  attachment: ReturnType<typeof makeDisplayAttachment>,
-): ConversationFileAsset {
-  return {
-    kind: "attachment",
-    id: `att-${attachment.id}`,
-    title: attachment.filename,
-    attachment,
-  };
-}
+const APP = makeAppSummary({ id: "app-1", name: "Trip Planner" });
+const DOCUMENT_ASSET = makeDocumentAsset(
+  makeDocumentSummary({ title: "Trip Notes" }),
+);
 
 function renderTile(ui: ReactElement) {
   const client = new QueryClient({
@@ -205,7 +176,7 @@ describe("ChatInfoFileTile documents", () => {
 
 describe("ChatInfoFileTile attachments", () => {
   test("renders an inline preview without fetching", () => {
-    const file = attachmentAsset(
+    const file = makeFileAsset(
       makeDisplayAttachment({
         id: "inline-1",
         filename: "harbour.png",
@@ -228,7 +199,7 @@ describe("ChatInfoFileTile attachments", () => {
   });
 
   test("spins while it fetches, then renders the object URL", async () => {
-    const file = attachmentAsset(
+    const file = makeFileAsset(
       makeDisplayAttachment({ id: "lazy-1", filename: "photo.png" }),
     );
     const { container } = renderTile(
@@ -251,7 +222,7 @@ describe("ChatInfoFileTile attachments", () => {
   });
 
   test("falls back to the image glyph when the bytes will not decode", async () => {
-    const file = attachmentAsset(
+    const file = makeFileAsset(
       makeDisplayAttachment({ id: "broken-1", filename: "broken.png" }),
     );
     const { container } = renderTile(
@@ -273,7 +244,7 @@ describe("ChatInfoFileTile attachments", () => {
 
   test("falls back to the image glyph when the fetch resolves nothing", async () => {
     fetchAttachmentContentBlob.mockImplementationOnce(async () => null);
-    const file = attachmentAsset(
+    const file = makeFileAsset(
       makeDisplayAttachment({ id: "missing-1", filename: "missing.png" }),
     );
     const { container } = renderTile(
@@ -292,7 +263,7 @@ describe("ChatInfoFileTile attachments", () => {
 
   test("falls back to the image glyph for a legacy image it can never fetch", () => {
     // A row reloaded from a summary line carries a synthetic id and no bytes.
-    const file = attachmentAsset(
+    const file = makeFileAsset(
       makeDisplayAttachment({ id: "rehydrated:0", filename: "legacy.png" }),
     );
     const { container } = renderTile(
@@ -309,7 +280,7 @@ describe("ChatInfoFileTile attachments", () => {
   });
 
   test("renders the PDF glyph without fetching", () => {
-    const file = attachmentAsset(
+    const file = makeFileAsset(
       makeDisplayAttachment({
         id: "pdf-1",
         filename: "report.pdf",
@@ -334,18 +305,15 @@ describe("ChatInfoFileTile camera frames", () => {
   const LOCALE = "en";
 
   function frameAsset(capturedAt: number): ConversationFileAsset {
-    return {
-      kind: "frame",
-      id: "frame-1",
-      title: "frame-01.jpg",
-      attachment: makeDisplayAttachment({
+    return makeFrameAsset(
+      makeDisplayAttachment({
         id: "frame-1",
         filename: "frame-01.jpg",
         mimeType: "image/jpeg",
         previewUrl: SAMPLE_PREVIEWS[1]!,
       }),
       capturedAt,
-    };
+    );
   }
 
   test("labels a frame from today with its time of day", () => {

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -1,0 +1,100 @@
+/**
+ * Fixtures for the Chat Info tests and stories: the two daemon summaries the
+ * panel lists, and the assets it renders as tiles.
+ *
+ * Every asset goes through `toConversationFileAssets`, the mapping the hook
+ * itself runs, so a fixture cannot drift from the ids and shapes the panel
+ * receives in the app.
+ *
+ * Kept free of any test-runner import so `.stories.tsx` files can use it, the
+ * way `utils/conversation-list.test-helper.ts` already is.
+ */
+
+import {
+  type ConversationFileAsset,
+  toConversationFileAssets,
+} from "@/domains/chat/hooks/use-conversation-assets";
+import type { ConversationAttachmentEntry } from "@/domains/chat/hooks/use-conversation-attachments";
+import type { AppSummary } from "@/types/app-types";
+import type { DisplayAttachment } from "@/types/attachment-types";
+import type { DocumentSummary } from "@/types/document-types";
+
+/** Fixed epoch ms, so nothing built here depends on the clock. */
+export const CHAT_INFO_T0 = 1_760_000_000_000;
+
+/** A daemon app summary with every field defaulted, `overrides` on top. */
+export function makeAppSummary(
+  overrides: Partial<AppSummary> = {},
+): AppSummary {
+  const id = overrides.id ?? "app-1";
+  return {
+    id,
+    name: "Trip Planner",
+    icon: "🧭",
+    createdAt: CHAT_INFO_T0,
+    updatedAt: CHAT_INFO_T0,
+    version: "1.0.0",
+    contentId: `${id}-content`,
+    origin: "workspace",
+    ...overrides,
+  };
+}
+
+/** A daemon document summary with every field defaulted, `overrides` on top. */
+export function makeDocumentSummary(
+  overrides: Partial<DocumentSummary> = {},
+): DocumentSummary {
+  const surfaceId = overrides.surfaceId ?? "surface-1";
+  return {
+    surfaceId,
+    conversationId: "conv-1",
+    title: "Trip Notes",
+    wordCount: 120,
+    createdAt: CHAT_INFO_T0,
+    updatedAt: CHAT_INFO_T0,
+    ...overrides,
+  };
+}
+
+/**
+ * One attachment entry as the transcript path produces it. The key is the
+ * attachment's own id, which is what the hook uses for anything but a legacy
+ * `rehydrated:N` row.
+ */
+export function makeAttachmentEntry(
+  attachment: DisplayAttachment,
+  overrides: Partial<Omit<ConversationAttachmentEntry, "attachment">> = {},
+): ConversationAttachmentEntry {
+  return {
+    key: attachment.id,
+    attachment,
+    messageId: "msg-1",
+    capturedAt: null,
+    sightFrame: false,
+    ...overrides,
+  };
+}
+
+/** One document as the file asset the panel hands a tile. */
+export function makeDocumentAsset(doc: DocumentSummary): ConversationFileAsset {
+  return toConversationFileAssets([doc], []).files[0]!;
+}
+
+/** One attachment as the file asset the panel hands a tile. */
+export function makeFileAsset(
+  attachment: DisplayAttachment,
+): ConversationFileAsset {
+  return toConversationFileAssets([], [makeAttachmentEntry(attachment)])
+    .files[0]!;
+}
+
+/** One attachment as the camera-frame asset the panel hands a tile. */
+export function makeFrameAsset(
+  attachment: DisplayAttachment,
+  capturedAt: number | null,
+): ConversationFileAsset {
+  return toConversationFileAssets(
+    [],
+    [makeAttachmentEntry(attachment, { sightFrame: true, capturedAt })],
+  ).frames[0]!;
+}

--- a/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
+++ b/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
@@ -8,7 +8,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useCallback, useState } from "react";
-import type { FC, KeyboardEvent, MouseEvent, ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 
 import { ActionMenu, Button, toast } from "@vellumai/design-library";
 
@@ -20,12 +20,13 @@ import type { DocumentSummary } from "@/types/document-types";
 import { shareApp } from "@/utils/share-app";
 
 /**
- * Per-row options menu ("dots") for the conversation assets pill: a trailing
- * `Ellipsis` button opening an `ActionMenu`, which resolves to a sheet on touch
- * and a dropdown under a pointer (see `docs/PLATFORM_ADAPTATION.md`).
+ * The options menu ("dots") the Chat Info panel's app and file tiles reveal
+ * over their preview: an `Ellipsis` button opening an `ActionMenu`, which
+ * resolves to a sheet on touch and a dropdown under a pointer (see
+ * `docs/PLATFORM_ADAPTATION.md`).
  *
  * Apps get the gallery's actions (Pin / Share / Delete). Documents get
- * Open / Download PDF — the daemon has no document-delete endpoint, so
+ * Open / Download PDF: the daemon has no document-delete endpoint, so
  * deletion is intentionally absent there.
  */
 
@@ -45,14 +46,6 @@ function MenuShell({
           expandOnMobile={false}
           iconOnly={<Ellipsis />}
           aria-label={title}
-          onClick={(e: MouseEvent) => e.stopPropagation()}
-          // PanelItem's row handler also acts on Enter/Space, so they stay
-          // local: opening the menu must not open the asset.
-          onKeyDown={(e: KeyboardEvent) => {
-            if (e.key === "Enter" || e.key === " ") {
-              e.stopPropagation();
-            }
-          }}
         />
       </ActionMenu.Trigger>
       <ActionMenu.Content title={title}>{children}</ActionMenu.Content>
@@ -70,7 +63,7 @@ interface AppAssetActionsProps {
   /**
    * Ask the owner to show the delete confirmation. The dialog must be
    * rendered OUTSIDE the hosting Popover/BottomSheet: it portals and steals
-   * focus, which the popover treats as an outside interaction and closes —
+   * focus, which the popover treats as an outside interaction and closes,
    * unmounting this component and any dialog state held here with it.
    */
   onRequestDelete: (app: AppSummary) => void;
@@ -105,10 +98,16 @@ export const AppAssetActions: FC<AppAssetActionsProps> = ({
   }, [assistantId, app.id, app.name, isSharing]);
 
   return (
-    <MenuShell title={t("chat:conversationAssetActions.optionsFor", { name: app.name })}>
+    <MenuShell
+      title={t("chat:conversationAssetActions.optionsFor", { name: app.name })}
+    >
       <ActionMenu.Item
         icon={isPinned ? PinOff : Pin}
-        label={isPinned ? t("chat:conversationAssetActions.unpin") : t("chat:conversationAssetActions.pin")}
+        label={
+          isPinned
+            ? t("chat:conversationAssetActions.unpin")
+            : t("chat:conversationAssetActions.pin")
+        }
         onSelect={() => togglePin(app.id)}
       />
       <ActionMenu.Item
@@ -151,8 +150,14 @@ export const DocumentAssetActions: FC<DocumentAssetActionsProps> = ({
   }, [assistantId, doc.surfaceId, doc.title]);
 
   return (
-    <MenuShell title={t("chat:conversationAssetActions.optionsFor", { name: doc.title })}>
-      <ActionMenu.Item icon={ExternalLink} label={t("chat:conversationAssetActions.open")} onSelect={onOpen} />
+    <MenuShell
+      title={t("chat:conversationAssetActions.optionsFor", { name: doc.title })}
+    >
+      <ActionMenu.Item
+        icon={ExternalLink}
+        label={t("chat:conversationAssetActions.open")}
+        onSelect={onOpen}
+      />
       <ActionMenu.Item
         icon={Download}
         label={t("chat:conversationAssetActions.downloadPdf")}

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -25,6 +25,7 @@ import {
 } from "@testing-library/react";
 import * as motionReact from "motion/react";
 
+import { makeDocumentSummary } from "@/domains/chat/components/chat-info.test-helper";
 import type { DocumentSummary } from "@/types/document-types";
 
 const isMobileRef = { value: false };
@@ -71,14 +72,7 @@ function makeDocument(
   conversationId = CONVERSATION_ID,
   surfaceId = SURFACE_ID,
 ): DocumentSummary {
-  return {
-    surfaceId,
-    conversationId,
-    title: DOC_TITLE,
-    wordCount: 12,
-    createdAt: 1_700_000_000_000,
-    updatedAt: 1_700_000_000_001,
-  };
+  return makeDocumentSummary({ surfaceId, conversationId, title: DOC_TITLE });
 }
 
 /**

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.stories.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.stories.tsx
@@ -14,53 +14,23 @@
  * Only ever mounted on a narrow window, hence the Mobile viewport on the meta.
  */
 
-import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
-import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import {
   CHAT_INFO_ASSISTANT_ID,
   CHAT_INFO_CONVERSATION_ID,
-  chatInfoApps,
-  chatInfoDocuments,
-  chatInfoMessages,
-  resetChatInfoTranscript,
-  seedChatInfoQueries,
-  seedChatInfoTranscript,
+  inChatInfoConversation,
 } from "@/domains/chat/components/chat-info-story-fixtures";
 
 import { MobileChatInfoOverlay } from "./mobile-chat-info-overlay";
-
-/** Seeds the two sources the panel's hooks read, on a client of this story's own. */
-const inConversation: Decorator = function InConversation(Story) {
-  const [client] = useState(() => {
-    const created = new QueryClient({
-      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-    });
-    seedChatInfoQueries(created, {
-      apps: chatInfoApps(12),
-      documents: chatInfoDocuments(2),
-    });
-    seedChatInfoTranscript(chatInfoMessages(makePreviewableImages(2)));
-    return created;
-  });
-  useEffect(() => resetChatInfoTranscript, []);
-
-  return (
-    <QueryClientProvider client={client}>
-      <Story />
-    </QueryClientProvider>
-  );
-};
 
 const meta: Meta<typeof MobileChatInfoOverlay> = {
   title: "Chat/MobileChatInfoOverlay",
   component: MobileChatInfoOverlay,
   parameters: { layout: "fullscreen" },
   globals: { viewport: { value: "sbMobile", isRotated: false } },
-  decorators: [inConversation],
+  decorators: [inChatInfoConversation],
   args: {
     payload: {
       assistantId: CHAT_INFO_ASSISTANT_ID,


### PR DESCRIPTION
## Summary
- one seeded-conversation decorator in the story fixtures, consumed by the panel, overlay, and header stories; stories seed before first paint and each mounts a single conversation
- chat-info.test-helper builds AppSummary and DocumentSummary once, and asset fixtures go through toConversationFileAssets
- chat-info files join the em-dash lint scope; I18N example, adaptive-popover, and conversation-asset-actions comments match the code

Part of plan: chat-info-assets-panel.md (remediation round 2)