### PR TITLE
fix(notifications): start the Android budget before the response head, time the iOS budget by the clock, pin the App Group in the preflight

### DIFF
--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -61,6 +61,7 @@ jobs:
             production)
               echo "scheme=App" >> "$GITHUB_OUTPUT"
               echo "bundle_id=ai.vocify-inc.vellum-assistant-ios" >> "$GITHUB_OUTPUT"
+              echo "app_group=group.ai.vocify-inc.vellum-assistant-ios" >> "$GITHUB_OUTPUT"
               echo "profile_key=IOS_PROVISIONING_PROFILE" >> "$GITHUB_OUTPUT"
               echo "profile_name=Vellum Assistant iOS Distribution" >> "$GITHUB_OUTPUT"
               echo "ext_bundle_id=ai.vocify-inc.vellum-assistant-ios.VoiceActivity" >> "$GITHUB_OUTPUT"
@@ -79,6 +80,7 @@ jobs:
             staging)
               echo "scheme=App Staging" >> "$GITHUB_OUTPUT"
               echo "bundle_id=ai.vocify-inc.vellum-assistant-ios.staging" >> "$GITHUB_OUTPUT"
+              echo "app_group=group.ai.vocify-inc.vellum-assistant-ios.staging" >> "$GITHUB_OUTPUT"
               echo "profile_key=IOS_PROVISIONING_PROFILE_STAGING" >> "$GITHUB_OUTPUT"
               echo "profile_name=Vellum Assistant iOS Staging Distribution" >> "$GITHUB_OUTPUT"
               echo "ext_bundle_id=ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity" >> "$GITHUB_OUTPUT"
@@ -97,6 +99,7 @@ jobs:
             dev)
               echo "scheme=App Dev" >> "$GITHUB_OUTPUT"
               echo "bundle_id=ai.vocify-inc.vellum-assistant-ios.dev" >> "$GITHUB_OUTPUT"
+              echo "app_group=group.ai.vocify-inc.vellum-assistant-ios.dev" >> "$GITHUB_OUTPUT"
               echo "profile_key=IOS_PROVISIONING_PROFILE_DEV" >> "$GITHUB_OUTPUT"
               echo "profile_name=Vellum Assistant iOS Dev Distribution" >> "$GITHUB_OUTPUT"
               echo "ext_bundle_id=ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity" >> "$GITHUB_OUTPUT"
@@ -273,16 +276,34 @@ jobs:
             fi
           }
 
+          # The App Group this environment's bundles name, restated from
+          # clients/ios/App/App/Config/App*.xcconfig and pinned to them by
+          # clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts.
+          APP_GROUP="${{ steps.config.outputs.app_group }}"
+
           # Every signed bundle declares the App Group: the app through
           # App/App.entitlements and App/App-Dev.entitlements, all three
           # appexes through App/Extension.entitlements. A profile issued before
           # the group was assigned to its App ID does not grant it, and the
           # build fails at Archive with an error that names neither the
           # entitlement nor the fix.
+          #
+          # The array has to carry this environment's group specifically. An
+          # empty array satisfies presence and grants nothing, and the
+          # production group is a prefix of the staging and dev ones, so a
+          # profile issued against the wrong environment's App ID passes any
+          # check looser than a whole-line match.
           require_app_group() {
             local plist="$1" secret="$2" target="$3"
             require_entitlement_present "$plist" com.apple.security.application-groups \
-              "Provisioning profile $secret does not grant com.apple.security.application-groups, which $target declares. Archive would fail while signing $target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md for this environment's row: assign the App Group to this App ID (steps 1 and 2), reissue its distribution profile under the identical name (steps 3 and 4), then replace $secret."
+              "Provisioning profile $secret does not grant com.apple.security.application-groups, which $target declares. Archive would fail while signing $target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md for this environment's row: assign $APP_GROUP to this App ID (steps 1 and 2), reissue its distribution profile under the identical name (steps 3 and 4), then replace $secret."
+            if ! /usr/libexec/PlistBuddy \
+              -c "Print :Entitlements:com.apple.security.application-groups" "$plist" \
+              | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+              | grep -qxF "$APP_GROUP"; then
+              echo "::error::Provisioning profile $secret grants com.apple.security.application-groups but not $APP_GROUP, which $target declares. Archive would fail while signing $target. Fix: 'Manual Apple Developer portal setup' in clients/ios/README.md for this environment's row: assign $APP_GROUP to this App ID (steps 1 and 2), reissue its distribution profile under the identical name (steps 3 and 4), then replace $secret."
+              exit 1
+            fi
           }
 
           # The app profile is non-negotiable: without it there is no build to

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -552,9 +552,18 @@ describe("syncAvatarToPlatform", () => {
     expect(patches[1].body).toEqual({
       avatar_base64: png("a").toString("base64"),
     });
+    // The disc key, not the disc-less one: the platform judged this render, so
+    // a later enqueue must not redraw it and take the same 400.
     expect(JSON.parse(readFileSync(syncStatePath, "utf-8")).key).toEndWith(
-      ":none",
+      ":disc",
     );
+
+    lastResvgSvg = "";
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(2);
+    expect(lastResvgSvg).toBe("");
   });
 
   test("a 400 naming something else is not re-sent without the disc", async () => {

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -33,8 +33,11 @@
  * A render that fails inside the body, after the key promised a disc, hands
  * the queue the disc-less key instead, so the next sync tries again rather
  * than recording a disc that never went up. If the platform rejects the field
- * outright with a 400, the queue re-sends the display avatar alone under that
- * same key, so a disc it will not take cannot block the avatar it will.
+ * outright with a 400, the queue re-sends the display avatar alone, and under
+ * the disc key: the 400 is a verdict on this render, so re-drawing it would
+ * only take the same 400 on every later enqueue. The key still moves when the
+ * raster, the accent or the spec does, which is when there is a different
+ * render to offer.
  */
 
 import { createHash } from "node:crypto";
@@ -179,21 +182,28 @@ async function buildPayload(): Promise<PatchPayload | undefined> {
         );
         return undefined;
       }
-      const withoutDisc = {
-        body: { avatar_base64: encoded },
-        key: keyFor(NONE_KEY),
-      };
+      const rasterOnly = { avatar_base64: encoded };
       const notification = await renderNotificationAvatarPng(state, bytes);
       if (!notification) {
-        return withoutDisc;
+        // Nothing was drawn, so the disc-less key goes up and the next sync
+        // draws again.
+        return { body: rasterOnly, key: keyFor(NONE_KEY) };
       }
+      const discKey = keyFor(DISC_KEY);
       return {
         body: {
           avatar_base64: encoded,
           notification_avatar_base64: notification.toString("base64"),
         },
-        key: keyFor(DISC_KEY),
-        retryWithout: { field: NOTIFICATION_FIELD, ...withoutDisc },
+        key: discKey,
+        // A 400 is the platform refusing this render rather than missing it,
+        // so the reduced send records the disc key: re-drawing would take the
+        // same 400 on every later enqueue.
+        retryWithout: {
+          field: NOTIFICATION_FIELD,
+          body: rasterOnly,
+          key: discKey,
+        },
       };
     },
   };

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -454,12 +454,15 @@ name or has grown past the 512 KB cap. The avatar is resolved once the renderer
 confirms a notification can be posted at all, and before it is posted: the cache
 first, then an HTTPS download verified against the pushed sha256. The download
 runs inside `onMessageReceived` with a 3 s connect timeout, a 2 s read timeout,
-and a 3 s total budget for the body, since the per-read timeout restarts on
-every chunk. The budget is only read between chunks and Android fixes the socket
-timeout when the connection is made, so the read that crosses the budget still
-runs its own timeout out: a connect, the budget, and that last read bound a
-responding host at 8 s. The local cache read carries the cap but no deadline,
-having no host to trickle it. A miss just posts without an avatar.
+and a 3 s total budget that starts before the response head and spans the body,
+since the per-read timeout restarts on every chunk. A head that arrives slowly
+spends the body's share rather than adding to it, and one that spends all of it
+gives up before a byte of body is read. The budget is only read between chunks
+and Android fixes the socket timeout when the connection is made, so the read
+that crosses it still runs its own timeout out: a connect, the budget, and that
+last read bound a responding host at 8 s. The local cache read carries the cap
+but no deadline, having no host to trickle it. A miss just posts without an
+avatar.
 
 ### Device QA checklist
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java
@@ -36,13 +36,16 @@ public final class AvatarCache {
     private static final int CONNECT_TIMEOUT_MILLIS = 3_000;
     // Bounds the response head and each body read alike.
     private static final int READ_TIMEOUT_MILLIS = 2_000;
-    // The read timeout restarts on every chunk, so the body also gets a total
-    // deadline: a host trickling bytes must not cost the whole notification.
-    // The deadline is only read between chunks, and Android fixes the socket
+    // The read timeout restarts on every chunk, so the response head and the
+    // body share one total deadline, started before the head is read: a host
+    // trickling bytes must not cost the whole notification. A head that
+    // arrives slowly spends the body's share rather than adding to it, and one
+    // that spends all of it gives up before a byte of body is read. The
+    // deadline is only read between chunks, and Android fixes the socket
     // timeout when the connection is made, so the read that crosses it still
     // runs its full timeout out: a connect, the budget, and that last read
     // bound a responding host at 8 s.
-    private static final long READ_BUDGET_MILLIS = 3_000;
+    private static final long RESPONSE_BUDGET_MILLIS = 3_000;
     // A local file has no host trickling it, so its read carries no deadline.
     private static final long NO_DEADLINE = 0;
     private static final int MAX_FILES = 8;
@@ -216,11 +219,16 @@ public final class AvatarCache {
             connection = (HttpsURLConnection) parsed.openConnection();
             connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
             connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+            long deadline = System.nanoTime() + RESPONSE_BUDGET_MILLIS * 1_000_000L;
             if (connection.getResponseCode() != HttpsURLConnection.HTTP_OK) {
                 return null;
             }
+            long remainingMillis = (deadline - System.nanoTime()) / 1_000_000L;
+            if (remainingMillis <= 0) {
+                return null;
+            }
             try (InputStream stream = connection.getInputStream()) {
-                return readCapped(stream, READ_BUDGET_MILLIS);
+                return readCapped(stream, remainingMillis);
             }
         } catch (IOException | RuntimeException exception) {
             return null;
@@ -233,8 +241,10 @@ public final class AvatarCache {
 
     /**
      * Bytes up to {@link #MAX_BYTES}, or null once the payload passes the cap
-     * or the budget runs out. A budget of {@link #NO_DEADLINE} reads to the end
-     * of the stream. Package-private so a test can burn a budget quickly.
+     * or the budget runs out. The budget is what the caller has left of
+     * {@link #RESPONSE_BUDGET_MILLIS}, not a fresh one. A budget of
+     * {@link #NO_DEADLINE} reads to the end of the stream. Package-private so a
+     * test can burn a budget quickly.
      */
     @Nullable
     static byte[] readCapped(InputStream stream, long budgetMillis) throws IOException {

--- a/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/push/AvatarCacheTest.java
@@ -63,6 +63,22 @@ public class AvatarCacheTest {
         assertEquals(5, read.length);
     }
 
+    /**
+     * The budget spans the response head, so what reaches the body is whatever
+     * the head left of it. A read bounded by a fixed budget of its own would
+     * read the same amount either way.
+     */
+    @Test
+    public void boundsTheBodyByTheBudgetItIsHanded() throws IOException {
+        TricklingStream brief = tricklingStream(10);
+        TricklingStream longer = tricklingStream(10);
+
+        assertNull(AvatarCache.readCapped(brief, 50));
+        assertNull(AvatarCache.readCapped(longer, 250));
+
+        assertTrue("a larger budget reads more", longer.served > brief.served);
+    }
+
     @Test
     public void acceptsLowercaseSha256HexAndNothingElseAsAFilename() {
         assertEquals(VELLUM_SHA256, AvatarCache.validated(VELLUM_SHA256));
@@ -167,34 +183,43 @@ public class AvatarCacheTest {
     }
 
     /** A host answering one byte per call, slowly enough to burn the budget. */
-    private static InputStream tricklingStream(long millisPerRead) {
+    private static TricklingStream tricklingStream(long millisPerRead) {
         return tricklingStream(millisPerRead, Integer.MAX_VALUE);
     }
 
-    private static InputStream tricklingStream(long millisPerRead, int bytes) {
-        return new InputStream() {
-            private int served;
+    private static TricklingStream tricklingStream(long millisPerRead, int bytes) {
+        return new TricklingStream(millisPerRead, bytes);
+    }
 
-            @Override
-            public int read() {
-                return 0;
-            }
+    private static final class TricklingStream extends InputStream {
+        private final long millisPerRead;
+        private final int limit;
+        private int served;
 
-            @Override
-            public int read(byte[] buffer, int offset, int length) throws IOException {
-                try {
-                    Thread.sleep(millisPerRead);
-                } catch (InterruptedException exception) {
-                    Thread.currentThread().interrupt();
-                    throw new IOException(exception);
-                }
-                if (served == bytes) {
-                    return -1;
-                }
-                served++;
-                buffer[offset] = 1;
-                return 1;
+        TricklingStream(long millisPerRead, int limit) {
+            this.millisPerRead = millisPerRead;
+            this.limit = limit;
+        }
+
+        @Override
+        public int read() {
+            return 0;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            try {
+                Thread.sleep(millisPerRead);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IOException(exception);
             }
-        };
+            if (served == limit) {
+                return -1;
+            }
+            served++;
+            buffer[offset] = 1;
+            return 1;
+        }
     }
 }

--- a/clients/ios/App/AppTests/AvatarCacheTests.swift
+++ b/clients/ios/App/AppTests/AvatarCacheTests.swift
@@ -182,15 +182,34 @@ final class AvatarCacheTests: XCTestCase {
             _ = try await AvatarCache.readAtMost(
                 AvatarCache.maxBytes,
                 from: feed.stream(),
-                before: .distantPast
+                within: .zero
             )
             XCTFail("expected the read to give up on the deadline")
         } catch let reason as AvatarCache.UnavailableReason {
             XCTAssertEqual(reason, .timedOut)
         }
-        // The deadline is checked once per stride rather than per byte, so the
-        // read stops at the first check instead of the first byte.
-        XCTAssertEqual(feed.produced, AvatarCache.deadlineCheckStride)
+        // The clock is read per byte, so a spent budget stops the read at the
+        // first one rather than at some multiple of it.
+        XCTAssertEqual(feed.produced, 1)
+    }
+
+    /// A host answering one byte at a time is what the budget exists for, and
+    /// what any amortized checking interval lets through: the whole body can be
+    /// shorter than the interval and still take longer than the budget.
+    func testGivesUpOnAHostTricklingOneByteAtATime() async throws {
+        let feed = ByteFeed(millisecondsPerByte: 20)
+        do {
+            _ = try await AvatarCache.readAtMost(
+                AvatarCache.maxBytes,
+                from: feed.stream(),
+                within: .milliseconds(100)
+            )
+            XCTFail("expected the read to give up on the deadline")
+        } catch let reason as AvatarCache.UnavailableReason {
+            XCTAssertEqual(reason, .timedOut)
+        }
+        // At this pace 50 bytes take a full second, ten times the budget.
+        XCTAssertLessThan(feed.produced, 50)
     }
 
     func testFetchRefusesANonHttpsURL() async throws {
@@ -369,20 +388,33 @@ private final class LoadCounter: @unchecked Sendable {
 }
 
 /// A byte sequence that hands out one byte at a time and counts how many it was
-/// asked for, so a test can assert that a reader stopped early.
+/// asked for, so a test can assert that a reader stopped early. The default
+/// `count` never runs out, and a `millisecondsPerByte` above zero paces the
+/// bytes, so a feed with both stops only when its reader gives up.
 private final class ByteFeed: @unchecked Sendable {
     private(set) var produced = 0
     private var remaining: Int
+    private let millisecondsPerByte: Int
 
-    init(count: Int) {
+    init(count: Int = .max, millisecondsPerByte: Int = 0) {
         remaining = count
+        self.millisecondsPerByte = millisecondsPerByte
     }
 
     func stream() -> AsyncStream<UInt8> {
-        AsyncStream(unfolding: { self.next() })
+        AsyncStream(unfolding: { await self.next() })
     }
 
-    private func next() -> UInt8? {
+    private func next() async -> UInt8? {
+        if millisecondsPerByte > 0 {
+            guard
+                (try? await Task.sleep(
+                    nanoseconds: UInt64(millisecondsPerByte) * 1_000_000
+                )) != nil
+            else {
+                return nil
+            }
+        }
         guard remaining > 0 else {
             return nil
         }

--- a/clients/ios/App/NotificationService/AvatarCache.swift
+++ b/clients/ios/App/NotificationService/AvatarCache.swift
@@ -27,10 +27,6 @@ struct AvatarCache {
     /// budget expired.
     static let downloadBudget: TimeInterval = 6
     static let readChunkSize = 16 * 1024
-    /// Bytes between deadline checks. Reading the clock costs more than copying
-    /// the byte it guards, so it is amortized rather than paid per byte while
-    /// staying frequent enough to catch a body arriving one byte at a time.
-    static let deadlineCheckStride = 512
 
     /// Why no avatar reached the notification. Every cause has its own stable
     /// token, so the Console line names which one it was instead of standing
@@ -203,29 +199,31 @@ struct AvatarCache {
     /// and a possible reallocation per byte, which is the whole of the
     /// extension's CPU budget on a 512 KB avatar.
     ///
-    /// Throws ``UnavailableReason/timedOut`` once `deadline` passes, so a body
+    /// Throws ``UnavailableReason/timedOut`` once `budget` is spent, so a body
     /// that keeps arriving too slowly to go idle is still bounded.
+    ///
+    /// The clock is read once per byte against a monotonic deadline. Any stride
+    /// between checks is a window a trickle hides in: a host answering fewer
+    /// bytes than the stride, however slowly, would never reach a check at all.
+    /// A full 512 KB body pays for one clock read per byte, tens of
+    /// milliseconds against a six-second budget.
     static func readAtMost<Bytes: AsyncSequence>(
         _ limit: Int,
         from bytes: Bytes,
         expecting expectedCount: Int? = nil,
-        before deadline: Date = Date().addingTimeInterval(downloadBudget)
+        within budget: Duration = .seconds(downloadBudget)
     ) async throws -> Data? where Bytes.Element == UInt8 {
+        let deadline = ContinuousClock.now + budget
         var data = Data()
         data.reserveCapacity(min(limit, expectedCount ?? readChunkSize))
         var chunk = [UInt8](repeating: 0, count: min(limit, readChunkSize))
         var filled = 0
-        var sinceDeadlineCheck = 0
         for try await byte in bytes {
             if data.count + filled >= limit {
                 return nil
             }
-            sinceDeadlineCheck += 1
-            if sinceDeadlineCheck == deadlineCheckStride {
-                sinceDeadlineCheck = 0
-                guard Date() < deadline else {
-                    throw UnavailableReason.timedOut
-                }
+            guard ContinuousClock.now < deadline else {
+                throw UnavailableReason.timedOut
             }
             chunk[filled] = byte
             filled += 1

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -942,11 +942,12 @@ line is enough to tell a trimmed payload from a rejected download:
 bounds: 512 KB whether the response declares a length or streams one, and six
 seconds of wall clock on top of the request's idle timeout, which bounds only a
 stall. Android bounds the same download the same way, reading 8 KB chunks under
-the same 512 KB cap against a four-second budget (`READ_BUDGET_MILLIS` in
+the same 512 KB cap against a three-second budget that spans the response head
+and the body (`RESPONSE_BUDGET_MILLIS` in
 `clients/android/app/src/main/java/ai/vellum/assistant/push/AvatarCache.java`).
 iOS buffers 16 KB chunks out of a per-byte `URLSession.AsyncBytes` sequence and
-checks the deadline once per 512 bytes, because reading the clock costs more
-than copying the byte it guards.
+reads a monotonic clock once per byte, since any stride between checks is a
+window a host answering fewer bytes than that stride hides in.
 
 A banner with no avatar and no `nse.` line at all is the entitlement and
 profile case rather than a code one. `updating(from:)` may throw, which lands

--- a/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
+++ b/clients/ios/scripts/__tests__/notification-service-bundle-ids.test.ts
@@ -113,6 +113,24 @@ describe("NSE bundle ids agree with release-ios.yaml", () => {
   });
 });
 
+describe("App Group ids agree with release-ios.yaml", () => {
+  // The workflow asserts each installed profile grants this environment's group
+  // by name, so a drift between it and the xcconfigs would either reject a
+  // correct profile or accept one issued against another environment's App ID.
+  const workflowGroups = workflowOutputs("app_group");
+
+  test("the workflow names one App Group per environment", () => {
+    expect(workflowGroups).toHaveLength(PAIRS.length);
+  });
+
+  test("every xcconfig App Group appears in the workflow", () => {
+    const configGroups = PAIRS.map(({ app }) =>
+      readSetting(app, "APP_GROUP_ID"),
+    ).sort();
+    expect(configGroups).toEqual(workflowGroups);
+  });
+});
+
 describe("every avatar failure token is documented", () => {
   // The README's `reason=` table is the only place a `nse.avatar_unavailable`
   // line can be decoded, so a token that reaches Console without a row there

--- a/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-avatar-sync.test.tsx
@@ -328,7 +328,9 @@ describe("useNotificationAvatarSync", () => {
     await waitFor(() => {
       expect(getNotificationAvatar()).not.toBeNull();
     });
-    expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(2);
+    // The render that gave nothing back, the one redraw it scheduled (which
+    // gave nothing back either), and the refetch.
+    expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(3);
   });
 
   test("draws again on the next refetch after the rasterizer threw", async () => {
@@ -364,7 +366,73 @@ describe("useNotificationAvatarSync", () => {
     await waitFor(() => {
       expect(getNotificationAvatar()).not.toBeNull();
     });
+    // The render that threw, the one redraw it scheduled (which threw too),
+    // and the refetch.
+    expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(3);
+  });
+
+  test("redraws from the URL a refetch minted under a render that then failed", async () => {
+    let releaseFirst = () => {};
+    let releaseRedraw = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const redrawGate = new Promise<void>((resolve) => {
+      releaseRedraw = resolve;
+    });
+    rasterizeGate = firstGate;
+    rasterizeThrows = true;
+    const { rerender } = renderHook(
+      ({ url }: { url: string }) =>
+        useNotificationAvatarSync(
+          ASSISTANT_ID,
+          url,
+          IMAGE_META,
+          null,
+          null,
+          ACCENT,
+        ),
+      { initialProps: { url: IMAGE_URL } },
+    );
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(1);
+    });
+
+    // A refetch mints a new URL for the same image while the first render is
+    // still in flight. The key is the image's identity, so that run matches it
+    // and returns: only the redraw the failure schedules can draw from the URL
+    // that is still live.
+    rerender({ url: "blob:avatar-1-refetched" });
+    rasterizeGate = redrawGate;
+    releaseFirst();
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(2);
+    });
+
+    rasterizeThrows = false;
+    releaseRedraw();
+
+    await waitFor(() => {
+      expect(getNotificationAvatar()).not.toBeNull();
+    });
+    expect(rasterizeNotificationAvatar).toHaveBeenLastCalledWith(
+      "blob:avatar-1-refetched",
+      ACCENT,
+    );
+  });
+
+  test("schedules one redraw, not a loop, for a picture that never draws", async () => {
+    rasterizeThrows = true;
+    render();
+
+    await waitFor(() => {
+      expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {});
+    await act(async () => {});
+
     expect(rasterizeNotificationAvatar).toHaveBeenCalledTimes(2);
+    expect(getNotificationAvatar()).toBeNull();
   });
 
   test("keeps the held avatar when a refetch mints a new URL for the same image", async () => {

--- a/clients/web/src/hooks/use-notification-avatar-sync.ts
+++ b/clients/web/src/hooks/use-notification-avatar-sync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { isElectron } from "@/runtime/is-electron";
 import {
@@ -51,8 +51,13 @@ import {
  *
  * A run that fails transiently (nothing came back from the canvas, the
  * rasterizer threw) drops the key too, so the next refetch draws again instead
- * of inheriting a claim on a picture that never landed. A render past the byte
- * cap keeps its claim: that outcome is the same every time it is redrawn.
+ * of inheriting a claim on a picture that never landed, and schedules one
+ * redraw rather than waiting for a refetch that may never come: the run that
+ * failed may have been drawing from a blob URL a refetch has already revoked,
+ * and the effect run that would have redrawn from the fresh one matched the
+ * stable key and returned. One redraw per key, so a picture the canvas cannot
+ * draw at all is not attempted forever. A render past the byte cap keeps its
+ * claim: that outcome is the same every time it is redrawn.
  */
 export function useNotificationAvatarSync(
   assistantId: string | null,
@@ -64,6 +69,8 @@ export function useNotificationAvatarSync(
 ): void {
   const enabled = useClientFeatureFlagStore.use.pushAvatarSender();
   const heldKey = useRef<string | null>(null);
+  const redrawnKey = useRef<string | null>(null);
+  const [redraws, setRedraws] = useState(0);
   const release = useCallback((): void => {
     heldKey.current = null;
     clearNotificationAvatar();
@@ -100,13 +107,22 @@ export function useNotificationAvatarSync(
     heldKey.current = key;
     clearNotificationAvatar();
 
+    const giveUp = (): void => {
+      release();
+      if (redrawnKey.current === key) {
+        return;
+      }
+      redrawnKey.current = key;
+      setRedraws((count) => count + 1);
+    };
+
     void rasterizeNotificationAvatar(src, accentHex)
       .then(async (png) => {
         if (heldKey.current !== key) {
           return;
         }
         if (!png) {
-          release();
+          giveUp();
           return;
         }
         if (png.byteLength > NOTIFICATION_AVATAR_MAX_LOCAL_BYTES) {
@@ -122,7 +138,7 @@ export function useNotificationAvatarSync(
       })
       .catch(() => {
         if (heldKey.current === key) {
-          release();
+          giveUp();
         }
       });
   }, [
@@ -133,6 +149,7 @@ export function useNotificationAvatarSync(
     components,
     traits,
     accentHex,
+    redraws,
     release,
   ]);
 }


### PR DESCRIPTION
## Summary

- **Android**: the 3 s download budget starts before `getResponseCode()` and what is left of it is handed to `readCapped`, so a slow response head spends the body's share rather than adding to it, and a head that spends all of it gives up before a byte of body is read. A responding host is bounded at the documented 8 s (connect + budget + the read that crosses it), not 10 s. `READ_BUDGET_MILLIS` is now `RESPONSE_BUDGET_MILLIS`; the constant comments and the README arithmetic say what the bound actually is.
- **iOS**: `AvatarCache.readAtMost` takes a `Duration` budget and reads a monotonic `ContinuousClock` once per byte instead of checking `Date()` once per 512 bytes. A host trickling fewer bytes than that stride, however slowly, never reached a check and so never tripped `timed_out`; now any byte arriving past the deadline does. `deadlineCheckStride` is gone.
- **Release preflight**: `require_app_group` asserts the profile's `com.apple.security.application-groups` array carries this environment's group as a whole-line exact match, not merely that the key is present. An empty array and a profile issued against another environment's App ID both fail now, and the production group being a prefix of the staging and dev ones is why the match has to be exact. The group comes from a new `app_group` config output, pinned to `App*.xcconfig` by `notification-service-bundle-ids.test.ts`.
- **Web**: a failed notification-avatar render schedules one redraw instead of only dropping its claim. A refetch that mints a new blob URL while a render is in flight matches the stable image key and returns, so when that render then fails nothing redrew until the next refetch; the redraw picks up the URL that is still live. Bounded to one per key, so a picture the canvas cannot draw is not attempted forever.
- **Daemon**: a 400 rejecting `notification_avatar_base64` persists the `:disc` key rather than `:none`. The 400 is a verdict on that render, so recording `:none` had the daemon redraw the disc and take the same 400 on every later enqueue. The key still moves when the raster, the accent or the spec does.

Round-4 self-review polish for the notification avatar feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1