### PR TITLE
chore(acp): pin claude-agent-acp and codex-acp versions and reinstall on mismatch

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -510,7 +510,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(args).toEqual([
       "add",
       "--global",
-      "@agentclientprotocol/claude-agent-acp",
+      "@agentclientprotocol/claude-agent-acp@0.75.1",
     ]);
     const { cwd, env } = options as { cwd?: string; env?: NodeJS.ProcessEnv };
     expect(cwd).toBeDefined();

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -80,13 +80,58 @@ function bunLinked(command: string): string {
 /** Manifest reads the probe performed since the last reset. */
 let manifestReads = 0;
 
+/** Package the pin names for each adapter binary. */
+const PINNED_PACKAGE: Record<string, string> = {
+  "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
+  "codex-acp": "@agentclientprotocol/codex-acp",
+};
+
+/** Default link owners: an installed pinned package owns its own bin. */
+function ownersFromVersions(
+  versions: Record<string, string>,
+): Record<string, string> {
+  const owners: Record<string, string> = {};
+  for (const [command, name] of Object.entries(PINNED_PACKAGE)) {
+    if (versions[name] !== undefined) {
+      owners[command] = name;
+    }
+  }
+  return owners;
+}
+
 /**
- * Point the version probe at an in-memory bun global tree. Keys are package
- * names; values are the `version` their manifest reports.
+ * `fs.realpath` over the fake bun tree: a `<bun>/bin/<name>` link resolves
+ * into the package that owns it, every other path resolves to itself. A
+ * binary missing from `owners` has a link that cannot be resolved.
  */
-function stubGlobalTree(versions: Record<string, string>): void {
+function fakeRealpath(
+  owners: Record<string, string>,
+): (path: string) => Promise<string> {
+  const binPrefix = `${BUN_ROOT}/bin/`;
+  return (path: string) => {
+    if (!path.startsWith(binPrefix)) {
+      return Promise.resolve(path);
+    }
+    const owner = owners[path.slice(binPrefix.length)];
+    if (owner === undefined) {
+      return Promise.reject(new Error("ENOENT"));
+    }
+    return Promise.resolve(`${GLOBAL_MODULES}/${owner}/dist/cli.js`);
+  };
+}
+
+/**
+ * Point the version probe at an in-memory bun global tree. `versions` maps a
+ * package name to the `version` its manifest reports; `owners` maps a binary
+ * name to the package its `<bun>/bin` link resolves into.
+ */
+function stubGlobalTree(
+  versions: Record<string, string>,
+  owners: Record<string, string> = ownersFromVersions(versions),
+): void {
   _setAdapterVersionProbeDepsForTests({
     bunInstallDir: () => BUN_ROOT,
+    realpath: fakeRealpath(owners),
     readFile: (path: string) => {
       manifestReads += 1;
       const name = path.slice(
@@ -208,13 +253,13 @@ describe("ensureAdapterInstalled", () => {
     expect(execFileMock).toHaveBeenCalledTimes(2);
   });
 
-  test("successful install is cached for the process lifetime", async () => {
+  test("a settled install is not cached: the next call probes again", async () => {
     execScripts.set(BUN_ADD_KEY, { stdout: "" });
 
     await ensureAdapterInstalled("claude-agent-acp");
     await ensureAdapterInstalled("claude-agent-acp");
 
-    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
   });
 
   test("concurrent calls dedupe to exactly one install", async () => {
@@ -363,6 +408,60 @@ describe("ensureAdapterInstalled - version pinning", () => {
     expect(result).toEqual({ installed: false });
     expect(manifestReads).toBe(0);
     expect(warnings().join(" ")).toContain("managed outside bun");
+  });
+
+  test("bun link owned by the pinned package at the pinned version: no install", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
+    stubGlobalTree(
+      { "@agentclientprotocol/codex-acp": "1.10.0" },
+      { "codex-acp": "@agentclientprotocol/codex-acp" },
+    );
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: false });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("bun link owned by another package: reinstalls even when the pinned manifest matches", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
+    // Both packages are installed and both keep a manifest, but the link
+    // resolves into the other one, so the pinned manifest describes an
+    // executable no spawn would run.
+    stubGlobalTree(
+      {
+        "@agentclientprotocol/codex-acp": "1.10.0",
+        "@zed-industries/codex-acp": "0.4.0",
+      },
+      { "codex-acp": "@zed-industries/codex-acp" },
+    );
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CODEX_SPEC,
+    ]);
+  });
+
+  test("bun link that cannot be resolved: reinstalls the pin", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "1.10.0" }, {});
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CODEX_SPEC,
+    ]);
   });
 
   test("binary missing from PATH: installs without consulting the probe", async () => {
@@ -519,6 +618,9 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
     });
     _setAdapterVersionProbeDepsForTests({
       bunInstallDir: () => BUN_ROOT,
+      realpath: fakeRealpath({
+        "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
+      }),
       readFile: () =>
         Promise.resolve(JSON.stringify({ version: installedVersion })),
     });
@@ -547,9 +649,12 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
 
   test("bun-managed adapter with an unreadable manifest: reinstalls the pin", async () => {
     which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
-    // Nothing under the pinned package's path: the binary came from another
-    // package that owns the same name.
-    stubGlobalTree({ "@zed-industries/codex-acp": "0.4.0" });
+    // The link resolves into the pinned package, but nothing is installed
+    // under its path, so the manifest read finds no version to trust.
+    stubGlobalTree(
+      { "@zed-industries/codex-acp": "0.4.0" },
+      { "codex-acp": "@agentclientprotocol/codex-acp" },
+    );
     execScripts.set(BUN_ADD_KEY, { stdout: "" });
 
     const result = await resolveAgentWithAutoInstall("codex");
@@ -586,7 +691,7 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
     ).toHaveLength(1);
   });
 
-  test("pin check is probed once per command per process", async () => {
+  test("a no-install decision is not cached: the pin is re-checked per spawn", async () => {
     which.setWhich({
       bun: BUN_BIN,
       "claude-agent-acp": bunLinked("claude-agent-acp"),
@@ -596,8 +701,42 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
     await resolveAgentWithAutoInstall("claude");
     await resolveAgentWithAutoInstall("claude");
 
-    expect(manifestReads).toBe(1);
+    expect(manifestReads).toBe(2);
     expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("an adapter replaced under a running daemon is caught on the next spawn", async () => {
+    let installedVersion = "1.10.0";
+    which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
+    _setAdapterVersionProbeDepsForTests({
+      bunInstallDir: () => BUN_ROOT,
+      realpath: fakeRealpath({
+        "codex-acp": "@agentclientprotocol/codex-acp",
+      }),
+      readFile: () => {
+        manifestReads += 1;
+        return Promise.resolve(JSON.stringify({ version: installedVersion }));
+      },
+    });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const first = await resolveAgentWithAutoInstall("codex");
+
+    expect(first.resolved.ok).toBe(true);
+    expect(execFileMock).not.toHaveBeenCalled();
+
+    // `bun add -g ...@latest` outside the daemon replaces the executable.
+    installedVersion = "1.11.0";
+    const second = await resolveAgentWithAutoInstall("codex");
+
+    expect(second.resolved.ok).toBe(true);
+    expect(manifestReads).toBe(2);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CODEX_SPEC,
+    ]);
   });
 
   test("reinstall fails: keeps the resolved adapter and surfaces no failure message", async () => {

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -35,15 +35,28 @@ afterAll(() => {
 
 // Spread the real module so other test files that load logger consumers
 // (e.g. `truncateForLog` importers) after this process-global mock still
-// resolve every named export.
+// resolve every named export. The recorded lines let the tests assert the
+// warnings the auto-installer emits instead of only its return values.
+const logRecords: { level: string; message: string }[] = [];
 const realLogger = await import("../util/logger.js");
 mock.module("../util/logger.js", () => ({
   ...realLogger,
   getLogger: () =>
     new Proxy({} as Record<string, unknown>, {
-      get: () => () => {},
+      get: (_target, level) => (fields: unknown, message?: unknown) => {
+        logRecords.push({
+          level: String(level),
+          message: typeof message === "string" ? message : String(fields),
+        });
+      },
     }),
 }));
+
+function warnings(): string[] {
+  return logRecords
+    .filter((record) => record.level === "warn")
+    .map((record) => record.message);
+}
 
 const {
   ensureAdapterInstalled,
@@ -56,7 +69,16 @@ const {
 /** Pinned specs under test, mirroring `DEFAULT_AGENT_NPM_PACKAGES`. */
 const CLAUDE_SPEC = "@agentclientprotocol/claude-agent-acp@0.75.1";
 const CODEX_SPEC = "@agentclientprotocol/codex-acp@1.10.0";
-const GLOBAL_MODULES = "/home/tester/.bun/install/global/node_modules";
+/** Stand-in for `BUN_INSTALL`: bun's global bin and module tree hang off it. */
+const BUN_ROOT = "/home/tester/.bun";
+const GLOBAL_MODULES = `${BUN_ROOT}/install/global/node_modules`;
+/** Where `bun add --global` links an adapter binary. */
+function bunLinked(command: string): string {
+  return `${BUN_ROOT}/bin/${command}`;
+}
+
+/** Manifest reads the probe performed since the last reset. */
+let manifestReads = 0;
 
 /**
  * Point the version probe at an in-memory bun global tree. Keys are package
@@ -64,8 +86,9 @@ const GLOBAL_MODULES = "/home/tester/.bun/install/global/node_modules";
  */
 function stubGlobalTree(versions: Record<string, string>): void {
   _setAdapterVersionProbeDepsForTests({
-    globalModulesDir: () => GLOBAL_MODULES,
+    bunInstallDir: () => BUN_ROOT,
     readFile: (path: string) => {
+      manifestReads += 1;
       const name = path.slice(
         `${GLOBAL_MODULES}/`.length,
         -"/package.json".length,
@@ -88,6 +111,8 @@ function lastInstallOptions(): { cwd?: string; env?: NodeJS.ProcessEnv } {
 beforeEach(() => {
   reset();
   _resetAdapterInstallCacheForTests();
+  logRecords.length = 0;
+  manifestReads = 0;
   config.setConfig({ agents: {} });
   // Default: bun on PATH, nothing else.
   which.setWhich({ bun: BUN_BIN });
@@ -259,7 +284,7 @@ describe("ensureAdapterInstalled - version pinning", () => {
   test("binary on PATH at the pinned version: no install", async () => {
     which.setWhich({
       bun: BUN_BIN,
-      "claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+      "claude-agent-acp": bunLinked("claude-agent-acp"),
     });
     stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.75.1" });
 
@@ -272,7 +297,7 @@ describe("ensureAdapterInstalled - version pinning", () => {
   test("binary on PATH at an older version: reinstalls the pinned spec", async () => {
     which.setWhich({
       bun: BUN_BIN,
-      "claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+      "claude-agent-acp": bunLinked("claude-agent-acp"),
     });
     stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.47.0" });
     execScripts.set(BUN_ADD_KEY, { stdout: "" });
@@ -289,7 +314,7 @@ describe("ensureAdapterInstalled - version pinning", () => {
   });
 
   test("binary on PATH from another package: reinstalls and takes the name over", async () => {
-    which.setWhich({ bun: BUN_BIN, "codex-acp": "/usr/local/bin/codex-acp" });
+    which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
     // An older `@zed-industries/codex-acp` owns the binary name and leaves
     // nothing under the pinned package's path.
     stubGlobalTree({ "@zed-industries/codex-acp": "0.4.0" });
@@ -303,6 +328,41 @@ describe("ensureAdapterInstalled - version pinning", () => {
       "--global",
       CODEX_SPEC,
     ]);
+  });
+
+  test("binary PATH selects from outside bun: no install, pin not enforced", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "codex-acp": "/opt/homebrew/bin/codex-acp",
+    });
+    // The pinned package IS present in bun's tree at the pinned version, but
+    // PATH selects the brew binary, so the manifest describes nothing that
+    // will spawn and a reinstall would not change which binary wins.
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "1.10.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: false });
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(manifestReads).toBe(0);
+    expect(warnings().join(" ")).toContain("managed outside bun");
+  });
+
+  test("stale bun manifest never overrides the binary PATH selects", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+    });
+    // Pinned version in bun's tree, older binary earlier on PATH: the probe
+    // must not report the pin as satisfied for a binary it does not describe.
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.75.1" });
+
+    const result = await ensureAdapterInstalled("claude-agent-acp");
+
+    expect(result).toEqual({ installed: false });
+    expect(manifestReads).toBe(0);
+    expect(warnings().join(" ")).toContain("managed outside bun");
   });
 
   test("binary missing from PATH: installs without consulting the probe", async () => {
@@ -429,5 +489,151 @@ describe("resolveAgentWithAutoInstall - resolution order", () => {
     }
     expect(result.resolved.agent.command).toBe("codex-acp");
     expect(execFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", () => {
+  test("bun-managed adapter at the pinned version: resolves with no install", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": bunLinked("claude-agent-acp"),
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.75.1" });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(true);
+    if (!result.resolved.ok) {
+      return;
+    }
+    expect(result.resolved.agent.command).toBe("claude-agent-acp");
+    expect(result.failureMessage).toBeUndefined();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("bun-managed adapter at an older version: reinstalls the pin and returns the re-resolved agent", async () => {
+    let installedVersion = "0.47.0";
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": bunLinked("claude-agent-acp"),
+    });
+    _setAdapterVersionProbeDepsForTests({
+      bunInstallDir: () => BUN_ROOT,
+      readFile: () =>
+        Promise.resolve(JSON.stringify({ version: installedVersion })),
+    });
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        installedVersion = "0.75.1";
+      },
+    });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(true);
+    if (!result.resolved.ok) {
+      return;
+    }
+    expect(result.resolved.agent.command).toBe("claude-agent-acp");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CLAUDE_SPEC,
+    ]);
+    expect(installedVersion).toBe("0.75.1");
+  });
+
+  test("bun-managed adapter with an unreadable manifest: reinstalls the pin", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
+    // Nothing under the pinned package's path: the binary came from another
+    // package that owns the same name.
+    stubGlobalTree({ "@zed-industries/codex-acp": "0.4.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await resolveAgentWithAutoInstall("codex");
+
+    expect(result.resolved.ok).toBe(true);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CODEX_SPEC,
+    ]);
+  });
+
+  test("adapter managed outside bun: warns once, never installs, resolves as-is", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.47.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const first = await resolveAgentWithAutoInstall("claude");
+    const second = await resolveAgentWithAutoInstall("claude");
+
+    expect(first.resolved.ok).toBe(true);
+    if (!first.resolved.ok) {
+      return;
+    }
+    expect(first.resolved.agent.command).toBe("claude-agent-acp");
+    expect(second.resolved.ok).toBe(true);
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(
+      warnings().filter((message) => message.includes("managed outside bun")),
+    ).toHaveLength(1);
+  });
+
+  test("pin check is probed once per command per process", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": bunLinked("claude-agent-acp"),
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.75.1" });
+
+    await resolveAgentWithAutoInstall("claude");
+    await resolveAgentWithAutoInstall("claude");
+
+    expect(manifestReads).toBe(1);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("reinstall fails: keeps the resolved adapter and surfaces no failure message", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": bunLinked("claude-agent-acp"),
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.47.0" });
+    execScripts.set(BUN_ADD_KEY, { error: new Error("network is down") });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(true);
+    if (!result.resolved.ok) {
+      return;
+    }
+    expect(result.resolved.agent.command).toBe("claude-agent-acp");
+    expect(result.failureMessage).toBeUndefined();
+    expect(warnings().join(" ")).toContain(
+      "Could not reinstall the ACP adapter",
+    );
+  });
+
+  test("agent whose command maps to no package: never touches the installer", async () => {
+    config.setConfig({
+      agents: { custom: { command: "some-other-binary", args: [] } },
+    });
+    which.setWhich({
+      bun: BUN_BIN,
+      "some-other-binary": "/usr/local/bin/some-other-binary",
+    });
+
+    const result = await resolveAgentWithAutoInstall("custom");
+
+    expect(result.resolved.ok).toBe(true);
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(warnings()).toEqual([]);
   });
 });

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -77,6 +77,14 @@ function bunLinked(command: string): string {
   return `${BUN_ROOT}/bin/${command}`;
 }
 
+/** A PATH entry that reaches bun's global bin dir through a symlinked dir. */
+const BUN_ALIAS_ROOT = "/home/tester/bun-alias";
+
+/** The same bun-linked binary, named through the aliased directory. */
+function aliasLinked(command: string): string {
+  return `${BUN_ALIAS_ROOT}/bin/${command}`;
+}
+
 /** Manifest reads the probe performed since the last reset. */
 let manifestReads = 0;
 
@@ -101,14 +109,19 @@ function ownersFromVersions(
 
 /**
  * `fs.realpath` over the fake bun tree: a `<bun>/bin/<name>` link resolves
- * into the package that owns it, every other path resolves to itself. A
+ * into the package that owns it, every other path resolves to itself. The
+ * alias bin dir is a symlink to the real one, so it resolves identically. A
  * binary missing from `owners` has a link that cannot be resolved.
  */
 function fakeRealpath(
   owners: Record<string, string>,
 ): (path: string) => Promise<string> {
   const binPrefix = `${BUN_ROOT}/bin/`;
-  return (path: string) => {
+  const aliasPrefix = `${BUN_ALIAS_ROOT}/bin/`;
+  return (rawPath: string) => {
+    const path = rawPath.startsWith(aliasPrefix)
+      ? `${binPrefix}${rawPath.slice(aliasPrefix.length)}`
+      : rawPath;
     if (!path.startsWith(binPrefix)) {
       return Promise.resolve(path);
     }
@@ -275,6 +288,40 @@ describe("ensureAdapterInstalled", () => {
     expect(b.installed).toBe(true);
     expect(c.installed).toBe(true);
     expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("concurrent calls on different PATHs each get their own decision", async () => {
+    const BREW_BIN_DIR = "/opt/homebrew/bin";
+    const BUN_BIN_DIR = `${BUN_ROOT}/bin`;
+    which.setWhich((cmd, options) => {
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (cmd !== "codex-acp") {
+        return null;
+      }
+      return options?.PATH === BREW_BIN_DIR
+        ? `${BREW_BIN_DIR}/codex-acp`
+        : bunLinked("codex-acp");
+    });
+    // Outdated in bun's tree: the bun-managed PATH must reinstall even though
+    // the brew PATH resolves first and decides not to.
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "0.4.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const [external, bunManaged] = await Promise.all([
+      ensureAdapterInstalled("codex-acp", BREW_BIN_DIR),
+      ensureAdapterInstalled("codex-acp", BUN_BIN_DIR),
+    ]);
+
+    expect(external).toEqual({ installed: false });
+    expect(bunManaged).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CODEX_SPEC,
+    ]);
   });
 
   test("different commands install independently", async () => {
@@ -462,6 +509,34 @@ describe("ensureAdapterInstalled - version pinning", () => {
       "--global",
       CODEX_SPEC,
     ]);
+  });
+
+  test("bun bin dir reached through a symlinked dir: still bun-managed", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": aliasLinked("codex-acp") });
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "0.4.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CODEX_SPEC,
+    ]);
+    expect(warnings().join(" ")).not.toContain("managed outside bun");
+  });
+
+  test("aliased bun bin dir at the pinned version: no install", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": aliasLinked("codex-acp") });
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "1.10.0" });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: false });
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(warnings().join(" ")).not.toContain("managed outside bun");
   });
 
   test("binary missing from PATH: installs without consulting the probe", async () => {

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -47,9 +47,37 @@ mock.module("../util/logger.js", () => ({
 
 const {
   ensureAdapterInstalled,
+  getInstalledAdapterVersion,
   resolveAgentWithAutoInstall,
   _resetAdapterInstallCacheForTests,
+  _setAdapterVersionProbeDepsForTests,
 } = await import("./auto-install.js");
+
+/** Pinned specs under test, mirroring `DEFAULT_AGENT_NPM_PACKAGES`. */
+const CLAUDE_SPEC = "@agentclientprotocol/claude-agent-acp@0.75.1";
+const CODEX_SPEC = "@agentclientprotocol/codex-acp@1.10.0";
+const GLOBAL_MODULES = "/home/tester/.bun/install/global/node_modules";
+
+/**
+ * Point the version probe at an in-memory bun global tree. Keys are package
+ * names; values are the `version` their manifest reports.
+ */
+function stubGlobalTree(versions: Record<string, string>): void {
+  _setAdapterVersionProbeDepsForTests({
+    globalModulesDir: () => GLOBAL_MODULES,
+    readFile: (path: string) => {
+      const name = path.slice(
+        `${GLOBAL_MODULES}/`.length,
+        -"/package.json".length,
+      );
+      const version = versions[name];
+      if (version === undefined) {
+        return Promise.reject(new Error("ENOENT"));
+      }
+      return Promise.resolve(JSON.stringify({ name, version }));
+    },
+  });
+}
 
 /** Latest call's execFile options ({ cwd, env, ... }). */
 function lastInstallOptions(): { cwd?: string; env?: NodeJS.ProcessEnv } {
@@ -75,11 +103,7 @@ describe("ensureAdapterInstalled", () => {
     expect(execFileMock).toHaveBeenCalledTimes(1);
     const [command, args] = execFileMock.mock.calls[0];
     expect(command).toBe(BUN_BIN);
-    expect(args).toEqual([
-      "add",
-      "--global",
-      "@agentclientprotocol/claude-agent-acp",
-    ]);
+    expect(args).toEqual(["add", "--global", CLAUDE_SPEC]);
   });
 
   test("installer never invokes npm", async () => {
@@ -197,10 +221,103 @@ describe("ensureAdapterInstalled", () => {
     const installedPackages = execFileMock.mock.calls.map(
       (call) => (call[1] as string[])[2],
     );
-    expect(installedPackages.sort()).toEqual([
-      "@agentclientprotocol/claude-agent-acp",
-      "@agentclientprotocol/codex-acp",
+    expect(installedPackages.sort()).toEqual([CLAUDE_SPEC, CODEX_SPEC]);
+  });
+});
+
+describe("getInstalledAdapterVersion", () => {
+  test("reads the version bun wrote into its global module tree", async () => {
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.47.0" });
+
+    expect(await getInstalledAdapterVersion("claude-agent-acp")).toBe("0.47.0");
+  });
+
+  test("undefined when the package is absent from the global tree", async () => {
+    stubGlobalTree({});
+
+    expect(await getInstalledAdapterVersion("codex-acp")).toBeUndefined();
+  });
+
+  test("undefined for a command outside the adapter allowlist", async () => {
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.75.1" });
+
+    expect(
+      await getInstalledAdapterVersion("some-arbitrary-binary"),
+    ).toBeUndefined();
+  });
+
+  test("undefined when the manifest is not valid JSON", async () => {
+    _setAdapterVersionProbeDepsForTests({
+      readFile: () => Promise.resolve("not json"),
+    });
+
+    expect(await getInstalledAdapterVersion("codex-acp")).toBeUndefined();
+  });
+});
+
+describe("ensureAdapterInstalled - version pinning", () => {
+  test("binary on PATH at the pinned version: no install", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.75.1" });
+
+    const result = await ensureAdapterInstalled("claude-agent-acp");
+
+    expect(result).toEqual({ installed: false });
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("binary on PATH at an older version: reinstalls the pinned spec", async () => {
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": "/usr/local/bin/claude-agent-acp",
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.47.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await ensureAdapterInstalled("claude-agent-acp");
+
+    expect(result).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CLAUDE_SPEC,
     ]);
+  });
+
+  test("binary on PATH from another package: reinstalls and takes the name over", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": "/usr/local/bin/codex-acp" });
+    // An older `@zed-industries/codex-acp` owns the binary name and leaves
+    // nothing under the pinned package's path.
+    stubGlobalTree({ "@zed-industries/codex-acp": "0.4.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: true });
+    expect(execFileMock.mock.calls[0][1]).toEqual([
+      "add",
+      "--global",
+      CODEX_SPEC,
+    ]);
+  });
+
+  test("binary missing from PATH: installs without consulting the probe", async () => {
+    which.setWhich({ bun: BUN_BIN });
+    _setAdapterVersionProbeDepsForTests({
+      readFile: () => {
+        throw new Error("probe must not run when the binary is missing");
+      },
+    });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const result = await ensureAdapterInstalled("codex-acp");
+
+    expect(result).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -231,9 +348,7 @@ describe("resolveAgentWithAutoInstall - resolution order", () => {
     }
     // The resolved command is the REAL binary, not a `bun x` wrapper.
     expect(result.resolved.agent.command).toBe("claude-agent-acp");
-    expect(result.autoInstalledPackage).toBe(
-      "@agentclientprotocol/claude-agent-acp",
-    );
+    expect(result.autoInstalledPackage).toBe(CLAUDE_SPEC);
     expect(result.failureMessage).toBeUndefined();
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(execFileMock.mock.calls[0][0]).toBe(BUN_BIN);
@@ -264,12 +379,12 @@ describe("resolveAgentWithAutoInstall - resolution order", () => {
       return;
     }
     expect(result.resolved.agent.command).toBe("codex-acp");
-    expect(result.autoInstalledPackage).toBe("@agentclientprotocol/codex-acp");
+    expect(result.autoInstalledPackage).toBe(CODEX_SPEC);
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(execFileMock.mock.calls[0][1]).toEqual([
       "add",
       "--global",
-      "@agentclientprotocol/codex-acp",
+      CODEX_SPEC,
     ]);
   });
 
@@ -294,9 +409,7 @@ describe("resolveAgentWithAutoInstall - resolution order", () => {
 
     expect(result.resolved.ok).toBe(false);
     expect(result.failureMessage).toContain("claude-agent-acp is not on PATH");
-    expect(result.failureMessage).toContain(
-      "bun add -g @agentclientprotocol/claude-agent-acp",
-    );
+    expect(result.failureMessage).toContain(`bun add -g ${CLAUDE_SPEC}`);
     expect(result.failureMessage).toContain("network is down");
     for (const call of execFileMock.mock.calls) {
       expect(call[0]).not.toBe("npm");

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -10,9 +10,13 @@
  * injected only at spawn).
  *
  * Installs name the pinned `name@version` spec from
- * `DEFAULT_AGENT_NPM_PACKAGES`, and an adapter already on PATH whose globally
- * installed version does not match that pin is reinstalled, so the daemon
- * always drives the adapter version it was built against.
+ * `DEFAULT_AGENT_NPM_PACKAGES`, and `resolveAgentWithAutoInstall` enforces
+ * that pin on every resolution, not only on the missing-binary path, so the
+ * daemon always drives the adapter version it was built against. The pin is
+ * enforced against the executable PATH actually selects: a bun-linked binary
+ * whose global manifest disagrees with the pin is reinstalled, while one
+ * installed by npm or brew is left alone with a warning, since a bun install
+ * would not change which binary spawns.
  *
  * Security boundaries (this is the ATL-808 fix):
  *  - Only commands present in `DEFAULT_AGENT_NPM_PACKAGES` are ever
@@ -35,12 +39,13 @@
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve as resolvePath } from "node:path";
 
 import {
   DEFAULT_AGENT_NPM_PACKAGES,
   splitPackageSpec,
 } from "../config/acp-defaults.js";
+import type { AcpAgentConfig } from "../config/acp-schema.js";
 import { getLogger } from "../util/logger.js";
 import {
   resolveAcpAgent,
@@ -126,24 +131,40 @@ function sanitizedInstallEnv(): NodeJS.ProcessEnv {
 
 interface AdapterVersionProbeDeps {
   readFile: (path: string) => Promise<string>;
-  /** The module tree `bun add --global` writes into. */
-  globalModulesDir: () => string;
+  /**
+   * Bun's global install root: `<root>/bin` holds the binaries `bun add
+   * --global` links, `<root>/install/global/node_modules` the packages they
+   * come from. Both halves of the pin check read this one root, so a manifest
+   * is only ever compared against a binary the same install produced.
+   */
+  bunInstallDir: () => string;
 }
 
 const REAL_PROBE_DEPS: AdapterVersionProbeDeps = {
   readFile: (path) => readFile(path, "utf8"),
-  globalModulesDir: () =>
-    join(
-      // `bun add --global` honours BUN_INSTALL, and the installer env is a
-      // copy of `process.env`, so the probe has to read the same override.
-      process.env.BUN_INSTALL ?? join(homedir(), ".bun"),
-      "install",
-      "global",
-      "node_modules",
-    ),
+  // `bun add --global` honours BUN_INSTALL, and the installer env is a copy of
+  // `process.env`, so the probe has to read the same override.
+  bunInstallDir: () => process.env.BUN_INSTALL ?? join(homedir(), ".bun"),
 };
 
 let probeDeps: AdapterVersionProbeDeps = REAL_PROBE_DEPS;
+
+/** The module tree `bun add --global` writes into. */
+function globalModulesDir(): string {
+  return join(probeDeps.bunInstallDir(), "install", "global", "node_modules");
+}
+
+/**
+ * Whether `binaryPath` is the binary `bun add --global` links for `command`.
+ * Only then does the pinned package's manifest describe the executable that a
+ * spawn would actually run, and only then can a reinstall change what PATH
+ * selects: an adapter installed by npm or brew keeps its place in PATH no
+ * matter what bun writes.
+ */
+function isBunManagedBinary(command: string, binaryPath: string): boolean {
+  const linked = join(probeDeps.bunInstallDir(), "bin", command);
+  return resolvePath(binaryPath) === resolvePath(linked);
+}
 
 /**
  * Version of the pinned adapter package as installed in bun's global tree, or
@@ -161,7 +182,7 @@ export async function getInstalledAdapterVersion(
     return undefined;
   }
   const manifest = join(
-    probeDeps.globalModulesDir(),
+    globalModulesDir(),
     ...splitPackageSpec(spec).name.split("/"),
     "package.json",
   );
@@ -184,6 +205,7 @@ export async function getInstalledAdapterVersion(
  */
 export function ensureAdapterInstalled(
   command: string,
+  searchPath?: string,
 ): Promise<AdapterInstallResult> {
   const packageSpec = DEFAULT_AGENT_NPM_PACKAGES[command];
   if (!packageSpec) {
@@ -200,34 +222,67 @@ export function ensureAdapterInstalled(
     return inFlight;
   }
 
-  const promise = installToPin(bunPath, command, packageSpec).then((result) => {
-    if (!result.installed) {
-      installPromises.delete(command);
-    }
-    return result;
-  });
+  const promise = installToPin(bunPath, command, packageSpec, searchPath).then(
+    (result) => {
+      // Only a genuine failure is evicted, so a later spawn can retry. A
+      // decision NOT to install (pin already satisfied, adapter managed
+      // outside bun) is cached, which is what keeps the probe to one read per
+      // command per process.
+      if (result.error) {
+        installPromises.delete(command);
+      }
+      return result;
+    },
+  );
   installPromises.set(command, promise);
   return promise;
 }
 
 /**
  * A binary missing from PATH always installs, unchanged. One already on PATH
- * installs only when its globally installed version differs from the pin,
- * which covers both an outdated install and one made from a different package
- * name that owns the same binary.
+ * installs only when it is the binary bun linked AND its globally installed
+ * version differs from the pin, which covers both an outdated install and one
+ * made from a different package name that owns the same binary. An adapter
+ * that came from anywhere else stays put: PATH would keep selecting it, so a
+ * bun install would change nothing but the disk.
  */
 async function installToPin(
   bunPath: string,
   command: string,
   packageSpec: string,
+  searchPath?: string,
 ): Promise<AdapterInstallResult> {
+  const binaryPath = whichOnPath(command, searchPath);
+  if (!binaryPath) {
+    return runInstall(bunPath, command, packageSpec);
+  }
   const { version } = splitPackageSpec(packageSpec);
-  if (version !== undefined && Bun.which(command)) {
-    if ((await getInstalledAdapterVersion(command)) === version) {
-      return { installed: false };
-    }
+  if (version === undefined) {
+    return { installed: false };
+  }
+  if (!isBunManagedBinary(command, binaryPath)) {
+    log.warn(
+      { command, binaryPath, packageSpec },
+      "ACP adapter is managed outside bun; leaving it in place and skipping the version pin",
+    );
+    return { installed: false };
+  }
+  if ((await getInstalledAdapterVersion(command)) === version) {
+    return { installed: false };
   }
   return runInstall(bunPath, command, packageSpec);
+}
+
+/**
+ * The executable a spawn would select, resolved on the same PATH the spawn
+ * will see: `AcpAgentProcess` spawns with `{ ...process.env, ...config.env }`,
+ * so a per-agent `env.PATH` override wins over the assistant's PATH.
+ */
+function whichOnPath(command: string, searchPath?: string): string | null {
+  return Bun.which(
+    command,
+    searchPath !== undefined ? { PATH: searchPath } : undefined,
+  );
 }
 
 async function runInstall(
@@ -287,7 +342,10 @@ export async function resolveAgentWithAutoInstall(
   agentId: string,
 ): Promise<ResolveWithAutoInstallResult> {
   const resolved = resolveAcpAgent(agentId);
-  if (resolved.ok || resolved.reason !== "binary_not_found") {
+  if (resolved.ok) {
+    return { resolved: await enforcePin(agentId, resolved.agent) };
+  }
+  if (resolved.reason !== "binary_not_found") {
     return { resolved };
   }
 
@@ -312,6 +370,37 @@ export async function resolveAgentWithAutoInstall(
     };
   }
   return { resolved };
+}
+
+/**
+ * A resolution that succeeded still has to satisfy the pin: the adapter on
+ * PATH may be an older bun-managed install, or one linked by a different
+ * package that owns the same binary name. Reinstall and re-resolve when it
+ * does not match. When the reinstall fails, keep the original resolution and
+ * warn: a stale adapter still beats no adapter.
+ */
+async function enforcePin(
+  agentId: string,
+  agent: AcpAgentConfig,
+): Promise<ResolveAcpAgentResult> {
+  const { command } = agent;
+  const install = await ensureAdapterInstalled(command, agent.env?.PATH);
+  if (install.installed) {
+    const retried = resolveAcpAgent(agentId);
+    if (retried.ok) {
+      log.info(
+        { agentId, command },
+        "Reinstalled the ACP adapter at its pinned version",
+      );
+      return retried;
+    }
+  } else if (install.error) {
+    log.warn(
+      { agentId, command, error: install.error },
+      "Could not reinstall the ACP adapter at its pinned version; spawning the installed one",
+    );
+  }
+  return { ok: true, agent };
 }
 
 /** @internal: exposed for tests only. */

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -72,12 +72,21 @@ export interface AdapterInstallResult {
 }
 
 /**
- * In-flight install promises, keyed by command. Concurrent spawns for the same
- * adapter dedupe to a single global install. Nothing is cached past settle:
- * the adapter on disk can change under a running daemon (a user running the
- * documented `bun add -g ...@latest`), so every spawn re-probes.
+ * In-flight install promises, keyed by command AND the search path the probe
+ * ran on. Concurrent spawns for the same adapter on the same PATH dedupe to a
+ * single global install, while two agents whose `env.PATH` selects different
+ * binaries each get their own decision: one PATH reaching an externally
+ * managed adapter must not exempt another PATH reaching an outdated
+ * bun-linked one. Nothing is cached past settle: the adapter on disk can
+ * change under a running daemon (a user running the documented `bun add -g
+ * ...@latest`), so every spawn re-probes.
  */
 const installPromises = new Map<string, Promise<AdapterInstallResult>>();
+
+/** Key for `installPromises`: the command plus the PATH the probe will use. */
+function inFlightKey(command: string, searchPath?: string): string {
+  return `${command}\u0000${searchPath ?? ""}`;
+}
 
 /**
  * Commands already reported as managed outside bun. The pin check runs per
@@ -173,10 +182,33 @@ function bunLinkPath(command: string): string {
 /**
  * Whether `binaryPath` is the link `bun add --global` writes for `command`.
  * Only then can a reinstall change what PATH selects: an adapter installed by
- * npm or brew keeps its place in PATH no matter what bun writes.
+ * npm or brew keeps its place in PATH no matter what bun writes. A lexical
+ * comparison is not enough, since a PATH entry reaching bun's global bin dir
+ * through a symlinked directory makes `Bun.which` report an aliased pathname
+ * for the very binary bun linked, so both sides go through realpath. A
+ * selected binary that cannot be resolved is left to the ownership check
+ * rather than exempted; a bun link that cannot be resolved means bun linked
+ * nothing here, so the selection really is external.
  */
-function isBunManagedBinary(command: string, binaryPath: string): boolean {
-  return resolvePath(binaryPath) === resolvePath(bunLinkPath(command));
+async function isBunManagedBinary(
+  command: string,
+  binaryPath: string,
+): Promise<boolean> {
+  const linkPath = bunLinkPath(command);
+  if (resolvePath(binaryPath) === resolvePath(linkPath)) {
+    return true;
+  }
+  let selected: string;
+  try {
+    selected = await probeDeps.realpath(binaryPath);
+  } catch {
+    return true;
+  }
+  try {
+    return selected === (await probeDeps.realpath(linkPath));
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -257,7 +289,8 @@ export function ensureAdapterInstalled(
     return Promise.resolve({ installed: false });
   }
 
-  const inFlight = installPromises.get(command);
+  const key = inFlightKey(command, searchPath);
+  const inFlight = installPromises.get(key);
   if (inFlight) {
     return inFlight;
   }
@@ -271,9 +304,9 @@ export function ensureAdapterInstalled(
     packageSpec,
     searchPath,
   ).finally(() => {
-    installPromises.delete(command);
+    installPromises.delete(key);
   });
-  installPromises.set(command, promise);
+  installPromises.set(key, promise);
   return promise;
 }
 
@@ -300,7 +333,7 @@ async function installToPin(
   if (version === undefined) {
     return { installed: false };
   }
-  if (!isBunManagedBinary(command, binaryPath)) {
+  if (!(await isBunManagedBinary(command, binaryPath))) {
     if (!warnedOutsideBun.has(command)) {
       warnedOutsideBun.add(command);
       log.warn(

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -9,6 +9,11 @@
  * PATH, and the session manager spawns it the usual way (project cwd, token
  * injected only at spawn).
  *
+ * Installs name the pinned `name@version` spec from
+ * `DEFAULT_AGENT_NPM_PACKAGES`, and an adapter already on PATH whose globally
+ * installed version does not match that pin is reinstalled, so the daemon
+ * always drives the adapter version it was built against.
+ *
  * Security boundaries (this is the ATL-808 fix):
  *  - Only commands present in `DEFAULT_AGENT_NPM_PACKAGES` are ever
  *    installed. The package names are vendored constants, NOT user input.
@@ -28,11 +33,14 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { DEFAULT_AGENT_NPM_PACKAGES } from "../config/acp-defaults.js";
+import {
+  DEFAULT_AGENT_NPM_PACKAGES,
+  splitPackageSpec,
+} from "../config/acp-defaults.js";
 import { getLogger } from "../util/logger.js";
 import {
   resolveAcpAgent,
@@ -116,18 +124,69 @@ function sanitizedInstallEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
+interface AdapterVersionProbeDeps {
+  readFile: (path: string) => Promise<string>;
+  /** The module tree `bun add --global` writes into. */
+  globalModulesDir: () => string;
+}
+
+const REAL_PROBE_DEPS: AdapterVersionProbeDeps = {
+  readFile: (path) => readFile(path, "utf8"),
+  globalModulesDir: () =>
+    join(
+      // `bun add --global` honours BUN_INSTALL, and the installer env is a
+      // copy of `process.env`, so the probe has to read the same override.
+      process.env.BUN_INSTALL ?? join(homedir(), ".bun"),
+      "install",
+      "global",
+      "node_modules",
+    ),
+};
+
+let probeDeps: AdapterVersionProbeDeps = REAL_PROBE_DEPS;
+
 /**
- * Install the npm-registry package mapped to `command` via a sandboxed `bun`
- * global install, if (and only if) the command is a known adapter binary and
- * `bun` is on PATH. Unknown commands, or hosts without `bun`, resolve to
- * `{ installed: false }` without ever invoking a package manager (see the
- * security boundary note in the module doc).
+ * Version of the pinned adapter package as installed in bun's global tree, or
+ * undefined when the manifest is missing or unreadable. Undefined is also what
+ * an adapter installed from a different package looks like (the older
+ * `@zed-industries/codex-acp` owns the same `codex-acp` binary name but writes
+ * nothing under the pinned package's path), which is why callers treat it as a
+ * mismatch rather than as "no opinion".
+ */
+export async function getInstalledAdapterVersion(
+  command: string,
+): Promise<string | undefined> {
+  const spec = DEFAULT_AGENT_NPM_PACKAGES[command];
+  if (!spec) {
+    return undefined;
+  }
+  const manifest = join(
+    probeDeps.globalModulesDir(),
+    ...splitPackageSpec(spec).name.split("/"),
+    "package.json",
+  );
+  try {
+    const parsed: unknown = JSON.parse(await probeDeps.readFile(manifest));
+    const version = (parsed as { version?: unknown }).version;
+    return typeof version === "string" ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Install the pinned npm-registry package spec mapped to `command` via a
+ * sandboxed `bun` global install, if (and only if) the command is a known
+ * adapter binary and `bun` is on PATH. Unknown commands, or hosts without
+ * `bun`, resolve to `{ installed: false }` without ever invoking a package
+ * manager (see the security boundary note in the module doc). An adapter
+ * already on PATH at the pinned version resolves the same way.
  */
 export function ensureAdapterInstalled(
   command: string,
 ): Promise<AdapterInstallResult> {
-  const packageName = DEFAULT_AGENT_NPM_PACKAGES[command];
-  if (!packageName) {
+  const packageSpec = DEFAULT_AGENT_NPM_PACKAGES[command];
+  if (!packageSpec) {
     return Promise.resolve({ installed: false });
   }
 
@@ -141,7 +200,7 @@ export function ensureAdapterInstalled(
     return inFlight;
   }
 
-  const promise = runInstall(bunPath, command, packageName).then((result) => {
+  const promise = installToPin(bunPath, command, packageSpec).then((result) => {
     if (!result.installed) {
       installPromises.delete(command);
     }
@@ -151,12 +210,32 @@ export function ensureAdapterInstalled(
   return promise;
 }
 
+/**
+ * A binary missing from PATH always installs, unchanged. One already on PATH
+ * installs only when its globally installed version differs from the pin,
+ * which covers both an outdated install and one made from a different package
+ * name that owns the same binary.
+ */
+async function installToPin(
+  bunPath: string,
+  command: string,
+  packageSpec: string,
+): Promise<AdapterInstallResult> {
+  const { version } = splitPackageSpec(packageSpec);
+  if (version !== undefined && Bun.which(command)) {
+    if ((await getInstalledAdapterVersion(command)) === version) {
+      return { installed: false };
+    }
+  }
+  return runInstall(bunPath, command, packageSpec);
+}
+
 async function runInstall(
   bunPath: string,
   command: string,
-  packageName: string,
+  packageSpec: string,
 ): Promise<AdapterInstallResult> {
-  log.info({ command, packageName }, "Auto-installing missing ACP adapter");
+  log.info({ command, packageSpec }, "Installing pinned ACP adapter");
   // Fresh empty dir guaranteed to have no project-local node_modules,
   // bunfig.toml, or .npmrc - this neutralizes the cwd-based resolution
   // hijacks the untrusted task dir would otherwise enable.
@@ -166,16 +245,16 @@ async function runInstall(
       bunPath,
       // `bun add --global` installs AND links the package bin into bun's
       // global bin dir (on PATH in every image).
-      ["add", "--global", packageName],
+      ["add", "--global", packageSpec],
       BUN_INSTALL_TIMEOUT_MS,
       { cwd: installDir, env: sanitizedInstallEnv() },
     );
-    log.info({ command, packageName }, "ACP adapter auto-install succeeded");
+    log.info({ command, packageSpec }, "ACP adapter auto-install succeeded");
     return { installed: true };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     log.warn(
-      { err, command, packageName },
+      { err, command, packageSpec },
       "ACP adapter auto-install failed (falling back to install hint)",
     );
     return { installed: false, error };
@@ -238,4 +317,12 @@ export async function resolveAgentWithAutoInstall(
 /** @internal: exposed for tests only. */
 export function _resetAdapterInstallCacheForTests(): void {
   installPromises.clear();
+  probeDeps = REAL_PROBE_DEPS;
+}
+
+/** @internal: exposed for tests only. */
+export function _setAdapterVersionProbeDepsForTests(
+  deps: Partial<AdapterVersionProbeDeps>,
+): void {
+  probeDeps = { ...REAL_PROBE_DEPS, ...deps };
 }

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -14,9 +14,11 @@
  * that pin on every resolution, not only on the missing-binary path, so the
  * daemon always drives the adapter version it was built against. The pin is
  * enforced against the executable PATH actually selects: a bun-linked binary
- * whose global manifest disagrees with the pin is reinstalled, while one
- * installed by npm or brew is left alone with a warning, since a bun install
- * would not change which binary spawns.
+ * is reinstalled unless the link resolves into the pinned package and that
+ * package's manifest reports the pinned version, while one installed by npm
+ * or brew is left alone with a warning, since a bun install would not change
+ * which binary spawns. The check runs on every resolution, never cached, so
+ * an adapter replaced under a running daemon is caught on the next spawn.
  *
  * Security boundaries (this is the ATL-808 fix):
  *  - Only commands present in `DEFAULT_AGENT_NPM_PACKAGES` are ever
@@ -37,9 +39,9 @@
  */
 
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve as resolvePath } from "node:path";
+import { join, resolve as resolvePath, sep } from "node:path";
 
 import {
   DEFAULT_AGENT_NPM_PACKAGES,
@@ -70,12 +72,18 @@ export interface AdapterInstallResult {
 }
 
 /**
- * Per-command install promises. Concurrent spawns for the same missing
- * binary dedupe to a single global install; successful results are cached for
- * the process lifetime. Failed installs are evicted so a later spawn can
- * retry (e.g. after the user fixes network or install permissions).
+ * In-flight install promises, keyed by command. Concurrent spawns for the same
+ * adapter dedupe to a single global install. Nothing is cached past settle:
+ * the adapter on disk can change under a running daemon (a user running the
+ * documented `bun add -g ...@latest`), so every spawn re-probes.
  */
 const installPromises = new Map<string, Promise<AdapterInstallResult>>();
+
+/**
+ * Commands already reported as managed outside bun. The pin check runs per
+ * spawn; the warning it can emit is worth saying once.
+ */
+const warnedOutsideBun = new Set<string>();
 
 /**
  * Run `execFile` with an AbortController-driven timeout. Returns the stdout
@@ -131,6 +139,8 @@ function sanitizedInstallEnv(): NodeJS.ProcessEnv {
 
 interface AdapterVersionProbeDeps {
   readFile: (path: string) => Promise<string>;
+  /** Resolve a path through symlinks, as `fs.realpath` does. */
+  realpath: (path: string) => Promise<string>;
   /**
    * Bun's global install root: `<root>/bin` holds the binaries `bun add
    * --global` links, `<root>/install/global/node_modules` the packages they
@@ -142,6 +152,7 @@ interface AdapterVersionProbeDeps {
 
 const REAL_PROBE_DEPS: AdapterVersionProbeDeps = {
   readFile: (path) => readFile(path, "utf8"),
+  realpath: (path) => realpath(path),
   // `bun add --global` honours BUN_INSTALL, and the installer env is a copy of
   // `process.env`, so the probe has to read the same override.
   bunInstallDir: () => process.env.BUN_INSTALL ?? join(homedir(), ".bun"),
@@ -154,25 +165,54 @@ function globalModulesDir(): string {
   return join(probeDeps.bunInstallDir(), "install", "global", "node_modules");
 }
 
+/** Where `bun add --global` links the bin a package exposes as `command`. */
+function bunLinkPath(command: string): string {
+  return join(probeDeps.bunInstallDir(), "bin", command);
+}
+
 /**
- * Whether `binaryPath` is the binary `bun add --global` links for `command`.
- * Only then does the pinned package's manifest describe the executable that a
- * spawn would actually run, and only then can a reinstall change what PATH
- * selects: an adapter installed by npm or brew keeps its place in PATH no
- * matter what bun writes.
+ * Whether `binaryPath` is the link `bun add --global` writes for `command`.
+ * Only then can a reinstall change what PATH selects: an adapter installed by
+ * npm or brew keeps its place in PATH no matter what bun writes.
  */
 function isBunManagedBinary(command: string, binaryPath: string): boolean {
-  const linked = join(probeDeps.bunInstallDir(), "bin", command);
-  return resolvePath(binaryPath) === resolvePath(linked);
+  return resolvePath(binaryPath) === resolvePath(bunLinkPath(command));
+}
+
+/**
+ * Whether the bun link for `command` resolves to an executable inside
+ * `packageName`'s directory in bun's global module tree. Bun gives one bin
+ * name to whichever package linked it last, so two installed packages
+ * exposing the same name (the pinned adapter and, say, the older
+ * `@zed-industries/codex-acp`) both keep a manifest while only one owns the
+ * link. Reading the pinned manifest alone would then report a version nothing
+ * spawns. Both sides go through realpath so a symlinked bun root cancels out
+ * instead of reinstalling forever. Anything that fails to resolve counts as
+ * not owned, so the caller reinstalls and bun re-links the bin.
+ */
+async function bunLinkOwnedBy(
+  command: string,
+  packageName: string,
+): Promise<boolean> {
+  try {
+    const target = await probeDeps.realpath(bunLinkPath(command));
+    const owner = await probeDeps.realpath(
+      join(globalModulesDir(), ...packageName.split("/")),
+    );
+    return target === owner || target.startsWith(owner + sep);
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Version of the pinned adapter package as installed in bun's global tree, or
  * undefined when the manifest is missing or unreadable. Undefined is also what
- * an adapter installed from a different package looks like (the older
- * `@zed-industries/codex-acp` owns the same `codex-acp` binary name but writes
- * nothing under the pinned package's path), which is why callers treat it as a
- * mismatch rather than as "no opinion".
+ * an adapter installed from a different package looks like when that package
+ * writes nothing under the pinned package's path, which is why callers treat
+ * it as a mismatch rather than as "no opinion". The manifest only describes
+ * the executable a spawn runs once `bunLinkOwnedBy` confirms the bin link
+ * still resolves into this package.
  */
 export async function getInstalledAdapterVersion(
   command: string,
@@ -222,29 +262,29 @@ export function ensureAdapterInstalled(
     return inFlight;
   }
 
-  const promise = installToPin(bunPath, command, packageSpec, searchPath).then(
-    (result) => {
-      // Only a genuine failure is evicted, so a later spawn can retry. A
-      // decision NOT to install (pin already satisfied, adapter managed
-      // outside bun) is cached, which is what keeps the probe to one read per
-      // command per process.
-      if (result.error) {
-        installPromises.delete(command);
-      }
-      return result;
-    },
-  );
+  // Evicted once settled, whatever the outcome: the probe is a manifest read
+  // plus a realpath, cheap enough to repeat, and caching a no-install decision
+  // would pin the daemon to whatever the adapter looked like at first spawn.
+  const promise = installToPin(
+    bunPath,
+    command,
+    packageSpec,
+    searchPath,
+  ).finally(() => {
+    installPromises.delete(command);
+  });
   installPromises.set(command, promise);
   return promise;
 }
 
 /**
  * A binary missing from PATH always installs, unchanged. One already on PATH
- * installs only when it is the binary bun linked AND its globally installed
- * version differs from the pin, which covers both an outdated install and one
- * made from a different package name that owns the same binary. An adapter
- * that came from anywhere else stays put: PATH would keep selecting it, so a
- * bun install would change nothing but the disk.
+ * skips the install only when bun linked it, the link still resolves into the
+ * pinned package, and that package's manifest reports the pinned version. Any
+ * other bun-linked case installs, which covers an outdated install and one
+ * whose bin another package has taken over. An adapter that came from
+ * anywhere else stays put: PATH would keep selecting it, so a bun install
+ * would change nothing but the disk.
  */
 async function installToPin(
   bunPath: string,
@@ -256,16 +296,22 @@ async function installToPin(
   if (!binaryPath) {
     return runInstall(bunPath, command, packageSpec);
   }
-  const { version } = splitPackageSpec(packageSpec);
+  const { name, version } = splitPackageSpec(packageSpec);
   if (version === undefined) {
     return { installed: false };
   }
   if (!isBunManagedBinary(command, binaryPath)) {
-    log.warn(
-      { command, binaryPath, packageSpec },
-      "ACP adapter is managed outside bun; leaving it in place and skipping the version pin",
-    );
+    if (!warnedOutsideBun.has(command)) {
+      warnedOutsideBun.add(command);
+      log.warn(
+        { command, binaryPath, packageSpec },
+        "ACP adapter is managed outside bun; leaving it in place and skipping the version pin",
+      );
+    }
     return { installed: false };
+  }
+  if (!(await bunLinkOwnedBy(command, name))) {
+    return runInstall(bunPath, command, packageSpec);
   }
   if ((await getInstalledAdapterVersion(command)) === version) {
     return { installed: false };
@@ -406,6 +452,7 @@ async function enforcePin(
 /** @internal: exposed for tests only. */
 export function _resetAdapterInstallCacheForTests(): void {
   installPromises.clear();
+  warnedOutsideBun.clear();
   probeDeps = REAL_PROBE_DEPS;
 }
 

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -56,7 +56,9 @@ describe("resolveAcpAgent", () => {
       return;
     }
     expect(result.agent.command).toBe("codex-acp");
-    expect(result.agent.description).toContain("@agentclientprotocol/codex-acp");
+    expect(result.agent.description).toContain(
+      "@agentclientprotocol/codex-acp",
+    );
   });
 
   test("falls back to default profile for claude when no user entry", () => {
@@ -191,7 +193,7 @@ describe("resolveAcpAgent", () => {
       return;
     }
     expect(result.hint).toBe(
-      "bun add -g @agentclientprotocol/claude-agent-acp",
+      "bun add -g @agentclientprotocol/claude-agent-acp@0.75.1",
     );
     expect(result.command).toBe("claude-agent-acp");
   });
@@ -240,7 +242,9 @@ describe("resolveAcpAgent", () => {
     if (result.reason !== "binary_not_found") {
       return;
     }
-    expect(result.hint).toBe("bun add -g @agentclientprotocol/codex-acp");
+    expect(result.hint).toBe(
+      "bun add -g @agentclientprotocol/codex-acp@1.10.0",
+    );
   });
 
   test("binary preflight honors agent.env.PATH override (matches spawn env)", () => {
@@ -332,7 +336,7 @@ describe("resolveAcpAgent - missing binary", () => {
     }
     expect(result.command).toBe("claude-agent-acp");
     expect(result.hint).toBe(
-      "bun add -g @agentclientprotocol/claude-agent-acp",
+      "bun add -g @agentclientprotocol/claude-agent-acp@0.75.1",
     );
   });
 
@@ -351,7 +355,7 @@ describe("resolveAcpAgent - missing binary", () => {
       return;
     }
     expect(result.hint).toBe(
-      "bun add -g @agentclientprotocol/claude-agent-acp",
+      "bun add -g @agentclientprotocol/claude-agent-acp@0.75.1",
     );
   });
 });
@@ -430,7 +434,9 @@ describe("listAcpAgents", () => {
     const codex = result.agents.find((a) => a.id === "codex");
     expect(codex?.available).toBe(false);
     expect(codex?.unavailableReason).toBe("'codex-acp' is not on PATH");
-    expect(codex?.setupHint).toBe("bun add -g @agentclientprotocol/codex-acp");
+    expect(codex?.setupHint).toBe(
+      "bun add -g @agentclientprotocol/codex-acp@1.10.0",
+    );
   });
 
   test("aliases are resolution sugar, not catalog entries", () => {

--- a/assistant/src/config/acp-defaults.test.ts
+++ b/assistant/src/config/acp-defaults.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_ACP_AGENT_PROFILES,
   DEFAULT_AGENT_NPM_PACKAGES,
+  splitPackageSpec,
 } from "./acp-defaults.js";
 
 describe("DEFAULT_ACP_AGENT_PROFILES", () => {
@@ -42,11 +43,19 @@ describe("DEFAULT_ACP_AGENT_PROFILES", () => {
 });
 
 describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
-  test("is keyed by command name with the canonical npm package", () => {
+  test("is keyed by command name with the pinned npm package spec", () => {
     expect(DEFAULT_AGENT_NPM_PACKAGES).toEqual({
-      "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
-      "codex-acp": "@agentclientprotocol/codex-acp",
+      "claude-agent-acp": "@agentclientprotocol/claude-agent-acp@0.75.1",
+      "codex-acp": "@agentclientprotocol/codex-acp@1.10.0",
     });
+  });
+
+  test("every spec pins an exact version", () => {
+    for (const spec of Object.values(DEFAULT_AGENT_NPM_PACKAGES)) {
+      const { name, version } = splitPackageSpec(spec);
+      expect(name.startsWith("@agentclientprotocol/")).toBe(true);
+      expect(version).toMatch(/^\d+\.\d+\.\d+$/);
+    }
   });
 
   test("every default profile's command has a matching npm package", () => {
@@ -57,5 +66,28 @@ describe("DEFAULT_AGENT_NPM_PACKAGES", () => {
 
   test("is frozen at runtime so mutation throws in strict mode", () => {
     expect(Object.isFrozen(DEFAULT_AGENT_NPM_PACKAGES)).toBe(true);
+  });
+});
+
+describe("splitPackageSpec", () => {
+  test("splits a scoped spec without eating the scope's leading @", () => {
+    expect(splitPackageSpec("@agentclientprotocol/codex-acp@1.10.0")).toEqual({
+      name: "@agentclientprotocol/codex-acp",
+      version: "1.10.0",
+    });
+  });
+
+  test("splits an unscoped spec", () => {
+    expect(splitPackageSpec("codex-acp@1.10.0")).toEqual({
+      name: "codex-acp",
+      version: "1.10.0",
+    });
+  });
+
+  test("reports no version for a bare name, scoped or not", () => {
+    expect(splitPackageSpec("@agentclientprotocol/codex-acp")).toEqual({
+      name: "@agentclientprotocol/codex-acp",
+    });
+    expect(splitPackageSpec("codex-acp")).toEqual({ name: "codex-acp" });
   });
 });

--- a/assistant/src/config/acp-defaults.ts
+++ b/assistant/src/config/acp-defaults.ts
@@ -33,15 +33,36 @@ export const DEFAULT_ACP_AGENT_PROFILES: Readonly<
 });
 
 /**
- * Single source of truth for adapter binary → npm package name. Automatic
- * installation and the resolver's install hints use this map, so a new
- * adapter only needs one entry here.
+ * Single source of truth for adapter binary → pinned npm package spec.
+ * Automatic installation and the resolver's install hints use this map, so a
+ * new adapter only needs one entry here.
  *
  * Keyed by command name (not agent id) so the mapping follows the binary
  * regardless of how a user's config aliases an agent.
+ *
+ * Values are `name@version` specs, not bare names: the adapters gate features
+ * the daemon depends on (session config options carrying the model list), so
+ * every install and every install hint names the exact version the daemon was
+ * built against. Use `splitPackageSpec` when a consumer needs the bare name.
  */
 export const DEFAULT_AGENT_NPM_PACKAGES: Readonly<Record<string, string>> =
   Object.freeze({
-    "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
-    "codex-acp": "@agentclientprotocol/codex-acp",
+    "claude-agent-acp": "@agentclientprotocol/claude-agent-acp@0.75.1",
+    "codex-acp": "@agentclientprotocol/codex-acp@1.10.0",
   });
+
+/**
+ * Split an npm package spec into its name and version. Handles scoped names,
+ * whose leading `@` is not a version separator, and bare names with no
+ * version.
+ */
+export function splitPackageSpec(spec: string): {
+  name: string;
+  version?: string;
+} {
+  const separator = spec.lastIndexOf("@");
+  if (separator <= 0) {
+    return { name: spec };
+  }
+  return { name: spec.slice(0, separator), version: spec.slice(separator + 1) };
+}

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -593,7 +593,7 @@ describe("POST /v1/acp/spawn: sandboxed bun auto-install on missing binary", () 
     expect(args).toEqual([
       "add",
       "--global",
-      "@agentclientprotocol/claude-agent-acp",
+      "@agentclientprotocol/claude-agent-acp@0.75.1",
     ]);
   });
 

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -146,8 +146,10 @@ import { initializeDb } from "../../../persistence/db-init.js";
 import { FailedDependencyError, NotFoundError } from "../errors.js";
 
 const { ROUTES } = await import("../acp-routes.js");
-const { _resetAdapterInstallCacheForTests } =
-  await import("../../../acp/auto-install.js");
+const {
+  _resetAdapterInstallCacheForTests,
+  _setAdapterVersionProbeDepsForTests,
+} = await import("../../../acp/auto-install.js");
 
 await initializeDb();
 
@@ -193,6 +195,13 @@ beforeEach(() => {
   steerOrResumeMock.mockClear();
   steerOrResumeImpl = defaultSteerOrResumeImpl;
   _resetAdapterInstallCacheForTests();
+  // Keep the pin probe off the real filesystem: the binaries these tests put
+  // on PATH are fictional, and a real `~/.bun` on the host would otherwise
+  // decide whether they count as bun-managed.
+  _setAdapterVersionProbeDepsForTests({
+    bunInstallDir: () => "/home/tester/.bun",
+    realpath: (path: string) => Promise.resolve(path),
+  });
   config.setConfig({});
   which.setWhich((cmd) => `/usr/local/bin/${cmd}`);
   approvalBehavior = "allow";

--- a/assistant/src/tools/acp/list-agents.test.ts
+++ b/assistant/src/tools/acp/list-agents.test.ts
@@ -90,7 +90,9 @@ describe("executeAcpListAgents", () => {
     const codex = parsed.agents.find((a: { id: string }) => a.id === "codex");
     expect(codex.available).toBe(false);
     expect(codex.unavailableReason).toBe("'codex-acp' is not on PATH");
-    expect(codex.setupHint).toBe("bun add -g @agentclientprotocol/codex-acp");
+    expect(codex.setupHint).toBe(
+      "bun add -g @agentclientprotocol/codex-acp@1.10.0",
+    );
 
     const claude = parsed.agents.find((a: { id: string }) => a.id === "claude");
     expect(claude.available).toBe(true);

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -309,7 +309,7 @@ describe("executeAcpSpawn: sandboxed bun auto-install on missing binary", () => 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(result.content);
     expect(payload.message).toContain(
-      "Installed @agentclientprotocol/claude-agent-acp automatically.",
+      "Installed @agentclientprotocol/claude-agent-acp@0.75.1 automatically.",
     );
     // The real binary was spawned with cwd = the project dir and token
     // injected (trusted-binary config, no resolution at spawn).
@@ -330,7 +330,7 @@ describe("executeAcpSpawn: sandboxed bun auto-install on missing binary", () => 
     expect(args).toEqual([
       "add",
       "--global",
-      "@agentclientprotocol/claude-agent-acp",
+      "@agentclientprotocol/claude-agent-acp@0.75.1",
     ]);
   });
 

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -143,8 +143,10 @@ mock.module("../../acp/index.js", () => ({
 }));
 
 const { executeAcpSpawn } = await import("./spawn.js");
-const { _resetAdapterInstallCacheForTests } =
-  await import("../../acp/auto-install.js");
+const {
+  _resetAdapterInstallCacheForTests,
+  _setAdapterVersionProbeDepsForTests,
+} = await import("../../acp/auto-install.js");
 const { ACP_CLAUDE_OAUTH_MISSING_CODE } =
   await import("../../acp/prepare-agent-env.js");
 const { ACP_CLAUDE_AUTH_REQUIRED_CODE, AcpAuthRequiredError } =
@@ -170,6 +172,13 @@ beforeEach(() => {
   resetExecFileStub();
   spawnMock.mockClear();
   _resetAdapterInstallCacheForTests();
+  // Keep the pin probe off the real filesystem: the binaries these tests put
+  // on PATH are fictional, and a real `~/.bun` on the host would otherwise
+  // decide whether they count as bun-managed.
+  _setAdapterVersionProbeDepsForTests({
+    bunInstallDir: () => "/home/tester/.bun",
+    realpath: (path: string) => Promise.resolve(path),
+  });
   config.setConfig({ agents: DEFAULT_TEST_AGENTS });
   // Default: every command (including bun and the adapters) on PATH, so
   // spawns resolve directly with no install.


### PR DESCRIPTION
## Summary

- `DEFAULT_AGENT_NPM_PACKAGES` now maps each adapter binary to a pinned `name@version` spec (`@agentclientprotocol/claude-agent-acp@0.75.1`, `@agentclientprotocol/codex-acp@1.10.0`). Both are npm latest at pin time, so this is a pin, not a downgrade. A new `splitPackageSpec` helper recovers the bare name where a consumer needs it; the resolver's install hints now read `bun add -g <pkg>@<version>`.
- `getInstalledAdapterVersion(command)` reads `<bun global>/node_modules/<name>/package.json` (honouring `BUN_INSTALL`, the same override `bun add --global` sees) and returns the installed version. Filesystem and install-dir access are injectable so tests never touch a real bun tree.
- `ensureAdapterInstalled` reinstalls the pinned spec when the binary is on PATH but its installed version differs from the pin, so an older local install is upgraded to the pin rather than silently kept. An older `@zed-industries/codex-acp` install reads as a mismatch (nothing under the pinned package's path), so it is replaced and its `codex-acp` symlink taken over. The "not on PATH" behaviour is unchanged.

Part of plan: acp-model-control.md (PR 11 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D