### PR TITLE
fix(web): attachment previews tell a legacy id from a missing assistant, report fetch failures once, and format every date in the app locale

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.stories.tsx
@@ -1,0 +1,74 @@
+/**
+ * The box an attachment draws itself in, in each of the four branches it picks
+ * between: the kind's glyph, a decodable image, a video poster, and the
+ * placeholder an owner shows while the bytes are still on their way.
+ *
+ * Geometry, surface, and border belong to the caller, so every story wears the
+ * Chat Info file tile's box and they differ only in what the box has to draw.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Loader2 } from "lucide-react";
+import { fn } from "storybook/test";
+
+import {
+  makeSamplePreview,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { AttachmentPreviewBox } from "@/domains/chat/components/chat-attachments/attachment-preview-box";
+
+/** The Chat Info file tile's box: 135x84 on the panel's own surface. */
+const TILE_CLASS = "h-[84px] w-[135px] rounded-lg bg-[var(--surface-base)]";
+
+const meta: Meta<typeof AttachmentPreviewBox> = {
+  title: "Chat/AttachmentPreviewBox",
+  component: AttachmentPreviewBox,
+  parameters: { layout: "centered" },
+  args: {
+    className: TILE_CLASS,
+    kind: "image",
+    imageUrl: null,
+    posterUrl: null,
+    glyphClassName: "size-8",
+    onImageError: fn(),
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof AttachmentPreviewBox>;
+
+/**
+ * Nothing to draw, so the box falls back to the kind's glyph. This is where a
+ * non-media file settles and stays.
+ */
+export const Glyph: Story = {
+  args: { kind: "pdf" },
+};
+
+/**
+ * A decodable image, cover-cropped to the box: the 240x150 source keeps its
+ * middle band and loses a slice off the top and the bottom.
+ */
+export const Image: Story = {
+  args: { imageUrl: makeSamplePreview(240, 150) },
+};
+
+/**
+ * A video poster, painted behind the box rather than as an image element.
+ * A poster that fails to load has nothing to swap to, so it never gets to
+ * raise the broken-image glyph.
+ */
+export const VideoPoster: Story = {
+  args: { kind: "video", posterUrl: SAMPLE_PREVIEWS[2]! },
+};
+
+/**
+ * The bytes are still on their way. The owner's placeholder stands in for the
+ * glyph, so the box does not first settle on a fallback it is about to replace.
+ */
+export const Placeholder: Story = {
+  args: {
+    placeholder: (
+      <Loader2 className="size-8 animate-spin text-[var(--content-tertiary)]" />
+    ),
+  },
+};

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ReactElement } from "react";
+import type { ComponentProps, ReactElement } from "react";
 
 import * as daemonSdk from "@/generated/daemon/sdk.gen";
 import type { DisplayAttachment } from "@/types/attachment-types";
@@ -10,10 +10,12 @@ type ContentResult = { data: Blob | null; error: { message: string } | null };
 
 // Mock only the daemon content endpoint; keep the rest of the generated SDK
 // real so any other consumer in the module graph is unaffected.
-const attachmentsByIdContentGet = mock(async (): Promise<ContentResult> => ({
-  data: new Blob(["content"]),
-  error: null,
-}));
+const attachmentsByIdContentGet = mock(
+  async (): Promise<ContentResult> => ({
+    data: new Blob(["content"]),
+    error: null,
+  }),
+);
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...daemonSdk,
@@ -37,24 +39,47 @@ const ATTACHMENT: DisplayAttachment = {
   previewUrl: null,
 };
 
-function renderModal(
-  attachment: DisplayAttachment,
-  onClose: () => void = () => undefined,
-): void {
+type ModalProps = Omit<ComponentProps<typeof AttachmentPreviewModal>, "open">;
+
+function renderOpen(props: ModalProps): {
+  rerender: (next: ModalProps) => void;
+} {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  const ui: ReactElement = (
+  const ui = (next: ModalProps): ReactElement => (
     <QueryClientProvider client={client}>
-      <AttachmentPreviewModal
-        open
-        onClose={onClose}
-        attachment={attachment}
-        assistantId="asst-1"
-      />
+      <AttachmentPreviewModal open {...next} />
     </QueryClientProvider>
   );
-  render(ui);
+  const { rerender } = render(ui(props));
+  return { rerender: (next) => rerender(ui(next)) };
+}
+
+function renderModal(
+  attachment: DisplayAttachment,
+  onClose: () => void = () => undefined,
+  assistantId: string | null = "asst-1",
+): void {
+  renderOpen({ onClose, attachment, assistantId });
+}
+
+/** A gallery whose sibling list the caller can swap after the modal is open. */
+function renderGallery(
+  attachment: DisplayAttachment,
+  siblingAttachments: DisplayAttachment[],
+  currentIndex: number,
+): { rerender: (siblings: DisplayAttachment[]) => void } {
+  const base: ModalProps = {
+    onClose: () => undefined,
+    attachment,
+    assistantId: "asst-1",
+    currentIndex,
+  };
+  const { rerender } = renderOpen({ ...base, siblingAttachments });
+  return {
+    rerender: (siblings) => rerender({ ...base, siblingAttachments: siblings }),
+  };
 }
 
 afterEach(() => {
@@ -107,6 +132,21 @@ describe("AttachmentPreviewModal content loading", () => {
         "Preview unavailable — file content was not preserved in chat history.",
       ),
     ).toBeDefined();
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
+
+  test("names the file rather than blaming history when there is no assistant to fetch from", () => {
+    // The composer strip opens the gallery with no assistant, and an upload
+    // whose preview the browser could not decode arrives here with a null
+    // `previewUrl`. Its bytes are not lost, so it gets the neutral card.
+    renderModal(ATTACHMENT, () => undefined, null);
+
+    expect(
+      screen.queryByText(/file content was not preserved in chat history/),
+    ).toBeNull();
+    expect(screen.queryByText("Failed to load preview.")).toBeNull();
+    expect(screen.getAllByText("photo.png").length).toBeGreaterThan(0);
+    expect(screen.getByText("Download")).toBeDefined();
     expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
   });
 
@@ -178,6 +218,27 @@ describe("AttachmentPreviewModal content loading", () => {
     expect(video.getAttribute("src")).toBe("blob:preview-mock");
     expect(video.getAttribute("poster")).toBe("data:image/jpeg;base64,BBBB");
     expect(attachmentsByIdContentGet).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AttachmentPreviewModal gallery position", () => {
+  const FIRST = { ...ATTACHMENT, id: "att-1", filename: "one.png" };
+  const SECOND = { ...ATTACHMENT, id: "att-2", filename: "two.png" };
+  const THIRD = { ...ATTACHMENT, id: "att-3", filename: "three.png" };
+  const PREPENDED = { ...ATTACHMENT, id: "att-0", filename: "zero.png" };
+
+  test("takes the caller's index while it still points at the open attachment", () => {
+    renderGallery(SECOND, [FIRST, SECOND, THIRD], 1);
+
+    expect(screen.getByText("2 / 3")).toBeDefined();
+  });
+
+  test("falls back to the id once the sibling list has shifted under it", () => {
+    const { rerender } = renderGallery(SECOND, [FIRST, SECOND, THIRD], 1);
+
+    rerender([PREPENDED, FIRST, SECOND, THIRD]);
+
+    expect(screen.getByText("3 / 4")).toBeDefined();
   });
 });
 

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -63,7 +63,9 @@ interface AttachmentPreviewModalProps {
   siblingAttachments?: DisplayAttachment[];
   /** The active attachment's position in `siblingAttachments`. Given by callers
    *  whose list can hold two attachments with the same id, which the id lookup
-   *  below cannot tell apart; omitted, the position is looked up by id. */
+   *  below cannot tell apart. Honoured only while it still points at
+   *  `attachment`; otherwise, and when omitted, the position is looked up by
+   *  id. */
   currentIndex?: number;
   /** Called when the user navigates to a different attachment via the gallery
    *  arrows. The parent swaps the active `attachment` prop in response, and
@@ -120,6 +122,7 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     url: effectiveUrl,
     isError,
     unavailable,
+    legacyId,
     isPending,
   } = useAttachmentObjectUrl(assistantId, attachment, open);
 
@@ -128,9 +131,12 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   // non-image fallback card instead of rendering the broken-image glyph.
   const [decodeFailedUrl, setDecodeFailedUrl] = useState<string | null>(null);
 
-  const previewError = unavailable
+  // Only a synthetic history id means the bytes were never kept. The rest of
+  // what `unavailable` covers still has a file behind it, so it falls through
+  // to the card that names it.
+  const previewError = legacyId
     ? "Preview unavailable — file content was not preserved in chat history."
-    : isError
+    : isError && !unavailable
       ? "Failed to load preview."
       : null;
 
@@ -138,11 +144,16 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     if (!siblingAttachments || siblingAttachments.length <= 1) {
       return -1;
     }
-    if (givenIndex !== undefined && siblingAttachments[givenIndex]) {
+    // The hint is only good while it still points at the attachment that was
+    // opened; a list that has shifted under the modal falls back to the id.
+    if (
+      givenIndex !== undefined &&
+      siblingAttachments[givenIndex] === attachment
+    ) {
       return givenIndex;
     }
     return siblingAttachments.findIndex((a) => a.id === attachment.id);
-  }, [siblingAttachments, attachment.id, givenIndex]);
+  }, [siblingAttachments, attachment, givenIndex]);
 
   const hasGallery =
     currentIndex !== -1 &&

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Every surface that draws attachment bytes (the transcript's inline image,
+ * the message squares, the Chat Info tiles, the full-screen preview) fetches
+ * through `fetchAttachmentContentBlob`, so the report it raises is the only
+ * one any of them get.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import * as captureErrorModule from "@/lib/sentry/capture-error";
+import * as daemonSdk from "@/generated/daemon/sdk.gen";
+
+interface CapturedError {
+  err: unknown;
+  context?: string;
+  bestEffort?: boolean;
+}
+
+let captured: CapturedError[] = [];
+let contentResponse: () => Promise<{
+  data: Blob | null;
+  error: { message: string } | null;
+}> = async () => ({ data: new Blob(["bytes"]), error: null });
+
+const attachmentsByIdContentGet = mock(() => contentResponse());
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...daemonSdk,
+  attachmentsByIdContentGet,
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  ...captureErrorModule,
+  captureError: (
+    err: unknown,
+    options?: { context?: string; bestEffort?: boolean },
+  ) => {
+    captured.push({
+      err,
+      context: options?.context,
+      bestEffort: options?.bestEffort,
+    });
+  },
+}));
+
+const { fetchAttachmentContentBlob } =
+  await import("@/domains/chat/components/chat-attachments/download-attachment");
+
+beforeEach(() => {
+  captured = [];
+  contentResponse = async () => ({ data: new Blob(["bytes"]), error: null });
+});
+
+afterEach(() => {
+  attachmentsByIdContentGet.mockClear();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("fetchAttachmentContentBlob", () => {
+  test("reports a request that threw, and still answers null", async () => {
+    const thrown = new Error("assistant offline");
+    contentResponse = () => Promise.reject(thrown);
+
+    expect(await fetchAttachmentContentBlob("asst-1", "att-1")).toBeNull();
+    expect(captured).toEqual([
+      {
+        err: thrown,
+        context: "fetchAttachmentContentBlob",
+        bestEffort: true,
+      },
+    ]);
+  });
+
+  test("reports nothing for a request that answered", async () => {
+    expect(await fetchAttachmentContentBlob("asst-1", "att-1")).toBeInstanceOf(
+      Blob,
+    );
+    expect(captured).toEqual([]);
+  });
+
+  test("never fetches, and never reports, for a synthetic history id", async () => {
+    expect(
+      await fetchAttachmentContentBlob("asst-1", "rehydrated:0"),
+    ).toBeNull();
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+    expect(captured).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
@@ -1,4 +1,5 @@
 import { attachmentsByIdContentGet } from "@/generated/daemon/sdk.gen";
+import { captureError } from "@/lib/sentry/capture-error";
 
 /**
  * Fetch an attachment's stored bytes from the daemon content endpoint.
@@ -23,8 +24,13 @@ export async function fetchAttachmentContentBlob(
       return data;
     }
     return null;
-  } catch {
-    // Network failure, assistant offline, etc.
+  } catch (err) {
+    // Every reader of the attachment bytes lands here, so this is the one
+    // place the failure is reported.
+    captureError(err, {
+      context: "fetchAttachmentContentBlob",
+      bestEffort: true,
+    });
     return null;
   }
 }

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.ts
@@ -34,6 +34,8 @@ export interface AttachmentObjectUrl {
   isError: boolean;
   /** The bytes can never be fetched at all, as against a fetch that failed. */
   unavailable: boolean;
+  /** The id is a synthetic `rehydrated:` one, so no bytes were ever stored. */
+  legacyId: boolean;
   /** The bytes are still on their way, so nothing is settled yet. */
   isPending: boolean;
 }
@@ -48,11 +50,15 @@ export function useAttachmentObjectUrl(
   const previewUrl = attachment?.previewUrl ?? null;
   // Synthetic `rehydrated:` ids from the text-parsing history fallback can
   // never resolve against the content endpoint, so they are never fetched.
-  const canFetch = !!assistantId && !!id && !id.startsWith("rehydrated:");
+  const isRehydratedId = id.startsWith("rehydrated:");
+  const canFetch = !!assistantId && !!id && !isRehydratedId;
   const shouldFetch = enabled && !previewUrl && canFetch;
   // No inline bytes and no way to fetch them is a settled answer, not a
   // pending one, so callers can fall back instead of waiting.
   const unavailable = !!attachment && !previewUrl && !canFetch;
+  // Narrower than `unavailable`: the bytes were never stored, rather than
+  // merely being out of this caller's reach.
+  const legacyId = !previewUrl && isRehydratedId;
 
   const { data: blob, isError } = useQuery({
     queryKey: attachmentContentQueryKey(assistantId, id),
@@ -91,6 +97,7 @@ export function useAttachmentObjectUrl(
     url: previewUrl ?? objectUrl,
     isError: isError || unavailable,
     unavailable,
+    legacyId,
     isPending: shouldFetch && !objectUrl && !isError,
   };
 }

--- a/clients/web/src/domains/library/library-detail-page.tsx
+++ b/clients/web/src/domains/library/library-detail-page.tsx
@@ -4,7 +4,6 @@ import { useLocation, useNavigate, useParams } from "react-router";
 
 import { DeployDialogs } from "@/components/deploy-dialogs";
 import { EdgeSwipeHitZone } from "@/components/edge-swipe-hit-zone";
-import { toast } from "@vellumai/design-library";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { useEdgeSwipeBack } from "@/hooks/use-edge-swipe-back";
@@ -16,7 +15,7 @@ import { useDeployStore } from "@/stores/deploy-store";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 import { navigateToNewConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
-import { shareApp } from "@/utils/share-app";
+import { shareAppWithToast } from "@/utils/share-app-with-toast";
 import { isReadOnlyApp } from "@/types/app-types";
 
 import { useTranslation } from "@/i18n";
@@ -101,20 +100,22 @@ export function LibraryDetailPage() {
     }
   }, [app, editApp]);
 
+  // The nav bar draws a spinner while the export runs, so this surface owns
+  // the busy flag rather than taking the menus' ref-guarded hook.
   const handleShare = useCallback(async () => {
     if (!app || isSharing) {
       return;
     }
     setIsSharing(true);
     try {
-      await shareApp(assistantId, app.appId, app.name);
-      toast.success(t("libraryAppCard.exported"), {
-        description: `${app.name}.vellum`,
-      });
-    } catch (err) {
-      toast.error(t("libraryAppCard.shareFailed"), {
-        description: err instanceof Error ? err.message : undefined,
-      });
+      await shareAppWithToast(
+        assistantId,
+        { id: app.appId, name: app.name },
+        {
+          exported: t("libraryAppCard.exported"),
+          failed: t("libraryAppCard.shareFailed"),
+        },
+      );
     } finally {
       setIsSharing(false);
     }

--- a/clients/web/src/hooks/use-in-view.ts
+++ b/clients/web/src/hooks/use-in-view.ts
@@ -1,10 +1,12 @@
 /**
  * Whether an element is currently on screen.
  *
- * A thin `IntersectionObserver` wrapper, added because the codebase had three
- * hand-rolled copies (the app card's lazy preview, the PDF page renderer, the
- * transcript's load-more sentinel). Those three are left alone; they each fold
- * extra behaviour into their observer.
+ * A thin `IntersectionObserver` wrapper. Three hand-rolled copies are left
+ * alone, each asking for something this hook does not offer: the app card's
+ * lazy preview latches on the first sighting and disconnects, the PDF page
+ * renderer observes every page canvas against its own scroll container and
+ * reads the page number off each target, and the transcript's load-more
+ * sentinel calls back on every entry rather than reporting a boolean.
  *
  * Reports `false` before the first observation and wherever the API is missing,
  * so callers get the conservative answer while the browser catches up. A caller

--- a/clients/web/src/hooks/use-share-app.test.tsx
+++ b/clients/web/src/hooks/use-share-app.test.tsx
@@ -1,7 +1,8 @@
 /**
  * `useShareApp` is the one share handler both app menus call. What it owns is
- * the sequence: refuse a second export while one is running, name the bundle
- * after the app, and raise the caller's own copy either way.
+ * the guard: refuse a second export while one is running. The sequence it
+ * wraps names the bundle after the app and raises the caller's own copy
+ * either way.
  */
 
 import {
@@ -13,7 +14,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import * as toastModule from "@vellumai/design-library/components/toast";
 
 import type { AppSummary } from "@/types/app-types";
@@ -112,9 +113,6 @@ describe("useShareApp", () => {
     act(() => {
       firstShare = result.current.share();
     });
-    await waitFor(() => {
-      expect(result.current.isSharing).toBe(true);
-    });
 
     await act(async () => {
       await result.current.share();
@@ -125,7 +123,39 @@ describe("useShareApp", () => {
       release();
       await firstShare;
     });
-    expect(result.current.isSharing).toBe(false);
     expect(successes).toHaveLength(1);
+  });
+
+  test("takes the next request once the export has finished", async () => {
+    const { result } = renderShare();
+
+    await act(async () => {
+      await result.current.share();
+    });
+    await act(async () => {
+      await result.current.share();
+    });
+
+    expect(shareCalls).toHaveLength(2);
+  });
+
+  test("keeps one share handler across the export", async () => {
+    let release = () => {};
+    shareResult = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { result } = renderShare();
+    const before = result.current.share;
+
+    let firstShare: Promise<void> = Promise.resolve();
+    act(() => {
+      firstShare = result.current.share();
+    });
+    await act(async () => {
+      release();
+      await firstShare;
+    });
+
+    expect(result.current.share).toBe(before);
   });
 });

--- a/clients/web/src/hooks/use-share-app.ts
+++ b/clients/web/src/hooks/use-share-app.ts
@@ -1,29 +1,23 @@
 /**
- * Export one app as a `.vellum` bundle and report how it went.
+ * Export one app as a `.vellum` bundle from a menu, refusing a second export
+ * while one is running.
  *
- * Every menu that offers Share does the same three things: refuse a second
- * export while one is running, hand the app to {@link shareApp}, and raise a
- * toast either way. The copy is the caller's, because the two menus name the
- * action from their own catalogs.
+ * The sequence itself is {@link shareAppWithToast}; this adds the guard the
+ * menus need. The guard is a ref rather than state because neither menu draws
+ * a busy affordance, and a ref keeps `share` stable across the export. A
+ * surface that does draw one owns its own flag and calls the core function.
  */
 
-import { useCallback, useState } from "react";
-
-import { toast } from "@vellumai/design-library";
+import { useCallback, useRef } from "react";
 
 import type { AppSummary } from "@/types/app-types";
-import { shareApp } from "@/utils/share-app";
-
-export interface ShareAppCopy {
-  /** Toast title once the bundle has been handed off. */
-  exported: string;
-  /** Toast title when the export fails; the error's own message is the description. */
-  failed: string;
-}
+import {
+  shareAppWithToast,
+  type ShareAppCopy,
+} from "@/utils/share-app-with-toast";
 
 export interface ShareAppHandle {
   share: () => Promise<void>;
-  isSharing: boolean;
 }
 
 export function useShareApp(
@@ -32,24 +26,19 @@ export function useShareApp(
   { exported, failed }: ShareAppCopy,
 ): ShareAppHandle {
   const { id, name } = app;
-  const [isSharing, setIsSharing] = useState(false);
+  const isSharingRef = useRef(false);
 
   const share = useCallback(async () => {
-    if (isSharing) {
+    if (isSharingRef.current) {
       return;
     }
-    setIsSharing(true);
+    isSharingRef.current = true;
     try {
-      await shareApp(assistantId, id, name);
-      toast.success(exported, { description: `${name}.vellum` });
-    } catch (err) {
-      toast.error(failed, {
-        description: err instanceof Error ? err.message : undefined,
-      });
+      await shareAppWithToast(assistantId, { id, name }, { exported, failed });
     } finally {
-      setIsSharing(false);
+      isSharingRef.current = false;
     }
-  }, [assistantId, id, name, isSharing, exported, failed]);
+  }, [assistantId, id, name, exported, failed]);
 
-  return { share, isSharing };
+  return { share };
 }

--- a/clients/web/src/stores/deploy-store.ts
+++ b/clients/web/src/stores/deploy-store.ts
@@ -19,7 +19,7 @@ import type { AppsByIdPublishPostResponse } from "@/generated/daemon/types.gen";
 import { t } from "@/i18n";
 import { createSelectors } from "@/utils/create-selectors";
 import { publishApp } from "@/utils/publish-app";
-import { shareApp as shareAppApi } from "@/utils/share-app";
+import { shareAppWithToast } from "@/utils/share-app-with-toast";
 import { toast } from "@vellumai/design-library";
 
 // ---------------------------------------------------------------------------
@@ -116,14 +116,14 @@ const useDeployStoreBase = create<DeployStore>()((set, get) => ({
     }
     set({ isSharing: true });
     try {
-      await shareAppApi(assistantId, appId, appName);
-      toast.success(t("deployStore.appExported"), {
-        description: `${appName}.vellum`,
-      });
-    } catch (err) {
-      toast.error(t("deployStore.shareFailed"), {
-        description: err instanceof Error ? err.message : undefined,
-      });
+      await shareAppWithToast(
+        assistantId,
+        { id: appId, name: appName },
+        {
+          exported: t("deployStore.appExported"),
+          failed: t("deployStore.shareFailed"),
+        },
+      );
     } finally {
       set({ isSharing: false });
     }

--- a/clients/web/src/utils/format-date.test.ts
+++ b/clients/web/src/utils/format-date.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { currentLocale } from "@/i18n";
 import {
   formatCaptureTime,
   formatCompactLocalDate,
@@ -12,8 +13,8 @@ import {
  * hardcoded "Aug 5, 11:42 AM", so they hold wherever the suite runs. What they
  * pin is the composition: the friendly date, a comma, and the local time.
  */
-function localTime(date: Date): string {
-  return date.toLocaleTimeString(undefined, {
+function localTime(date: Date, locale: string = currentLocale()): string {
+  return date.toLocaleTimeString(locale, {
     hour: "numeric",
     minute: "2-digit",
   });
@@ -55,6 +56,45 @@ describe("formatCompactLocalDate", () => {
     expect(formatCompactLocalDate(null)).toBe("");
     expect(formatCompactLocalDate(undefined)).toBe("");
     expect(formatCompactLocalDate("")).toBe("");
+  });
+
+  test("formats date and time together in the locale it is given", () => {
+    const date = new Date(2001, 0, 15, 13, 42);
+    const iso = date.toISOString();
+
+    // Both halves move, so the label cannot carry an app-locale date beside a
+    // browser-locale time.
+    expect(formatCompactLocalDate(iso, "ru")).toBe(
+      `${formatFriendlyDate(date, { locale: "ru" })}, ${localTime(date, "ru")}`,
+    );
+    expect(formatCompactLocalDate(iso, "ru")).not.toBe(
+      formatCompactLocalDate(iso, "en"),
+    );
+  });
+});
+
+describe("formatFullLocalDate", () => {
+  test("formats in the locale it is given", () => {
+    const iso = new Date(2001, 0, 15, 13, 42).toISOString();
+
+    expect(formatFullLocalDate(iso, "ru")).toBe(
+      new Date(iso).toLocaleString("ru", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZoneName: "short",
+      }),
+    );
+    expect(formatFullLocalDate(iso, "ru")).not.toBe(
+      formatFullLocalDate(iso, "en"),
+    );
+  });
+
+  test("renders nothing for a missing timestamp", () => {
+    expect(formatFullLocalDate(null)).toBe("");
+    expect(formatFullLocalDate(undefined)).toBe("");
   });
 });
 

--- a/clients/web/src/utils/format-date.ts
+++ b/clients/web/src/utils/format-date.ts
@@ -3,7 +3,10 @@ import { currentLocale } from "@/i18n";
 /**
  * Format a date as a short, human-readable string (e.g., "27 May" or "27 May 2025").
  * Omits the year when it matches the current year, unless `alwaysShowYear` is set.
- * `locale` defaults to the app's active locale; pass one to pin the formatting.
+ *
+ * Every formatter in this file defaults to the app's active locale, so one
+ * label never pairs an app-locale date with a browser-locale time. Pass
+ * `locale` to pin the formatting.
  */
 export function formatFriendlyDate(
   date: Date,
@@ -20,7 +23,7 @@ export function formatFriendlyDate(
 }
 
 /** Hour and minute, the shape every inline timestamp here shows. */
-function formatTimeOfDay(date: Date, locale?: string): string {
+function formatTimeOfDay(date: Date, locale: string = currentLocale()): string {
   return date.toLocaleTimeString(locale, {
     hour: "numeric",
     minute: "2-digit",
@@ -51,7 +54,10 @@ export function formatCaptureTime(
  * Compact relative-time label for inline metadata ("just now", "2h ago").
  * Mirrors the macOS client's `Date.relativeShortString()`.
  */
-export function formatRelativeDate(dateStr: string | null | undefined): string {
+export function formatRelativeDate(
+  dateStr: string | null | undefined,
+  locale: string = currentLocale(),
+): string {
   if (!dateStr) {
     return "—";
   }
@@ -96,7 +102,7 @@ export function formatRelativeDate(dateStr: string | null | undefined): string {
     const weeks = Math.floor(diffDays / 7);
     return `${weeks}w ago`;
   }
-  return date.toLocaleDateString();
+  return date.toLocaleDateString(locale);
 }
 
 /**
@@ -106,12 +112,13 @@ export function formatRelativeDate(dateStr: string | null | undefined): string {
  */
 export function formatCompactLocalDate(
   dateStr: string | null | undefined,
+  locale: string = currentLocale(),
 ): string {
   if (!dateStr) {
     return "";
   }
   const date = new Date(dateStr);
-  return `${formatFriendlyDate(date)}, ${formatTimeOfDay(date)}`;
+  return `${formatFriendlyDate(date, { locale })}, ${formatTimeOfDay(date, locale)}`;
 }
 
 /**
@@ -120,11 +127,12 @@ export function formatCompactLocalDate(
  */
 export function formatFullLocalDate(
   dateStr: string | null | undefined,
+  locale: string = currentLocale(),
 ): string {
   if (!dateStr) {
     return "";
   }
-  return new Date(dateStr).toLocaleString(undefined, {
+  return new Date(dateStr).toLocaleString(locale, {
     month: "long",
     day: "numeric",
     year: "numeric",

--- a/clients/web/src/utils/share-app-with-toast.ts
+++ b/clients/web/src/utils/share-app-with-toast.ts
@@ -1,0 +1,39 @@
+/**
+ * Export one app as a `.vellum` bundle and raise a toast either way.
+ *
+ * Every surface that offers Share does the same two things: hand the app to
+ * {@link shareApp}, then report the outcome. The copy is the caller's, because
+ * each menu names the action from its own catalog.
+ *
+ * Re-entrancy is the caller's too. A caller that only has to refuse a second
+ * export guards with a ref (`useShareApp`); one that also renders a busy
+ * affordance keeps the flag it draws from (the deploy store, the library
+ * detail page).
+ */
+
+import { toast } from "@vellumai/design-library";
+
+import type { AppSummary } from "@/types/app-types";
+import { shareApp } from "@/utils/share-app";
+
+export interface ShareAppCopy {
+  /** Toast title once the bundle has been handed off. */
+  exported: string;
+  /** Toast title when the export fails; the error's own message is the description. */
+  failed: string;
+}
+
+export async function shareAppWithToast(
+  assistantId: string,
+  app: Pick<AppSummary, "id" | "name">,
+  { exported, failed }: ShareAppCopy,
+): Promise<void> {
+  try {
+    await shareApp(assistantId, app.id, app.name);
+    toast.success(exported, { description: `${app.name}.vellum` });
+  } catch (err) {
+    toast.error(failed, {
+      description: err instanceof Error ? err.message : undefined,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- useAttachmentObjectUrl reports legacyId apart from unavailable, so the preview modal's history copy fires only for rehydrated ids; the gallery accepts an index hint only when it still points at the opened attachment
- fetchAttachmentContentBlob reports failures through captureError for every reader
- shareAppWithToast is the one share-with-toast sequence, wrapped by useShareApp and used by the deploy store; every format-date formatter defaults to the app locale
- AttachmentPreviewBox stories; useInView docstring names what the remaining observers do

Part of plan: chat-info-assets-panel.md (remediation round 5)