### PR TITLE
feat(acp): persist session model and per-conversation model preference

### DIFF
--- a/assistant/src/__tests__/prune-old-conversations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-conversations-job.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { AssistantConfig } from "../config/schema.js";
+import { upsertAcpConversationModelPreference } from "../persistence/acp-model-preference.js";
 import { getDb, getTelemetryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { pruneOldConversationsJob } from "../persistence/job-handlers/cleanup.js";
 import type { MemoryJob } from "../persistence/jobs-store.js";
 import {
+  acpConversationModelPreference,
   conversations,
   telemetryEvents,
   toolInvocations,
@@ -56,11 +58,19 @@ function seedConversation(id: string, updatedAt: number): void {
       payload: "{}",
     })
     .run();
+  // Conversation-keyed with no foreign key, so only an explicit delete in the
+  // prune transaction reaches it.
+  upsertAcpConversationModelPreference({
+    parentConversationId: id,
+    agentId: "claude",
+    model: "opus",
+  });
 }
 
 function countRows(conversationId: string): {
   invocations: number;
   telemetryRows: number;
+  modelPreferences: number;
 } {
   const db = getDb();
   return {
@@ -74,6 +84,11 @@ function countRows(conversationId: string): {
       .from(telemetryEvents)
       .all()
       .filter((r) => r.conversationId === conversationId).length,
+    modelPreferences: db
+      .select()
+      .from(acpConversationModelPreference)
+      .all()
+      .filter((r) => r.parentConversationId === conversationId).length,
   };
 }
 
@@ -82,6 +97,7 @@ describe("pruneOldConversationsJob", () => {
     const db = getDb();
     getTelemetryDb()!.delete(telemetryEvents).run();
     db.delete(toolInvocations).run();
+    db.delete(acpConversationModelPreference).run();
     db.delete(conversations).run();
   });
 
@@ -92,8 +108,16 @@ describe("pruneOldConversationsJob", () => {
 
     pruneOldConversationsJob(JOB, CONFIG);
 
-    expect(countRows(STALE_ID)).toEqual({ invocations: 0, telemetryRows: 0 });
-    expect(countRows(FRESH_ID)).toEqual({ invocations: 1, telemetryRows: 1 });
+    expect(countRows(STALE_ID)).toEqual({
+      invocations: 0,
+      telemetryRows: 0,
+      modelPreferences: 0,
+    });
+    expect(countRows(FRESH_ID)).toEqual({
+      invocations: 1,
+      telemetryRows: 1,
+      modelPreferences: 1,
+    });
     const remaining = getDb().select().from(conversations).all();
     expect(remaining.map((c) => c.id)).toEqual([FRESH_ID]);
   });

--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -32,6 +32,7 @@ export interface HistoryRow {
   output_tokens: number | null;
   auth_error_code: string | null;
   auth_error_credential: string | null;
+  model: string | null;
 }
 
 export function clearHistory(): void {
@@ -66,6 +67,7 @@ export function insertHistoryRow(row: {
   outputTokens?: number | null;
   authErrorCode?: string | null;
   authErrorCredential?: string | null;
+  model?: string | null;
 }): void {
   getSqlite()
     .query(
@@ -74,8 +76,9 @@ export function insertHistoryRow(row: {
          started_at, completed_at, status, stop_reason, error,
          event_log_json, cwd, task, parent_tool_use_id,
          used_tokens, context_size, cost_amount, cost_currency,
-         input_tokens, output_tokens, auth_error_code, auth_error_credential
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         input_tokens, output_tokens, auth_error_code, auth_error_credential,
+         model
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     )
     .run(
       row.id,
@@ -99,6 +102,7 @@ export function insertHistoryRow(row: {
       row.outputTokens ?? null,
       row.authErrorCode ?? null,
       row.authErrorCredential ?? null,
+      row.model ?? null,
     );
 }
 
@@ -110,8 +114,34 @@ export function readHistoryRow(id: string): HistoryRow | null {
               event_log_json, cwd, task, parent_tool_use_id,
               used_tokens, context_size, cost_amount, cost_currency,
               input_tokens, output_tokens, auth_error_code,
-              auth_error_credential
+              auth_error_credential, model
        FROM acp_session_history WHERE id = ?`,
     )
     .get(id) as HistoryRow | null;
+}
+
+/**
+ * Seeds a conversation's model preference for an agent.
+ *
+ * Written directly rather than through the store so a suite can set up the
+ * state a spawn inherits without depending on the write path it is testing.
+ */
+export function insertModelPreferenceRow(row: {
+  parentConversationId: string;
+  agentId?: string;
+  model: string;
+  updatedAt?: number;
+}): void {
+  getSqlite()
+    .query(
+      `INSERT OR REPLACE INTO acp_conversation_model_preference (
+         parent_conversation_id, agent_id, model, updated_at
+       ) VALUES (?, ?, ?, ?)`,
+    )
+    .run(
+      row.parentConversationId,
+      row.agentId ?? "claude",
+      row.model,
+      row.updatedAt ?? 1234,
+    );
 }

--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -119,29 +119,3 @@ export function readHistoryRow(id: string): HistoryRow | null {
     )
     .get(id) as HistoryRow | null;
 }
-
-/**
- * Seeds a conversation's model preference for an agent.
- *
- * Written directly rather than through the store so a suite can set up the
- * state a spawn inherits without depending on the write path it is testing.
- */
-export function insertModelPreferenceRow(row: {
-  parentConversationId: string;
-  agentId?: string;
-  model: string;
-  updatedAt?: number;
-}): void {
-  getSqlite()
-    .query(
-      `INSERT OR REPLACE INTO acp_conversation_model_preference (
-         parent_conversation_id, agent_id, model, updated_at
-       ) VALUES (?, ?, ?, ?)`,
-    )
-    .run(
-      row.parentConversationId,
-      row.agentId ?? "claude",
-      row.model,
-      row.updatedAt ?? 1234,
-    );
-}

--- a/assistant/src/persistence/acp-model-preference.test.ts
+++ b/assistant/src/persistence/acp-model-preference.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The per-conversation ACP model preference: an explicit choice, keyed per
+ * agent, that a later spawn reads before the run starts. It is scoped to a
+ * conversation, so it has to go away when the conversation does.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  deleteAcpConversationModelPreferences,
+  getAcpConversationModelPreference,
+  upsertAcpConversationModelPreference,
+} from "./acp-model-preference.js";
+import {
+  createConversation,
+  deleteConversation,
+  deleteConversationGently,
+} from "./conversation-crud.js";
+import { getSqlite } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+
+await initializeDb();
+
+afterEach(() => {
+  getSqlite().run("DELETE FROM acp_conversation_model_preference");
+});
+
+describe("getAcpConversationModelPreference", () => {
+  test("returns undefined when the conversation has chosen nothing", () => {
+    expect(
+      getAcpConversationModelPreference("conv-1", "claude"),
+    ).toBeUndefined();
+  });
+
+  test("reads back the recorded choice", () => {
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-1",
+      agentId: "claude",
+      model: "opus",
+    });
+
+    expect(getAcpConversationModelPreference("conv-1", "claude")).toBe("opus");
+  });
+
+  test("is scoped to the agent, whose model vocabularies do not overlap", () => {
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-1",
+      agentId: "claude",
+      model: "opus",
+    });
+
+    expect(
+      getAcpConversationModelPreference("conv-1", "codex"),
+    ).toBeUndefined();
+    expect(
+      getAcpConversationModelPreference("conv-2", "claude"),
+    ).toBeUndefined();
+  });
+});
+
+describe("upsertAcpConversationModelPreference", () => {
+  test("a later choice replaces the earlier one for the same pair", () => {
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-1",
+      agentId: "claude",
+      model: "opus",
+    });
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-1",
+      agentId: "claude",
+      model: "sonnet",
+    });
+
+    expect(getAcpConversationModelPreference("conv-1", "claude")).toBe(
+      "sonnet",
+    );
+    const rows = getSqlite()
+      .query("SELECT model FROM acp_conversation_model_preference")
+      .all();
+    expect(rows).toEqual([{ model: "sonnet" }]);
+  });
+
+  test("moves updated_at forward so the row dates the choice, not the first one", () => {
+    const before = Date.now();
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-1",
+      agentId: "claude",
+      model: "opus",
+    });
+    const first = updatedAt();
+    expect(first).toBeGreaterThanOrEqual(before);
+
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-1",
+      agentId: "claude",
+      model: "sonnet",
+    });
+
+    expect(updatedAt()).toBeGreaterThanOrEqual(first);
+  });
+});
+
+describe("deleteAcpConversationModelPreferences", () => {
+  test("drops every agent's preference for the conversation, and only that one", () => {
+    for (const agentId of ["claude", "codex"]) {
+      upsertAcpConversationModelPreference({
+        parentConversationId: "conv-1",
+        agentId,
+        model: "opus",
+      });
+    }
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-2",
+      agentId: "claude",
+      model: "opus",
+    });
+
+    deleteAcpConversationModelPreferences("conv-1");
+
+    expect(
+      getAcpConversationModelPreference("conv-1", "claude"),
+    ).toBeUndefined();
+    expect(
+      getAcpConversationModelPreference("conv-1", "codex"),
+    ).toBeUndefined();
+    expect(getAcpConversationModelPreference("conv-2", "claude")).toBe("opus");
+  });
+
+  test("deleting a conversation takes its preferences with it", () => {
+    const conversation = createConversation("acp model preference");
+    upsertAcpConversationModelPreference({
+      parentConversationId: conversation.id,
+      agentId: "claude",
+      model: "opus",
+    });
+
+    deleteConversation(conversation.id);
+
+    expect(
+      getAcpConversationModelPreference(conversation.id, "claude"),
+    ).toBeUndefined();
+  });
+
+  test("the gentle delete purges them too", async () => {
+    const conversation = createConversation("acp model preference gently");
+    upsertAcpConversationModelPreference({
+      parentConversationId: conversation.id,
+      agentId: "claude",
+      model: "opus",
+    });
+
+    await deleteConversationGently(conversation.id);
+
+    expect(
+      getAcpConversationModelPreference(conversation.id, "claude"),
+    ).toBeUndefined();
+  });
+});
+
+function updatedAt(): number {
+  const row = getSqlite()
+    .query(
+      `SELECT updated_at FROM acp_conversation_model_preference
+       WHERE parent_conversation_id = 'conv-1' AND agent_id = 'claude'`,
+    )
+    .get() as { updated_at: number };
+  return row.updated_at;
+}

--- a/assistant/src/persistence/acp-model-preference.test.ts
+++ b/assistant/src/persistence/acp-model-preference.test.ts
@@ -12,6 +12,7 @@ import {
   upsertAcpConversationModelPreference,
 } from "./acp-model-preference.js";
 import {
+  clearAll,
   createConversation,
   deleteConversation,
   deleteConversationGently,
@@ -139,6 +140,23 @@ describe("deleteAcpConversationModelPreferences", () => {
     expect(
       getAcpConversationModelPreference(conversation.id, "claude"),
     ).toBeUndefined();
+  });
+
+  test("clear-all wipes them, so a reused id inherits no one else's choice", async () => {
+    const conversation = createConversation("acp model preference clear all");
+    upsertAcpConversationModelPreference({
+      parentConversationId: conversation.id,
+      agentId: "claude",
+      model: "opus",
+    });
+
+    await clearAll();
+
+    expect(
+      getSqlite()
+        .query("SELECT COUNT(*) AS c FROM acp_conversation_model_preference")
+        .get(),
+    ).toEqual({ c: 0 });
   });
 
   test("the gentle delete purges them too", async () => {

--- a/assistant/src/persistence/acp-model-preference.ts
+++ b/assistant/src/persistence/acp-model-preference.ts
@@ -1,0 +1,78 @@
+/**
+ * The per-conversation ACP model preference.
+ *
+ * Answers, before a run starts, which model this conversation's next run on a
+ * given agent should be put on. Written only when the user chooses one, so it
+ * never inherits a fallback the user never asked for; `acp_session_history` is
+ * the record of what a finished run actually used.
+ */
+
+import { and, eq } from "drizzle-orm";
+
+import { type DrizzleDb, getDb } from "./db-connection.js";
+import { acpConversationModelPreference } from "./schema/index.js";
+
+/**
+ * Enough of a database handle to delete rows.
+ *
+ * Named as a slice so the delete can be handed the open transaction of a
+ * conversation delete, and the preference rows commit or roll back with the
+ * conversation row they belong to.
+ */
+type ModelPreferenceWriter = Pick<DrizzleDb, "delete">;
+
+/** The model this conversation prefers for this agent, if it has chosen one. */
+export function getAcpConversationModelPreference(
+  parentConversationId: string,
+  agentId: string,
+): string | undefined {
+  const row = getDb()
+    .select({ model: acpConversationModelPreference.model })
+    .from(acpConversationModelPreference)
+    .where(
+      and(
+        eq(
+          acpConversationModelPreference.parentConversationId,
+          parentConversationId,
+        ),
+        eq(acpConversationModelPreference.agentId, agentId),
+      ),
+    )
+    .get();
+  return row?.model;
+}
+
+/** Record an explicit choice, replacing whatever this pair preferred before. */
+export function upsertAcpConversationModelPreference(preference: {
+  parentConversationId: string;
+  agentId: string;
+  model: string;
+}): void {
+  const updatedAt = Date.now();
+  getDb()
+    .insert(acpConversationModelPreference)
+    .values({ ...preference, updatedAt })
+    .onConflictDoUpdate({
+      target: [
+        acpConversationModelPreference.parentConversationId,
+        acpConversationModelPreference.agentId,
+      ],
+      set: { model: preference.model, updatedAt },
+    })
+    .run();
+}
+
+/** Drop every agent's preference for a conversation that is going away. */
+export function deleteAcpConversationModelPreferences(
+  parentConversationId: string,
+  db: ModelPreferenceWriter = getDb(),
+): void {
+  db.delete(acpConversationModelPreference)
+    .where(
+      eq(
+        acpConversationModelPreference.parentConversationId,
+        parentConversationId,
+      ),
+    )
+    .run();
+}

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -54,6 +54,7 @@ import {
   purgeAllWatchTimelines,
   purgeWatchTimelineForConversation,
 } from "../watch/watch-timeline.js";
+import { deleteAcpConversationModelPreferences } from "./acp-model-preference.js";
 import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,
@@ -2242,6 +2243,7 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       .where(eq(toolInvocations.conversationId, id))
       .run();
     tx.delete(messages).where(eq(messages.conversationId, id)).run();
+    deleteAcpConversationModelPreferences(id, tx);
     // Raw SQL on the same bun:sqlite handle Drizzle wraps, so the subagent rows
     // commit or roll back with the conversation row they describe.
     deleteSubagentRecordsByParent(id);
@@ -2392,6 +2394,7 @@ export async function deleteConversationGently(
     tx.delete(toolInvocations)
       .where(eq(toolInvocations.conversationId, id))
       .run();
+    deleteAcpConversationModelPreferences(id, tx);
     // Raw SQL on the same bun:sqlite handle Drizzle wraps, so the subagent rows
     // commit or roll back with the conversation row they describe.
     deleteSubagentRecordsByParent(id);

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -3830,6 +3830,10 @@ export async function clearAll(): Promise<{
   // cascade; wipe them explicitly so labels/objectives don't survive (or
   // rehydrate after) a clear-all.
   await runOrThrow("DELETE FROM subagents");
+  // Per-conversation ACP model preferences are conversation-keyed with no FK
+  // cascade either, so a wipe that skipped them would hand a reused id someone
+  // else's model choice.
+  await runOrThrow("DELETE FROM acp_conversation_model_preference");
   // Watch-session timelines are conversation-keyed rows the cascade does not
   // reach. They come after `conversations` so this statement is the last thing
   // that needs to reach one: an append arriving from here on finds no

--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -4,6 +4,7 @@ import { runHook } from "../../plugins/pipeline.js";
 import { rotateToolInvocations } from "../../telemetry/tool-usage-store.js";
 import { getLogger } from "../../util/logger.js";
 import { getLogsDbPath } from "../../util/logs-db-path.js";
+import { deleteAcpConversationModelPreferences } from "../acp-model-preference.js";
 import { purgeConversationSegments } from "../conversation-crud.js";
 import { runAsyncSqlite } from "../db-async-query.js";
 import { getDb } from "../db-connection.js";
@@ -161,9 +162,10 @@ function parseDeletedCount(stdout: string | undefined): number {
  * Tables with onDelete cascade on conversation FK (memory_segments,
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
  * external_conversation_bindings) are handled automatically. Tables without
- * cascade (messages, tool_invocations, plus llm_request_logs and
- * conversation-scoped telemetry_events rows on their dedicated connections)
- * are deleted explicitly before removing the conversation row.
+ * cascade (messages, tool_invocations, acp_conversation_model_preference,
+ * plus llm_request_logs and conversation-scoped telemetry_events rows on
+ * their dedicated connections) are deleted explicitly before removing the
+ * conversation row.
  */
 export function pruneOldConversationsJob(
   job: MemoryJob,
@@ -198,7 +200,7 @@ export function pruneOldConversationsJob(
   const db = getDb();
   const prunedIds: string[] = [];
   for (const { id } of stale) {
-    db.transaction(() => {
+    db.transaction((tx) => {
       // Re-check staleness inside the transaction to avoid racing with a conversation
       // that became active again between the initial SELECT and this DELETE.
       const still = rawAll<{ id: string }>(
@@ -238,6 +240,10 @@ export function pruneOldConversationsJob(
         `DELETE FROM messages WHERE conversation_id = ?`,
         id,
       );
+      // Conversation-keyed, no foreign key of its own, so the cascade below
+      // never reaches it. Handed the open transaction so the preference rows
+      // commit or roll back with the conversation row they belong to.
+      deleteAcpConversationModelPreferences(id, tx);
       // Conversation row deletion cascades to remaining dependent tables
       rawRun(
         "cleanup:pruneOldConversations:conv",

--- a/assistant/src/persistence/migrations/377-acp-session-history-model.ts
+++ b/assistant/src/persistence/migrations/377-acp-session-history-model.ts
@@ -1,0 +1,33 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const TABLE = "acp_session_history";
+const COLUMN = "model";
+
+/**
+ * Add a nullable `model TEXT` column to `acp_session_history`.
+ *
+ * Records which model the adapter confirmed the run was on, so a finished run
+ * can say what produced it. It is a record of the past, not the source a later
+ * spawn inherits from: history is written once at terminal transition, while
+ * inheritance has to answer before a run starts. That question belongs to
+ * `acp_conversation_model_preference`.
+ *
+ * `NULL` for rows written before this migration ran, and for every run on an
+ * adapter that advertises no model selector.
+ *
+ * Idempotent: the PRAGMA guard makes re-running a no-op once the column
+ * exists.
+ */
+export function migrateAcpSessionHistoryModel(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(${TABLE})`).all() as Array<{
+    name: string;
+  }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  if (!columnNames.has(COLUMN)) {
+    raw.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${COLUMN} TEXT`);
+  }
+}

--- a/assistant/src/persistence/migrations/378-create-acp-conversation-model-preference.ts
+++ b/assistant/src/persistence/migrations/378-create-acp-conversation-model-preference.ts
@@ -1,0 +1,34 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const TABLE = "acp_conversation_model_preference";
+
+/**
+ * Create `acp_conversation_model_preference`: which model a conversation's
+ * next run on a given agent starts on.
+ *
+ * Keyed `(parent_conversation_id, agent_id)` because a conversation can drive
+ * more than one coding agent and their model vocabularies do not overlap.
+ *
+ * Its own table rather than a column on `acp_session_history`, because history
+ * answers a different question. History is written once, when a run reaches a
+ * terminal state, so it cannot be read before the next run starts and it
+ * records whatever the adapter happened to report. A preference is written
+ * only when the user chooses, so it never drifts into inheriting a fallback
+ * the user never asked for.
+ *
+ * Idempotent via IF NOT EXISTS.
+ */
+export function migrateCreateAcpConversationModelPreference(
+  database: DrizzleDb,
+): void {
+  getSqliteFrom(database).exec(
+    `CREATE TABLE IF NOT EXISTS ${TABLE} (
+       parent_conversation_id TEXT NOT NULL,
+       agent_id TEXT NOT NULL,
+       model TEXT NOT NULL,
+       updated_at INTEGER NOT NULL,
+       PRIMARY KEY (parent_conversation_id, agent_id)
+     )`,
+  );
+}

--- a/assistant/src/persistence/migrations/__tests__/377-acp-session-history-model.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/377-acp-session-history-model.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Migration 377 adds the nullable `model` column that records which model a
+ * finished ACP run was on, and is idempotent so a repair flow can re-run it.
+ */
+
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../../db-connection.js";
+import * as schema from "../../schema.js";
+import { migrateAcpSessionHistoryModel } from "../377-acp-session-history-model.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec(
+    "CREATE TABLE acp_session_history (id TEXT PRIMARY KEY, status TEXT)",
+  );
+  return drizzle(sqlite, { schema });
+}
+
+function columnNames(db: ReturnType<typeof createTestDb>): string[] {
+  const rows = getSqliteFrom(db)
+    .prepare("PRAGMA table_info(acp_session_history)")
+    .all() as { name: string }[];
+  return rows.map((row) => row.name);
+}
+
+describe("migrateAcpSessionHistoryModel", () => {
+  test("adds the column when it is missing", () => {
+    const db = createTestDb();
+
+    migrateAcpSessionHistoryModel(db);
+
+    expect(columnNames(db)).toContain("model");
+  });
+
+  test("re-running is a no-op", () => {
+    const db = createTestDb();
+
+    migrateAcpSessionHistoryModel(db);
+    migrateAcpSessionHistoryModel(db);
+
+    expect(columnNames(db)).toContain("model");
+  });
+
+  test("preserves existing rows, leaving their model unknown", () => {
+    // A run that finished before the column existed reported no model. Null
+    // says exactly that, which is what keeps a detail panel from claiming a
+    // model the run may never have been on.
+    const db = createTestDb();
+    getSqliteFrom(db).exec(
+      "INSERT INTO acp_session_history (id, status) VALUES ('run-1', 'completed')",
+    );
+
+    migrateAcpSessionHistoryModel(db);
+
+    const row = getSqliteFrom(db)
+      .prepare(
+        "SELECT status, model FROM acp_session_history WHERE id = 'run-1'",
+      )
+      .get() as { status: string; model: string | null };
+    expect(row).toEqual({ status: "completed", model: null });
+  });
+});

--- a/assistant/src/persistence/migrations/__tests__/378-create-acp-conversation-model-preference.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/378-create-acp-conversation-model-preference.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Migration 378 creates `acp_conversation_model_preference`, the record of
+ * which model a conversation's next run on an agent starts on. Its composite
+ * primary key is what makes an explicit choice replace the previous one per
+ * agent rather than accumulate.
+ */
+
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../../db-connection.js";
+import * as schema from "../../schema.js";
+import { migrateCreateAcpConversationModelPreference } from "../378-create-acp-conversation-model-preference.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  return drizzle(sqlite, { schema });
+}
+
+function tableNames(db: ReturnType<typeof createTestDb>): string[] {
+  const rows = getSqliteFrom(db)
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+    .all() as { name: string }[];
+  return rows.map((row) => row.name);
+}
+
+describe("migrateCreateAcpConversationModelPreference", () => {
+  test("creates the table", () => {
+    const db = createTestDb();
+
+    migrateCreateAcpConversationModelPreference(db);
+
+    expect(tableNames(db)).toContain("acp_conversation_model_preference");
+  });
+
+  test("re-running preserves existing rows", () => {
+    const db = createTestDb();
+    migrateCreateAcpConversationModelPreference(db);
+    const raw = getSqliteFrom(db);
+    raw.exec(
+      `INSERT INTO acp_conversation_model_preference
+         (parent_conversation_id, agent_id, model, updated_at)
+       VALUES ('conv-1', 'claude', 'opus', 10)`,
+    );
+
+    migrateCreateAcpConversationModelPreference(db);
+
+    const rows = raw
+      .prepare(
+        "SELECT parent_conversation_id, agent_id, model FROM acp_conversation_model_preference",
+      )
+      .all();
+    expect(rows).toEqual([
+      { parent_conversation_id: "conv-1", agent_id: "claude", model: "opus" },
+    ]);
+  });
+
+  test("keys on the conversation and agent together", () => {
+    const db = createTestDb();
+    migrateCreateAcpConversationModelPreference(db);
+    const raw = getSqliteFrom(db);
+
+    raw.exec(
+      `INSERT INTO acp_conversation_model_preference
+         (parent_conversation_id, agent_id, model, updated_at)
+       VALUES ('conv-1', 'claude', 'opus', 10)`,
+    );
+    // A second agent in the same conversation is a separate preference.
+    raw.exec(
+      `INSERT INTO acp_conversation_model_preference
+         (parent_conversation_id, agent_id, model, updated_at)
+       VALUES ('conv-1', 'codex', 'gpt-5', 11)`,
+    );
+    // The same pair replaces rather than accumulates.
+    raw.exec(
+      `INSERT OR REPLACE INTO acp_conversation_model_preference
+         (parent_conversation_id, agent_id, model, updated_at)
+       VALUES ('conv-1', 'claude', 'sonnet', 12)`,
+    );
+
+    const rows = raw
+      .prepare(
+        `SELECT agent_id, model FROM acp_conversation_model_preference
+         ORDER BY agent_id`,
+      )
+      .all();
+    expect(rows).toEqual([
+      { agent_id: "claude", model: "sonnet" },
+      { agent_id: "codex", model: "gpt-5" },
+    ]);
+  });
+});

--- a/assistant/src/persistence/schema/acp.ts
+++ b/assistant/src/persistence/schema/acp.ts
@@ -1,6 +1,7 @@
 import {
   index,
   integer,
+  primaryKey,
   real,
   sqliteTable,
   text,
@@ -45,6 +46,11 @@ export const acpSessionHistory = sqliteTable(
     // before these columns existed.
     inputTokens: integer("input_tokens"),
     outputTokens: integer("output_tokens"),
+    /** Model the adapter confirmed the run was on. Null when the adapter
+     *  advertises no model selector, and for rows written before migration
+     *  377. A record of the run, never the source a later spawn inherits
+     *  from: see `acpConversationModelPreference`. */
+    model: text("model"),
   },
   (table) => [
     index("idx_acp_session_history_started_at").on(table.startedAt),
@@ -74,3 +80,29 @@ export const acpRefusedCredentials = sqliteTable("acp_refused_credentials", {
   digest: text("digest").primaryKey(),
   refusedAt: integer("refused_at").notNull(),
 });
+
+/**
+ * Which model a conversation's next run on a given agent starts on.
+ *
+ * Written only when the user chooses one: a spawn parameter, a live switch, a
+ * typed command. Never from adapter-reported state, so an agent falling back
+ * to its own default cannot quietly become the conversation's preference.
+ *
+ * Keyed per agent because one conversation can drive several coding agents and
+ * their model vocabularies do not overlap. Values are adapter aliases (for
+ * example "opus"), not Assistant catalog ids.
+ *
+ * Created by migration 378.
+ */
+export const acpConversationModelPreference = sqliteTable(
+  "acp_conversation_model_preference",
+  {
+    parentConversationId: text("parent_conversation_id").notNull(),
+    agentId: text("agent_id").notNull(),
+    model: text("model").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.parentConversationId, table.agentId] }),
+  ],
+);

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -484,6 +484,8 @@ import { migrateAcpAuthMarkerIndex } from "./migrations/373-acp-auth-marker-inde
 import { migrateChannelInboundMessageIdIndex } from "./migrations/374-channel-inbound-message-id-index.js";
 import { migrateCreateChannelOutboundPosts } from "./migrations/375-create-channel-outbound-posts.js";
 import { migrateNotificationDeliveriesCanonicalMessageId } from "./migrations/376-notification-deliveries-canonical-message-id.js";
+import { migrateAcpSessionHistoryModel } from "./migrations/377-acp-session-history-model.js";
+import { migrateCreateAcpConversationModelPreference } from "./migrations/378-create-acp-conversation-model-preference.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1602,4 +1604,6 @@ export const migrationSteps: MigrationStep[] = [
   migrateChannelInboundMessageIdIndex,
   migrateCreateChannelOutboundPosts,
   migrateNotificationDeliveriesCanonicalMessageId,
+  migrateAcpSessionHistoryModel,
+  migrateCreateAcpConversationModelPreference,
 ];


### PR DESCRIPTION
## Summary

- Migration 377 adds a nullable `model` column to `acp_session_history` (what a finished run was on), and migration 378 creates `acp_conversation_model_preference` keyed `(parent_conversation_id, agent_id)` (what the next run starts on). Two tables because history is written once at terminal transition and cannot be read before a run starts, and because a preference must only ever record an explicit user choice.
- New `persistence/acp-model-preference.ts` with get / upsert / delete over the preference table, following the `getDb()` style of its neighbours. The delete takes an optional writer so both `deleteConversation` and `deleteConversationGently` purge preference rows inside the transaction that removes the conversation.
- Drizzle schema, migration registration, and the shared `acp-history-db` test helper extended to match; tests cover migration idempotency and row preservation, upsert semantics on the composite key, agent and conversation scoping, and the delete cascade.

Part of plan: acp-model-control.md (PR 4 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D