### PR TITLE
feat(acp): resolve and apply the session model at spawn, persist it, and pin it on resume

### DIFF
--- a/assistant/src/acp/__tests__/helpers/acp-model-option.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-model-option.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared test fixture: the `SessionConfigOption` an adapter advertises for
+ * model selection, shaped the way claude-agent-acp reports one (a `select`
+ * with id and category `model`).
+ */
+
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+
+/** A model selector currently sitting on `currentValue`. */
+export function modelOption(currentValue: string): SessionConfigOption {
+  return {
+    type: "select",
+    id: "model",
+    name: "Model",
+    category: "model",
+    currentValue,
+    options: [
+      { value: "sonnet", name: "Sonnet" },
+      { value: "opus", name: "Opus", description: "Most capable" },
+    ],
+  };
+}
+
+/** `modelOption`'s options as `deriveModelInfo` flattens them. */
+export const MODEL_OPTION_MODELS = [
+  { value: "sonnet", label: "Sonnet" },
+  { value: "opus", label: "Opus", description: "Most capable" },
+];

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -37,6 +37,7 @@ function buildSessionWithFakeProcess(opts: {
   task?: string;
   parentToolUseId?: string;
   latestUsage?: AcpUsageSnapshot;
+  model?: string;
 }): {
   manager: AcpSessionManager;
   resolvePrompt: (v: {
@@ -113,6 +114,7 @@ function buildSessionWithFakeProcess(opts: {
       task: opts.task,
       parentToolUseId: opts.parentToolUseId,
       latestUsage: opts.latestUsage,
+      model: opts.model,
     },
     clientHandler,
     sendToVellum: wrappedSend,
@@ -464,6 +466,27 @@ describe("AcpSessionManager — terminal persistence", () => {
     expect(row!.cost_currency).toBeNull();
     expect(row!.input_tokens).toBeNull();
     expect(row!.output_tokens).toBeNull();
+    // Nothing pinned a model, so the column stays empty.
+    expect(row!.model).toBeNull();
+  });
+
+  test("persists the model the session ran on", async () => {
+    const id = "session-model-1";
+    const handles = buildSessionWithFakeProcess({
+      id,
+      agentId: "agent-model",
+      protocolSessionId: "proto-model",
+      parentConversationId: "conv-model",
+      model: "claude-opus-4-5",
+    });
+
+    handles.resolvePrompt({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const row = readHistoryRow(id);
+    expect(row).not.toBeNull();
+    expect(row!.model).toBe("claude-opus-4-5");
   });
 
   test("emits acp_session_usage and persists input/output tokens from PromptResponse.usage", async () => {

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -12,6 +12,10 @@
 import { tmpdir } from "node:os";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+
+import { modelOption } from "./helpers/acp-model-option.js";
+
 // ---------------------------------------------------------------------------
 // Fake AcpAgentProcess with scriptable capabilities and history replay.
 // ---------------------------------------------------------------------------
@@ -31,6 +35,14 @@ let promptThrowsSync = false;
  * the resume has not yet settled.
  */
 let resumeSessionGate: Promise<void> | null = null;
+/** Config options session/resume and session/load report back. */
+let resumeConfigOptions: SessionConfigOption[] = [];
+/** Every `setConfigOption` the manager dispatched during a resume. */
+const setConfigOptionCalls: Array<{
+  sessionId: string;
+  configId: string;
+  value: string | boolean;
+}> = [];
 const fakeInstances: FakeAcpAgentProcess[] = [];
 
 class FakeAcpAgentProcess {
@@ -69,32 +81,44 @@ class FakeAcpAgentProcess {
 
   async createSession(
     _cwd: string,
-  ): Promise<{ sessionId: string; configOptions: [] }> {
+  ): Promise<{ sessionId: string; configOptions: SessionConfigOption[] }> {
     return { sessionId: "proto-new", configOptions: [] };
   }
 
   async loadSession(
     sessionId: string,
     cwd: string,
-  ): Promise<{ configOptions: [] }> {
+  ): Promise<{ configOptions: SessionConfigOption[] }> {
     this.loadSessionCalls.push({ sessionId, cwd });
     // Replay history through the client handler before resolving, exactly
     // as a real agent does per the ACP spec for session/load.
     for (const text of replayChunks) {
       await this.emitChunk(text);
     }
-    return { configOptions: [] };
+    return { configOptions: resumeConfigOptions };
   }
 
   async resumeSession(
     sessionId: string,
     cwd: string,
-  ): Promise<{ configOptions: [] }> {
+  ): Promise<{ configOptions: SessionConfigOption[] }> {
     if (resumeSessionGate) {
       await resumeSessionGate;
     }
     this.resumeSessionCalls.push({ sessionId, cwd });
-    return { configOptions: [] };
+    return { configOptions: resumeConfigOptions };
+  }
+
+  /** Answers the way an adapter does: the selector now sits on `value`. */
+  async setConfigOption(
+    sessionId: string,
+    configId: string,
+    value: string | boolean,
+  ): Promise<SessionConfigOption[]> {
+    setConfigOptionCalls.push({ sessionId, configId, value });
+    return typeof value === "string"
+      ? [modelOption(value)]
+      : resumeConfigOptions;
   }
 
   /** Drives an agent_message_chunk through the real client handler. */
@@ -219,6 +243,7 @@ const BUN_ADD_KEY = `${BUN_BIN} add`;
 
 import type { AcpSessionUpdateEvent } from "../../api/events/acp-session-update.js";
 import type { AssistantEvent } from "../../api/index.js";
+import { getAcpConversationModelPreference } from "../../persistence/acp-model-preference.js";
 import { getSqlite } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import type { AcpSessionState } from "../types.js";
@@ -274,6 +299,8 @@ beforeEach(() => {
   prepareAgentEnvGate = null;
   prepareAgentEnvCommands = [];
   resumeSessionGate = null;
+  resumeConfigOptions = [];
+  setConfigOptionCalls.length = 0;
   resolveImpl = () => ({
     ok: true,
     agent: { command: "claude-agent-acp", args: [] },
@@ -719,6 +746,58 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(row.context_size).toBe(200_000);
     expect(row.cost_amount).toBe(0.05);
     expect(row.cost_currency).toBe("USD");
+  });
+
+  test("re-terminate after a resume keeps the recorded model when the adapter reports no selector", async () => {
+    fakeCaps.resume = true;
+    insertHistoryRow({
+      id: "resume-model-1",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+      model: "claude-opus-4-5",
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-model-1", () => {});
+
+    // Seeded from the row, so the terminal upsert rewrites it instead of
+    // NULLing a column the resumed run never touched.
+    expect((manager.getStatus("resume-model-1") as AcpSessionState).model).toBe(
+      "claude-opus-4-5",
+    );
+    expect(setConfigOptionCalls).toEqual([]);
+
+    await manager.steer("resume-model-1", "keep going");
+    fakeInstances[0]!.resolvePrompt!({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readHistoryRow("resume-model-1")!.model).toBe("claude-opus-4-5");
+  });
+
+  test("resume puts the fresh adapter process back on the recorded model", async () => {
+    fakeCaps.resume = true;
+    // A new adapter process starts on its own default, not the model the
+    // original run was pinned to.
+    resumeConfigOptions = [modelOption("default")];
+    insertHistoryRow({ id: "resume-model-2", model: "opus" });
+
+    const manager = new AcpSessionManager(4);
+    const sent: AssistantEvent[] = [];
+    await manager.resumeFromHistory("resume-model-2", (msg) => sent.push(msg));
+
+    expect(setConfigOptionCalls).toEqual([
+      { sessionId: "proto-old", configId: "model", value: "opus" },
+    ]);
+    const state = manager.getStatus("resume-model-2") as AcpSessionState;
+    expect(state.model).toBe("opus");
+    expect(sent.map((m) => m.type)).toEqual([
+      "acp_session_spawned",
+      "acp_session_model_update",
+    ]);
+    // Resuming is not choosing: the conversation preference is untouched.
+    expect(
+      getAcpConversationModelPreference("conv-1", "claude"),
+    ).toBeUndefined();
   });
 
   test("concurrent resumes of the same id: one wins, the loser fails cleanly without leaking a process", async () => {

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -1,19 +1,43 @@
 /**
  * Regression tests for AcpSessionManager state population — specifically
  * that `parentConversationId` is set on every session state at spawn time
- * and is therefore visible through `getStatus()` from t=0.
+ * and is therefore visible through `getStatus()` from t=0, plus the model a
+ * spawn resolves, applies through the adapter, and publishes.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 
+import type { AssistantEvent } from "../../api/index.js";
+import {
+  getAcpConversationModelPreference,
+  upsertAcpConversationModelPreference,
+} from "../../persistence/acp-model-preference.js";
+import { getSqlite } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
 import type { VellumAcpClientHandler } from "../client-handler.js";
 import type { AcpSessionState } from "../types.js";
+import { installAcpConfigStub } from "./helpers/acp-config-stub.js";
+import {
+  MODEL_OPTION_MODELS,
+  modelOption,
+} from "./helpers/acp-model-option.js";
 
 // Records every `cancel(protocolSessionId)` the manager dispatches to a fake
 // process, so tests can assert which sessions were cancelled.
 const cancelCalls: string[] = [];
+
+/** Config options each `createSession` reports, one entry per call. */
+let scriptedConfigOptions: SessionConfigOption[][] = [];
+/** Every `setConfigOption` the manager dispatched to a fake process. */
+const setConfigOptionCalls: Array<{
+  sessionId: string;
+  configId: string;
+  value: string | boolean;
+}> = [];
+/** What `setConfigOption` answers with; an Error is thrown instead. */
+let setConfigOptionResult: SessionConfigOption[] | Error = [];
 
 // Stub the agent-process module so spawn() does not actually launch a child
 // process. Each fake instance records the cwd it was spawned in and resolves
@@ -31,8 +55,22 @@ mock.module("../agent-process.js", () => ({
     async initialize(): Promise<void> {}
     async createSession(
       _cwd: string,
-    ): Promise<{ sessionId: string; configOptions: [] }> {
-      return { sessionId: `proto-${this.agentId}`, configOptions: [] };
+    ): Promise<{ sessionId: string; configOptions: SessionConfigOption[] }> {
+      return {
+        sessionId: `proto-${this.agentId}`,
+        configOptions: scriptedConfigOptions.shift() ?? [],
+      };
+    }
+    async setConfigOption(
+      sessionId: string,
+      configId: string,
+      value: string | boolean,
+    ): Promise<SessionConfigOption[]> {
+      setConfigOptionCalls.push({ sessionId, configId, value });
+      if (setConfigOptionResult instanceof Error) {
+        throw setConfigOptionResult;
+      }
+      return setConfigOptionResult;
     }
     async prompt(): Promise<{ stopReason: string }> {
       // Never resolves — keeps the session alive in `running` state for
@@ -56,7 +94,19 @@ mock.module("../agent-process.js", () => ({
   },
 }));
 
+// Installed before the manager is imported so its `getConfig` call resolves
+// through the stub, which is what drives the global-default rung.
+const config = await installAcpConfigStub();
 const { AcpSessionManager } = await import("../session-manager.js");
+await initializeDb();
+
+beforeEach(() => {
+  scriptedConfigOptions = [];
+  setConfigOptionCalls.length = 0;
+  setConfigOptionResult = [];
+  config.setConfig({});
+  getSqlite().run("DELETE FROM acp_conversation_model_preference");
+});
 
 describe("AcpSessionManager — parentConversationId population", () => {
   const noopSend = () => {};
@@ -171,17 +221,7 @@ describe("AcpSessionManager — cancelForParent", () => {
 describe("AcpSessionManager config option updates", () => {
   const noopSend = () => {};
 
-  const MODEL_OPTION: SessionConfigOption = {
-    type: "select",
-    id: "model",
-    name: "Model",
-    category: "model",
-    currentValue: "opus",
-    options: [
-      { value: "sonnet", name: "Sonnet" },
-      { value: "opus", name: "Opus" },
-    ],
-  };
+  const MODEL_OPTION = modelOption("opus");
 
   test("a config_option_update notification refreshes the process cache", async () => {
     const manager = new AcpSessionManager(5);
@@ -216,5 +256,213 @@ describe("AcpSessionManager config option updates", () => {
     });
 
     expect(entry?.process.appliedConfigOptions).toEqual([[MODEL_OPTION]]);
+  });
+});
+
+describe("AcpSessionManager: model selection at spawn", () => {
+  /**
+   * Spawns one session with the ladder rungs the case cares about set, and
+   * returns the events it emitted alongside the resulting state.
+   */
+  async function spawnWithModel(opts: {
+    conversationId: string;
+    agentId?: string;
+    agentModel?: string;
+    requestedModel?: string;
+  }): Promise<{ state: AcpSessionState; sent: AssistantEvent[] }> {
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const { acpSessionId } = await manager.spawn(
+      opts.agentId ?? "agent-model",
+      { command: "echo", args: ["hi"], model: opts.agentModel },
+      "task",
+      "/tmp",
+      opts.conversationId,
+      (msg) => sent.push(msg),
+      opts.requestedModel ? { model: opts.requestedModel } : {},
+    );
+    return {
+      state: manager.getStatus(acpSessionId) as AcpSessionState,
+      sent,
+    };
+  }
+
+  /** The model value the adapter was asked to select, if it was asked. */
+  function selectedValue(): string | boolean | undefined {
+    return setConfigOptionCalls[0]?.value;
+  }
+
+  test("state carries the model and options the adapter reported", async () => {
+    scriptedConfigOptions = [[modelOption("opus")]];
+
+    const { state } = await spawnWithModel({ conversationId: "conv-report" });
+
+    expect(state.model).toBe("opus");
+    expect(state.availableModels).toEqual(MODEL_OPTION_MODELS);
+    // Nothing was requested and the adapter is already on a model, so it was
+    // never asked to change.
+    expect(setConfigOptionCalls).toEqual([]);
+  });
+
+  test("the model event follows the spawned event", async () => {
+    scriptedConfigOptions = [[modelOption("opus")]];
+
+    const { sent } = await spawnWithModel({ conversationId: "conv-event" });
+
+    expect(sent.map((e) => e.type)).toEqual([
+      "acp_session_spawned",
+      "acp_session_model_update",
+    ]);
+    expect(sent[1]).toMatchObject({
+      model: "opus",
+      availableModels: MODEL_OPTION_MODELS,
+    });
+  });
+
+  test("an adapter with no model selector publishes nothing and stays unset", async () => {
+    const { state, sent } = await spawnWithModel({
+      conversationId: "conv-no-selector",
+      requestedModel: "opus",
+    });
+
+    expect(state.model).toBeUndefined();
+    expect(state.availableModels).toBeUndefined();
+    expect(setConfigOptionCalls).toEqual([]);
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_spawned"]);
+    // A model that cannot be applied is not a failed spawn.
+    expect(state.status).toBe("running");
+  });
+
+  test("an explicit request outranks every other rung", async () => {
+    config.setConfig({ defaultModel: "haiku" });
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-ladder",
+      agentId: "agent-model",
+      model: "sonnet",
+    });
+    scriptedConfigOptions = [[modelOption("default")]];
+
+    await spawnWithModel({
+      conversationId: "conv-ladder",
+      agentModel: "fable",
+      requestedModel: "opus",
+    });
+
+    expect(setConfigOptionCalls).toEqual([
+      { sessionId: "proto-agent-model", configId: "model", value: "opus" },
+    ]);
+  });
+
+  test("the conversation preference outranks the agent and global defaults", async () => {
+    config.setConfig({ defaultModel: "haiku" });
+    upsertAcpConversationModelPreference({
+      parentConversationId: "conv-ladder",
+      agentId: "agent-model",
+      model: "sonnet",
+    });
+    scriptedConfigOptions = [[modelOption("default")]];
+
+    await spawnWithModel({
+      conversationId: "conv-ladder",
+      agentModel: "fable",
+    });
+
+    expect(selectedValue()).toBe("sonnet");
+  });
+
+  test("the agent's own model outranks the global default", async () => {
+    config.setConfig({ defaultModel: "haiku" });
+    scriptedConfigOptions = [[modelOption("default")]];
+
+    await spawnWithModel({
+      conversationId: "conv-ladder",
+      agentModel: "fable",
+    });
+
+    expect(selectedValue()).toBe("fable");
+  });
+
+  test("the global default applies when nothing more specific is set", async () => {
+    config.setConfig({ defaultModel: "haiku" });
+    scriptedConfigOptions = [[modelOption("default")]];
+
+    await spawnWithModel({ conversationId: "conv-ladder" });
+
+    expect(selectedValue()).toBe("haiku");
+  });
+
+  test("a spawn with no rung set leaves the adapter on its own model", async () => {
+    scriptedConfigOptions = [[modelOption("default")]];
+
+    const { state } = await spawnWithModel({ conversationId: "conv-ladder" });
+
+    expect(setConfigOptionCalls).toEqual([]);
+    expect(state.model).toBe("default");
+    expect(
+      getAcpConversationModelPreference("conv-ladder", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("an explicit request is remembered as the value the adapter confirmed", async () => {
+    scriptedConfigOptions = [[modelOption("default")]];
+    // The adapter resolves the alias it was handed to a full model id.
+    setConfigOptionResult = [modelOption("claude-opus-4-5")];
+
+    const { state } = await spawnWithModel({
+      conversationId: "conv-remember",
+      requestedModel: "opus",
+    });
+
+    expect(state.model).toBe("claude-opus-4-5");
+    expect(
+      getAcpConversationModelPreference("conv-remember", "agent-model"),
+    ).toBe("claude-opus-4-5");
+  });
+
+  test("an inherited model is applied but never becomes the conversation's choice", async () => {
+    config.setConfig({ defaultModel: "sonnet" });
+    scriptedConfigOptions = [[modelOption("default")]];
+    setConfigOptionResult = [modelOption("sonnet")];
+
+    const { state } = await spawnWithModel({ conversationId: "conv-inherit" });
+
+    expect(state.model).toBe("sonnet");
+    expect(
+      getAcpConversationModelPreference("conv-inherit", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("a refused model warns, runs unpinned, and records no preference", async () => {
+    scriptedConfigOptions = [[modelOption("opus")]];
+    setConfigOptionResult = new Error(
+      "Invalid value for config option model: nope",
+    );
+
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const result = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-refused",
+      (msg) => sent.push(msg),
+      { model: "nope" },
+    );
+
+    expect(result.modelWarning).toBe(
+      "Invalid value for config option model: nope",
+    );
+    const state = manager.getStatus(result.acpSessionId) as AcpSessionState;
+    // The run is live on whatever the adapter chose for itself.
+    expect(state.status).toBe("running");
+    expect(state.model).toBe("opus");
+    expect(
+      getAcpConversationModelPreference("conv-refused", "agent-model"),
+    ).toBeUndefined();
+    expect(sent.map((e) => e.type)).toEqual([
+      "acp_session_spawned",
+      "acp_session_model_update",
+    ]);
   });
 });

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -6,12 +6,18 @@
 import { randomUUID } from "node:crypto";
 import { basename } from "node:path";
 
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { eq, inArray } from "drizzle-orm";
 
 import type { AcpSessionUpdateEvent } from "../api/events/acp-session-update.js";
 import type { AssistantEvent } from "../api/index.js";
+import { getConfig } from "../config/loader.js";
 import { findConversation } from "../daemon/conversation-registry.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import {
+  getAcpConversationModelPreference,
+  upsertAcpConversationModelPreference,
+} from "../persistence/acp-model-preference.js";
 import { getDb } from "../persistence/db-connection.js";
 import { acpSessionHistory } from "../persistence/schema/index.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
@@ -32,6 +38,11 @@ import {
 import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { deriveFailureError } from "./failure-error.js";
+import {
+  type AcpModelInfo,
+  deriveModelInfo,
+  resolveAcpModel,
+} from "./model-config.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
 import { formatResolveFailure } from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
@@ -61,6 +72,46 @@ function claudeAuthRequiredCode(
     isClaudeAuthFailureMessage(failureMessage)
     ? ACP_CLAUDE_AUTH_REQUIRED_CODE
     : undefined;
+}
+
+/**
+ * The model this conversation last chose for this agent, if any. Best-effort:
+ * a lookup that fails leaves the run to the next rung of the ladder rather
+ * than sinking the spawn.
+ */
+function readConversationModelPreference(
+  parentConversationId: string,
+  agentId: string,
+): string | undefined {
+  try {
+    return getAcpConversationModelPreference(parentConversationId, agentId);
+  } catch (err) {
+    log.warn(
+      { parentConversationId, agentId, err },
+      "Failed to read the ACP conversation model preference",
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Remembers an explicit model choice for this conversation. Best-effort: the
+ * session is already running on the model, so a failed write costs only the
+ * inheritance the next run would have had.
+ */
+function rememberConversationModelPreference(preference: {
+  parentConversationId: string;
+  agentId: string;
+  model: string;
+}): void {
+  try {
+    upsertAcpConversationModelPreference(preference);
+  } catch (err) {
+    log.warn(
+      { ...preference, err },
+      "Failed to record the ACP conversation model preference",
+    );
+  }
 }
 
 /**
@@ -124,6 +175,10 @@ interface SessionEntry {
    *  rather than needing a sweep to retire it. Absent for agents that use no
    *  Claude credential. */
   credentialDigest?: string;
+  /** Config id of the adapter's model selector, absent when it advertises
+   *  none. Both the id to write a model back through and the flag that says
+   *  this session has a model to publish at all. */
+  modelConfigId?: string;
 }
 
 /**
@@ -231,6 +286,10 @@ export class AcpSessionManager {
    *
    * The prompt is fired in the background — results stream via sessionUpdate
    * callbacks and completion/error messages are sent when the prompt finishes.
+   *
+   * `modelWarning` comes back when the adapter refused the model the session
+   * was asked for: the run is live on the adapter's own default, and the
+   * caller relays the reason rather than treating the spawn as failed.
    */
   async spawn(
     agentId: string,
@@ -239,8 +298,12 @@ export class AcpSessionManager {
     cwd: string,
     parentConversationId: string,
     sendToVellum: (msg: AssistantEvent) => void,
-    parentToolUseId?: string,
-  ): Promise<{ acpSessionId: string; protocolSessionId: string }> {
+    options?: { parentToolUseId?: string; model?: string },
+  ): Promise<{
+    acpSessionId: string;
+    protocolSessionId: string;
+    modelWarning?: string;
+  }> {
     this.assertCapacity();
 
     const acpSessionId = randomUUID();
@@ -263,11 +326,24 @@ export class AcpSessionManager {
       cwd,
       startedAt: Date.now(),
       sendToVellum,
-      parentToolUseId,
+      parentToolUseId: options?.parentToolUseId,
       task,
     });
     const { process: agentProcess, state } = entry;
 
+    // Resolved before the adapter is asked for anything, so the ladder is
+    // walked once against the config and conversation the spawn was made in.
+    const resolvedModel = resolveAcpModel({
+      requestedModel: options?.model,
+      conversationPreference: readConversationModelPreference(
+        parentConversationId,
+        agentId,
+      ),
+      agentModel: agentConfig.model,
+      defaultModel: getConfig().acp.defaultModel,
+    });
+
+    let configOptions: SessionConfigOption[] = [];
     try {
       log.info({ acpSessionId, agentId }, "ACP spawning child process");
       agentProcess.spawn(cwd);
@@ -277,8 +353,9 @@ export class AcpSessionManager {
       );
       await agentProcess.initialize();
       log.info({ acpSessionId, agentId }, "ACP creating session");
-      const { sessionId: acpProtocolSessionId } =
-        await agentProcess.createSession(cwd);
+      const created = await agentProcess.createSession(cwd);
+      const acpProtocolSessionId = created.sessionId;
+      configOptions = created.configOptions;
       state.acpSessionId = acpProtocolSessionId;
       state.status = "running";
       log.info(
@@ -300,7 +377,26 @@ export class AcpSessionManager {
       throw err;
     }
 
+    const modelWarning = await this.pinSessionModel(
+      entry,
+      configOptions,
+      resolvedModel,
+    );
+
+    // Only an explicit request becomes the conversation's preference, and only
+    // once the session is confirmed to be on it. Inherited rungs are already
+    // recorded where they came from, and re-recording them here would freeze a
+    // config default into the conversation.
+    if (options?.model && !modelWarning && state.model) {
+      rememberConversationModelPreference({
+        parentConversationId,
+        agentId,
+        model: state.model,
+      });
+    }
+
     this.sendSpawnedEvent(acpSessionId, entry);
+    this.sendModelEvent(acpSessionId, entry);
 
     // Fire prompt in the background — don't await
     entry.currentPrompt = this.firePromptInBackground(
@@ -310,7 +406,75 @@ export class AcpSessionManager {
       task,
     );
 
-    return { acpSessionId, protocolSessionId: state.acpSessionId };
+    return {
+      acpSessionId,
+      protocolSessionId: state.acpSessionId,
+      ...(modelWarning ? { modelWarning } : {}),
+    };
+  }
+
+  /**
+   * Records what the adapter says about the session's model. `modelConfigId`
+   * doubles as the "this adapter has a model selector" flag, so state is left
+   * untouched when there is none: a resumed session keeps the model its
+   * history row recorded instead of having it wiped by an adapter that never
+   * reports one.
+   */
+  private applyModelInfo(
+    entry: SessionEntry,
+    configOptions: SessionConfigOption[],
+  ): AcpModelInfo {
+    const info = deriveModelInfo(configOptions);
+    entry.modelConfigId = info.modelConfigId;
+    if (info.modelConfigId) {
+      entry.state.model = info.model;
+      entry.state.availableModels = info.availableModels;
+    }
+    return info;
+  }
+
+  /**
+   * Puts a session on `resolvedModel` and records what the adapter reports
+   * back. The value crosses the wire unvalidated: the adapter's own resolver
+   * accepts aliases and full ids and rejects everything else, and duplicating
+   * that judgement here would refuse values it would have taken. A refusal
+   * leaves the run on the adapter's default and comes back as the message to
+   * relay, because a session that is live and working is worth more than one
+   * that never started over a model name.
+   */
+  private async pinSessionModel(
+    entry: SessionEntry,
+    configOptions: SessionConfigOption[],
+    resolvedModel: string | undefined,
+  ): Promise<string | undefined> {
+    const { state, process: agentProcess } = entry;
+    const info = this.applyModelInfo(entry, configOptions);
+    if (!resolvedModel || resolvedModel === info.model) {
+      return undefined;
+    }
+    if (!info.modelConfigId) {
+      log.info(
+        { acpSessionId: state.id, agentId: state.agentId, resolvedModel },
+        "ACP agent advertises no model selector; running on its own model",
+      );
+      return undefined;
+    }
+
+    try {
+      const refreshed = await agentProcess.setConfigOption(
+        state.acpSessionId,
+        info.modelConfigId,
+        resolvedModel,
+      );
+      this.applyModelInfo(entry, refreshed);
+      return undefined;
+    } catch (err) {
+      log.warn(
+        { acpSessionId: state.id, agentId: state.agentId, resolvedModel, err },
+        "ACP agent refused the requested model; running on its own model",
+      );
+      return err instanceof Error ? err.message : String(err);
+    }
   }
 
   /**
@@ -420,6 +584,24 @@ export class AcpSessionManager {
       parentConversationId: entry.parentConversationId,
       parentToolUseId: entry.parentToolUseId,
       task: entry.task,
+    });
+  }
+
+  /**
+   * Publishes the session's model selection. Silent for adapters with no
+   * model selector: the client renders nothing rather than an empty picker.
+   * A separate frame from `acp_session_spawned`, which carries a fixed subset
+   * older clients parse.
+   */
+  private sendModelEvent(acpSessionId: string, entry: SessionEntry): void {
+    if (!entry.modelConfigId) {
+      return;
+    }
+    entry.sendToVellum({
+      type: "acp_session_model_update",
+      acpSessionId,
+      model: entry.state.model,
+      availableModels: entry.state.availableModels ?? [],
     });
   }
 
@@ -560,6 +742,11 @@ export class AcpSessionManager {
     );
     const { process: agentProcess, state } = entry;
 
+    // The terminal upsert rewrites every column, so a model left unseeded
+    // would be NULLed by a resumed run that never touched one. It is also
+    // what the pin after reattach puts the fresh adapter process back on.
+    state.model = row.model ?? undefined;
+
     // Seed the latest usage snapshot from the persisted columns. A fresh
     // usage_update during the resumed run overwrites this; if none fires the
     // prior snapshot is re-persisted on terminal transition. Pre-migration
@@ -602,6 +789,7 @@ export class AcpSessionManager {
     // Seed before the child process spawns so no live update can fire first.
     entry.clientHandler.seedSeq(maxSeq);
 
+    let configOptions: SessionConfigOption[] = [];
     try {
       log.info(
         { acpSessionId, agentId: row.agentId },
@@ -611,14 +799,20 @@ export class AcpSessionManager {
       await agentProcess.initialize();
       if (agentProcess.supportsSessionResume) {
         // session/resume reattaches without replaying history.
-        await agentProcess.resumeSession(row.acpSessionId, row.cwd);
+        ({ configOptions } = await agentProcess.resumeSession(
+          row.acpSessionId,
+          row.cwd,
+        ));
       } else if (agentProcess.supportsLoadSession) {
         // session/load replays the full history as session/update
         // notifications before resolving; suppress forwarding so the
         // conversation and ring buffer don't receive duplicates.
         entry.clientHandler.beginReplaySuppression();
         try {
-          await agentProcess.loadSession(row.acpSessionId, row.cwd);
+          ({ configOptions } = await agentProcess.loadSession(
+            row.acpSessionId,
+            row.cwd,
+          ));
         } finally {
           entry.clientHandler.endReplaySuppression();
         }
@@ -647,7 +841,13 @@ export class AcpSessionManager {
       throw err;
     }
 
+    // A fresh adapter process starts on its own default, so the run the user
+    // resumes is put back on the model its history row recorded. No preference
+    // is written: resuming is not choosing.
+    await this.pinSessionModel(entry, configOptions, row.model ?? undefined);
+
     this.sendSpawnedEvent(acpSessionId, entry);
+    this.sendModelEvent(acpSessionId, entry);
   }
 
   /**
@@ -1000,6 +1200,7 @@ export class AcpSessionManager {
       parentToolUseId: entry.state.parentToolUseId ?? null,
       authErrorCode: entry.state.authErrorCode ?? null,
       authErrorCredential: entry.state.authErrorCredential ?? null,
+      model: entry.state.model ?? null,
       usedTokens: usage?.usedTokens ?? null,
       contextSize: usage?.contextSize ?? null,
       costAmount: usage?.costAmount ?? null,

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -4,6 +4,8 @@
 
 import type { StopReason } from "@agentclientprotocol/sdk";
 
+import type { AcpModelOption } from "./model-config.js";
+
 /**
  * Configuration for a single ACP agent process.
  */
@@ -12,6 +14,12 @@ export interface AcpAgentConfig {
   args: string[];
   description?: string;
   env?: Record<string, string>;
+  /**
+   * Model this agent's sessions start on, from `acp.agents.<id>.model`. An
+   * adapter-reported alias, outranked only by an explicit request and the
+   * conversation's own preference.
+   */
+  model?: string;
   /**
    * Identity of the Claude token `prepareAgentEnv` resolved into `env`,
    * whichever source it came from. Recorded on the history row when Claude
@@ -51,6 +59,14 @@ export interface AcpSessionState {
   authErrorCredential?: string;
   /** Latest context-window usage gauge, from the most recent `usage_update`. */
   latestUsage?: AcpUsageSnapshot;
+  /**
+   * Model the session is running on, as the adapter reports it. Absent while
+   * the adapter advertises no model selector, which is how the feature stays
+   * invisible for agents that cannot switch models.
+   */
+  model?: string;
+  /** Models this session can switch to, flattened from the adapter's selector. */
+  availableModels?: AcpModelOption[];
 }
 
 /** Context-window usage snapshot tracked from ACP `usage_update`. */

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -269,6 +269,7 @@ async function spawnSession({ body, abortSignal }: RouteHandlerArgs) {
     cwd,
     conversationId,
     broadcastMessage,
+    {},
   );
 
   log.info({ acpSessionId, protocolSessionId, agent }, "ACP spawn succeeded");

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -124,7 +124,7 @@ const spawnMock = mock(
     _cwd: string,
     _parentConversationId: string,
     _sendToVellum: (msg: unknown) => void,
-    _parentToolUseId?: string,
+    _options?: { parentToolUseId?: string; model?: string },
   ) => ({
     acpSessionId: "acp-session-test",
     protocolSessionId: "proto-session-test",
@@ -223,8 +223,10 @@ describe("executeAcpSpawn - happy path", () => {
 
     expect(result.isError).toBe(false);
     expect(spawnMock).toHaveBeenCalledTimes(1);
-    // parentToolUseId is the 7th positional arg to spawn().
-    expect(spawnMock.mock.calls[0][6]).toBe("toolu_abc123");
+    // The options bag is the 7th positional arg to spawn().
+    expect(spawnMock.mock.calls[0][6]).toEqual({
+      parentToolUseId: "toolu_abc123",
+    });
   });
 
   test("default-profile fallback when user config is empty", async () => {

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -126,7 +126,7 @@ export async function executeAcpSpawn(
       cwd,
       context.conversationId,
       sendToClient,
-      context.toolUseId,
+      { parentToolUseId: context.toolUseId },
     );
 
     // Claude Code-only resume hint; empty for other adapters. Keyed off the


### PR DESCRIPTION
## Summary

- `AcpSessionManager.spawn()` resolves a model through the request > conversation preference > agent config > global default ladder and applies it via `session/set_config_option` right after `session/new`; an adapter refusal returns `modelWarning` and leaves the run on the adapter's own model instead of failing the spawn.
- The conversation preference is written only for an explicit request and only with the adapter-confirmed value; `persistTerminal` records the model, and a resume re-seeds it from the history row and pins the fresh adapter process back onto it.
- `acp_session_model_update` is emitted right after `acp_session_spawned`, only when the adapter advertises a model selector, so agents without one are unaffected.

Part of plan: acp-model-control.md (PR 7 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D