### PR TITLE
fix(web): chat-info attachments follow the transcript owner and app opening shares one helper

### DIFF
--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -35,6 +35,7 @@ import {
   type ConversationFileAsset,
   useConversationAssets,
 } from "@/domains/chat/hooks/use-conversation-assets";
+import { openAppFromChat } from "@/domains/chat/hooks/use-open-app-from-chat";
 import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-changes-store";
 import { useAppDelete } from "@/hooks/use-app-delete";
 import { useTranslation } from "@/i18n";
@@ -107,9 +108,8 @@ export function ChatInfoPanel({
   // under the panel's own assistant, which need not be the active one.
   const handleOpenApp = useCallback(
     (appId: string) => {
-      haptic.light();
       useViewerStore.getState().closeChatInfo();
-      void useViewerStore.getState().loadApp(assistantId, appId);
+      void openAppFromChat(assistantId, appId);
     },
     [assistantId],
   );

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -20,8 +20,10 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import {
   CHAT_INFO_T0,
+  clearTranscriptOwner,
   makeAppSummary,
   makeDocumentSummary,
+  seedTranscriptOwner,
 } from "@/domains/chat/components/chat-info.test-helper";
 import type {
   DisplayAttachment,
@@ -219,7 +221,7 @@ function seedChatInfoQueries(
   }
 }
 
-/** Installs `messages` as the rendered transcript. */
+/** Installs `messages` as the rendered transcript, under its owner. */
 function seedChatInfoTranscript(messages: DisplayMessage[]): void {
   useChatSessionStore.getState().seedSnapshot(CHAT_INFO_CONVERSATION_ID, {
     messages,
@@ -228,11 +230,13 @@ function seedChatInfoTranscript(messages: DisplayMessage[]): void {
     oldestMessageId: null,
     seq: 1,
   });
+  seedTranscriptOwner(CHAT_INFO_ASSISTANT_ID, CHAT_INFO_CONVERSATION_ID);
 }
 
 /** Drops the seeded transcript, so a story cannot leak into the next one. */
 function resetChatInfoTranscript(): void {
   useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
+  clearTranscriptOwner();
 }
 
 /**

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -10,6 +10,7 @@
  * way `utils/conversation-list.test-helper.ts` already is.
  */
 
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import {
   type ConversationFileAsset,
   toConversationFileAssets,
@@ -97,4 +98,26 @@ export function makeFrameAsset(
     [],
     [makeAttachmentEntry(attachment, { sightFrame: true, capturedAt })],
   ).frames[0]!;
+}
+
+/**
+ * Names the conversation the seeded chat-session snapshot belongs to, which is
+ * what `useConversationAttachments` gates on.
+ */
+export function seedTranscriptOwner(
+  assistantId: string,
+  conversationId: string,
+): void {
+  useChatSessionStore.setState({
+    previousAssistantId: assistantId,
+    previousConversationId: conversationId,
+  });
+}
+
+/** Unnames the owner, so a seeded transcript cannot outlive its test or story. */
+export function clearTranscriptOwner(): void {
+  useChatSessionStore.setState({
+    previousAssistantId: null,
+    previousConversationId: null,
+  });
 }

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
@@ -8,7 +8,15 @@
  * suite mocks it.
  */
 
-import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook } from "@testing-library/react";
 
@@ -31,6 +39,8 @@ const {
   useConversationAssets,
   toConversationFileAssets,
 } = await import("@/domains/chat/hooks/use-conversation-assets");
+const { clearTranscriptOwner, seedTranscriptOwner } =
+  await import("@/domains/chat/components/chat-info.test-helper");
 const { makeDisplayAttachment } =
   await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
 const {
@@ -145,9 +155,14 @@ function renderCounts({
   );
 }
 
+beforeEach(() => {
+  seedTranscriptOwner(ASSISTANT_ID, CONVERSATION_ID);
+});
+
 afterEach(() => {
   cleanup();
   messagesRef.value = [];
+  clearTranscriptOwner();
 });
 
 // `mock.module` is process-global in this runner, so the module graph is put

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -5,10 +5,17 @@
  * everything asserted here is the walk over those rows.
  */
 
-import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
-import type * as ConversationStore from "@/stores/conversation-store";
 import type * as TranscriptMessages from "@/domains/chat/transcript/use-transcript-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
@@ -23,19 +30,10 @@ mock.module(
   }),
 );
 
-const openConversationRef: { value: string | null } = { value: "conv-1" };
-
-mock.module(
-  "@/stores/conversation-store",
-  (): Partial<typeof ConversationStore> => ({
-    useConversationStore: {
-      use: { activeConversationId: () => openConversationRef.value },
-    } as unknown as typeof ConversationStore.useConversationStore,
-  }),
-);
-
 const { useConversationAttachments } =
   await import("@/domains/chat/hooks/use-conversation-attachments");
+const { clearTranscriptOwner, seedTranscriptOwner } =
+  await import("@/domains/chat/components/chat-info.test-helper");
 const { makeDisplayAttachment } =
   await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
 
@@ -45,10 +43,14 @@ function makeMessage(overrides: Partial<DisplayMessage>): DisplayMessage {
   return { id: "msg-1", role: "user", ...overrides };
 }
 
+beforeEach(() => {
+  seedTranscriptOwner(TARGET.assistantId, TARGET.conversationId);
+});
+
 afterEach(() => {
   cleanup();
   messagesRef.value = [];
-  openConversationRef.value = "conv-1";
+  clearTranscriptOwner();
 });
 
 afterAll(() => {
@@ -231,8 +233,7 @@ describe("useConversationAttachments", () => {
     expect(result.current.entries).toBe(first);
   });
 
-  test("lists the loaded transcript when it is the target conversation's", () => {
-    openConversationRef.value = "conv-1";
+  test("lists the loaded transcript when the target owns the snapshot", () => {
     messagesRef.value = [
       makeMessage({ attachments: [makeDisplayAttachment({ id: "mine" })] }),
     ];
@@ -244,8 +245,8 @@ describe("useConversationAttachments", () => {
     ]);
   });
 
-  test("lists nothing when the loaded transcript is another conversation's", () => {
-    openConversationRef.value = "conv-2";
+  test("lists nothing when another conversation owns the snapshot", () => {
+    seedTranscriptOwner(TARGET.assistantId, "conv-2");
     messagesRef.value = [
       makeMessage({ attachments: [makeDisplayAttachment({ id: "theirs" })] }),
     ];
@@ -256,18 +257,28 @@ describe("useConversationAttachments", () => {
     expect(result.current.totalFiles).toBe(0);
   });
 
-  test("lists the transcript when no conversation is named as open", () => {
-    // Nothing open is nothing to confuse these rows with, so the rows stand.
-    openConversationRef.value = null;
+  test("lists nothing when another assistant owns the snapshot", () => {
+    seedTranscriptOwner("asst-2", TARGET.conversationId);
+    messagesRef.value = [
+      makeMessage({ attachments: [makeDisplayAttachment({ id: "theirs" })] }),
+    ];
+
+    const { result } = renderHook(() => useConversationAttachments(TARGET));
+
+    expect(result.current.entries).toHaveLength(0);
+    expect(result.current.totalFiles).toBe(0);
+  });
+
+  test("lists nothing when no conversation owns the snapshot", () => {
+    clearTranscriptOwner();
     messagesRef.value = [
       makeMessage({ attachments: [makeDisplayAttachment({ id: "draft" })] }),
     ];
 
     const { result } = renderHook(() => useConversationAttachments(TARGET));
 
-    expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
-      "draft",
-    ]);
+    expect(result.current.entries).toHaveLength(0);
+    expect(result.current.totalFiles).toBe(0);
   });
 
   test("keeps the load-more callbacks stable", () => {

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -10,8 +10,8 @@
 
 import { useMemo } from "react";
 
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
-import { useConversationStore } from "@/stores/conversation-store";
 import type { DisplayAttachment } from "@/types/attachment-types";
 
 export interface ConversationAttachmentEntry {
@@ -62,19 +62,19 @@ export function useConversationAttachments(target: {
   assistantId: string;
   conversationId: string;
 }): ConversationAttachments {
-  // The transcript holds whichever conversation is open and its snapshot names
-  // no conversation of its own, so a caller asking about a different one is
-  // answered with nothing rather than with the open conversation's files. With
-  // none open there is no other conversation to mistake these rows for.
-  const activeConversationId = useConversationStore.use.activeConversationId();
-  const isOtherConversation =
-    activeConversationId !== null &&
-    activeConversationId !== target.conversationId;
+  // The chat-session store names the conversation its snapshot was loaded for.
+  // The navigation selection flips a render before that snapshot is cleared, so
+  // gating on it would list the outgoing conversation's files under the new id.
+  const ownerAssistantId = useChatSessionStore.use.previousAssistantId();
+  const ownerConversationId = useChatSessionStore.use.previousConversationId();
+  const ownsTranscript =
+    ownerAssistantId === target.assistantId &&
+    ownerConversationId === target.conversationId;
 
   const messages = useTranscriptMessages();
 
   const entries = useMemo(() => {
-    if (isOtherConversation) {
+    if (!ownsTranscript) {
       return NO_ENTRIES;
     }
     const collected: ConversationAttachmentEntry[] = [];
@@ -111,7 +111,7 @@ export function useConversationAttachments(target: {
       }
     }
     return collected.length === 0 ? NO_ENTRIES : collected;
-  }, [messages, isOtherConversation]);
+  }, [messages, ownsTranscript]);
 
   return useMemo(
     () => ({

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
 // `mock.module` is safe for `use-is-mobile` because it's a pure
@@ -14,8 +22,9 @@ mock.module("@/hooks/use-is-mobile", () => ({
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
+import { haptic } from "@/utils/haptics";
 
-import { useOpenAppFromChat } from "./use-open-app-from-chat";
+import { openAppFromChat, useOpenAppFromChat } from "./use-open-app-from-chat";
 
 // We can't safely `mock.module(...)` core stores like viewer/conversation
 // because Bun module mocks are process-global. They leak into every
@@ -28,6 +37,8 @@ let viewerSnapshot: ReturnType<typeof useViewerStore.getState>;
 let conversationSnapshot: ReturnType<typeof useConversationStore.getState>;
 let selectionSnapshot: ReturnType<typeof useResolvedAssistantsStore.getState>;
 
+let lightSpy: ReturnType<typeof spyOn<typeof haptic, "light">>;
+
 const loadAppMock = mock(async (_assistantId: string, _appId: string) => {});
 const enterAppEditingMock = mock(() => undefined);
 const setEditingConversationIdMock = mock((_id: string | null) => undefined);
@@ -36,6 +47,8 @@ beforeEach(() => {
   viewerSnapshot = useViewerStore.getState();
   conversationSnapshot = useConversationStore.getState();
   selectionSnapshot = useResolvedAssistantsStore.getState();
+
+  lightSpy = spyOn(haptic, "light").mockImplementation(async () => {});
 
   mobileRef.current = false;
   loadAppMock.mockReset();
@@ -77,6 +90,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  lightSpy.mockRestore();
   useViewerStore.setState(viewerSnapshot, true);
   useConversationStore.setState(conversationSnapshot, true);
   useResolvedAssistantsStore.setState(selectionSnapshot, true);
@@ -152,5 +166,14 @@ describe("useOpenAppFromChat", () => {
     expect(useViewerStore.getState().mainView).toBe("chat");
     expect(enterAppEditingMock).not.toHaveBeenCalled();
     expect(setEditingConversationIdMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("openAppFromChat", () => {
+  test("buzzes and opens the app under the assistant it is given", async () => {
+    await openAppFromChat("asst-other", "app-42");
+
+    expect(lightSpy).toHaveBeenCalledTimes(1);
+    expect(loadAppMock).toHaveBeenCalledWith("asst-other", "app-42");
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
+++ b/clients/web/src/domains/chat/hooks/use-open-app-from-chat.ts
@@ -4,6 +4,15 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { haptic } from "@/utils/haptics";
 
+/** Opens `appId` under `assistantId` in the viewer panel. */
+export async function openAppFromChat(
+  assistantId: string,
+  appId: string,
+): Promise<void> {
+  haptic.light();
+  await useViewerStore.getState().loadApp(assistantId, appId);
+}
+
 /**
  * Open an app in the viewer panel from inside the chat surface: the sidebar's
  * pinned-app click and the transcript's "Open App" affordance.
@@ -32,8 +41,8 @@ import { haptic } from "@/utils/haptics";
  * Single source of truth for the active assistant's apps, used by
  * `chat-layout.tsx` (sidebar) and `chat-route-content.tsx` (transcript).
  * Don't inline a copy. A surface that opens an app for some other assistant
- * (the chat-info panel opens the one its payload names) calls `loadApp`
- * directly instead.
+ * (the chat-info panel opens the one its payload names) calls
+ * {@link openAppFromChat} with that assistant.
  */
 export function useOpenAppFromChat(): (appId: string) => Promise<void> {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
@@ -43,8 +52,7 @@ export function useOpenAppFromChat(): (appId: string) => Promise<void> {
       if (!assistantId) {
         return;
       }
-      haptic.light();
-      await useViewerStore.getState().loadApp(assistantId, appId);
+      await openAppFromChat(assistantId, appId);
     },
     [assistantId],
   );


### PR DESCRIPTION
## Summary
- useConversationAttachments answers only for the conversation and assistant that own the chat-session snapshot, so a navigation to another conversation cannot show the outgoing one's files for a render
- openAppFromChat(assistantId, appId) is the one place that opens an app from the chat surface; the hook and the Chat Info panel both use it
- story fixtures and tests seed the snapshot owner alongside the transcript

Part of plan: chat-info-assets-panel.md (remediation round 3)