### PR TITLE
refactor(web): MidlineDot and DetailShellNotice replace every hand-drawn copy

### DIFF
--- a/clients/web/src/components/detail-shell.tsx
+++ b/clients/web/src/components/detail-shell.tsx
@@ -9,9 +9,9 @@
  * alone, exported for hosts whose body/footer can't fit the default
  * scrollable-body wrapper (e.g. `AcpRunChatView`, which owns its own inner
  * scroll container and a sticky composer) but still need a pixel-identical
- * header. `DetailShellTitleWithCount` is the "title · N" header cluster,
- * exported with its midline dot and the shell's inset so every panel draws
- * them from one place.
+ * header. `DetailShellTitleWithCount` is the "title · N" header cluster and
+ * `DetailShellNotice` the quiet centred line an empty or failed body renders,
+ * both exported so every panel draws them from one place.
  */
 
 import type { LucideIcon } from "lucide-react";
@@ -20,21 +20,34 @@ import type { ReactNode } from "react";
 
 import { Button, Typography } from "@vellumai/design-library";
 
+import { MidlineDot } from "@/components/midline-dot";
 import { cn } from "@/utils/misc";
 
-/** Horizontal inset of the shell's header, body, and footer, in px. */
+/**
+ * Horizontal inset of `DetailShell`'s header, body, and footer, in px. A host
+ * that mounts `DetailShellHeader` on its own insets its own body.
+ */
 export const DETAIL_SHELL_BODY_INSET_PX = 20;
 
-/** The 3px midline dot between a title and the count beside it. */
-export function DetailShellMidlineDot({ className }: { className?: string }) {
+/** The quiet centred line a body renders when it is empty or failed to load. */
+export function DetailShellNotice({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <span
-      aria-hidden
+    <Typography
+      as="p"
+      variant="body-small-default"
       className={cn(
-        "size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]",
+        "py-4 text-center text-[var(--content-tertiary)]",
         className,
       )}
-    />
+    >
+      {children}
+    </Typography>
   );
 }
 
@@ -54,7 +67,7 @@ export function DetailShellTitleWithCount({
       >
         {title}
       </Typography>
-      <DetailShellMidlineDot />
+      <MidlineDot />
       <Typography
         variant="title-medium"
         className="shrink-0 whitespace-nowrap leading-snug text-[var(--content-secondary)]"

--- a/clients/web/src/components/midline-dot.tsx
+++ b/clients/web/src/components/midline-dot.tsx
@@ -1,0 +1,19 @@
+/**
+ * The 3px dot that separates a title from the count or meta beside it. Panel
+ * headers, chat chips, card surfaces, and list rows all draw it, so it sits
+ * above any one of their shells.
+ */
+
+import { cn } from "@/utils/misc";
+
+export function MidlineDot({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "size-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]",
+        className,
+      )}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/channel-sidecar/channel-transcript-panel-view.tsx
+++ b/clients/web/src/domains/chat/channel-sidecar/channel-transcript-panel-view.tsx
@@ -18,7 +18,7 @@ import { ExternalLink } from "lucide-react";
 import { channelReportsMessageProvenance } from "@/domains/chat/channel-sidecar/channel-message-provenance";
 import type { ChannelTranscriptEntry } from "@/domains/chat/channel-sidecar/channel-sidecar-transcript";
 import { ChannelTranscriptEntryRow } from "@/domains/chat/channel-sidecar/channel-transcript-entry-row";
-import { DetailShell } from "@/components/detail-shell";
+import { DetailShell, DetailShellNotice } from "@/components/detail-shell";
 import { useTranslation } from "@/i18n";
 import type { ChannelSidecarRef } from "@/stores/viewer-store";
 import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
@@ -113,17 +113,13 @@ export function ChannelTranscriptPanelView({
       </Typography>
 
       {entries.length === 0 ? (
-        <Typography
-          as="p"
-          variant="body-small-default"
-          className="py-4 text-center text-[var(--content-tertiary)]"
-        >
+        <DetailShellNotice>
           {channelReportsMessageProvenance(sidecarRef.channelId)
             ? t("channelTranscriptPanel.emptyThread", { channel: channelLabel })
             : t("channelTranscriptPanel.emptyNoMessageDetail", {
                 channel: channelLabel,
               })}
-        </Typography>
+        </DetailShellNotice>
       ) : (
         <div className="flex flex-col gap-1">
           {entries.map((entry) => (

--- a/clients/web/src/domains/chat/components/chat-info-section.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.tsx
@@ -12,10 +12,8 @@ import type { CSSProperties, ReactNode } from "react";
 
 import { Button, ScrollShadow, Typography } from "@vellumai/design-library";
 
-import {
-  DETAIL_SHELL_BODY_INSET_PX,
-  DetailShellMidlineDot,
-} from "@/components/detail-shell";
+import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
+import { MidlineDot } from "@/components/midline-dot";
 import { useElementSize } from "@/hooks/use-element-size";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTranslation } from "@/i18n";
@@ -91,7 +89,7 @@ export function ChatInfoSection<T>({
           >
             {title}
           </Typography>
-          <DetailShellMidlineDot className="bg-[var(--content-disabled)]" />
+          <MidlineDot className="bg-[var(--content-disabled)]" />
           <Typography
             variant="title-small"
             className="shrink-0 text-[var(--content-disabled)]"

--- a/clients/web/src/domains/chat/components/message-files-panel.tsx
+++ b/clients/web/src/domains/chat/components/message-files-panel.tsx
@@ -13,10 +13,9 @@
 
 import { Paperclip } from "lucide-react";
 
-import { Typography } from "@vellumai/design-library";
-
 import {
   DetailShell,
+  DetailShellNotice,
   DetailShellTitleWithCount,
 } from "@/components/detail-shell";
 import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
@@ -55,12 +54,7 @@ export function MessageFilesPanel({
       onClose={onClose}
     >
       {displayAttachments.length === 0 ? (
-        <Typography
-          variant="body-small-default"
-          className="py-4 text-center text-[var(--content-tertiary)]"
-        >
-          {t("messageFilesPanel.empty")}
-        </Typography>
+        <DetailShellNotice>{t("messageFilesPanel.empty")}</DetailShellNotice>
       ) : (
         // Wraps rather than sitting on a fixed column count: the drawer is
         // drag-resizable and the mobile overlay renders this same panel at

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -25,7 +25,7 @@ import { useTranslation } from "@/i18n";
 import { FileMarkdown } from "@/components/file-markdown";
 import { SkillLineageLink } from "@/components/skill-lineage-link";
 import { SkillRemovalDialog } from "@/components/skill-removal-dialog";
-import { DetailShell } from "@/components/detail-shell";
+import { DetailShell, DetailShellNotice } from "@/components/detail-shell";
 import {
   skillsByIdGetOptions,
   useSkillsByIdDeleteMutation,
@@ -165,13 +165,9 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
             degrades to the cached render, while an error with nothing to
             show surfaces the failure (matching `skill-detail-page`). */}
         {skillQuery.isError && !skill ? (
-          <Typography
-            variant="body-medium-lighter"
-            as="p"
-            className="py-8 text-center text-[var(--content-tertiary)]"
-          >
+          <DetailShellNotice>
             {t("skillDetailPanel.loadError")}
-          </Typography>
+          </DetailShellNotice>
         ) : isLoading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-5 w-5 animate-spin text-[var(--content-tertiary)]" />

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -19,7 +19,7 @@ import {
 import { motion, useReducedMotion } from "motion/react";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
-import { DetailShell } from "@/components/detail-shell";
+import { DetailShell, DetailShellNotice } from "@/components/detail-shell";
 import {
   AnimatedMetricCard,
   formatNumber,
@@ -505,12 +505,9 @@ export function SubagentDetailPanel({
                     isRunning={isRunning}
                   />
                 ) : (
-                  <Typography
-                    variant="body-small-default"
-                    className="py-4 text-center text-[var(--content-tertiary)]"
-                  >
+                  <DetailShellNotice>
                     {t("subagentDetailPanel.noEventsYet")}
-                  </Typography>
+                  </DetailShellNotice>
                 )}
               </div>
             </>

--- a/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -11,7 +11,7 @@ import {
 import { CardSurfaceDataSchema } from "@vellumai/assistant-api";
 import type { Surface } from "@/domains/chat/types/types";
 
-import { DetailShellMidlineDot } from "@/components/detail-shell";
+import { MidlineDot } from "@/components/midline-dot";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { SurfaceContainer } from "@/domains/chat/components/surfaces/surface-container";
@@ -352,7 +352,7 @@ export function TaskProgressBody({ progress }: { progress: TaskProgress }) {
         <span className="min-w-0 truncate py-0.5 text-title-small leading-snug text-[var(--content-strong)]">
           {progress.title}
         </span>
-        <DetailShellMidlineDot />
+        <MidlineDot />
         <span className="shrink-0 whitespace-nowrap py-0.5 text-title-small font-normal! leading-snug text-[var(--content-tertiary)]">
           {t("progressRail.stepCounter", { current, total })}
         </span>

--- a/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -28,7 +28,7 @@ import { useTranslation } from "@/i18n";
 
 import { Button } from "@vellumai/design-library";
 
-import { DetailShellMidlineDot } from "@/components/detail-shell";
+import { MidlineDot } from "@/components/midline-dot";
 import { AllowOptionsMenu } from "@/domains/chat/components/allow-options-menu";
 import { offersRuleOption } from "@/domains/chat/confirmation-decisions";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
@@ -192,7 +192,7 @@ export function InlineConfirmationCard({
           </span>
           {contextLabel ? (
             <>
-              <DetailShellMidlineDot />
+              <MidlineDot />
               <span className="min-w-0 truncate">{contextLabel}</span>
             </>
           ) : null}

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
-import { DetailShell } from "@/components/detail-shell";
+import { DetailShell, DetailShellNotice } from "@/components/detail-shell";
 import { DetailPanelStopButton } from "@/components/detail-panel-stop-button";
 import {
   AnimatedMetricCard,
@@ -251,12 +251,9 @@ export function WorkflowDetailPanel({
                   {t("workflowDetailPanel.subagents")}
                 </Typography>
                 {sortedLeaves.length === 0 ? (
-                  <Typography
-                    variant="body-small-default"
-                    className="py-4 text-center text-[var(--content-tertiary)]"
-                  >
+                  <DetailShellNotice>
                     {t("workflowDetailPanel.noSubagentsYet")}
-                  </Typography>
+                  </DetailShellNotice>
                 ) : (
                   <div className="flex flex-col gap-1">
                     {sortedLeaves.map((leaf) => (

--- a/clients/web/src/domains/home/components/notifications-bell-panel.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell-panel.tsx
@@ -1,6 +1,7 @@
 import { Trash2 } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { MidlineDot } from "@/components/midline-dot";
 import { useTranslation } from "@/i18n";
 import { Button, Typography } from "@vellumai/design-library";
 
@@ -56,10 +57,7 @@ export function NotificationsBellPanel({
         </Typography>
         {count > 0 ? (
           <>
-            <span
-              aria-hidden="true"
-              className="h-[3px] w-[3px] rounded-full bg-[var(--content-tertiary)]"
-            />
+            <MidlineDot />
             <Typography
               variant="title-small"
               data-testid="notifications-bell-count"

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -33,6 +33,7 @@ import { Card, toast } from "@vellumai/design-library";
 
 import { AvatarManagementModal } from "@/components/avatar/avatar-management-modal";
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { MidlineDot } from "@/components/midline-dot";
 import { PageShell } from "@/components/page-shell";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useElementSize } from "@/hooks/use-element-size";
@@ -1122,10 +1123,7 @@ function OverviewBento({
                   </span>
                   {scheduleCount !== undefined && (
                     <>
-                      <span
-                        className="h-[3px] w-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]"
-                        aria-hidden
-                      />
+                      <MidlineDot />
                       <span className="text-title-small leading-normal text-[var(--content-tertiary)]">
                         {scheduleCount}
                       </span>

--- a/clients/web/src/domains/schedules/components/schedule-row.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-row.tsx
@@ -2,6 +2,7 @@ import { Fragment, type ReactNode } from "react";
 
 import { ChevronRight } from "lucide-react";
 
+import { MidlineDot } from "@/components/midline-dot";
 import {
   disarmReasonLabelKey,
   pluginNameFromSourceKey,
@@ -107,9 +108,7 @@ export function ScheduleRowShell({
             <span className="flex min-w-0 items-center gap-2 text-label-small-default text-[var(--content-tertiary)]">
               {metaParts.map((part, index) => (
                 <Fragment key={index}>
-                  {index > 0 ? (
-                    <span className="h-[3px] w-[3px] shrink-0 rounded-full bg-[var(--content-tertiary)]" />
-                  ) : null}
+                  {index > 0 ? <MidlineDot /> : null}
                   <span className="truncate">{part}</span>
                 </Fragment>
               ))}


### PR DESCRIPTION
## Summary
- the 3px midline dot lives in components/midline-dot.tsx and replaces the five remaining copies; DetailShell imports it for its title cluster
- DetailShellNotice is the one quiet centred body line, used by the message-files, channel transcript, workflow, subagent, and skill panels
- DETAIL_SHELL_BODY_INSET_PX's docstring names what it actually insets

Part of plan: chat-info-assets-panel.md (remediation round 5)