### PR TITLE
fix(desktop): verify a cached notification avatar's digest before serving it

### DIFF
--- a/packages/electron-desktop/src/notification-avatar-file.test.ts
+++ b/packages/electron-desktop/src/notification-avatar-file.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -35,6 +36,14 @@ const avatarDir = (): string => path.join(userDataDir, "notification-avatars");
 
 const age = (file: string, offset = 0): void => {
   utimesSync(file, AGED_SECONDS + offset, AGED_SECONDS + offset);
+};
+
+/** A cache entry as an earlier run of the app left it, unknown to this one. */
+const seedCacheEntry = (bytes: Buffer): string => {
+  mkdirSync(avatarDir(), { recursive: true });
+  const file = path.join(avatarDir(), `${HASH}.png`);
+  writeFileSync(file, bytes);
+  return file;
 };
 
 beforeEach(() => {
@@ -77,6 +86,47 @@ describe("ensureNotificationAvatarFile", () => {
   test("rewrites a cache entry a partial write left behind", () => {
     const file = ensureNotificationAvatarFile(userDataDir, PNG, HASH);
     writeFileSync(file, Buffer.alloc(0));
+
+    expect(ensureNotificationAvatarFile(userDataDir, PNG, HASH)).toBe(file);
+    expect(readFileSync(file)).toEqual(PNG);
+  });
+
+  test("rewrites a cache entry whose bytes hash to something else", () => {
+    const impostor = pngFor("b");
+    expect(impostor.length).toBe(PNG.length);
+    const file = seedCacheEntry(impostor);
+
+    expect(ensureNotificationAvatarFile(userDataDir, PNG, HASH)).toBe(file);
+    expect(readFileSync(file)).toEqual(PNG);
+  });
+
+  test("reads a cache entry for its digest once per process", () => {
+    const file = seedCacheEntry(PNG);
+    ensureNotificationAvatarFile(userDataDir, PNG, HASH);
+
+    // The digest guards a file this process found on disk, not one changed
+    // under it, so a verified entry is served without being read again.
+    const impostor = pngFor("b");
+    writeFileSync(file, impostor);
+    ensureNotificationAvatarFile(userDataDir, PNG, HASH);
+
+    expect(readFileSync(file)).toEqual(impostor);
+  });
+
+  test("re-reads an avatar the prune removed before serving it again", () => {
+    const file = seedCacheEntry(PNG);
+    ensureNotificationAvatarFile(userDataDir, PNG, HASH);
+    age(file);
+    for (let index = 0; index < 16; index++) {
+      const bytes = pngFor(`avatar-${index}`);
+      age(
+        ensureNotificationAvatarFile(userDataDir, bytes, hashOf(bytes)),
+        index + 1,
+      );
+    }
+    expect(existsSync(file)).toBe(false);
+
+    seedCacheEntry(pngFor("b"));
 
     expect(ensureNotificationAvatarFile(userDataDir, PNG, HASH)).toBe(file);
     expect(readFileSync(file)).toEqual(PNG);

--- a/packages/electron-desktop/src/notification-avatar-file.ts
+++ b/packages/electron-desktop/src/notification-avatar-file.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import {
   mkdirSync,
   readdirSync,
+  readFileSync,
   renameSync,
   rmSync,
   statSync,
@@ -22,9 +23,10 @@ import { NOTIFICATION_AVATAR_HASH_PATTERN } from "@vellumai/ipc-contract";
  * the old one rather than replacing a file a live toast is still reading. The
  * name is only safe as a name if it is also true of the bytes, so the digest
  * is recomputed here rather than trusted: a mismatch throws and the caller
- * posts the app-icon toast. A cache entry counts as a hit only while its
- * length matches the bytes in hand, so a truncated or emptied file is
- * rewritten instead of served forever.
+ * posts the app-icon toast. A cache entry counts as a hit only while its own
+ * bytes still hash to its name, so a truncated, corrupted, or substituted
+ * file is rewritten instead of served forever. Each entry is read for that
+ * digest once per process, and served from {@link verifiedFiles} after.
  *
  * Every hit stamps the file's mtime, which is what the prune orders by, so the
  * assistants actually being notified about keep their entries. A file younger
@@ -48,6 +50,15 @@ const PRUNE_MIN_AGE_MS = 10 * 60 * 1000;
 const TEMPORARY_SUFFIX = ".tmp";
 
 /**
+ * Absolute paths whose bytes this process has hashed against their own name.
+ * A path leaves the set when the file behind it is rewritten or pruned.
+ */
+const verifiedFiles = new Set<string>();
+
+const sha256Hex = (bytes: Buffer): string =>
+  createHash("sha256").update(bytes).digest("hex");
+
+/**
  * Writes `avatarPng` to `<userDataDir>/notification-avatars/<avatarHash>.png`
  * unless it is already there intact, prunes the directory to the newest
  * {@link MAX_FILES} files, and returns the absolute path.
@@ -67,14 +78,15 @@ export const ensureNotificationAvatarFile = (
       "A notification avatar hash must be 64 lowercase hex characters",
     );
   }
-  if (createHash("sha256").update(avatarPng).digest("hex") !== avatarHash) {
+  if (sha256Hex(avatarPng) !== avatarHash) {
     throw new Error("A notification avatar hash must match its bytes");
   }
   const directory = path.join(userDataDir, DIRECTORY_NAME);
   const file = path.join(directory, `${avatarHash}.png`);
-  if (touchIfIntact(file, avatarPng.length)) {
+  if (touchIfIntact(file, avatarPng.length, avatarHash)) {
     return file;
   }
+  verifiedFiles.delete(file);
   mkdirSync(directory, { recursive: true });
   writeAtomically(file, avatarPng);
   // A file a live notification still holds open can refuse to be removed, and
@@ -91,14 +103,26 @@ export const ensureNotificationAvatarFile = (
  * Whether `file` already holds the cached avatar, stamping its mtime when it
  * does so the prune orders by last use rather than by first write.
  *
- * The length has to match the bytes in hand: the cache is hash-addressed, so
- * equal lengths are the same picture, and a truncated or emptied file is a
- * miss to rewrite rather than a hit to serve.
+ * The cache is hash-addressed, so the file's own bytes have to hash to
+ * `avatarHash`: a length is cheap to match, and a same-length file written by
+ * anything but this cache would otherwise be served under its name forever.
+ * The read behind that digest happens once per file per process, so a stream
+ * of notifications for one assistant re-reads nothing.
  */
-const touchIfIntact = (file: string, bytes: number): boolean => {
+const touchIfIntact = (
+  file: string,
+  bytes: number,
+  avatarHash: string,
+): boolean => {
   try {
     if (statSync(file).size !== bytes) {
       return false;
+    }
+    if (!verifiedFiles.has(file)) {
+      if (sha256Hex(readFileSync(file)) !== avatarHash) {
+        return false;
+      }
+      verifiedFiles.add(file);
     }
   } catch {
     return false;
@@ -158,6 +182,7 @@ const pruneToNewest = (directory: string): void => {
   for (const stale of cached.slice(MAX_FILES)) {
     if (stale.age >= PRUNE_MIN_AGE_MS) {
       rmSync(stale.full, { force: true });
+      verifiedFiles.delete(stale.full);
     }
   }
 };


### PR DESCRIPTION
## Summary

- A cache hit on `<hash>.png` was decided on byte length alone, so a same-length corrupted or substituted file was served under that name indefinitely. `touchIfIntact` now hashes the file's own bytes and treats a mismatch as a miss, falling through to the atomic rewrite.
- A module-level set of verified absolute paths keeps that read to once per file per process. A path leaves the set when the file behind it is rewritten or pruned, so a pruned-then-recreated entry is checked again.
- A `utimesSync` failure still counts as a hit, as before, and the module docstring no longer claims the cache is trusted on length.
- Tests cover a same-length impostor being replaced, the digest read happening once per process, and the prune clearing the verified set.

Addresses the Codex finding on #42336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1