### PR TITLE
test(web): chat-info story fixture seeds the transcript for the story's own conversation

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -31,6 +31,7 @@ import { Button } from "@vellumai/design-library";
 
 import { ChannelSourceLinkPill } from "@/domains/chat/components/channel-source-link-pill";
 import { ChatLayoutHeader } from "@/domains/chat/chat-layout-header";
+import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { inChatInfoConversation } from "@/domains/chat/components/chat-info-story-fixtures";
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
 import { MOBILE_MEDIA_QUERY } from "@/hooks/use-is-mobile";
@@ -219,9 +220,11 @@ export const MobileBaseline: Story = {
 
 /**
  * The Chat Info panel is open on this conversation, so the Assets glyph carries
- * the `active` fill that marks it as the selected view.
+ * the `active` fill that marks it as the selected view. Two transcript images
+ * join the app, so the trigger counts both of the sources it reads.
  */
 export const AssetsPanelOpen: Story = {
   args: { isMobile: false },
+  parameters: { chatInfo: { attachments: makePreviewableImages(2) } },
   decorators: [withChatInfoOpen],
 };

--- a/clients/web/src/domains/chat/components/adaptive-popover.tsx
+++ b/clients/web/src/domains/chat/components/adaptive-popover.tsx
@@ -4,9 +4,10 @@
  *
  * The split is not a style preference. A popover anchored near the bottom of a
  * phone screen opens into the thumb's own reach and lands under the soft
- * keyboard, so the touch path has to be a sheet. The chat controls that open a
- * panel share this one implementation, so a fix to the touch path cannot land
- * on one and miss the others.
+ * keyboard, so the touch path has to be a sheet. The agents control and the
+ * progress card open their panels through here, so a fix to the touch path
+ * reaches both. `InChatPluginPill` writes the same branch by hand, so a fix
+ * here does not reach it.
  *
  * Branches on {@link useTouchMobile} (coarse pointer AND phone width), not on
  * width alone: a narrow desktop window still wants the popover, since a bottom

--- a/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
@@ -9,6 +9,10 @@
  * decorator does that seeding for every story; a story that wants a different
  * conversation names it in `parameters.chatInfo`.
  *
+ * There is no Camera Frames story. The seeded transcript carries no frame tag,
+ * so that row has nothing to build from until frames come from the daemon's
+ * attachment list.
+ *
  * The frame is the shipped drawer, so a story opens at its 400px default and
  * the rows fit what that width holds. Drag the drawer's left edge to walk the
  * fit rule out to the mock's wider column.

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -221,16 +221,20 @@ function seedChatInfoQueries(
   }
 }
 
-/** Installs `messages` as the rendered transcript, under its owner. */
-function seedChatInfoTranscript(messages: DisplayMessage[]): void {
-  useChatSessionStore.getState().seedSnapshot(CHAT_INFO_CONVERSATION_ID, {
-    messages,
+/** Installs the story's attachments as the rendered transcript, under its owner. */
+function seedChatInfoTranscript({
+  assistantId,
+  conversationId,
+  attachments,
+}: ChatInfoStoryConversation): void {
+  useChatSessionStore.getState().seedSnapshot(conversationId, {
+    messages: chatInfoMessages(attachments),
     hasMore: false,
     oldestTimestamp: null,
     oldestMessageId: null,
     seq: 1,
   });
-  seedTranscriptOwner(CHAT_INFO_ASSISTANT_ID, CHAT_INFO_CONVERSATION_ID);
+  seedTranscriptOwner(assistantId, conversationId);
 }
 
 /** Drops the seeded transcript, so a story cannot leak into the next one. */
@@ -261,7 +265,7 @@ export const inChatInfoConversation: Decorator =
         defaultOptions: { queries: { retry: false, staleTime: Infinity } },
       });
       seedChatInfoQueries(created, conversation);
-      seedChatInfoTranscript(chatInfoMessages(conversation.attachments));
+      seedChatInfoTranscript(conversation);
       return created;
     });
     useEffect(() => resetChatInfoTranscript, []);

--- a/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.tsx
+++ b/clients/web/src/domains/chat/components/inchat-plugin-pill/inchat-plugin-pill.tsx
@@ -27,8 +27,9 @@ export interface InChatPluginPillProps {
  * Top-right chat pill summarizing the conversation's active plugins. Clicking it
  * opens a read-only list of those plugins plus a "Manage" shortcut to the
  * plugins page: editing the set happens there, not in this menu. Sits in the
- * header's top-right cluster, and splits its disclosure between a desktop
- * popover and a touch bottom sheet.
+ * header's top-right cluster, and branches its disclosure between a desktop
+ * popover and a touch bottom sheet here rather than through `AdaptivePopover`,
+ * which is where the other chat panels get that split.
  */
 export function InChatPluginPill({
   assistantId,

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from "@/i18n";
 /**
  * Side-drawer panel listing every attachment on one transcript message.
  * Opened by the overflow tile on a truncated attachment strip (see
@@ -22,6 +21,7 @@ import {
 } from "@/components/detail-shell";
 import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
 import { useLiveMessageAttachments } from "@/domains/chat/hooks/use-live-message-attachments";
+import { useTranslation } from "@/i18n";
 import type { MessageFilesPayload } from "@/stores/viewer-store";
 
 interface MessageFilesPanelProps {

--- a/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -11,6 +11,7 @@ import {
 import { CardSurfaceDataSchema } from "@vellumai/assistant-api";
 import type { Surface } from "@/domains/chat/types/types";
 
+import { DetailShellMidlineDot } from "@/components/detail-shell";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
@@ -351,10 +352,7 @@ export function TaskProgressBody({ progress }: { progress: TaskProgress }) {
         <span className="min-w-0 truncate py-0.5 text-title-small leading-snug text-[var(--content-strong)]">
           {progress.title}
         </span>
-        <span
-          aria-hidden
-          className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
-        />
+        <DetailShellMidlineDot />
         <span className="shrink-0 whitespace-nowrap py-0.5 text-title-small font-normal! leading-snug text-[var(--content-tertiary)]">
           {t("progressRail.stepCounter", { current, total })}
         </span>

--- a/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -28,6 +28,7 @@ import { useTranslation } from "@/i18n";
 
 import { Button } from "@vellumai/design-library";
 
+import { DetailShellMidlineDot } from "@/components/detail-shell";
 import { AllowOptionsMenu } from "@/domains/chat/components/allow-options-menu";
 import { offersRuleOption } from "@/domains/chat/confirmation-decisions";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
@@ -191,10 +192,7 @@ export function InlineConfirmationCard({
           </span>
           {contextLabel ? (
             <>
-              <span
-                aria-hidden
-                className="size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
-              />
+              <DetailShellMidlineDot />
               <span className="min-w-0 truncate">{contextLabel}</span>
             </>
           ) : null}


### PR DESCRIPTION
## Summary
- the shared decorator seeds the snapshot and its owner under the ids a story declares, and the header story now carries attachments to prove it
- the panel stories state that the Camera Frames row has no story until frames can be seeded
- tool-call-chip and card-surface use DetailShellMidlineDot; adaptive-popover and inchat-plugin-pill docblocks match their consumers; message-files-panel's docstring leads the file

Part of plan: chat-info-assets-panel.md (remediation round 4)