### PR TITLE
feat(acp): forward config_option_update notifications instead of dropping them

### DIFF
--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import type { SessionNotification } from "@agentclientprotocol/sdk";
+import type {
+  SessionConfigOption,
+  SessionNotification,
+} from "@agentclientprotocol/sdk";
 
 import type { AssistantEvent } from "../../api/index.js";
 import { VellumAcpClientHandler } from "../client-handler.js";
@@ -11,16 +14,21 @@ const PARENT_CONVERSATION_ID = "conv-xyz";
 function makeHandler(): {
   handler: VellumAcpClientHandler;
   sent: AssistantEvent[];
+  configOptionUpdates: SessionConfigOption[][];
 } {
   const sent: AssistantEvent[] = [];
+  const configOptionUpdates: SessionConfigOption[][] = [];
   const handler = new VellumAcpClientHandler(
     ACP_SESSION_ID,
     (msg) => {
       sent.push(msg);
     },
     PARENT_CONVERSATION_ID,
+    (configOptions) => {
+      configOptionUpdates.push(configOptions);
+    },
   );
-  return { handler, sent };
+  return { handler, sent, configOptionUpdates };
 }
 
 describe("VellumAcpClientHandler.sessionUpdate", () => {
@@ -780,5 +788,94 @@ describe("VellumAcpClientHandler seq + enriched fields", () => {
     const msg = sent[0] as { toolTitle?: string };
     expect(msg.toolTitle).not.toContain("AKIAFA01L49X7HW9DM2Y");
     expect(msg.toolTitle).toContain("<redacted");
+  });
+});
+
+describe("VellumAcpClientHandler config_option_update", () => {
+  const MODEL_OPTION: SessionConfigOption = {
+    type: "select",
+    id: "model",
+    name: "Model",
+    category: "model",
+    currentValue: "sonnet",
+    options: [
+      { value: "sonnet", name: "Sonnet" },
+      { value: "opus", name: "Opus" },
+    ],
+  };
+
+  const THOUGHT_OPTION: SessionConfigOption = {
+    type: "boolean",
+    id: "thinking",
+    name: "Extended thinking",
+    currentValue: true,
+  };
+
+  function configOptionUpdate(
+    configOptions: SessionConfigOption[],
+  ): SessionNotification {
+    return {
+      sessionId: ACP_SESSION_ID,
+      update: { sessionUpdate: "config_option_update", configOptions },
+    };
+  }
+
+  test("invokes the callback with the full option array", async () => {
+    const { handler, sent, configOptionUpdates } = makeHandler();
+
+    await handler.sessionUpdate(
+      configOptionUpdate([MODEL_OPTION, THOUGHT_OPTION]),
+    );
+
+    expect(configOptionUpdates).toEqual([[MODEL_OPTION, THOUGHT_OPTION]]);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("callback fires during replay suppression", async () => {
+    const { handler, sent, configOptionUpdates } = makeHandler();
+
+    handler.beginReplaySuppression();
+    await handler.sessionUpdate(configOptionUpdate([MODEL_OPTION]));
+
+    expect(configOptionUpdates).toEqual([[MODEL_OPTION]]);
+    expect(sent).toHaveLength(0);
+  });
+
+  test("a handler without the callback tolerates the update", async () => {
+    const sent: AssistantEvent[] = [];
+    const handler = new VellumAcpClientHandler(
+      ACP_SESSION_ID,
+      (msg) => {
+        sent.push(msg);
+      },
+      PARENT_CONVERSATION_ID,
+    );
+
+    await handler.sessionUpdate(configOptionUpdate([MODEL_OPTION]));
+
+    expect(sent).toHaveLength(0);
+  });
+
+  test("the remaining unhandled update types stay unforwarded", async () => {
+    const { handler, sent, configOptionUpdates } = makeHandler();
+
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: {
+        sessionUpdate: "available_commands_update",
+        availableCommands: [{ name: "create_plan", description: "Plan work" }],
+      },
+    });
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: { sessionUpdate: "current_mode_update", currentModeId: "ask" },
+    });
+    await handler.sessionUpdate({
+      sessionId: ACP_SESSION_ID,
+      update: { sessionUpdate: "session_info_update", title: "Refactor" },
+    });
+
+    expect(sent).toHaveLength(0);
+    expect(configOptionUpdates).toHaveLength(0);
   });
 });

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -21,6 +21,7 @@ import type {
   ReleaseTerminalResponse,
   RequestPermissionRequest,
   RequestPermissionResponse,
+  SessionConfigOption,
   SessionNotification,
   TerminalOutputRequest,
   TerminalOutputResponse,
@@ -103,6 +104,9 @@ export class VellumAcpClientHandler implements Client {
     private readonly acpSessionId: string,
     private readonly sendToVellum: (msg: AssistantEvent) => void,
     private readonly parentConversationId: string,
+    private readonly onConfigOptions?: (
+      configOptions: SessionConfigOption[],
+    ) => void,
   ) {}
 
   /** Forwards an update to Vellum, stamping a contiguous per-session `seq`. */
@@ -182,7 +186,12 @@ export class VellumAcpClientHandler implements Client {
   async sessionUpdate(params: SessionNotification): Promise<void> {
     const update = params.update;
 
-    if (this.suppressForwarding) {
+    // Config options are current state rather than transcript history, so they
+    // are applied even while a replay is being suppressed.
+    if (
+      this.suppressForwarding &&
+      update.sessionUpdate !== "config_option_update"
+    ) {
       log.debug(
         { acpSessionId: this.acpSessionId, updateType: update.sessionUpdate },
         "Dropping replayed session update during suppression",
@@ -286,10 +295,14 @@ export class VellumAcpClientHandler implements Client {
         break;
       }
 
+      case "config_option_update": {
+        this.onConfigOptions?.(update.configOptions);
+        break;
+      }
+
       default: {
         // Other update types (available_commands_update, current_mode_update,
-        // config_option_update, session_info_update) are not forwarded to
-        // Vellum.
+        // session_info_update) are not forwarded to Vellum.
         log.debug(
           {
             acpSessionId: this.acpSessionId,


### PR DESCRIPTION
## Summary
- Add an optional `onConfigOptions` callback to `VellumAcpClientHandler`, wired as a fourth constructor param alongside the existing injected `sendToVellum`.
- Handle `config_option_update` in `sessionUpdate()` instead of letting it fall through to the default branch, and drop it from that branch's comment.
- Config options are current state, not history, so the callback fires even while replay suppression is active. Tests cover the new case, the suppression path, the no-callback path, and the three still-unhandled update types.

Part of plan: acp-model-control.md (PR 6 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D