### PR TITLE
test(web): chat-info stories and tests build on one helper layer

### DIFF
--- a/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
@@ -7,35 +7,30 @@
  * tile to see the options menu appear; on a touch device it is always visible.
  */
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 import {
   CHAT_INFO_ASSISTANT_ID,
-  chatInfoPreviewHtml,
+  CHAT_INFO_CONVERSATION_ID,
+  chatInfoApps,
+  primeChatInfoAppPreviews,
 } from "@/domains/chat/components/chat-info-story-fixtures";
-import { makeAppSummary } from "@/domains/chat/components/chat-info.test-helper";
-import { appsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
-import type { AppSummary } from "@/types/app-types";
-import { primeAppHtmlCache } from "@/utils/app-html-cache";
+import {
+  CHAT_INFO_DRAWER_WIDTH_PX,
+  makeAppSummary,
+  makeChatInfoQueryClient,
+  seedChatInfoConversation,
+} from "@/domains/chat/components/chat-info.test-helper";
 
 import { ChatInfoAppTile } from "./chat-info-app-tile";
 
-const TRIP_PLANNER = makeAppSummary({
-  id: "app-trip-planner",
-  name: "Trip Planner",
-});
-const PACKING_LIST = makeAppSummary({
-  id: "app-packing-list",
-  name: "Packing List",
-  icon: "🧳",
-});
-const FERRY_TIMES = makeAppSummary({
-  id: "app-ferry-times",
-  name: "Ferry Times",
-  icon: "⛴️",
-});
+const FEATURED = chatInfoApps(3);
+const TRIP_PLANNER = FEATURED[0]!;
+const PACKING_LIST = FEATURED[1]!;
+const FERRY_TIMES = FEATURED[2]!;
+
 const LONG_NAME = makeAppSummary({
   id: "app-itinerary",
   name: "Coastal Itinerary and Harbour Tour Booking Planner",
@@ -48,31 +43,16 @@ const NO_PREVIEW = makeAppSummary({
   icon: "📓",
 });
 
-const PRIMED: Array<[AppSummary, string[]]> = [
-  [TRIP_PLANNER, ["Book the ferry", "Pack a rain shell", "Confirm the tour"]],
-  [PACKING_LIST, ["Rain shell", "Walking boots", "Ferry tickets"]],
-  [FERRY_TIMES, ["07:40 harbour", "11:15 harbour", "16:50 harbour"]],
-  [LONG_NAME, ["Day 1 coast road", "Day 2 harbour", "Day 3 return"]],
-];
+const PRIMED = [...FEATURED, LONG_NAME];
+primeChatInfoAppPreviews(CHAT_INFO_ASSISTANT_ID, PRIMED);
 
-for (const [app, items] of PRIMED) {
-  primeAppHtmlCache(
-    CHAT_INFO_ASSISTANT_ID,
-    app.id,
-    chatInfoPreviewHtml(app.name, items),
-  );
-}
-
-const storyClient = new QueryClient({
-  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-});
+const storyClient = makeChatInfoQueryClient();
 // The options menu reads the app list to know whether the app is pinned.
-storyClient.setQueryData(
-  appsGetQueryKey({ path: { assistant_id: CHAT_INFO_ASSISTANT_ID } }),
-  {
-    apps: [TRIP_PLANNER, PACKING_LIST, FERRY_TIMES, LONG_NAME, NO_PREVIEW],
-  },
-);
+seedChatInfoConversation(storyClient, {
+  assistantId: CHAT_INFO_ASSISTANT_ID,
+  conversationId: CHAT_INFO_CONVERSATION_ID,
+  apps: [...PRIMED, NO_PREVIEW],
+});
 
 const withPrimedPreviews: Decorator = (Story) => (
   <QueryClientProvider client={storyClient}>
@@ -106,7 +86,7 @@ export const Default: Story = {};
 export const Stretched: Story = {
   args: { stretch: true },
   render: (args) => (
-    <div className="flex w-[569px] gap-2">
+    <div className="flex gap-2" style={{ width: CHAT_INFO_DRAWER_WIDTH_PX }}>
       <ChatInfoAppTile {...args} app={TRIP_PLANNER} />
       <ChatInfoAppTile {...args} app={PACKING_LIST} />
       <ChatInfoAppTile {...args} app={FERRY_TIMES} />

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
@@ -9,7 +9,7 @@
  * shows the fetched path without a daemon behind it.
  */
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
@@ -22,6 +22,7 @@ import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attach
 import { CHAT_INFO_ASSISTANT_ID } from "@/domains/chat/components/chat-info-story-fixtures";
 import {
   CHAT_INFO_T0,
+  makeChatInfoQueryClient,
   makeDocumentAsset,
   makeDocumentSummary,
   makeFileAsset,
@@ -95,9 +96,7 @@ const FRAME_FILE = makeFrameAsset(
   CHAT_INFO_T0,
 );
 
-const storyClient = new QueryClient({
-  defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-});
+const storyClient = makeChatInfoQueryClient();
 // The bytes the daemon would return, decoded from a sample preview data URL.
 storyClient.setQueryData(
   attachmentContentQueryKey(CHAT_INFO_ASSISTANT_ID, LAZY_IMAGE_ATTACHMENT.id),

--- a/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
@@ -11,16 +11,21 @@
  * it under a row that looks complete.
  *
  * Read the phone stories at the Mobile viewports: the frame draws
- * `DetailShell`'s lift surface and 20px body inset, which the strip cancels.
+ * `DetailShell`'s lift surface and body inset, which the strip cancels.
  */
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
+import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
 import {
   makeMixedAttachments,
   makePreviewableImages,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
+import {
+  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_NARROW_PHONE_PX,
+} from "@/domains/chat/components/chat-info.test-helper";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
 import {
@@ -40,22 +45,31 @@ const FITTING_SET: DisplayAttachment[] = [
   ...makeMixedAttachments().filter((file) => file.previewUrl === null),
 ];
 
-/** The drawer body's column on the desktop mock: 569px inside `DetailShell`'s lift surface and 20px inset. */
+/** The drawer body's column on the desktop mock, inside `DetailShell`'s lift surface and body inset. */
 const inDrawerColumn: Decorator = (Story) => (
-  <div className="bg-[var(--surface-lift)] p-5">
-    <div className="w-[569px]">
+  <div
+    className="bg-[var(--surface-lift)]"
+    style={{ padding: DETAIL_SHELL_BODY_INSET_PX }}
+  >
+    <div style={{ width: CHAT_INFO_DRAWER_WIDTH_PX }}>
       <Story />
     </div>
   </div>
 );
 
 /**
- * A phone page at the shell's 20px body inset, which the strip's negative
- * margin cancels so the tiles run to the screen edge and the last one is cut
- * off, as in the mobile mock.
+ * A phone page at the shell's body inset, which the strip's negative margin
+ * cancels so the tiles run to the screen edge and the last one is cut off, as
+ * in the mobile mock.
  */
 const inPhonePage: Decorator = (Story) => (
-  <div className="max-w-[402px] bg-[var(--surface-lift)] p-5">
+  <div
+    className="bg-[var(--surface-lift)]"
+    style={{
+      maxWidth: CHAT_INFO_NARROW_PHONE_PX,
+      padding: DETAIL_SHELL_BODY_INSET_PX,
+    }}
+  >
     <Story />
   </div>
 );

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -22,37 +22,30 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
 import { CHAT_INFO_APP_TILE_WIDTH_PX } from "@/domains/chat/components/chat-info-app-tile";
 import { CHAT_INFO_FILE_TILE_WIDTH_PX } from "@/domains/chat/components/chat-info-file-tile";
-import type * as ElementSizeModule from "@/hooks/use-element-size";
-import type * as IsMobileModule from "@/hooks/use-is-mobile";
+import {
+  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_NARROW_PHONE_PX,
+  makeElementSizeMock,
+  makeIsMobileMock,
+} from "@/domains/chat/components/chat-info.test-helper";
 
-const widthRef = { value: 569 };
+const widthRef = { value: CHAT_INFO_DRAWER_WIDTH_PX };
 const isMobileRef = { value: false };
 
-mock.module(
-  "@/hooks/use-element-size",
-  (): Partial<typeof ElementSizeModule> => ({
-    useElementSize: () => ({
-      ref: () => {},
-      size: { w: widthRef.value, h: 0 },
-    }),
-  }),
+mock.module("@/hooks/use-element-size", () =>
+  makeElementSizeMock(() => widthRef.value),
 );
 
-mock.module(
-  "@/hooks/use-is-mobile",
-  (): Partial<typeof IsMobileModule> => ({
-    useIsMobile: () => isMobileRef.value,
-    MOBILE_MEDIA_QUERY: "(max-width: 767px)",
-  }),
+mock.module("@/hooks/use-is-mobile", () =>
+  makeIsMobileMock(() => isMobileRef.value),
 );
 
 const { ChatInfoSection, fitTileCount } =
   await import("@/domains/chat/components/chat-info-section");
 
-/** The drawer's body width on the desktop mock. */
-const DRAWER_WIDTH = 569;
-/** What a 402px phone leaves once the body takes its inset off both edges. */
-const NARROW_COLUMN_WIDTH = 402 - DETAIL_SHELL_BODY_INSET_PX * 2;
+/** What the narrowest phone leaves once the body takes its inset off both edges. */
+const NARROW_COLUMN_WIDTH =
+  CHAT_INFO_NARROW_PHONE_PX - DETAIL_SHELL_BODY_INSET_PX * 2;
 
 const SEE_ALL_ARIA = "See all apps";
 const TILE_TESTID = "section-tile";
@@ -104,7 +97,7 @@ function seeAll(): HTMLElement | null {
 }
 
 beforeEach(() => {
-  widthRef.value = DRAWER_WIDTH;
+  widthRef.value = CHAT_INFO_DRAWER_WIDTH_PX;
   isMobileRef.value = false;
 });
 
@@ -118,8 +111,8 @@ afterAll(() => {
 
 describe("fitTileCount", () => {
   test.each([
-    [DRAWER_WIDTH, CHAT_INFO_APP_TILE_WIDTH_PX, 3],
-    [DRAWER_WIDTH, CHAT_INFO_FILE_TILE_WIDTH_PX, 4],
+    [CHAT_INFO_DRAWER_WIDTH_PX, CHAT_INFO_APP_TILE_WIDTH_PX, 3],
+    [CHAT_INFO_DRAWER_WIDTH_PX, CHAT_INFO_FILE_TILE_WIDTH_PX, 4],
     [378, CHAT_INFO_APP_TILE_WIDTH_PX, 2],
     [378, CHAT_INFO_FILE_TILE_WIDTH_PX, 2],
     [0, CHAT_INFO_FILE_TILE_WIDTH_PX, 1],

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -13,26 +13,21 @@
  */
 
 import type { Decorator } from "@storybook/react-vite";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
-import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import {
+  attachmentRows,
   CHAT_INFO_T0,
-  clearTranscriptOwner,
+  clearTranscriptMessages,
   makeAppSummary,
+  makeChatInfoQueryClient,
   makeDocumentSummary,
-  seedTranscriptOwner,
+  seedChatInfoConversation,
+  seedTranscriptMessages,
 } from "@/domains/chat/components/chat-info.test-helper";
-import type {
-  DisplayAttachment,
-  DisplayMessage,
-} from "@/domains/chat/types/types";
-import {
-  appsGetQueryKey,
-  documentsGetQueryKey,
-} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { DisplayAttachment } from "@/domains/chat/types/types";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
@@ -111,7 +106,7 @@ export function chatInfoPreviewHtml(title: string, lines: string[]): string {
 }
 
 /** The first `count` fixture apps, newest first. */
-function chatInfoApps(count: number): AppSummary[] {
+export function chatInfoApps(count: number): AppSummary[] {
   return APP_SEEDS.slice(0, count).map((seed, index) =>
     makeAppSummary({
       id: `app-${index + 1}`,
@@ -145,33 +140,6 @@ function chatInfoDocuments(
   );
 }
 
-/**
- * Two transcript rows carrying `attachments`: the user's upload, then the
- * assistant's reply. This is the source `useConversationAttachments` reads,
- * so the panel's Documents & Images row lists exactly these files.
- */
-function chatInfoMessages(attachments: DisplayAttachment[]): DisplayMessage[] {
-  const half = Math.ceil(attachments.length / 2);
-  return [
-    {
-      id: "msg-user",
-      role: "user",
-      timestamp: CHAT_INFO_T0,
-      textSegments: ["Here are the shots from the harbour."],
-      contentOrder: [{ type: "text", id: "0" }],
-      attachments: attachments.slice(0, half),
-    },
-    {
-      id: "msg-assistant",
-      role: "assistant",
-      timestamp: CHAT_INFO_T0 + 1_000,
-      textSegments: ["Added them to the trip notes."],
-      contentOrder: [{ type: "text", id: "0" }],
-      attachments: attachments.slice(half),
-    },
-  ];
-}
-
 /** The conversation a story asks for through `parameters.chatInfo`. */
 export interface ChatInfoStoryConversation {
   assistantId: string;
@@ -191,26 +159,13 @@ const DEFAULT_CONVERSATION: ChatInfoStoryConversation = {
 };
 
 /**
- * Fills the query cache the way the daemon would, and primes each app's html
- * so the tiles render a live preview instead of the icon placeholder.
+ * Primes each app's html so its tile renders a live preview instead of the
+ * icon placeholder, on the fixture lines the app's position carries.
  */
-function seedChatInfoQueries(
-  client: QueryClient,
-  {
-    assistantId,
-    conversationId,
-    appCount,
-    documentCount,
-  }: ChatInfoStoryConversation,
+export function primeChatInfoAppPreviews(
+  assistantId: string,
+  apps: AppSummary[],
 ): void {
-  const apps = chatInfoApps(appCount);
-  const documents = chatInfoDocuments(documentCount, conversationId);
-  const path = { assistant_id: assistantId };
-  const query = { conversationId };
-  client.setQueryData(appsGetQueryKey({ path, query }), { apps });
-  // The app options menu reads the unscoped list to know whether a pin exists.
-  client.setQueryData(appsGetQueryKey({ path }), { apps });
-  client.setQueryData(documentsGetQueryKey({ path, query }), { documents });
   for (const [index, app] of apps.entries()) {
     const seed = APP_SEEDS[index % APP_SEEDS.length]!;
     primeAppHtmlCache(
@@ -221,26 +176,37 @@ function seedChatInfoQueries(
   }
 }
 
+/** Fills the query cache the way the daemon would, previews included. */
+function seedChatInfoQueries(
+  client: QueryClient,
+  {
+    assistantId,
+    conversationId,
+    appCount,
+    documentCount,
+  }: ChatInfoStoryConversation,
+): void {
+  const apps = chatInfoApps(appCount);
+  seedChatInfoConversation(client, {
+    assistantId,
+    conversationId,
+    apps,
+    documents: chatInfoDocuments(documentCount, conversationId),
+  });
+  primeChatInfoAppPreviews(assistantId, apps);
+}
+
 /** Installs the story's attachments as the rendered transcript, under its owner. */
 function seedChatInfoTranscript({
   assistantId,
   conversationId,
   attachments,
 }: ChatInfoStoryConversation): void {
-  useChatSessionStore.getState().seedSnapshot(conversationId, {
-    messages: chatInfoMessages(attachments),
-    hasMore: false,
-    oldestTimestamp: null,
-    oldestMessageId: null,
-    seq: 1,
-  });
-  seedTranscriptOwner(assistantId, conversationId);
-}
-
-/** Drops the seeded transcript, so a story cannot leak into the next one. */
-function resetChatInfoTranscript(): void {
-  useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
-  clearTranscriptOwner();
+  seedTranscriptMessages(
+    assistantId,
+    conversationId,
+    attachmentRows(attachments),
+  );
 }
 
 /**
@@ -261,14 +227,12 @@ export const inChatInfoConversation: Decorator =
           | Partial<ChatInfoStoryConversation>
           | undefined),
       };
-      const created = new QueryClient({
-        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-      });
+      const created = makeChatInfoQueryClient();
       seedChatInfoQueries(created, conversation);
       seedChatInfoTranscript(conversation);
       return created;
     });
-    useEffect(() => resetChatInfoTranscript, []);
+    useEffect(() => clearTranscriptMessages, []);
 
     return (
       <QueryClientProvider client={client}>

--- a/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
@@ -21,9 +21,9 @@ import {
 } from "@testing-library/react";
 import type { ReactElement } from "react";
 
-import * as appHtmlCache from "@/utils/app-html-cache";
 import {
   CHAT_INFO_OBJECT_URL,
+  chatInfoAppHtmlCacheMock,
   installChatInfoDomStubs,
   makeAppSummary,
   makeChatInfoQueryClient,
@@ -39,13 +39,7 @@ import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversatio
 installChatInfoDomStubs();
 
 // The app tile's live preview would otherwise call the daemon's open endpoint.
-mock.module(
-  "@/utils/app-html-cache",
-  (): Partial<typeof appHtmlCache> => ({
-    ...appHtmlCache,
-    getCachedAppHtml: async () => "<!doctype html><title>App</title>",
-  }),
-);
+mock.module("@/utils/app-html-cache", chatInfoAppHtmlCacheMock);
 
 const { ChatInfoAppTile } =
   await import("@/domains/chat/components/chat-info-app-tile");

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -1,14 +1,18 @@
 /**
  * Fixtures and the shared harness for the Chat Info tests and stories: the two
- * daemon summaries the panel lists, the assets it renders as tiles, the query
- * client its hooks read, and the browser APIs happy-dom leaves out.
+ * daemon summaries the panel lists, the assets it renders as tiles, the
+ * transcript rows those assets come from, the query client its hooks read, the
+ * modules a suite hands `mock.module`, and the browser APIs happy-dom leaves
+ * out.
  *
  * Every asset goes through `toConversationFileAssets`, the mapping the hook
  * itself runs, so a fixture cannot drift from the ids and shapes the panel
  * receives in the app.
  *
  * Kept free of any test-runner import so `.stories.tsx` files can use it, the
- * way `utils/conversation-list.test-helper.ts` already is.
+ * way `utils/conversation-list.test-helper.ts` already is. A `mock.module`
+ * call is process-global, so it stays in the suite; only the module body it
+ * installs lives here.
  */
 
 import { QueryClient } from "@tanstack/react-query";
@@ -24,29 +28,34 @@ import {
   appsGetQueryKey,
   documentsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
+import type * as ElementSizeModule from "@/hooks/use-element-size";
+import type * as IsMobileModule from "@/hooks/use-is-mobile";
+import { makeAppSummary as makeSharedAppSummary } from "@/types/app-summary.test-helper";
 import type { AppSummary } from "@/types/app-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
 import type { DocumentSummary } from "@/types/document-types";
+import * as appHtmlCache from "@/utils/app-html-cache";
 
 /** Fixed epoch ms, so nothing built here depends on the clock. */
 export const CHAT_INFO_T0 = 1_760_000_000_000;
 
-/** A daemon app summary with every field defaulted, `overrides` on top. */
+/** The drawer body's column on the desktop mock: 3 app tiles, 4 file tiles. */
+export const CHAT_INFO_DRAWER_WIDTH_PX = 569;
+
+/** The narrowest phone the app runs on, screen width and all. */
+export const CHAT_INFO_NARROW_PHONE_PX = 402;
+
+/** The shared app builder, under the defaults every Chat Info fixture wants. */
 export function makeAppSummary(
   overrides: Partial<AppSummary> = {},
 ): AppSummary {
-  const id = overrides.id ?? "app-1";
-  return {
-    id,
-    name: "Trip Planner",
+  return makeSharedAppSummary({
+    id: "app-1",
     icon: "🧭",
     createdAt: CHAT_INFO_T0,
     updatedAt: CHAT_INFO_T0,
-    version: "1.0.0",
-    contentId: `${id}-content`,
-    origin: "workspace",
     ...overrides,
-  };
+  });
 }
 
 /** A daemon document summary with every field defaulted, `overrides` on top. */
@@ -70,7 +79,7 @@ export function makeDocumentSummary(
  * attachment's own id, which is what the hook uses for anything but a legacy
  * `rehydrated:N` row.
  */
-export function makeAttachmentEntry(
+function makeAttachmentEntry(
   attachment: DisplayAttachment,
   overrides: Partial<Omit<ConversationAttachmentEntry, "attachment">> = {},
 ): ConversationAttachmentEntry {
@@ -105,6 +114,30 @@ export function makeFrameAsset(
     [],
     [makeAttachmentEntry(attachment, { sightFrame: true, capturedAt })],
   ).frames[0]!;
+}
+
+/** One transcript row, carrying only the fields a Chat Info fixture sets. */
+export function makeTranscriptRow(
+  overrides: Partial<DisplayMessage> = {},
+): DisplayMessage {
+  return { id: "msg-1", role: "user", ...overrides };
+}
+
+/**
+ * One row per attachment, oldest first from {@link CHAT_INFO_T0}. This is the
+ * source `useConversationAttachments` walks, so the panel lists exactly these
+ * files, newest first.
+ */
+export function attachmentRows(
+  attachments: DisplayAttachment[],
+): DisplayMessage[] {
+  return attachments.map((attachment, index) =>
+    makeTranscriptRow({
+      id: `msg-${index + 1}`,
+      timestamp: CHAT_INFO_T0 + index * 1_000,
+      attachments: [attachment],
+    }),
+  );
 }
 
 /**
@@ -163,6 +196,39 @@ export function installChatInfoDomStubs(): void {
   }
   globalThis.IntersectionObserver =
     ImmediateIntersectionObserver as unknown as typeof IntersectionObserver;
+}
+
+/**
+ * The `@/utils/app-html-cache` module body a suite installs, so an app tile's
+ * live preview settles instead of calling the daemon's open endpoint.
+ */
+export function chatInfoAppHtmlCacheMock(): Partial<typeof appHtmlCache> {
+  return {
+    ...appHtmlCache,
+    getCachedAppHtml: async () => "<!doctype html><title>App</title>",
+  };
+}
+
+/**
+ * The `@/hooks/use-element-size` module body a suite installs: happy-dom
+ * reports a zero box for everything, so the row's width is read from here.
+ */
+export function makeElementSizeMock(
+  readWidth: () => number,
+): Partial<typeof ElementSizeModule> {
+  return {
+    useElementSize: () => ({ ref: () => {}, size: { w: readWidth(), h: 0 } }),
+  };
+}
+
+/** The `@/hooks/use-is-mobile` module body a suite installs. */
+export function makeIsMobileMock(
+  readIsMobile: () => boolean,
+): Partial<typeof IsMobileModule> {
+  return {
+    useIsMobile: () => readIsMobile(),
+    MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+  };
 }
 
 /**
@@ -243,15 +309,15 @@ export function seedTranscriptMessages(
   conversationId: string,
   messages: DisplayMessage[],
 ): void {
-  useChatSessionStore.setState({
-    snapshot: {
-      messages,
-      hasMore: false,
-      oldestTimestamp: null,
-      oldestMessageId: null,
-      seq: 1,
-    },
-    optimisticSends: [],
+  // A seeded transcript has nothing in flight; the seed itself only prunes
+  // the sends its messages confirm.
+  useChatSessionStore.setState({ optimisticSends: [] });
+  useChatSessionStore.getState().seedSnapshot(conversationId, {
+    messages,
+    hasMore: false,
+    oldestTimestamp: null,
+    oldestMessageId: null,
+    seq: 1,
   });
   seedTranscriptOwner(assistantId, conversationId);
 }


### PR DESCRIPTION
## Summary
- the story fixtures seed queries and the transcript through the test helper instead of re-implementing it; the helper's makeAppSummary wraps the shared app-summary builder
- sibling stories use makeChatInfoQueryClient and the fixtures' app seeds; mock bodies, frame widths, and transcript-row builders live in the helper

Part of plan: chat-info-assets-panel.md (remediation round 5)