### PR TITLE
feat(acp): add acp.defaultModel and per-agent model config leaves

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -36283,6 +36283,14 @@ components:
                   additionalProperties: {}
                 - type: "null"
           additionalProperties: {}
+        acp:
+          type: object
+          properties:
+            defaultModel:
+              anyOf:
+                - type: string
+                - type: "null"
+          additionalProperties: {}
       additionalProperties: {}
     LLMProvider:
       type: string
@@ -37122,6 +37130,12 @@ components:
                 mode:
                   $ref: "#/components/schemas/ServiceMode"
               additionalProperties: {}
+          additionalProperties: {}
+        acp:
+          type: object
+          properties:
+            defaultModel:
+              type: string
           additionalProperties: {}
       additionalProperties: {}
     ProfileEntry:

--- a/assistant/src/acp/__tests__/helpers/acp-config-stub.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-config-stub.ts
@@ -22,11 +22,13 @@ import type { AcpAgentConfig } from "../../../config/acp-schema.js";
 export interface MockAcpConfig {
   maxConcurrentSessions: number;
   agents: Record<string, AcpAgentConfig>;
+  defaultModel?: string;
 }
 
 const DEFAULT_CONFIG: MockAcpConfig = {
   maxConcurrentSessions: 4,
   agents: {},
+  defaultModel: undefined,
 };
 
 export interface AcpConfigStubHandle {

--- a/assistant/src/config/acp-schema.test.ts
+++ b/assistant/src/config/acp-schema.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Covers the ACP config leaves that carry model selection: `acp.defaultModel`
+ * and the per-agent `model` override. Both are optional with no `.default()`,
+ * so an absent value must stay absent after parsing rather than becoming a
+ * value the daemon would then apply to a session.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { AcpAgentConfigSchema, AcpConfigSchema } from "./acp-schema.js";
+
+describe("AcpConfigSchema", () => {
+  test("populates defaults and leaves defaultModel unset for an empty config", () => {
+    const parsed = AcpConfigSchema.parse({});
+
+    expect(parsed).toEqual({ maxConcurrentSessions: 4, agents: {} });
+    expect(parsed.defaultModel).toBeUndefined();
+    expect("defaultModel" in parsed).toBe(false);
+  });
+
+  test("round-trips a defaultModel alias", () => {
+    expect(AcpConfigSchema.parse({ defaultModel: "opus" }).defaultModel).toBe(
+      "opus",
+    );
+  });
+
+  test("rejects a non-string defaultModel", () => {
+    expect(AcpConfigSchema.safeParse({ defaultModel: 3 }).success).toBe(false);
+  });
+});
+
+describe("AcpAgentConfigSchema", () => {
+  test("round-trips a per-agent model override", () => {
+    expect(
+      AcpAgentConfigSchema.parse({
+        command: "claude-agent-acp",
+        model: "opus",
+      }),
+    ).toEqual({ command: "claude-agent-acp", args: [], model: "opus" });
+  });
+
+  test("leaves model unset when omitted", () => {
+    const parsed = AcpAgentConfigSchema.parse({ command: "claude-agent-acp" });
+
+    expect(parsed.model).toBeUndefined();
+    expect("model" in parsed).toBe(false);
+  });
+});

--- a/assistant/src/config/acp-schema.ts
+++ b/assistant/src/config/acp-schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-const AcpAgentConfigSchema = z
+export const AcpAgentConfigSchema = z
   .object({
     command: z.string().describe("Command to spawn the ACP agent process"),
     args: z
@@ -15,6 +15,12 @@ const AcpAgentConfigSchema = z
       .record(z.string(), z.string())
       .optional()
       .describe("Environment variables set for the agent process"),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "Default model for this agent, overriding acp.defaultModel. An adapter-reported alias.",
+      ),
   })
   .describe("Configuration for an individual ACP agent");
 
@@ -32,6 +38,12 @@ export const AcpConfigSchema = z
       .record(z.string(), AcpAgentConfigSchema)
       .default({})
       .describe("Map of agent names to their configurations"),
+    defaultModel: z
+      .string()
+      .optional()
+      .describe(
+        "Default model the coding agent starts with (an adapter-reported alias such as 'opus' or 'sonnet' for Claude, not an Assistant catalog id). Unset means the agent's own default.",
+      ),
   })
   .describe(
     "Agent Communication Protocol (ACP) — inter-agent communication and delegation",

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -2,6 +2,8 @@ import { utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { z } from "zod";
+
 import {
   sampleConcepts as sharedSampleConcepts,
   sampleConfig,
@@ -1938,5 +1940,39 @@ describe("ingress URL writes through the generic config routes", () => {
     const ingress = savedIngress();
     expect(ingress.assistantId).toBe("assistant-1");
     expect(ingress.lastTunnel).toEqual(LAST_TUNNEL);
+  });
+});
+
+describe("acp config wire schemas", () => {
+  const getSchema = ROUTES.find((r) => r.operationId === "config_get")!
+    .responseBody as z.ZodTypeAny;
+  const patchSchema = ROUTES.find((r) => r.operationId === "config_patch")!
+    .requestBody as z.ZodTypeAny;
+
+  test("the GET response carries acp.defaultModel", () => {
+    expect(getSchema.parse({ acp: { defaultModel: "opus" } })).toEqual({
+      acp: { defaultModel: "opus" },
+    });
+  });
+
+  test("the PATCH body carries acp.defaultModel", () => {
+    expect(patchSchema.parse({ acp: { defaultModel: "sonnet" } })).toEqual({
+      acp: { defaultModel: "sonnet" },
+    });
+  });
+
+  test("the PATCH body accepts a null defaultModel so the key can be deleted", () => {
+    expect(patchSchema.parse({ acp: { defaultModel: null } })).toEqual({
+      acp: { defaultModel: null },
+    });
+  });
+
+  test("both schemas reject a non-string defaultModel", () => {
+    expect(getSchema.safeParse({ acp: { defaultModel: 3 } }).success).toBe(
+      false,
+    );
+    expect(patchSchema.safeParse({ acp: { defaultModel: 3 } }).success).toBe(
+      false,
+    );
   });
 });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -777,6 +777,12 @@ const ConfigGetResponseSchema = z
       })
       .passthrough()
       .optional(),
+    acp: z
+      .object({
+        defaultModel: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
   })
   .passthrough()
   .meta({ id: "ConfigGetResponse" });
@@ -883,6 +889,12 @@ const ConfigPatchRequestSchema = z
           .passthrough()
           .nullable()
           .optional(),
+      })
+      .passthrough()
+      .optional(),
+    acp: z
+      .object({
+        defaultModel: z.string().nullable().optional(),
       })
       .passthrough()
       .optional(),


### PR DESCRIPTION
## Summary

- Add `acp.defaultModel` to `AcpConfigSchema` and a per-agent `model` override to `AcpAgentConfigSchema`, both optional with no `.default()`: absent means do not apply a model, so the adapter keeps its own default.
- Add the matching `acp` section to `ConfigGetResponseSchema` and `ConfigPatchRequestSchema` (nullable leaf on PATCH so the key can be deleted), and regenerate `assistant/openapi.yaml`.
- Extend the shared ACP config test stub with `defaultModel`, plus schema tests for the new leaves and the two wire schemas.

Part of plan: acp-model-control.md (PR 1 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D