### PR TITLE
refactor(web): one attachment preview box, one object-URL path, and one DetailShell inset for the chat-info tiles

### DIFF
--- a/clients/web/src/components/detail-shell.tsx
+++ b/clients/web/src/components/detail-shell.tsx
@@ -10,7 +10,7 @@
  * scrollable-body wrapper (e.g. `AcpRunChatView`, which owns its own inner
  * scroll container and a sticky composer) but still need a pixel-identical
  * header. `DetailShellTitleWithCount` is the "title · N" header cluster,
- * exported with its midline dot and the body's inset so every panel draws
+ * exported with its midline dot and the shell's inset so every panel draws
  * them from one place.
  */
 
@@ -22,7 +22,7 @@ import { Button, Typography } from "@vellumai/design-library";
 
 import { cn } from "@/utils/misc";
 
-/** Horizontal inset of the scrollable body, in px. */
+/** Horizontal inset of the shell's header, body, and footer, in px. */
 export const DETAIL_SHELL_BODY_INSET_PX = 20;
 
 /** The 3px midline dot between a title and the count beside it. */
@@ -111,7 +111,10 @@ export function DetailShellHeader({
     // Divider uses `--border-hover` (the Figma sidepanel divider, #F6F5F4 in
     // light) rather than `--border-base`, which equals the drawer's
     // `--surface-lift` in dark mode and would render invisible.
-    <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] px-5 py-4">
+    <div
+      className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hover)] py-4"
+      style={{ paddingInline: DETAIL_SHELL_BODY_INSET_PX }}
+    >
       {/* The leading cluster absorbs all the shrink (title truncates first,
           then the cluster clips) so the trailing controls, above all the
           close X, stay visible however narrow the panel gets. */}
@@ -197,7 +200,10 @@ export function DetailShell({
           `--border-base` equals the drawer's `--surface-lift` in dark mode
           and renders invisible. */}
       {footer && (
-        <div className="shrink-0 border-t border-[var(--border-hover)] px-5 py-4">
+        <div
+          className="shrink-0 border-t border-[var(--border-hover)] py-4"
+          style={{ paddingInline: DETAIL_SHELL_BODY_INSET_PX }}
+        >
           {footer}
         </div>
       )}

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.tsx
@@ -1,0 +1,87 @@
+/**
+ * The box an attachment draws itself in, wherever one is shown: a message
+ * square in the transcript, a file tile in the Chat Info panel.
+ *
+ * An image fills the box edge to edge as a real `<img>`, so bytes the browser
+ * cannot decode raise `onImageError` and the owner can fall back. A video
+ * poster stays a CSS background instead: there is nothing to swap to when a
+ * poster fails, so an `<img>` would surface the broken-image glyph. With
+ * neither, the box draws the kind's glyph, or whatever `placeholder` the owner
+ * shows while the bytes are still on their way.
+ *
+ * The box carries only its own layout; geometry, surface, and border come from
+ * the caller's `className`.
+ */
+
+import type { ReactNode } from "react";
+
+import {
+  ATTACHMENT_ICON_BY_KIND,
+  type AttachmentIconKind,
+} from "@/domains/chat/components/chat-attachments/utils";
+import { cn } from "@/utils/misc";
+
+export interface AttachmentPreviewBoxProps {
+  /** Geometry, surface, and border classes for the box. */
+  className?: string;
+  /** Picks the fallback glyph. */
+  kind: AttachmentIconKind;
+  /** Drawn edge to edge when set. */
+  imageUrl?: string | null;
+  /** Video poster, painted behind the box. */
+  posterUrl?: string | null;
+  /** The browser could not decode `imageUrl`. */
+  onImageError?: () => void;
+  /** Sizing for the fallback glyph, which differs between surfaces. */
+  glyphClassName?: string;
+  /** Stands in for the glyph while the bytes are still being fetched. */
+  placeholder?: ReactNode;
+}
+
+export function AttachmentPreviewBox({
+  className,
+  kind,
+  imageUrl,
+  posterUrl,
+  onImageError,
+  glyphClassName,
+  placeholder,
+}: AttachmentPreviewBoxProps) {
+  const Icon = ATTACHMENT_ICON_BY_KIND[kind];
+
+  let content: ReactNode;
+  if (imageUrl) {
+    content = (
+      <img
+        src={imageUrl}
+        alt=""
+        aria-hidden
+        onError={onImageError}
+        className="h-full w-full object-cover"
+      />
+    );
+  } else if (placeholder) {
+    content = placeholder;
+  } else if (posterUrl) {
+    content = null;
+  } else {
+    content = <Icon className={glyphClassName} />;
+  }
+
+  return (
+    <div
+      data-slot="attachment-preview-box"
+      className={cn(
+        "flex items-center justify-center overflow-hidden bg-cover bg-center text-[var(--content-secondary)]",
+        className,
+      )}
+      style={
+        posterUrl
+          ? { backgroundImage: `url(${JSON.stringify(posterUrl)})` }
+          : undefined
+      }
+    >
+      {content}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
 import {
   ChevronLeft,
   ChevronRight,
@@ -11,7 +10,6 @@ import type { FC, KeyboardEvent, MouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { fetchAttachmentContentBlob } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { Button, Typography } from "@vellumai/design-library";
 
 import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-preview";
@@ -21,7 +19,7 @@ import {
   classifyAttachment,
   formatAttachmentSize,
 } from "@/domains/chat/components/chat-attachments/utils";
-import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
+import { useAttachmentObjectUrl } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import { useGallerySwipe } from "@/domains/chat/components/chat-attachments/use-gallery-swipe";
 import { baseMimeType, extensionOf } from "@/domains/chat/utils/mime-sniff";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
@@ -71,11 +69,9 @@ interface AttachmentPreviewModalProps {
 /**
  * Full-screen preview modal for chat attachments. Handles images, videos, and
  * a non-previewable fallback card. When `previewUrl` is missing but
- * `assistantId` is provided, the modal lazily fetches the attachment content
- * from the backend, converts it to a blob URL, and revokes the URL on
- * cleanup. Dismissable via backdrop click, close button, or Escape key.
- *
- * Async fetch pattern modeled on `app/admin/AttachmentLightbox.tsx`.
+ * `assistantId` is provided, the bytes come from `useAttachmentObjectUrl`, so a
+ * thumbnail that has already fetched them hands this a cache hit rather than a
+ * second request. Dismissable via backdrop click, close button, or Escape key.
  */
 export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   open,
@@ -114,70 +110,19 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     return () => unregisterBackOwner();
   }, [open, registerBackOwner, unregisterBackOwner]);
 
-  // Synthetic IDs from the text-parsing history fallback
-  // (parseAttachmentSummariesFromContent) can never resolve against the
-  // daemon's content endpoint, so we never fetch them — we show a clear message
-  // instead of a misleading network error.
-  const isRehydrated =
-    !attachment.previewUrl && attachment.id.startsWith("rehydrated:");
-
-  // Fetch content from the daemon only when there's no inline previewUrl and we
-  // have a real, resolvable id to fetch with.
-  const shouldFetch =
-    open &&
-    !attachment.previewUrl &&
-    !!assistantId &&
-    !!attachment.id &&
-    !isRehydrated;
-
-  const { data: blob, isError } = useQuery({
-    // The attachment id is stable and unique, so it is the cache key. Reopening
-    // the same attachment, or opening one a thumbnail already fetched, reuses
-    // that blob instead of refetching.
-    queryKey: attachmentContentQueryKey(assistantId, attachment.id),
-    queryFn: async () => {
-      const data = await fetchAttachmentContentBlob(
-        assistantId!,
-        attachment.id,
-      );
-      if (!data) {
-        throw new Error("Failed to load file");
-      }
-      return data;
-    },
-    enabled: shouldFetch,
-    staleTime: Infinity,
-    retry: false,
-  });
-
-  // Hold the fetched blob as an object URL for the media/text renderers, and
-  // revoke it when the blob changes or the modal unmounts.
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  useEffect(() => {
-    if (!blob) {
-      setObjectUrl(null);
-      return;
-    }
-    const url = URL.createObjectURL(blob);
-    setObjectUrl(url);
-    return () => {
-      URL.revokeObjectURL(url);
-      setObjectUrl(null);
-    };
-  }, [blob]);
-
-  const effectiveUrl = attachment.previewUrl ?? objectUrl;
+  const {
+    url: effectiveUrl,
+    isError,
+    unavailable,
+    isPending,
+  } = useAttachmentObjectUrl(assistantId, attachment, open);
 
   // A full-size image whose bytes the browser can't decode (e.g. HEIC on
   // Chromium, even after fetching the stored original) falls through to the
   // non-image fallback card instead of rendering the broken-image glyph.
   const [decodeFailedUrl, setDecodeFailedUrl] = useState<string | null>(null);
 
-  // Loading until there's a usable URL: covers the fetch and the one-render gap
-  // between the blob arriving and its object URL being created.
-  const isLoadingPreview = shouldFetch && !objectUrl && !isError;
-
-  const previewError = isRehydrated
+  const previewError = unavailable
     ? "Preview unavailable — file content was not preserved in chat history."
     : isError
       ? "Failed to load preview."
@@ -290,7 +235,7 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     TEXT_PREVIEW_EXTENSIONS.has(extension);
 
   const renderContent = () => {
-    if (isLoadingPreview) {
+    if (isPending) {
       return (
         <div className="flex items-center justify-center py-24">
           <Loader2 className="h-8 w-8 animate-spin text-white/70" />

--- a/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/message-attachment-square.tsx
@@ -3,15 +3,16 @@ import { useCallback } from "react";
 
 import { Typography } from "@vellumai/design-library";
 import { AttachmentDownloadOverlay } from "@/domains/chat/components/chat-attachments/attachment-download-overlay";
+import { AttachmentPreviewBox } from "@/domains/chat/components/chat-attachments/attachment-preview-box";
 
 import {
-  ATTACHMENT_ICON_BY_KIND,
   classifyAttachment,
   formatAttachmentSize,
   middleTruncate,
 } from "@/domains/chat/components/chat-attachments/utils";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { cn } from "@/utils/misc";
 
 /**
  * Geometry of the square's inner tile box. Shared with
@@ -47,10 +48,7 @@ export function MessageAttachmentSquare({
   const { filename, mimeType, sizeBytes, previewUrl, thumbnailUrl } =
     attachment;
   const kind = classifyAttachment(mimeType, filename);
-  const Icon = ATTACHMENT_ICON_BY_KIND[kind];
   const hasImagePreview = kind === "image" && previewUrl !== null;
-  // Video posters stay a CSS background: there is no fallback to swap to when
-  // a poster fails, so an <img> would surface the browser's broken glyph.
   const backgroundImageUrl =
     kind === "video" && thumbnailUrl != null ? thumbnailUrl : null;
   // With nothing filling the tile, its `--surface-lift` fill disappears on a
@@ -92,30 +90,18 @@ export function MessageAttachmentSquare({
       className={`group flex flex-col gap-1${isClickable ? " cursor-pointer" : ""}`}
     >
       <div className="relative w-fit">
-        <div
-          className={`${ATTACHMENT_TILE_BOX_CLASS} flex items-center justify-center overflow-hidden bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]${showsIcon ? " border border-[var(--border-element)]" : ""}`}
-          style={
-            backgroundImageUrl
-              ? {
-                  backgroundImage: `url(${JSON.stringify(backgroundImageUrl)})`,
-                }
-              : undefined
-          }
-        >
-          {hasImagePreview ? (
-            // A real <img> rather than a CSS background so an undecodable
-            // preview raises `onError` and the owner can fall back to the icon.
-            <img
-              src={previewUrl}
-              alt=""
-              aria-hidden
-              onError={onPreviewError}
-              className="h-full w-full object-cover"
-            />
-          ) : backgroundImageUrl ? null : (
-            <Icon className="h-6 w-6" />
+        <AttachmentPreviewBox
+          className={cn(
+            ATTACHMENT_TILE_BOX_CLASS,
+            "bg-[var(--surface-lift)]",
+            showsIcon && "border border-[var(--border-element)]",
           )}
-        </div>
+          kind={kind}
+          imageUrl={hasImagePreview ? previewUrl : null}
+          posterUrl={backgroundImageUrl}
+          onImageError={onPreviewError}
+          glyphClassName="h-6 w-6"
+        />
         {onDownload && (
           <AttachmentDownloadOverlay
             filename={filename}

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
@@ -8,10 +8,9 @@
  * nothing at all, so a caller with an optional attachment still calls this
  * unconditionally.
  *
- * The fetch runs under {@link attachmentContentQueryKey}, which
- * `AttachmentPreviewModal` fetches under too: the modal keeps its own query so
- * it can tell a legacy row apart from a failed fetch, but a thumbnail that has
- * already loaded hands it a cache hit instead of a second request.
+ * Every reader fetches under {@link attachmentContentQueryKey}, so a thumbnail,
+ * the full-screen preview, and an inline markdown image of the same attachment
+ * share one request and one cached blob.
  */
 
 import { useQuery } from "@tanstack/react-query";
@@ -33,6 +32,10 @@ export interface AttachmentObjectUrl {
   url: string | null;
   /** The bytes failed to load, or can never be fetched (no assistant, no resolvable id). */
   isError: boolean;
+  /** The bytes can never be fetched at all, as against a fetch that failed. */
+  unavailable: boolean;
+  /** The bytes are still on their way, so nothing is settled yet. */
+  isPending: boolean;
 }
 
 export function useAttachmentObjectUrl(
@@ -84,5 +87,10 @@ export function useAttachmentObjectUrl(
     };
   }, [shownBlob]);
 
-  return { url: previewUrl ?? objectUrl, isError: isError || unavailable };
+  return {
+    url: previewUrl ?? objectUrl,
+    isError: isError || unavailable,
+    unavailable,
+    isPending: shouldFetch && !objectUrl && !isError,
+  };
 }

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
@@ -8,7 +8,10 @@ import { useCallback } from "react";
 import { cn, Typography } from "@vellumai/design-library";
 
 import { AppPreviewThumbnail } from "@/components/app-card";
-import { AppAssetActions } from "@/domains/chat/components/conversation-asset-actions";
+import {
+  AppAssetActions,
+  AssetActionsSlot,
+} from "@/domains/chat/components/conversation-asset-actions";
 import { useTranslation } from "@/i18n";
 import type { AppSummary } from "@/types/app-types";
 import { getCachedAppHtml } from "@/utils/app-html-cache";
@@ -63,16 +66,13 @@ export function ChatInfoAppTile({
         />
       </button>
 
-      <span
-        data-reveal=""
-        className="absolute right-1 top-1 rounded-md bg-[var(--surface-lift)]"
-      >
+      <AssetActionsSlot>
         <AppAssetActions
           assistantId={assistantId}
           app={app}
           onRequestDelete={onRequestDelete}
         />
-      </span>
+      </AssetActionsSlot>
 
       <Typography
         variant="body-small-default"

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
@@ -1,7 +1,8 @@
 /**
  * One file in the Chat Info panel: a daemon document, a message attachment, or
  * a camera frame. Documents and non-image attachments show their kind's glyph;
- * an image shows its picture, fetched only once the tile is on screen.
+ * an image shows its picture, fetched and held only while the tile is on
+ * screen.
  */
 
 import { Loader2 } from "lucide-react";
@@ -9,12 +10,13 @@ import { useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
 
-import { DocumentAssetActions } from "@/domains/chat/components/conversation-asset-actions";
-import { useAttachmentObjectUrl } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import {
-  ATTACHMENT_ICON_BY_KIND,
-  classifyAttachment,
-} from "@/domains/chat/components/chat-attachments/utils";
+  AssetActionsSlot,
+  DocumentAssetActions,
+} from "@/domains/chat/components/conversation-asset-actions";
+import { AttachmentPreviewBox } from "@/domains/chat/components/chat-attachments/attachment-preview-box";
+import { useAttachmentObjectUrl } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
+import { classifyAttachment } from "@/domains/chat/components/chat-attachments/utils";
 import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
 import { useInView } from "@/hooks/use-in-view";
 import { useTranslation } from "@/i18n";
@@ -34,13 +36,13 @@ export function ChatInfoFileTile({
   assistantId,
   onOpen,
 }: ChatInfoFileTileProps) {
-  const { t, i18n } = useTranslation("chat");
+  const { t } = useTranslation("chat");
   const boxRef = useRef<HTMLButtonElement>(null);
 
-  const hasSeenTile = useInView(boxRef, { rootMargin: "200px", once: true });
+  const isOnScreen = useInView(boxRef, { rootMargin: "200px" });
   // A browser without IntersectionObserver loads every tile rather than none:
   // the picture is the tile's content here, not an enhancement of it.
-  const isVisible = hasSeenTile || typeof IntersectionObserver === "undefined";
+  const isVisible = isOnScreen || typeof IntersectionObserver === "undefined";
 
   const attachment = file.kind === "document" ? null : file.attachment;
   // A document's own glyph is the `document` kind's, so the three kinds of tile
@@ -56,8 +58,6 @@ export function ChatInfoFileTile({
     isVisible && kind === "image",
   );
 
-  // Video posters stay a CSS background: there is no fallback to swap to when
-  // a poster fails, so an <img> would surface the browser's broken glyph.
   const posterUrl =
     kind === "video" && attachment?.thumbnailUrl != null
       ? attachment.thumbnailUrl
@@ -76,34 +76,10 @@ export function ChatInfoFileTile({
 
   const label =
     file.kind === "frame" && file.capturedAt !== null
-      ? formatCaptureTime(file.capturedAt, i18n.resolvedLanguage)
+      ? formatCaptureTime(file.capturedAt)
       : file.title;
 
-  const renderBoxContent = () => {
-    if (kind === "image" && !previewFailed) {
-      if (url) {
-        return (
-          <img
-            src={url}
-            alt=""
-            aria-hidden
-            className="h-full w-full object-cover"
-            onError={() => setPreviewFailed(true)}
-          />
-        );
-      }
-      if (!isError) {
-        return (
-          <Loader2 className="size-8 animate-spin text-[var(--content-tertiary)]" />
-        );
-      }
-    }
-    if (posterUrl) {
-      return null;
-    }
-    const Icon = ATTACHMENT_ICON_BY_KIND[kind];
-    return <Icon className="size-8" />;
-  };
+  const showsImage = kind === "image" && !previewFailed;
 
   return (
     <div
@@ -116,25 +92,32 @@ export function ChatInfoFileTile({
         type="button"
         aria-label={ariaLabel}
         onClick={() => onOpen(file)}
-        style={
-          posterUrl
-            ? { backgroundImage: `url(${JSON.stringify(posterUrl)})` }
-            : undefined
-        }
-        className="relative flex h-[84px] w-full cursor-pointer items-center justify-center overflow-hidden rounded-lg bg-[var(--surface-base)] bg-cover bg-center text-[var(--content-secondary)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        className="block h-[84px] w-full cursor-pointer overflow-hidden rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
-        {renderBoxContent()}
+        <AttachmentPreviewBox
+          className="h-full w-full rounded-lg bg-[var(--surface-base)]"
+          kind={kind}
+          imageUrl={showsImage ? url : null}
+          posterUrl={posterUrl}
+          onImageError={() => setPreviewFailed(true)}
+          glyphClassName="size-8"
+          placeholder={
+            showsImage && !isError ? (
+              <Loader2 className="size-8 animate-spin text-[var(--content-tertiary)]" />
+            ) : null
+          }
+        />
       </button>
 
       {/* Attachments and frames carry no menu: the preview modal already offers Download. */}
       {file.kind === "document" ? (
-        <span data-reveal="" className="absolute right-1 top-1">
+        <AssetActionsSlot>
           <DocumentAssetActions
             assistantId={assistantId}
             doc={file.doc}
             onOpen={() => onOpen(file)}
           />
-        </span>
+        </AssetActionsSlot>
       ) : null}
 
       <Typography

--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -236,7 +236,7 @@ export function ChatInfoPanel({
             tileWidth={CHAT_INFO_APP_TILE_WIDTH_PX}
             seeAllAriaLabel={t("chatInfoPanel.seeAllAppsAria")}
             onSeeAll={() => onSelectCategory("apps")}
-            renderTile={(app, _index, layout) => (
+            renderTile={(app, layout) => (
               <ChatInfoAppTile
                 key={app.id}
                 app={app}

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -86,7 +86,7 @@ function renderSection({
       tileWidth={tileWidth}
       seeAllAriaLabel={SEE_ALL_ARIA}
       onSeeAll={onSeeAll}
-      renderTile={(item, _index, layout) => (
+      renderTile={(item, layout) => (
         <div key={item.id} data-testid={TILE_TESTID} data-layout={layout}>
           {item.id}
         </div>
@@ -126,10 +126,6 @@ describe("fitTileCount", () => {
     [100, CHAT_INFO_FILE_TILE_WIDTH_PX, 1],
   ])("fits %p / %p tiles on one line", (rowWidth, tileWidth, expected) => {
     expect(fitTileCount(rowWidth, tileWidth)).toBe(expected);
-  });
-
-  test("a wider gutter fits fewer tiles on the same row", () => {
-    expect(fitTileCount(DRAWER_WIDTH, CHAT_INFO_APP_TILE_WIDTH_PX, 40)).toBe(2);
   });
 });
 
@@ -195,19 +191,47 @@ describe("ChatInfoSection", () => {
       tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
     });
     expect(seeAll()).toBeNull();
-    // Nothing runs past the edge, so the strip claims no trailing inset.
-    expect(fitted.container.querySelector("[data-overflow]")).toBeNull();
     fitted.unmount();
 
-    const overflowing = renderSection({
+    renderSection({
       items: makeItems(3),
       count: 3,
       tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
     });
     expect(seeAll()).not.toBeNull();
-    expect(
-      overflowing.container.querySelector("[data-overflow]"),
-    ).not.toBeNull();
+  });
+
+  test("pays the reclaimed inset back on both edges of the strip", () => {
+    // A strip that fits is then exactly as wide as its scroller, and one that
+    // runs past the column stops with the inset showing past its last tile.
+    isMobileRef.value = true;
+    widthRef.value = NARROW_COLUMN_WIDTH;
+
+    for (const itemCount of [2, 8]) {
+      const { container, unmount } = renderSection({
+        items: makeItems(itemCount),
+        count: itemCount,
+        tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
+      });
+      const strip = container.querySelector(
+        '[data-slot="scroll-shadow"][data-orientation="horizontal"]',
+      );
+      expect(strip?.className).toContain("px-[var(--chat-info-strip-bleed)]");
+      unmount();
+    }
+  });
+
+  test("names the section by its title", () => {
+    const { container } = renderSection({
+      items: makeItems(2),
+      tileWidth: CHAT_INFO_FILE_TILE_WIDTH_PX,
+    });
+
+    const labelledBy = container
+      .querySelector("section")
+      ?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)?.textContent).toBe("Apps");
   });
 
   test("calls onSeeAll when the control is activated", () => {

--- a/clients/web/src/domains/chat/components/chat-info-section.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.tsx
@@ -7,6 +7,7 @@
  * fit rule.
  */
 
+import { useId } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
 import { Button, ScrollShadow, Typography } from "@vellumai/design-library";
@@ -18,25 +19,23 @@ import {
 import { useElementSize } from "@/hooks/use-element-size";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTranslation } from "@/i18n";
-import { cn } from "@/utils/misc";
 
-/** Gutter between tiles, the pixel value behind the rows' `gap-2`. */
-export const CHAT_INFO_TILE_GAP_PX = 8;
+/** Gutter between tiles, read by both the fit rule and the rows that draw it. */
+const CHAT_INFO_TILE_GAP_PX = 8;
 
 /** Feeds the strip's own margin and padding classes below. */
 const STRIP_BLEED_STYLE = {
   "--chat-info-strip-bleed": `${DETAIL_SHELL_BODY_INSET_PX}px`,
 } as CSSProperties;
 
+const TILE_ROW_STYLE: CSSProperties = { gap: CHAT_INFO_TILE_GAP_PX };
+
 /** Whole tiles that fit on one line of `rowWidth`, never fewer than one. */
-export function fitTileCount(
-  rowWidth: number,
-  tileWidth: number,
-  gap = CHAT_INFO_TILE_GAP_PX,
-): number {
+export function fitTileCount(rowWidth: number, tileWidth: number): number {
   if (!(rowWidth > 0)) {
     return 1;
   }
+  const gap = CHAT_INFO_TILE_GAP_PX;
   return Math.max(1, Math.floor((rowWidth + gap) / (tileWidth + gap)));
 }
 
@@ -48,7 +47,7 @@ export interface ChatInfoSectionProps<T> {
   /** Fixed (strip) or minimum (fitted row) width of one tile, for the fit computation. */
   tileWidth: number;
   /** Returns the tile element with its own `key`: the caller owns tile identity. */
-  renderTile: (item: T, index: number, layout: "fitted" | "strip") => ReactNode;
+  renderTile: (item: T, layout: "fitted" | "strip") => ReactNode;
   seeAllAriaLabel: string;
   onSeeAll: () => void;
 }
@@ -67,6 +66,7 @@ export function ChatInfoSection<T>({
   onSeeAll,
 }: ChatInfoSectionProps<T>) {
   const { t } = useTranslation("chat");
+  const titleId = useId();
   const { ref, size } = useElementSize();
   const isMobile = useIsMobile();
   // The strip runs through the body's right inset, so that width counts too.
@@ -75,15 +75,17 @@ export function ChatInfoSection<T>({
     tileWidth,
   );
   const showSeeAll = count > fit;
-  // Trailing padding only when tiles run past the edge: a strip that fits
-  // must not scroll into blank inset or fade an edge nothing hides behind.
-  const stripOverflows = items.length > fit;
 
   return (
-    <section className="flex flex-col gap-3" style={STRIP_BLEED_STYLE}>
+    <section
+      aria-labelledby={titleId}
+      className="flex flex-col gap-3"
+      style={STRIP_BLEED_STYLE}
+    >
       <div className="flex items-center justify-between gap-3">
         <span className="flex min-w-0 items-center gap-1">
           <Typography
+            id={titleId}
             variant="title-small"
             className="truncate text-[var(--content-emphasised)]"
           >
@@ -119,26 +121,22 @@ export function ChatInfoSection<T>({
           `DetailShell`'s body inset so tiles run to the viewport edge. */}
       <div ref={ref} className="w-full">
         {isMobile ? (
+          // The reclaimed inset is paid back as padding on both edges, so a
+          // line that fits inside the column is exactly as wide as its
+          // scroller and does not scroll, while a longer one stops with the
+          // inset showing past its last tile.
           <ScrollShadow
             orientation="horizontal"
             hideScrollBar
-            className={cn(
-              "-mx-[var(--chat-info-strip-bleed)] pl-[var(--chat-info-strip-bleed)]",
-              stripOverflows && "pr-[var(--chat-info-strip-bleed)]",
-            )}
+            className="-mx-[var(--chat-info-strip-bleed)] px-[var(--chat-info-strip-bleed)]"
           >
-            <div
-              className="flex w-max gap-2"
-              data-overflow={stripOverflows || undefined}
-            >
-              {items.map((item, index) => renderTile(item, index, "strip"))}
+            <div className="flex w-max" style={TILE_ROW_STYLE}>
+              {items.map((item) => renderTile(item, "strip"))}
             </div>
           </ScrollShadow>
         ) : (
-          <div className="flex w-full gap-2">
-            {items
-              .slice(0, fit)
-              .map((item, index) => renderTile(item, index, "fitted"))}
+          <div className="flex w-full" style={TILE_ROW_STYLE}>
+            {items.slice(0, fit).map((item) => renderTile(item, "fitted"))}
           </div>
         )}
       </div>

--- a/clients/web/src/domains/chat/components/chat-markdown-message.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-markdown-message.test.tsx
@@ -107,6 +107,9 @@ const { ChatMarkdownMessage, isVellumLink } = await import(
   "@/domains/chat/components/chat-markdown-message"
 );
 const { useViewerStore } = await import("@/stores/viewer-store");
+const { attachmentContentQueryKey } = await import(
+  "@/domains/chat/components/chat-attachments/use-attachment-object-url"
+);
 
 function makeAttachment(
   overrides: Pick<DisplayAttachment, "filename" | "mimeType"> &
@@ -115,10 +118,14 @@ function makeAttachment(
   return { id: "att-1", sizeBytes: 1024, previewUrl: null, ...overrides };
 }
 
-function renderMarkdown(props: ChatMarkdownMessageProps) {
+function renderMarkdown(
+  props: ChatMarkdownMessageProps,
+  seed?: (client: QueryClient) => void,
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  seed?.(queryClient);
   return render(<ChatMarkdownMessage {...props} />, {
     wrapper: ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -421,6 +428,27 @@ describe("ChatMarkdownMessage (image dispatch)", () => {
     ).toBeTruthy();
     expect(attachmentsByIdContentGet).toHaveBeenCalledTimes(1);
     expect(workspaceFileContentGet).not.toHaveBeenCalled();
+  });
+
+  test("an image draws bytes another reader already cached, with no fetch of its own", async () => {
+    const { container } = renderMarkdown(
+      {
+        content: "![alt](vellum://workspace/scratch/chart.png)",
+        attachments: [
+          makeAttachment({ filename: "chart.png", mimeType: "image/png" }),
+        ],
+        assistantId: "asst-1",
+      },
+      (client) => {
+        client.setQueryData(
+          attachmentContentQueryKey("asst-1", "att-1"),
+          new Blob([new Uint8Array(PNG_BYTES)], { type: "image/png" }),
+        );
+      },
+    );
+
+    await waitFor(() => expect(container.querySelector("img")).not.toBeNull());
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
   });
 
   test("a vellum:// image with no matching attachment renders the workspace embed", async () => {

--- a/clients/web/src/domains/chat/components/chat-markdown-message.tsx
+++ b/clients/web/src/domains/chat/components/chat-markdown-message.tsx
@@ -10,19 +10,17 @@ import {
   memo,
   type ReactNode,
   useCallback,
-  useEffect,
   useMemo,
   useState,
 } from "react";
 
-import { attachmentsByIdContentGet } from "@/generated/daemon/sdk.gen";
-import { captureError } from "@/lib/sentry/capture-error";
 import {
   type MarkdownImageComponent,
   MarkdownMessage,
   type MarkdownMessageProps,
 } from "@vellumai/design-library";
 import type { DisplayAttachment } from "@/types/attachment-types";
+import { useAttachmentObjectUrl } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
 import { defaultUrlTransform } from "react-markdown";
 import {
@@ -209,58 +207,17 @@ function WorkspaceInlineImage({
   onOpenPreview?: (attachment: DisplayAttachment) => void;
 }) {
   const { t } = useTranslation("chat");
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [failed, setFailed] = useState(false);
+  const { url, isError } = useAttachmentObjectUrl(
+    assistantId,
+    attachment,
+    true,
+  );
 
-  useEffect(() => {
-    if (!assistantId || attachment.id.startsWith("rehydrated:")) {
-      return;
-    }
-
-    let revoked = false;
-    (async () => {
-      try {
-        const { data, error } = await attachmentsByIdContentGet({
-          path: { assistant_id: assistantId, id: attachment.id },
-          parseAs: "blob",
-          throwOnError: false,
-        });
-        if (revoked) {
-          return;
-        }
-        if (error || !(data instanceof Blob)) {
-          setFailed(true);
-          return;
-        }
-        const url = URL.createObjectURL(data);
-        setObjectUrl(url);
-      } catch (err) {
-        if (!revoked) {
-          setFailed(true);
-          captureError(err, {
-            context: "WorkspaceInlineImage",
-            bestEffort: true,
-          });
-        }
-      }
-    })();
-
-    return () => {
-      revoked = true;
-      setObjectUrl((prev) => {
-        if (prev) {
-          URL.revokeObjectURL(prev);
-        }
-        return null;
-      });
-    };
-  }, [attachment, assistantId]);
-
-  if (failed) {
+  if (isError) {
     return <ImageErrorFallback alt={alt || attachment.filename} />;
   }
 
-  if (!objectUrl) {
+  if (!url) {
     return (
       <span className="inline-flex items-center gap-1 rounded bg-[var(--surface-sunken)] px-1.5 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
         {alt
@@ -270,7 +227,7 @@ function WorkspaceInlineImage({
     );
   }
 
-  const image = <img src={objectUrl} alt={alt} className={IMAGE_CLASSES} />;
+  const image = <img src={url} alt={alt} className={IMAGE_CLASSES} />;
 
   if (!onOpenPreview) {
     return image;
@@ -282,10 +239,10 @@ function WorkspaceInlineImage({
       onClick={() => onOpenPreview(attachment)}
       className="cursor-zoom-in appearance-none border-0 bg-transparent p-0"
       aria-label={
-              alt
-                ? t("chatMarkdownMessage.expandImageAriaWithAlt", { alt })
-                : t("chatMarkdownMessage.expandImageAria")
-            }
+        alt
+          ? t("chatMarkdownMessage.expandImageAriaWithAlt", { alt })
+          : t("chatMarkdownMessage.expandImageAria")
+      }
     >
       {image}
     </button>

--- a/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
+++ b/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
@@ -7,7 +7,7 @@ import {
   PinOff,
   Trash2,
 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import type { FC, ReactNode } from "react";
 
 import { ActionMenu, Button, toast } from "@vellumai/design-library";
@@ -15,9 +15,9 @@ import { ActionMenu, Button, toast } from "@vellumai/design-library";
 import { downloadDocumentPdf } from "@/domains/chat/api/surfaces";
 import { t } from "@/i18n";
 import { usePinnedApps } from "@/hooks/use-pinned-apps";
+import { useShareApp } from "@/hooks/use-share-app";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
-import { shareApp } from "@/utils/share-app";
 
 /**
  * The options menu ("dots") the Chat Info panel's app and file tiles reveal
@@ -29,6 +29,22 @@ import { shareApp } from "@/utils/share-app";
  * Open / Download PDF: the daemon has no document-delete endpoint, so
  * deletion is intentionally absent there.
  */
+
+/**
+ * Plate the revealed options menu sits on, pinned to the tile's top-right
+ * corner. Both tiles share it so the menu keeps reading against whatever the
+ * preview underneath happens to be.
+ */
+export function AssetActionsSlot({ children }: { children: ReactNode }) {
+  return (
+    <span
+      data-reveal=""
+      className="absolute right-1 top-1 rounded-md bg-[var(--surface-lift)]"
+    >
+      {children}
+    </span>
+  );
+}
 
 function MenuShell({
   title,
@@ -61,10 +77,9 @@ interface AppAssetActionsProps {
   assistantId: string;
   app: AppSummary;
   /**
-   * Ask the owner to show the delete confirmation. The dialog must be
-   * rendered OUTSIDE the hosting Popover/BottomSheet: it portals and steals
-   * focus, which the popover treats as an outside interaction and closes,
-   * unmounting this component and any dialog state held here with it.
+   * Ask the owner to show the delete confirmation. The panel owns the dialog
+   * so it survives this tile remounting or the panel switching level; the menu
+   * only asks for it.
    */
   onRequestDelete: (app: AppSummary) => void;
 }
@@ -77,25 +92,10 @@ export const AppAssetActions: FC<AppAssetActionsProps> = ({
   const { togglePin, pinnedAppIds } = usePinnedApps(assistantId);
   const isPinned = pinnedAppIds.has(app.id);
 
-  const [isSharing, setIsSharing] = useState(false);
-  const handleShare = useCallback(async () => {
-    if (isSharing) {
-      return;
-    }
-    setIsSharing(true);
-    try {
-      await shareApp(assistantId, app.id, app.name);
-      toast.success(t("chat:appAssetActions.appExported"), {
-        description: `${app.name}.vellum`,
-      });
-    } catch (err) {
-      toast.error(t("chat:appAssetActions.shareFailed"), {
-        description: err instanceof Error ? err.message : undefined,
-      });
-    } finally {
-      setIsSharing(false);
-    }
-  }, [assistantId, app.id, app.name, isSharing]);
+  const { share } = useShareApp(assistantId, app, {
+    exported: t("chat:appAssetActions.appExported"),
+    failed: t("chat:appAssetActions.shareFailed"),
+  });
 
   return (
     <MenuShell
@@ -114,7 +114,7 @@ export const AppAssetActions: FC<AppAssetActionsProps> = ({
         icon={ArrowUp}
         label={t("chat:conversationAssetActions.share")}
         description={t("chat:conversationAssetActions.exportAsVellum")}
-        onSelect={() => void handleShare()}
+        onSelect={() => void share()}
       />
       <ActionMenu.Item
         icon={Trash2}

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -21,9 +21,9 @@ import { type AppSummary, isReadOnlyApp } from "@/types/app-types";
 import { getCachedAppHtml } from "@/utils/app-html-cache";
 import { formatFriendlyDate } from "@/utils/format-date";
 import { cn } from "@/utils/misc";
-import { shareApp } from "@/utils/share-app";
+import { useShareApp } from "@/hooks/use-share-app";
 import type { SwipeAction } from "@/hooks/use-swipe-to-reveal";
-import { ActionMenu, Button, toast } from "@vellumai/design-library";
+import { ActionMenu, Button } from "@vellumai/design-library";
 
 interface LibraryAppCardProps {
   app: AppSummary;
@@ -49,7 +49,6 @@ export function LibraryAppCard({
   onAnimationEnd,
 }: LibraryAppCardProps) {
   const { t } = useTranslation("library");
-  const [isSharing, setIsSharing] = useState(false);
   // Plugin-bundled apps are read-only: the daemon rejects delete/share/deploy
   // against them, so drop those actions here rather than render buttons that
   // error. Pin/Open stay — pinning is a client-only preference and opening is
@@ -61,24 +60,10 @@ export function LibraryAppCard({
     () => getCachedAppHtml(assistantId, app.id),
     [assistantId, app.id],
   );
-  const handleShare = useCallback(async () => {
-    if (isSharing) {
-      return;
-    }
-    setIsSharing(true);
-    try {
-      await shareApp(assistantId, app.id, app.name);
-      toast.success(t("libraryAppCard.exported"), {
-        description: `${app.name}.vellum`,
-      });
-    } catch (err) {
-      toast.error(t("libraryAppCard.shareFailed"), {
-        description: err instanceof Error ? err.message : undefined,
-      });
-    } finally {
-      setIsSharing(false);
-    }
-  }, [assistantId, app.id, app.name, isSharing, t]);
+  const { share } = useShareApp(assistantId, app, {
+    exported: t("libraryAppCard.exported"),
+    failed: t("libraryAppCard.shareFailed"),
+  });
 
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -166,7 +151,7 @@ export function LibraryAppCard({
             }}
             onPin={() => onPin(app)}
             onDelete={deleteAction ? () => deleteAction(app) : undefined}
-            onShare={readOnly ? undefined : handleShare}
+            onShare={readOnly ? undefined : share}
             onDeploy={deployAction}
             deployedUrl={deployedUrl}
             onCopyDeployedLink={handleCopyDeployedLink}

--- a/clients/web/src/hooks/use-in-view.test.tsx
+++ b/clients/web/src/hooks/use-in-view.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * `useInView` reports the live intersection state rather than a latch: it turns
+ * true as the element arrives, false as it leaves, and false again the moment
+ * the observation ends, so a caller holding a resource while its element is on
+ * screen releases it when the element goes away.
+ *
+ * Driven through a stub `IntersectionObserver`, since happy-dom implements
+ * neither the API nor the layout that would drive it.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+
+import { useInView } from "@/hooks/use-in-view";
+
+interface ObserverRecord {
+  options: IntersectionObserverInit | undefined;
+  callback: IntersectionObserverCallback;
+  observed: Element[];
+  disconnects: number;
+}
+
+let observers: ObserverRecord[] = [];
+
+class StubIntersectionObserver {
+  private readonly record: ObserverRecord;
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverInit,
+  ) {
+    this.record = { options, callback, observed: [], disconnects: 0 };
+    observers.push(this.record);
+  }
+
+  observe(target: Element): void {
+    this.record.observed.push(target);
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {
+    this.record.disconnects += 1;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+const realIntersectionObserver = globalThis.IntersectionObserver;
+
+function report(index: number, isIntersecting: boolean): void {
+  const record = observers[index]!;
+  act(() => {
+    record.callback(
+      [{ isIntersecting } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+  });
+}
+
+function renderInView(rootMargin?: string) {
+  const ref: RefObject<Element | null> = {
+    current: document.createElement("div"),
+  };
+  return renderHook(
+    ({ margin }: { margin?: string }) => useInView(ref, { rootMargin: margin }),
+    { initialProps: { margin: rootMargin } },
+  );
+}
+
+beforeEach(() => {
+  observers = [];
+  globalThis.IntersectionObserver =
+    StubIntersectionObserver as unknown as typeof IntersectionObserver;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  globalThis.IntersectionObserver = realIntersectionObserver;
+});
+
+describe("useInView", () => {
+  test("hands rootMargin to the observer it builds", () => {
+    renderInView("200px");
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0]!.options?.rootMargin).toBe("200px");
+    expect(observers[0]!.observed).toHaveLength(1);
+  });
+
+  test("turns true when the element arrives and false when it leaves", () => {
+    const { result } = renderInView();
+
+    expect(result.current).toBe(false);
+
+    report(0, true);
+    expect(result.current).toBe(true);
+
+    report(0, false);
+    expect(result.current).toBe(false);
+  });
+
+  test("forgets its last answer when the observation ends", () => {
+    const { result, rerender } = renderInView("200px");
+    report(0, true);
+    expect(result.current).toBe(true);
+
+    // A changed option tears the observer down and builds another, which is
+    // the same cleanup an unmount runs.
+    rerender({ margin: "400px" });
+
+    expect(observers[0]!.disconnects).toBe(1);
+    expect(observers).toHaveLength(2);
+    expect(result.current).toBe(false);
+  });
+
+  test("disconnects on unmount", () => {
+    const { unmount } = renderInView();
+    report(0, true);
+
+    unmount();
+
+    expect(observers[0]!.disconnects).toBe(1);
+  });
+});

--- a/clients/web/src/hooks/use-in-view.ts
+++ b/clients/web/src/hooks/use-in-view.ts
@@ -19,7 +19,6 @@ export function useInView(
   {
     threshold = 0,
     rootMargin,
-    once = false,
   }: {
     /**
      * Fraction of the element that must be showing to count as visible. The
@@ -29,8 +28,6 @@ export function useInView(
     threshold?: number;
     /** Grows the viewport the element is tested against, e.g. `"200px"` to start loading just before it scrolls in. */
     rootMargin?: string;
-    /** Latch on the first sighting and stop observing, for work that only needs doing once. */
-    once?: boolean;
   } = {},
 ): boolean {
   const [inView, setInView] = useState(false);
@@ -43,29 +40,22 @@ export function useInView(
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
-        if (!entry || (once && !entry.isIntersecting)) {
+        if (!entry) {
           return;
         }
         setInView(entry.isIntersecting);
-        if (once) {
-          observer.disconnect();
-        }
       },
       { threshold, rootMargin },
     );
     observer.observe(el);
     return () => {
       observer.disconnect();
-      if (!once) {
-        // An unmounting element is not on screen. Without this a control that
-        // scrolls out of the virtualised transcript would leave its last
-        // "visible" answer behind and suppress the floating copy forever. A
-        // latched caller keeps its answer: it asked for one sighting, not for
-        // the live state.
-        setInView(false);
-      }
+      // An element that is no longer observed is not on screen. Without this a
+      // control that scrolls out of the virtualised transcript would leave its
+      // last "visible" answer behind and suppress the floating copy forever.
+      setInView(false);
     };
-  }, [ref, threshold, rootMargin, once]);
+  }, [ref, threshold, rootMargin]);
 
   return inView;
 }

--- a/clients/web/src/hooks/use-share-app.test.tsx
+++ b/clients/web/src/hooks/use-share-app.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * `useShareApp` is the one share handler both app menus call. What it owns is
+ * the sequence: refuse a second export while one is running, name the bundle
+ * after the app, and raise the caller's own copy either way.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import * as toastModule from "@vellumai/design-library/components/toast";
+
+import type { AppSummary } from "@/types/app-types";
+
+interface RaisedToast {
+  title: string;
+  description?: string;
+}
+
+let successes: RaisedToast[] = [];
+let errors: RaisedToast[] = [];
+let shareCalls: Array<[string, string, string]> = [];
+let shareResult: Promise<void> = Promise.resolve();
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastModule,
+  toast: {
+    success: (title: string, options?: { description?: string }) => {
+      successes.push({ title, description: options?.description });
+    },
+    error: (title: string, options?: { description?: string }) => {
+      errors.push({ title, description: options?.description });
+    },
+  },
+}));
+
+mock.module("@/utils/share-app", () => ({
+  shareApp: (assistantId: string, appId: string, appName: string) => {
+    shareCalls.push([assistantId, appId, appName]);
+    return shareResult;
+  },
+}));
+
+const { useShareApp } = await import("@/hooks/use-share-app");
+
+const ASSISTANT_ID = "asst-1";
+const APP = { id: "app-1", name: "Trip Planner" } as AppSummary;
+const COPY = { exported: "Exported", failed: "Export failed" };
+
+function renderShare() {
+  return renderHook(() => useShareApp(ASSISTANT_ID, APP, COPY));
+}
+
+beforeEach(() => {
+  successes = [];
+  errors = [];
+  shareCalls = [];
+  shareResult = Promise.resolve();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("useShareApp", () => {
+  test("exports the app and names the bundle after it", async () => {
+    const { result } = renderShare();
+
+    await act(async () => {
+      await result.current.share();
+    });
+
+    expect(shareCalls).toEqual([[ASSISTANT_ID, "app-1", "Trip Planner"]]);
+    expect(successes).toEqual([
+      { title: "Exported", description: "Trip Planner.vellum" },
+    ]);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("reports the failure with the caller's copy and the error's message", async () => {
+    shareResult = Promise.reject(new Error("no bundle"));
+    const { result } = renderShare();
+
+    await act(async () => {
+      await result.current.share();
+    });
+
+    expect(errors).toEqual([
+      { title: "Export failed", description: "no bundle" },
+    ]);
+    expect(successes).toHaveLength(0);
+  });
+
+  test("ignores a second request while one is still in flight", async () => {
+    let release = () => {};
+    shareResult = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { result } = renderShare();
+
+    let firstShare: Promise<void> = Promise.resolve();
+    act(() => {
+      firstShare = result.current.share();
+    });
+    await waitFor(() => {
+      expect(result.current.isSharing).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.share();
+    });
+    expect(shareCalls).toHaveLength(1);
+
+    await act(async () => {
+      release();
+      await firstShare;
+    });
+    expect(result.current.isSharing).toBe(false);
+    expect(successes).toHaveLength(1);
+  });
+});

--- a/clients/web/src/hooks/use-share-app.ts
+++ b/clients/web/src/hooks/use-share-app.ts
@@ -1,0 +1,55 @@
+/**
+ * Export one app as a `.vellum` bundle and report how it went.
+ *
+ * Every menu that offers Share does the same three things: refuse a second
+ * export while one is running, hand the app to {@link shareApp}, and raise a
+ * toast either way. The copy is the caller's, because the two menus name the
+ * action from their own catalogs.
+ */
+
+import { useCallback, useState } from "react";
+
+import { toast } from "@vellumai/design-library";
+
+import type { AppSummary } from "@/types/app-types";
+import { shareApp } from "@/utils/share-app";
+
+export interface ShareAppCopy {
+  /** Toast title once the bundle has been handed off. */
+  exported: string;
+  /** Toast title when the export fails; the error's own message is the description. */
+  failed: string;
+}
+
+export interface ShareAppHandle {
+  share: () => Promise<void>;
+  isSharing: boolean;
+}
+
+export function useShareApp(
+  assistantId: string,
+  app: Pick<AppSummary, "id" | "name">,
+  { exported, failed }: ShareAppCopy,
+): ShareAppHandle {
+  const { id, name } = app;
+  const [isSharing, setIsSharing] = useState(false);
+
+  const share = useCallback(async () => {
+    if (isSharing) {
+      return;
+    }
+    setIsSharing(true);
+    try {
+      await shareApp(assistantId, id, name);
+      toast.success(exported, { description: `${name}.vellum` });
+    } catch (err) {
+      toast.error(failed, {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    } finally {
+      setIsSharing(false);
+    }
+  }, [assistantId, id, name, isSharing, exported, failed]);
+
+  return { share, isSharing };
+}

--- a/clients/web/src/utils/format-date.ts
+++ b/clients/web/src/utils/format-date.ts
@@ -1,13 +1,15 @@
+import { currentLocale } from "@/i18n";
+
 /**
  * Format a date as a short, human-readable string (e.g., "27 May" or "27 May 2025").
  * Omits the year when it matches the current year, unless `alwaysShowYear` is set.
- * `locale` defaults to the browser's; pass the app's where the two can differ.
+ * `locale` defaults to the app's active locale; pass one to pin the formatting.
  */
 export function formatFriendlyDate(
   date: Date,
   opts?: { alwaysShowYear?: boolean; locale?: string },
 ): string {
-  return date.toLocaleDateString(opts?.locale, {
+  return date.toLocaleDateString(opts?.locale ?? currentLocale(), {
     day: "numeric",
     month: "short",
     year:
@@ -30,7 +32,10 @@ function formatTimeOfDay(date: Date, locale?: string): string {
  * today, the friendly date for an older one. A run of captures from a single
  * session all fall on one date, so the date alone would label them identically.
  */
-export function formatCaptureTime(ms: number, locale?: string): string {
+export function formatCaptureTime(
+  ms: number,
+  locale: string = currentLocale(),
+): string {
   const date = new Date(ms);
   const now = new Date();
   const isToday =


### PR DESCRIPTION
## Summary
- MessageAttachmentSquare and ChatInfoFileTile render one AttachmentPreviewBox; the preview modal and the markdown inline image read attachments through useAttachmentObjectUrl on the shared cache
- DetailShell's header, body, and footer insets and the section's tile gap derive from their constants; the mobile strip always keeps its trailing inset; sections carry an accessible name
- tiles release object URLs when they leave the viewport, format capture times in the app locale, share one options-menu plate and one share handler

Part of plan: chat-info-assets-panel.md (remediation round 4)