### PR TITLE
feat(acp): add acp_session_model_update event and wire it into the web run store

### DIFF
--- a/assistant/src/api/events/acp-session-model-update.test.ts
+++ b/assistant/src/api/events/acp-session-model-update.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { AcpSessionModelUpdateEventSchema } from "./acp-session-model-update.js";
+
+describe("AcpSessionModelUpdateEventSchema", () => {
+  test("parses an event carrying the selection and grouped options", () => {
+    const event = {
+      type: "acp_session_model_update" as const,
+      acpSessionId: "acp-session-abc",
+      model: "opus",
+      availableModels: [
+        { value: "opus", label: "Opus", description: "Most capable" },
+        { value: "sonnet", label: "Sonnet", group: "Recommended" },
+      ],
+    };
+
+    const result = AcpSessionModelUpdateEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("parses an adapter with no selection and no options", () => {
+    const event = {
+      type: "acp_session_model_update" as const,
+      acpSessionId: "acp-session-abc",
+      availableModels: [],
+    };
+
+    const result = AcpSessionModelUpdateEventSchema.safeParse(event);
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual(event);
+  });
+
+  test("rejects a missing availableModels array", () => {
+    const result = AcpSessionModelUpdateEventSchema.safeParse({
+      type: "acp_session_model_update",
+      acpSessionId: "acp-session-abc",
+      model: "opus",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an unrecognized field under .strict()", () => {
+    const result = AcpSessionModelUpdateEventSchema.safeParse({
+      type: "acp_session_model_update",
+      acpSessionId: "acp-session-abc",
+      availableModels: [],
+      unexpected: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/assistant/src/api/events/acp-session-model-update.ts
+++ b/assistant/src/api/events/acp-session-model-update.ts
@@ -1,0 +1,42 @@
+/**
+ * `acp_session_model_update` SSE event.
+ *
+ * Server to client snapshot of an ACP session's model selection, derived from
+ * the adapter's `configOptions`. `model` is the currently selected value (absent
+ * when the adapter reports none) and `availableModels` is the flattened set of
+ * values the session can switch to, empty when the adapter advertises no model
+ * selector. A side gauge, not part of the ordered update timeline: carries no
+ * `seq`.
+ *
+ * `.strict()` like the other ACP events, for the reason spelled out in
+ * `acp-auth-required.ts`: an older packaged client rejects an event carrying a
+ * field it does not know, so additive signals get their own event type.
+ *
+ * Canonical wire-contract source. Re-exported to external consumers via
+ * `@vellumai/assistant-api` (the `api/index.ts` barrel).
+ */
+
+import { z } from "zod";
+
+export const AcpSessionModelUpdateEventSchema = z
+  .object({
+    type: z.literal("acp_session_model_update"),
+    acpSessionId: z.string(),
+    model: z.string().optional(),
+    availableModels: z.array(
+      z.object({
+        /** Adapter-reported value to pass back when selecting this model. */
+        value: z.string(),
+        /** Human-readable label from the adapter. */
+        label: z.string(),
+        description: z.string().optional(),
+        /** Name of the adapter's option group, when the options were grouped. */
+        group: z.string().optional(),
+      }),
+    ),
+  })
+  .strict();
+
+export type AcpSessionModelUpdateEvent = z.infer<
+  typeof AcpSessionModelUpdateEventSchema
+>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { AcpAuthRequiredEventSchema } from "./events/acp-auth-required.js";
 import { AcpSessionCompletedEventSchema } from "./events/acp-session-completed.js";
 import { AcpSessionErrorEventSchema } from "./events/acp-session-error.js";
+import { AcpSessionModelUpdateEventSchema } from "./events/acp-session-model-update.js";
 import { AcpSessionSpawnedEventSchema } from "./events/acp-session-spawned.js";
 import { AcpSessionUpdateEventSchema } from "./events/acp-session-update.js";
 import { AcpSessionUsageEventSchema } from "./events/acp-session-usage.js";
@@ -186,6 +187,10 @@ export {
   type AcpSessionErrorEvent,
   AcpSessionErrorEventSchema,
 } from "./events/acp-session-error.js";
+export {
+  type AcpSessionModelUpdateEvent,
+  AcpSessionModelUpdateEventSchema,
+} from "./events/acp-session-model-update.js";
 export {
   type AcpSessionSpawnedEvent,
   AcpSessionSpawnedEventSchema,
@@ -964,6 +969,7 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   AcpAuthRequiredEventSchema,
   AcpSessionCompletedEventSchema,
   AcpSessionErrorEventSchema,
+  AcpSessionModelUpdateEventSchema,
   AcpSessionSpawnedEventSchema,
   AcpSessionUpdateEventSchema,
   AcpSessionUsageEventSchema,

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -952,6 +952,35 @@ describe("seedFromHistory", () => {
     expect(entry.availableModels).toEqual([{ value: "opus", label: "Opus" }]);
   });
 
+  it("stamps a freshly inserted snapshot row so an older response cannot replace it", () => {
+    // Empty store: the newer request (opus) inserts the row, then the older
+    // request (haiku) answers. Insertion must carry the fetch time as well.
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "opus",
+          availableModels: [{ value: "opus", label: "Opus" }],
+        }),
+      ],
+      { fetchedAt: 200 },
+    );
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "haiku",
+          availableModels: [{ value: "haiku", label: "Haiku" }],
+        }),
+      ],
+      { fetchedAt: 100 },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("opus");
+    expect(entry.modelUpdatedAt).toBe(200);
+  });
+
   it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {
     const entry = historyEntry({ acpSessionId: "acp-h1" });
     getState().seedFromHistory([entry]);

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -817,6 +817,44 @@ describe("seedFromHistory", () => {
     expect(getState().byId["acp-1"]!.model).toBe("haiku");
   });
 
+  it("clears a stale model when the row carries an empty option set", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+
+    getState().seedFromHistory([
+      historyEntry({ acpSessionId: "acp-1", availableModels: [] }),
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBeUndefined();
+    expect(entry.availableModels).toEqual([]);
+  });
+
+  it("replaces both fields when the row carries a model and options", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+
+    getState().seedFromHistory([
+      historyEntry({
+        acpSessionId: "acp-1",
+        model: "haiku",
+        availableModels: [{ value: "haiku", label: "Haiku" }],
+      }),
+    ]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("haiku");
+    expect(entry.availableModels).toEqual([{ value: "haiku", label: "Haiku" }]);
+  });
+
   it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {
     const entry = historyEntry({ acpSessionId: "acp-h1" });
     getState().seedFromHistory([entry]);

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -701,6 +701,59 @@ describe("updateUsage", () => {
 });
 
 // ---------------------------------------------------------------------------
+// setModel
+// ---------------------------------------------------------------------------
+
+describe("setModel", () => {
+  it("records the selection and the adapter's options", () => {
+    spawn();
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [
+        { value: "opus", label: "Opus" },
+        { value: "sonnet", label: "Sonnet" },
+      ],
+    });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("opus");
+    expect(entry.availableModels).toEqual([
+      { value: "opus", label: "Opus" },
+      { value: "sonnet", label: "Sonnet" },
+    ]);
+  });
+
+  it("replaces both fields wholesale so a cleared selection sticks", () => {
+    spawn();
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+    getState().setModel({
+      acpSessionId: "acp-1",
+      availableModels: [],
+    });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBeUndefined();
+    expect(entry.availableModels).toEqual([]);
+  });
+
+  it("ignores an unknown session", () => {
+    const before = { ...getState().byId };
+    getState().setModel({
+      acpSessionId: "acp-missing",
+      model: "opus",
+      availableModels: [],
+    });
+
+    expect(getState().byId).toEqual(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // seedFromHistory
 // ---------------------------------------------------------------------------
 
@@ -732,6 +785,36 @@ describe("seedFromHistory", () => {
     expect(getState().byId["acp-h1"]!.status).toBe("completed");
     expect(getState().byToolUseId.get("tool-h1")).toBe("acp-h1");
     expect(getState().highWaterMark.get("acp-h1")).toBe(7);
+  });
+
+  it("keeps a live model and options when the history row omits them", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+
+    getState().seedFromHistory([historyEntry({ acpSessionId: "acp-1" })]);
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("opus");
+    expect(entry.availableModels).toEqual([{ value: "opus", label: "Opus" }]);
+  });
+
+  it("takes the history row's model when it carries one", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+
+    getState().seedFromHistory([
+      historyEntry({ acpSessionId: "acp-1", model: "haiku" }),
+    ]);
+
+    expect(getState().byId["acp-1"]!.model).toBe("haiku");
   });
 
   it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -741,6 +741,19 @@ describe("setModel", () => {
     expect(entry.availableModels).toEqual([]);
   });
 
+  it("stamps when the live selection landed", () => {
+    spawn();
+    const before = Date.now();
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+
+    const stamped = getState().byId["acp-1"]!.modelUpdatedAt;
+    expect(stamped).toBeGreaterThanOrEqual(before);
+  });
+
   it("ignores an unknown session", () => {
     const before = { ...getState().byId };
     getState().setModel({
@@ -853,6 +866,60 @@ describe("seedFromHistory", () => {
     const entry = getState().byId["acp-1"]!;
     expect(entry.model).toBe("haiku");
     expect(entry.availableModels).toEqual([{ value: "haiku", label: "Haiku" }]);
+  });
+
+  it("keeps a live update that landed after the fetch began", () => {
+    // The fetch read model A, then a live update moved the session to B before
+    // the response arrived. The older snapshot must not roll it back.
+    spawn({ acpSessionId: "acp-1" });
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+    const modelUpdatedAt = getState().byId["acp-1"]!.modelUpdatedAt!;
+
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "opus",
+          availableModels: [{ value: "opus", label: "Opus" }],
+        }),
+      ],
+      { fetchedAt: modelUpdatedAt - 1 },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("sonnet");
+    expect(entry.availableModels).toEqual([
+      { value: "sonnet", label: "Sonnet" },
+    ]);
+  });
+
+  it("applies a snapshot whose fetch began after the live update", () => {
+    spawn({ acpSessionId: "acp-1" });
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+    const modelUpdatedAt = getState().byId["acp-1"]!.modelUpdatedAt!;
+
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "opus",
+          availableModels: [{ value: "opus", label: "Opus" }],
+        }),
+      ],
+      { fetchedAt: modelUpdatedAt + 1 },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("opus");
+    expect(entry.availableModels).toEqual([{ value: "opus", label: "Opus" }]);
   });
 
   it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -922,6 +922,36 @@ describe("seedFromHistory", () => {
     expect(entry.availableModels).toEqual([{ value: "opus", label: "Opus" }]);
   });
 
+  it("ignores a superseded snapshot answered after a newer one", () => {
+    // Two overlapping fetches: the newer request (opus) returns first, then
+    // the older request (haiku) returns. The older answer must not win.
+    spawn({ acpSessionId: "acp-1" });
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "opus",
+          availableModels: [{ value: "opus", label: "Opus" }],
+        }),
+      ],
+      { fetchedAt: 200 },
+    );
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "haiku",
+          availableModels: [{ value: "haiku", label: "Haiku" }],
+        }),
+      ],
+      { fetchedAt: 100 },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("opus");
+    expect(entry.availableModels).toEqual([{ value: "opus", label: "Opus" }]);
+  });
+
   it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {
     const entry = historyEntry({ acpSessionId: "acp-h1" });
     getState().seedFromHistory([entry]);

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -109,6 +109,13 @@ export interface AcpRunEntry {
   model?: string;
   /** Models the session can switch to; absent when the adapter has no selector. */
   availableModels?: AcpModelOption[];
+  /**
+   * When `setModel` last recorded a live selection, in `Date.now()` ms. Store
+   * local, never on the wire: it orders a live update against a snapshot whose
+   * fetch began earlier, so an in-flight `/acp/sessions` read cannot replace a
+   * selection the adapter has already moved past.
+   */
+  modelUpdatedAt?: number;
   events: AcpRunRawEvent[];
 }
 
@@ -228,7 +235,8 @@ export interface AcpRunActions {
    * Record the session's model selection. Unlike `updateUsage`, both fields are
    * replaced wholesale: the adapter reports its full current state, so a
    * cleared selection or a shrunken option set must not be masked by the
-   * previous one.
+   * previous one. Stamps `modelUpdatedAt` so a snapshot requested before this
+   * update cannot roll it back.
    */
   setModel: (params: {
     acpSessionId: string;
@@ -242,8 +250,16 @@ export interface AcpRunActions {
    * stale-but-longer snapshot, while always merging terminal/status/usage
    * metadata from the history entry. Sets `highWaterMark` to the max seq over
    * the merged buffer and indexes `byToolUseId`.
+   *
+   * `fetchedAt` is when the caller issued the request these entries answer.
+   * A model update stamped at or after it is newer than the snapshot, so the
+   * live selection is kept. Callers that cannot say omit it and get the plain
+   * snapshot rules.
    */
-  seedFromHistory: (entries: AcpRunEntry[]) => void;
+  seedFromHistory: (
+    entries: AcpRunEntry[],
+    options?: { fetchedAt?: number },
+  ) => void;
 
   reset: () => void;
 }
@@ -312,16 +328,34 @@ function mergeEvents(
 }
 
 /**
- * Fold a snapshot's model selection into a live entry. A row carrying
- * `availableModels` is authoritative for both fields, so the supported
- * no-selection state (no `model`, empty options) clears a stale selection. A
- * legacy row that omits the option set keeps the store's options and only
- * upgrades a model it actually carries.
+ * Fold a snapshot's model selection into a live entry.
+ *
+ * A live `acp_session_model_update` that landed at or after `fetchedAt` is
+ * newer than anything this response can carry: the fetch and the SSE stream are
+ * separate asynchronous paths, so a request that read model A can be answered
+ * after the adapter already moved to model B. That live selection is kept.
+ *
+ * Otherwise the snapshot rules apply: a row carrying `availableModels` is
+ * authoritative for both fields, so the supported no-selection state (no
+ * `model`, empty options) clears a stale selection, while a legacy row that
+ * omits the option set keeps the store's options and only upgrades a model it
+ * actually carries.
  */
 function mergeModelSelection(
   existing: AcpRunEntry,
   incoming: AcpRunEntry,
+  fetchedAt?: number,
 ): Pick<AcpRunEntry, "model" | "availableModels"> {
+  if (
+    fetchedAt !== undefined &&
+    existing.modelUpdatedAt !== undefined &&
+    existing.modelUpdatedAt >= fetchedAt
+  ) {
+    return {
+      model: existing.model,
+      availableModels: existing.availableModels,
+    };
+  }
   if (incoming.availableModels !== undefined) {
     return {
       model: incoming.model,
@@ -344,6 +378,7 @@ function mergeModelSelection(
 function mergeHistoryEntry(
   existing: AcpRunEntry,
   incoming: AcpRunEntry,
+  fetchedAt?: number,
 ): AcpRunEntry {
   const events = mergeEvents(existing.events, incoming.events);
 
@@ -366,7 +401,7 @@ function mergeHistoryEntry(
     outputTokens: incoming.outputTokens ?? existing.outputTokens,
     costAmount: incoming.costAmount ?? existing.costAmount,
     costCurrency: incoming.costCurrency ?? existing.costCurrency,
-    ...mergeModelSelection(existing, incoming),
+    ...mergeModelSelection(existing, incoming, fetchedAt),
     task: existing.task ?? incoming.task,
     parentToolUseId: existing.parentToolUseId ?? incoming.parentToolUseId,
   };
@@ -680,12 +715,13 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
           ...existing,
           model: params.model,
           availableModels: params.availableModels,
+          modelUpdatedAt: Date.now(),
         },
       },
     });
   },
 
-  seedFromHistory: (entries) => {
+  seedFromHistory: (entries, options) => {
     const { byId, orderedIds, byToolUseId, highWaterMark } = get();
 
     // Union live + history events by seq and always merge terminal/status/
@@ -698,7 +734,8 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         byId,
         orderedIds,
         idOf: (entry) => entry.acpSessionId,
-        merge: mergeHistoryEntry,
+        merge: (existing, incoming) =>
+          mergeHistoryEntry(existing, incoming, options?.fetchedAt),
       });
 
     let nextByToolUseId = byToolUseId;

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -12,6 +12,8 @@
 
 import { create } from "zustand";
 
+import type { AcpSessionModelUpdateEvent } from "@vellumai/assistant-api";
+
 import { createSelectors } from "@/utils/create-selectors";
 import { isActiveAcpStatus, type AcpRunStatus } from "@/utils/acp-run-status";
 import {
@@ -68,6 +70,10 @@ export interface AcpRunRawEvent {
   messageId?: string;
 }
 
+/** One selectable model as the ACP adapter reported it. */
+export type AcpModelOption =
+  AcpSessionModelUpdateEvent["availableModels"][number];
+
 export interface AcpRunEntry {
   acpSessionId: string;
   agent: string;
@@ -99,6 +105,10 @@ export interface AcpRunEntry {
   /** Cumulative cost reported by the agent, when available. */
   costAmount?: number;
   costCurrency?: string;
+  /** Model the session currently runs on, when the adapter reports one. */
+  model?: string;
+  /** Models the session can switch to; absent when the adapter has no selector. */
+  availableModels?: AcpModelOption[];
   events: AcpRunRawEvent[];
 }
 
@@ -215,6 +225,18 @@ export interface AcpRunActions {
   }) => void;
 
   /**
+   * Record the session's model selection. Unlike `updateUsage`, both fields are
+   * replaced wholesale: the adapter reports its full current state, so a
+   * cleared selection or a shrunken option set must not be masked by the
+   * previous one.
+   */
+  setModel: (params: {
+    acpSessionId: string;
+    model?: string;
+    availableModels: AcpModelOption[];
+  }) => void;
+
+  /**
    * Idempotent merge of history entries keyed by acpSessionId. Unions live and
    * incoming `events` by `seq` so a live stream is never clobbered by a
    * stale-but-longer snapshot, while always merging terminal/status/usage
@@ -321,6 +343,8 @@ function mergeHistoryEntry(
     outputTokens: incoming.outputTokens ?? existing.outputTokens,
     costAmount: incoming.costAmount ?? existing.costAmount,
     costCurrency: incoming.costCurrency ?? existing.costCurrency,
+    model: incoming.model ?? existing.model,
+    availableModels: incoming.availableModels ?? existing.availableModels,
     task: existing.task ?? incoming.task,
     parentToolUseId: existing.parentToolUseId ?? incoming.parentToolUseId,
   };
@@ -615,6 +639,25 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
           outputTokens: params.outputTokens ?? existing.outputTokens,
           costAmount: params.costAmount ?? existing.costAmount,
           costCurrency: params.costCurrency ?? existing.costCurrency,
+        },
+      },
+    });
+  },
+
+  setModel: (params) => {
+    const { byId } = get();
+    const existing = byId[params.acpSessionId];
+    if (!existing) {
+      return;
+    }
+
+    set({
+      byId: {
+        ...byId,
+        [params.acpSessionId]: {
+          ...existing,
+          model: params.model,
+          availableModels: params.availableModels,
         },
       },
     });

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -734,14 +734,21 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
     // usage metadata from history so a live entry can't stay stale. The shared
     // helper owns the byId/orderedIds insertion; the seq high-water mark and the
     // tool-use index are acp-specific and folded in from the merged result.
+    // A row inserted fresh carries the fetch time too, so an older overlapping
+    // response cannot roll it back through the merge path afterwards.
+    const fetchedAt = options?.fetchedAt;
+    const stamped =
+      fetchedAt === undefined
+        ? entries
+        : entries.map((entry) => ({ ...entry, modelUpdatedAt: fetchedAt }));
     const { byId: nextById, orderedIds: nextOrderedIds } =
       seedEntriesFromHistory({
-        entries,
+        entries: stamped,
         byId,
         orderedIds,
         idOf: (entry) => entry.acpSessionId,
         merge: (existing, incoming) =>
-          mergeHistoryEntry(existing, incoming, options?.fetchedAt),
+          mergeHistoryEntry(existing, incoming, fetchedAt),
       });
 
     let nextByToolUseId = byToolUseId;

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -333,7 +333,9 @@ function mergeEvents(
  * A live `acp_session_model_update` that landed at or after `fetchedAt` is
  * newer than anything this response can carry: the fetch and the SSE stream are
  * separate asynchronous paths, so a request that read model A can be answered
- * after the adapter already moved to model B. That live selection is kept.
+ * after the adapter already moved to model B. That live selection is kept. A
+ * snapshot that applies stamps its own `fetchedAt`, so an older request that
+ * is answered after a newer one is ignored by the same rule.
  *
  * Otherwise the snapshot rules apply: a row carrying `availableModels` is
  * authoritative for both fields, so the supported no-selection state (no
@@ -345,7 +347,7 @@ function mergeModelSelection(
   existing: AcpRunEntry,
   incoming: AcpRunEntry,
   fetchedAt?: number,
-): Pick<AcpRunEntry, "model" | "availableModels"> {
+): Pick<AcpRunEntry, "model" | "availableModels" | "modelUpdatedAt"> {
   if (
     fetchedAt !== undefined &&
     existing.modelUpdatedAt !== undefined &&
@@ -354,17 +356,21 @@ function mergeModelSelection(
     return {
       model: existing.model,
       availableModels: existing.availableModels,
+      modelUpdatedAt: existing.modelUpdatedAt,
     };
   }
+  const modelUpdatedAt = fetchedAt ?? existing.modelUpdatedAt;
   if (incoming.availableModels !== undefined) {
     return {
       model: incoming.model,
       availableModels: incoming.availableModels,
+      modelUpdatedAt,
     };
   }
   return {
     model: incoming.model ?? existing.model,
     availableModels: existing.availableModels,
+    modelUpdatedAt,
   };
 }
 

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -312,6 +312,29 @@ function mergeEvents(
 }
 
 /**
+ * Fold a snapshot's model selection into a live entry. A row carrying
+ * `availableModels` is authoritative for both fields, so the supported
+ * no-selection state (no `model`, empty options) clears a stale selection. A
+ * legacy row that omits the option set keeps the store's options and only
+ * upgrades a model it actually carries.
+ */
+function mergeModelSelection(
+  existing: AcpRunEntry,
+  incoming: AcpRunEntry,
+): Pick<AcpRunEntry, "model" | "availableModels"> {
+  if (incoming.availableModels !== undefined) {
+    return {
+      model: incoming.model,
+      availableModels: incoming.availableModels,
+    };
+  }
+  return {
+    model: incoming.model ?? existing.model,
+    availableModels: existing.availableModels,
+  };
+}
+
+/**
  * Merge a history entry into an existing live entry. Unions both event buffers
  * by `seq` (never dropping the newest live events) and always folds in the
  * history entry's terminal/status/usage metadata. A terminal history status
@@ -343,8 +366,7 @@ function mergeHistoryEntry(
     outputTokens: incoming.outputTokens ?? existing.outputTokens,
     costAmount: incoming.costAmount ?? existing.costAmount,
     costCurrency: incoming.costCurrency ?? existing.costCurrency,
-    model: incoming.model ?? existing.model,
-    availableModels: incoming.availableModels ?? existing.availableModels,
+    ...mergeModelSelection(existing, incoming),
     task: existing.task ?? incoming.task,
     parentToolUseId: existing.parentToolUseId ?? incoming.parentToolUseId,
   };

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration-reconnect-refetch.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration-reconnect-refetch.test.tsx
@@ -400,3 +400,63 @@ describe("useAcpRunRehydration: re-reading once a Connect flow settles", () => {
     expect(getCalls).toBe(0);
   });
 });
+
+describe("useAcpRunRehydration: a snapshot in flight cannot roll back a model", () => {
+  const flush = () => new Promise((r) => setTimeout(r, 5));
+
+  test("keeps a live model update that landed while the fetch was open", async () => {
+    // The request read `opus`; a live `acp_session_model_update` moved the
+    // session to `sonnet` before the response arrived. Seeding stamps the
+    // moment the request went out, so the older snapshot leaves it alone.
+    useAcpRunStore.getState().spawnRun({
+      acpSessionId: "run-A",
+      agent: "claude",
+      parentConversationId: "conv-A",
+      startedAt: 0,
+    });
+
+    let releaseSnapshot = (_v: unknown) => {};
+    const held = new Promise((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    mockGetImpl = async () => {
+      await held;
+      return {
+        data: {
+          sessions: [
+            {
+              id: "run-A",
+              agentId: "claude",
+              acpSessionId: "run-A",
+              parentConversationId: "conv-A",
+              status: "running",
+              startedAt: 0,
+              model: "opus",
+              availableModels: [{ value: "opus", label: "Opus" }],
+            },
+          ],
+        },
+        response: { ok: true },
+      };
+    };
+
+    renderHook(() => useAcpRunRehydration("asst-1", "conv-A"));
+    await flush();
+
+    useAcpRunStore.getState().setModel({
+      acpSessionId: "run-A",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+
+    releaseSnapshot(undefined);
+    await flush();
+
+    const entry = useAcpRunStore.getState().byId["run-A"]!;
+    expect(entry.model).toBe("sonnet");
+    expect(entry.availableModels).toEqual([
+      { value: "sonnet", label: "Sonnet" },
+    ]);
+    mockGetImpl = undefined;
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -29,6 +29,7 @@ import { client as daemonClient } from "@/generated/daemon/client.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import {
   useAcpRunStore,
+  type AcpModelOption,
   type AcpRunEntry,
   type AcpRunRawEvent,
 } from "@/domains/chat/acp-run-store";
@@ -73,6 +74,8 @@ interface AcpSessionRow {
   outputTokens?: number;
   costAmount?: number;
   costCurrency?: string;
+  model?: string;
+  availableModels?: AcpModelOption[];
   eventLog?: AcpSessionEventLogItem[];
 }
 
@@ -152,6 +155,8 @@ function toRunEntry(row: AcpSessionRow): AcpRunEntry {
     outputTokens: row.outputTokens,
     costAmount: row.costAmount,
     costCurrency: row.costCurrency,
+    model: row.model,
+    availableModels: row.availableModels,
     events,
   };
 }

--- a/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
+++ b/clients/web/src/domains/chat/hooks/use-acp-run-rehydration.ts
@@ -345,6 +345,10 @@ function activeRunIdsFor(conversationId: string): string[] {
  * A full page (>= `ACP_SNAPSHOT_LIMIT`) may have paginated an older
  * still-running run off the snapshot, so absence isn't authoritative there —
  * we seed but skip retirement rather than risk cancelling a live run.
+ *
+ * `fetchStartedAt` is stamped before the request goes out. A live model update
+ * that lands while it is in flight is newer than anything the response can
+ * carry, and seeding uses it to keep that selection.
  */
 /**
  * Newest snapshot request issued per conversation.
@@ -391,6 +395,7 @@ function applyAcpSnapshot(
   snapshotConversationId: string | null = null,
   revisionAtFetch: number = useInteractionStore.getState().acpConnectRevision,
   generation?: number,
+  fetchStartedAt?: number,
 ): void {
   if (entries === null) {
     return;
@@ -402,7 +407,7 @@ function applyAcpSnapshot(
     isNewestAcpSnapshot(snapshotConversationId, generation);
   const store = useAcpRunStore.getState();
   if (entries.length > 0) {
-    store.seedFromHistory(entries);
+    store.seedFromHistory(entries, { fetchedAt: fetchStartedAt });
   }
   // Outside the length check: a conversation whose only marked run was cleared
   // can come back empty, and that emptiness is exactly the signal that the
@@ -443,6 +448,7 @@ export function useAcpRunRehydration(
     // response must not speak for.
     const revisionAtFetch = useInteractionStore.getState().acpConnectRevision;
     const generation = beginAcpSnapshot(conversationId);
+    const fetchStartedAt = Date.now();
     void fetchAcpSessions(assistantId, conversationId).then((entries) => {
       if (cancelled) {
         return;
@@ -453,6 +459,7 @@ export function useAcpRunRehydration(
         conversationId ?? null,
         revisionAtFetch,
         generation,
+        fetchStartedAt,
       );
     });
     return () => {
@@ -503,6 +510,7 @@ export function useAcpRunRehydration(
     const priorActiveIds = activeRunIdsFor(conversationId);
     const revisionAtFetch = useInteractionStore.getState().acpConnectRevision;
     const generation = beginAcpSnapshot(conversationId);
+    const fetchStartedAt = Date.now();
     void fetchAcpSessions(assistantId, conversationId).then((entries) => {
       applyAcpSnapshot(
         entries,
@@ -510,6 +518,7 @@ export function useAcpRunRehydration(
         conversationId ?? null,
         revisionAtFetch,
         generation,
+        fetchStartedAt,
       );
     });
   });
@@ -537,6 +546,7 @@ export function useAcpRunRehydration(
     const priorActiveIds = activeRunIdsFor(conversationId);
     const revisionAtFetch = useInteractionStore.getState().acpConnectRevision;
     const generation = beginAcpSnapshot(conversationId);
+    const fetchStartedAt = Date.now();
     void fetchAcpSessions(assistantId, conversationId).then((entries) => {
       applyAcpSnapshot(
         entries,
@@ -544,6 +554,7 @@ export function useAcpRunRehydration(
         conversationId,
         revisionAtFetch,
         generation,
+        fetchStartedAt,
       );
     });
   }, [flowActive, assistantId, conversationId]);
@@ -564,6 +575,7 @@ export function useAcpRunRehydration(
       const priorActiveIds = activeRunIdsFor(conversationId);
       const revisionAtFetch = useInteractionStore.getState().acpConnectRevision;
       const generation = beginAcpSnapshot(conversationId);
+      const fetchStartedAt = Date.now();
       void fetchAcpSessions(assistantId, conversationId).then((entries) => {
         applyAcpSnapshot(
           entries,
@@ -571,6 +583,7 @@ export function useAcpRunRehydration(
           conversationId ?? null,
           revisionAtFetch,
           generation,
+          fetchStartedAt,
         );
       });
     },

--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -74,6 +74,7 @@ import {
   handleAcpSessionSpawned,
   handleAcpSessionUpdate,
   handleAcpSessionUsage,
+  handleAcpSessionModelUpdate,
   handleAcpSessionCompleted,
   handleAcpAuthRequired,
   handleAcpSessionError,
@@ -421,6 +422,9 @@ export function useStreamEventHandler(
           break;
         case "acp_session_usage":
           handleAcpSessionUsage(event);
+          break;
+        case "acp_session_model_update":
+          handleAcpSessionModelUpdate(event);
           break;
         case "acp_session_completed":
           handleAcpSessionCompleted(event);

--- a/clients/web/src/domains/chat/utils/chat.test.ts
+++ b/clients/web/src/domains/chat/utils/chat.test.ts
@@ -77,6 +77,7 @@ describe("chat utilities", () => {
     test("matches the subagent/acp global treatment", () => {
       expect(scoped("subagent_spawned")).toBe(false);
       expect(scoped("acp_session_completed")).toBe(false);
+      expect(scoped("acp_session_model_update")).toBe(false);
     });
 
     test("ordinary conversation events stay scoped", () => {

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -82,6 +82,7 @@ const GLOBAL_STREAM_EVENT_TYPE_NAMES = [
   "acp_session_spawned",
   "acp_session_update",
   "acp_session_usage",
+  "acp_session_model_update",
   "acp_session_completed",
   "acp_session_error",
   "acp_auth_required",

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -9,6 +9,7 @@ import {
   handleAcpSessionSpawned,
   handleAcpSessionUpdate,
   handleAcpSessionUsage,
+  handleAcpSessionModelUpdate,
   handleAcpSessionCompleted,
   handleAcpSessionError,
 } from "@/domains/chat/utils/stream-handlers/acp-handlers";
@@ -169,6 +170,49 @@ describe("handleAcpSessionUsage", () => {
       acpSessionId: "acp-missing",
       usedTokens: 1,
       contextSize: 1,
+    });
+    expect(getState().byId).toEqual({});
+  });
+});
+
+describe("handleAcpSessionModelUpdate", () => {
+  it("records the model and the adapter's options on the run", () => {
+    spawn();
+    handleAcpSessionModelUpdate({
+      type: "acp_session_model_update",
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [
+        { value: "opus", label: "Opus" },
+        { value: "haiku", label: "Haiku", group: "Fast" },
+      ],
+    });
+    const entry = getState().byId["acp-1"];
+    expect(entry?.model).toBe("opus");
+    expect(entry?.availableModels).toEqual([
+      { value: "opus", label: "Opus" },
+      { value: "haiku", label: "Haiku", group: "Fast" },
+    ]);
+  });
+
+  it("records an adapter with no model selector", () => {
+    spawn();
+    handleAcpSessionModelUpdate({
+      type: "acp_session_model_update",
+      acpSessionId: "acp-1",
+      availableModels: [],
+    });
+    const entry = getState().byId["acp-1"];
+    expect(entry?.model).toBeUndefined();
+    expect(entry?.availableModels).toEqual([]);
+  });
+
+  it("ignores a model update for an unknown session", () => {
+    handleAcpSessionModelUpdate({
+      type: "acp_session_model_update",
+      acpSessionId: "acp-missing",
+      model: "opus",
+      availableModels: [],
     });
     expect(getState().byId).toEqual({});
   });

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.ts
@@ -3,6 +3,7 @@ import type {
   AcpSessionSpawnedEvent,
   AcpSessionUpdateEvent,
   AcpSessionUsageEvent,
+  AcpSessionModelUpdateEvent,
   AcpSessionCompletedEvent,
   AcpSessionErrorEvent,
 } from "@vellumai/assistant-api";
@@ -66,6 +67,16 @@ export function handleAcpSessionUsage(event: AcpSessionUsageEvent): void {
     outputTokens: event.outputTokens,
     costAmount: event.costAmount,
     costCurrency: event.costCurrency,
+  });
+}
+
+export function handleAcpSessionModelUpdate(
+  event: AcpSessionModelUpdateEvent,
+): void {
+  useAcpRunStore.getState().setModel({
+    acpSessionId: event.acpSessionId,
+    model: event.model,
+    availableModels: event.availableModels,
   });
 }
 


### PR DESCRIPTION
## Summary

- New `acp_session_model_update` SSE event under `assistant/src/api/events/`, `.strict()` like the six sibling ACP events, carrying the session's current `model` and the adapter's flattened `availableModels`. Registered in the `AssistantEventSchema` union.
- Web run store gains `model` / `availableModels` on `AcpRunEntry` plus a `setModel` action (wholesale replace, no-op for unknown sessions); history merges and `/acp/sessions` rehydration carry both fields.
- Handler `handleAcpSessionModelUpdate` plus the `acp_session_model_update` case in the exhaustive stream switch, and the event added to `GLOBAL_STREAM_EVENT_TYPE_NAMES` so it is not dropped for background conversations. No daemon emitter yet: that lands in PR 7.

Part of plan: acp-model-control.md (PR 5 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D