### PR TITLE
feat(acp): pure helpers to derive model info from configOptions and resolve the requested model

### DIFF
--- a/assistant/src/acp/model-config.test.ts
+++ b/assistant/src/acp/model-config.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the pure ACP model-config helpers: flattening an adapter's model
+ * `SessionConfigOption` into publishable model info, and the spawn-time
+ * precedence ladder.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+
+import { deriveModelInfo, resolveAcpModel } from "./model-config.js";
+
+const flatModelOption: SessionConfigOption = {
+  type: "select",
+  id: "model",
+  name: "Model",
+  category: "model",
+  currentValue: "sonnet",
+  options: [
+    { value: "sonnet", name: "Sonnet", description: "Balanced" },
+    { value: "opus", name: "Opus" },
+  ],
+};
+
+describe("deriveModelInfo", () => {
+  test("flattens flat options and reports the current value", () => {
+    expect(deriveModelInfo([flatModelOption])).toEqual({
+      model: "sonnet",
+      modelConfigId: "model",
+      availableModels: [
+        { value: "sonnet", label: "Sonnet", description: "Balanced" },
+        { value: "opus", label: "Opus" },
+      ],
+    });
+  });
+
+  test("flattens grouped options and carries the group name", () => {
+    const grouped: SessionConfigOption = {
+      type: "select",
+      id: "model",
+      name: "Model",
+      category: "model",
+      currentValue: "opus",
+      options: [
+        {
+          group: "anthropic",
+          name: "Anthropic",
+          options: [
+            { value: "opus", name: "Opus" },
+            { value: "haiku", name: "Haiku", description: "Fast" },
+          ],
+        },
+        {
+          group: "aliases",
+          name: "Aliases",
+          options: [{ value: "best", name: "Best available" }],
+        },
+      ],
+    };
+
+    expect(deriveModelInfo([grouped])).toEqual({
+      model: "opus",
+      modelConfigId: "model",
+      availableModels: [
+        { value: "opus", label: "Opus", group: "Anthropic" },
+        {
+          value: "haiku",
+          label: "Haiku",
+          description: "Fast",
+          group: "Anthropic",
+        },
+        { value: "best", label: "Best available", group: "Aliases" },
+      ],
+    });
+  });
+
+  test("matches on id alone when no category is reported", () => {
+    const uncategorized: SessionConfigOption = {
+      type: "select",
+      id: "model",
+      name: "Model",
+      currentValue: "haiku",
+      options: [{ value: "haiku", name: "Haiku" }],
+    };
+
+    const info = deriveModelInfo([uncategorized]);
+
+    expect(info.modelConfigId).toBe("model");
+    expect(info.model).toBe("haiku");
+  });
+
+  test("matches on category alone when the id differs", () => {
+    const byCategory: SessionConfigOption = {
+      type: "select",
+      id: "llm",
+      name: "LLM",
+      category: "model",
+      currentValue: "gpt-5",
+      options: [{ value: "gpt-5", name: "GPT-5" }],
+    };
+
+    expect(deriveModelInfo([byCategory]).modelConfigId).toBe("llm");
+  });
+
+  test("ignores a boolean option even when its category is model", () => {
+    const booleanOption: SessionConfigOption = {
+      type: "boolean",
+      id: "model",
+      name: "Model",
+      category: "model",
+      currentValue: true,
+    };
+
+    expect(deriveModelInfo([booleanOption])).toEqual({ availableModels: [] });
+  });
+
+  test("skips non-model select options and picks the first match", () => {
+    const mode: SessionConfigOption = {
+      type: "select",
+      id: "mode",
+      name: "Mode",
+      category: "mode",
+      currentValue: "ask",
+      options: [{ value: "ask", name: "Ask" }],
+    };
+
+    expect(deriveModelInfo([mode, flatModelOption]).modelConfigId).toBe(
+      "model",
+    );
+  });
+
+  test("returns no model info for an empty array", () => {
+    expect(deriveModelInfo([])).toEqual({ availableModels: [] });
+  });
+
+  test("returns no model info for null", () => {
+    expect(deriveModelInfo(null)).toEqual({ availableModels: [] });
+  });
+
+  test("returns no model info for undefined", () => {
+    expect(deriveModelInfo(undefined)).toEqual({ availableModels: [] });
+  });
+});
+
+describe("resolveAcpModel", () => {
+  test("prefers the requested model over every other rung", () => {
+    expect(
+      resolveAcpModel({
+        requestedModel: "opus",
+        conversationPreference: "sonnet",
+        agentModel: "haiku",
+        defaultModel: "fable",
+      }),
+    ).toBe("opus");
+  });
+
+  test("falls back to the conversation preference", () => {
+    expect(
+      resolveAcpModel({
+        conversationPreference: "sonnet",
+        agentModel: "haiku",
+        defaultModel: "fable",
+      }),
+    ).toBe("sonnet");
+  });
+
+  test("falls back to the per-agent model", () => {
+    expect(
+      resolveAcpModel({ agentModel: "haiku", defaultModel: "fable" }),
+    ).toBe("haiku");
+  });
+
+  test("falls back to the global default model", () => {
+    expect(resolveAcpModel({ defaultModel: "fable" })).toBe("fable");
+  });
+
+  test("returns undefined when every rung is unset", () => {
+    expect(resolveAcpModel({})).toBeUndefined();
+  });
+
+  test("treats blank and whitespace-only values as unset", () => {
+    expect(
+      resolveAcpModel({
+        requestedModel: "",
+        conversationPreference: "   ",
+        agentModel: "\t\n",
+        defaultModel: "fable",
+      }),
+    ).toBe("fable");
+  });
+
+  test("returns undefined when every rung is whitespace", () => {
+    expect(
+      resolveAcpModel({ requestedModel: " ", defaultModel: "  " }),
+    ).toBeUndefined();
+  });
+
+  test("trims the value it returns", () => {
+    expect(resolveAcpModel({ requestedModel: "  opus  " })).toBe("opus");
+  });
+});

--- a/assistant/src/acp/model-config.ts
+++ b/assistant/src/acp/model-config.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure helpers for ACP session model selection.
+ *
+ * ACP 0.25.0 has no `session/set_model`: a model is one `SessionConfigOption`
+ * among the set an adapter reports from `session/new`, `session/load`,
+ * `session/resume`, and `session/set_config_option`. `deriveModelInfo` turns
+ * that raw set into the trio the daemon publishes and persists (current model,
+ * selectable options, and the config id to write back through
+ * `setSessionConfigOption`), flattening the grouped `options` variant so
+ * callers never branch on it.
+ *
+ * The model option is identified by `type === "select"` and `id === "model"`
+ * or `category === "model"` only. Option `name` is a human label an adapter
+ * may localize or restyle at will, so it is never matched against.
+ *
+ * `resolveAcpModel` is the precedence ladder a spawn walks before it talks to
+ * the adapter: an explicit request beats the conversation's remembered choice,
+ * which beats the per-agent config default, which beats the global one. Values
+ * are adapter-reported aliases (`opus`, `sonnet`), never Assistant catalog ids,
+ * and are passed through unvalidated: only the adapter knows what it accepts.
+ *
+ * Both helpers are synchronous and side-effect free.
+ */
+
+import type {
+  SessionConfigOption,
+  SessionConfigSelectGroup,
+  SessionConfigSelectOption,
+} from "@agentclientprotocol/sdk";
+
+/** A selectable model as reported by the adapter, flattened out of its group. */
+export type AcpModelOption = {
+  value: string;
+  label: string;
+  description?: string;
+  group?: string;
+};
+
+export type AcpModelInfo = {
+  model?: string;
+  availableModels: AcpModelOption[];
+  modelConfigId?: string;
+};
+
+export type ResolveAcpModelInput = {
+  requestedModel?: string;
+  conversationPreference?: string;
+  agentModel?: string;
+  defaultModel?: string;
+};
+
+function isGroup(
+  entry: SessionConfigSelectOption | SessionConfigSelectGroup,
+): entry is SessionConfigSelectGroup {
+  return "group" in entry;
+}
+
+function toModelOption(
+  option: SessionConfigSelectOption,
+  group?: string,
+): AcpModelOption {
+  return {
+    value: option.value,
+    label: option.name,
+    ...(option.description ? { description: option.description } : {}),
+    ...(group ? { group } : {}),
+  };
+}
+
+/**
+ * Extract current model, selectable models, and the config id to write back.
+ * Returns `{ availableModels: [] }` when the adapter advertises no model
+ * selector, which is how the whole feature degrades to invisible.
+ */
+export function deriveModelInfo(
+  configOptions: SessionConfigOption[] | null | undefined,
+): AcpModelInfo {
+  const modelOption = configOptions?.find(
+    (option): option is Extract<SessionConfigOption, { type: "select" }> =>
+      option.type === "select" &&
+      (option.id === "model" || option.category === "model"),
+  );
+
+  if (!modelOption) {
+    return { availableModels: [] };
+  }
+
+  const availableModels: AcpModelOption[] = [];
+  for (const entry of modelOption.options) {
+    if (isGroup(entry)) {
+      for (const option of entry.options) {
+        availableModels.push(toModelOption(option, entry.name));
+      }
+      continue;
+    }
+    availableModels.push(toModelOption(entry));
+  }
+
+  return {
+    ...(modelOption.currentValue ? { model: modelOption.currentValue } : {}),
+    availableModels,
+    modelConfigId: modelOption.id,
+  };
+}
+
+/**
+ * Pick the model a session should start on. Blank and whitespace-only values
+ * count as unset so an empty config field never pins anything.
+ */
+export function resolveAcpModel(
+  input: ResolveAcpModelInput,
+): string | undefined {
+  const ladder = [
+    input.requestedModel,
+    input.conversationPreference,
+    input.agentModel,
+    input.defaultModel,
+  ];
+
+  for (const candidate of ladder) {
+    const trimmed = candidate?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Add `deriveModelInfo(configOptions)`: flattens an adapter's `SessionConfigOption` set into `{ model, availableModels, modelConfigId }`, matching the model option on `type === "select"` plus `id === "model"` or `category === "model"` only (never on option names), and flattening the grouped `options` variant so callers never branch on it. Absent, null, or empty input returns `{ availableModels: [] }` with no `modelConfigId`, which is how the feature stays invisible for adapters with no model selector.
- Add `resolveAcpModel(input)`: the pure synchronous spawn-time ladder (requested model > conversation preference > per-agent model > global default), treating blank and whitespace-only strings as unset.
- Both helpers are new and unreferenced: no runtime behavior changes in this PR. 17 colocated tests cover flat and grouped options, id-only and category-only matches, a boolean-typed option being ignored, empty/null/undefined input, and every rung of the ladder including whitespace.

Part of plan: acp-model-control.md (PR 2 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D