### PR TITLE
feat(acp): live model switching and unsolicited config-option updates in the session manager

### DIFF
--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -524,6 +524,13 @@ async function spawnSwitchable(conversationId: string): Promise<{
   return { manager, acpSessionId, sent };
 }
 
+/** Resolves once the manager has dispatched `count` `setConfigOption` calls. */
+async function waitForConfigOptionCalls(count: number): Promise<void> {
+  while (setConfigOptionCalls.length < count) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 describe("AcpSessionManager: live model switching", () => {
   test("applies the model, publishes it, and remembers what the adapter confirmed", async () => {
     const { manager, acpSessionId, sent } = await spawnSwitchable("conv-set");
@@ -653,6 +660,96 @@ describe("AcpSessionManager: live model switching", () => {
       "Invalid value for config option model: opus",
     );
     await expect(next).resolves.toMatchObject({ model: "sonnet" });
+  });
+
+  test("a response that drops the selector clears the model and empties the picker", async () => {
+    const { manager, acpSessionId, sent } = await spawnSwitchable(
+      "conv-switch-dropped",
+    );
+    setConfigOptionResult = [
+      {
+        type: "select",
+        id: "mode",
+        name: "Mode",
+        currentValue: "default",
+        options: [{ value: "default", name: "Default" }],
+      },
+    ];
+
+    const state = await manager.setModel(acpSessionId, "opus");
+
+    expect(state.model).toBeUndefined();
+    expect(state.availableModels).toEqual([]);
+    expect(sent).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId,
+        availableModels: [],
+      },
+    ]);
+    expect(
+      getAcpConversationModelPreference("conv-switch-dropped", "agent-model"),
+    ).toBeUndefined();
+    await expect(manager.setModel(acpSessionId, "opus")).rejects.toBeInstanceOf(
+      AcpModelSelectionUnsupportedError,
+    );
+  });
+
+  test("a response landing after the session closed changes nothing", async () => {
+    const { manager, acpSessionId, sent } = await spawnSwitchable("conv-late");
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    setConfigOptionResponder = async (value) => {
+      await held;
+      return [modelOption(String(value))];
+    };
+
+    const switched = manager.setModel(acpSessionId, "opus");
+    await waitForConfigOptionCalls(1);
+    manager.close(acpSessionId);
+    release();
+
+    await expect(switched).rejects.toBeInstanceOf(AcpSessionNotFoundError);
+    expect(state.model).toBe("sonnet");
+    expect(sent).toEqual([]);
+    expect(
+      getAcpConversationModelPreference("conv-late", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("a switch queued behind a slow one never reaches a closed session", async () => {
+    const { manager, acpSessionId } = await spawnSwitchable("conv-late-queued");
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    setConfigOptionResponder = async (value) => {
+      await held;
+      return [modelOption(String(value))];
+    };
+
+    // Settled up front: the queued switch rejects while the first one is
+    // still being awaited, and an unhandled rejection would fail the test.
+    const settled = Promise.allSettled([
+      manager.setModel(acpSessionId, "opus"),
+      manager.setModel(acpSessionId, "sonnet"),
+    ]);
+    await waitForConfigOptionCalls(1);
+    manager.close(acpSessionId);
+    release();
+
+    const outcomes = await settled;
+    for (const outcome of outcomes) {
+      expect(outcome.status).toBe("rejected");
+      expect((outcome as PromiseRejectedResult).reason).toBeInstanceOf(
+        AcpSessionNotFoundError,
+      );
+    }
+    // The queued switch never reached the adapter.
+    expect(setConfigOptionCalls.map((call) => call.value)).toEqual(["opus"]);
   });
 
   test("an adapter refusal surfaces verbatim and leaves the session as it was", async () => {

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -2,7 +2,9 @@
  * Regression tests for AcpSessionManager state population — specifically
  * that `parentConversationId` is set on every session state at spawn time
  * and is therefore visible through `getStatus()` from t=0, plus the model a
- * spawn resolves, applies through the adapter, and publishes.
+ * spawn resolves, applies through the adapter, and publishes, the live switch
+ * that changes it mid-session, and the unsolicited updates an adapter sends
+ * when the user changes the model from the transcript.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -97,8 +99,14 @@ mock.module("../agent-process.js", () => ({
 // Installed before the manager is imported so its `getConfig` call resolves
 // through the stub, which is what drives the global-default rung.
 const config = await installAcpConfigStub();
-const { AcpSessionManager } = await import("../session-manager.js");
+const {
+  AcpModelSelectionUnsupportedError,
+  AcpSessionManager,
+  AcpSessionNotFoundError,
+} = await import("../session-manager.js");
 await initializeDb();
+
+type Manager = InstanceType<typeof AcpSessionManager>;
 
 beforeEach(() => {
   scriptedConfigOptions = [];
@@ -464,5 +472,194 @@ describe("AcpSessionManager: model selection at spawn", () => {
       "acp_session_spawned",
       "acp_session_model_update",
     ]);
+  });
+});
+
+/** The client handler the manager wired for a session, to drive updates. */
+function clientHandlerFor(
+  manager: Manager,
+  acpSessionId: string,
+): VellumAcpClientHandler {
+  const entry = (
+    manager as unknown as {
+      sessions: Map<string, { clientHandler: VellumAcpClientHandler }>;
+    }
+  ).sessions.get(acpSessionId);
+  if (!entry) {
+    throw new Error(`No ACP session registered for "${acpSessionId}"`);
+  }
+  return entry.clientHandler;
+}
+
+/**
+ * A running session whose adapter advertises the model selector and sits on
+ * `sonnet`, with the spawn events already drained so a test asserts only what
+ * its own action emitted.
+ */
+async function spawnSwitchable(conversationId: string): Promise<{
+  manager: Manager;
+  acpSessionId: string;
+  sent: AssistantEvent[];
+}> {
+  scriptedConfigOptions = [[modelOption("sonnet")]];
+  const manager = new AcpSessionManager(5);
+  const sent: AssistantEvent[] = [];
+  const { acpSessionId } = await manager.spawn(
+    "agent-model",
+    { command: "echo", args: ["hi"] },
+    "task",
+    "/tmp",
+    conversationId,
+    (msg) => sent.push(msg),
+  );
+  sent.length = 0;
+  return { manager, acpSessionId, sent };
+}
+
+describe("AcpSessionManager: live model switching", () => {
+  test("applies the model, publishes it, and remembers what the adapter confirmed", async () => {
+    const { manager, acpSessionId, sent } = await spawnSwitchable("conv-set");
+    // The adapter resolves the alias it was handed to a full model id.
+    setConfigOptionResult = [modelOption("claude-opus-4-5")];
+
+    const state = await manager.setModel(acpSessionId, "opus");
+
+    expect(setConfigOptionCalls).toEqual([
+      { sessionId: "proto-agent-model", configId: "model", value: "opus" },
+    ]);
+    expect(state.model).toBe("claude-opus-4-5");
+    expect(state.availableModels).toEqual(MODEL_OPTION_MODELS);
+    expect(getAcpConversationModelPreference("conv-set", "agent-model")).toBe(
+      "claude-opus-4-5",
+    );
+    expect(sent).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId,
+        model: "claude-opus-4-5",
+        availableModels: MODEL_OPTION_MODELS,
+      },
+    ]);
+  });
+
+  test("the prompt in flight keeps running", async () => {
+    cancelCalls.length = 0;
+    const { manager, acpSessionId } = await spawnSwitchable("conv-in-flight");
+    setConfigOptionResult = [modelOption("opus")];
+
+    await manager.setModel(acpSessionId, "opus");
+
+    expect(cancelCalls).toEqual([]);
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).status).toBe(
+      "running",
+    );
+  });
+
+  test("an unknown session id is a not-found error", async () => {
+    const manager = new AcpSessionManager(5);
+
+    await expect(
+      manager.setModel("no-such-session", "opus"),
+    ).rejects.toBeInstanceOf(AcpSessionNotFoundError);
+    expect(setConfigOptionCalls).toEqual([]);
+  });
+
+  test("an adapter with no model selector cannot be switched", async () => {
+    const manager = new AcpSessionManager(5);
+    const { acpSessionId } = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-unsupported",
+      () => {},
+    );
+
+    await expect(manager.setModel(acpSessionId, "opus")).rejects.toBeInstanceOf(
+      AcpModelSelectionUnsupportedError,
+    );
+    expect(setConfigOptionCalls).toEqual([]);
+  });
+
+  test("a value the adapter never offered is rejected without a round trip", async () => {
+    const { manager, acpSessionId, sent } =
+      await spawnSwitchable("conv-unknown-value");
+
+    await expect(manager.setModel(acpSessionId, "gpt-5")).rejects.toThrow(
+      'does not offer model "gpt-5"',
+    );
+    expect(setConfigOptionCalls).toEqual([]);
+    expect(sent).toEqual([]);
+    expect(
+      getAcpConversationModelPreference("conv-unknown-value", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("an adapter refusal surfaces verbatim and leaves the session as it was", async () => {
+    const { manager, acpSessionId, sent } =
+      await spawnSwitchable("conv-refuse");
+    setConfigOptionResult = new Error(
+      "Invalid value for config option model: opus",
+    );
+
+    await expect(manager.setModel(acpSessionId, "opus")).rejects.toThrow(
+      "Invalid value for config option model: opus",
+    );
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.status).toBe("running");
+    expect(state.model).toBe("sonnet");
+    expect(sent).toEqual([]);
+    expect(
+      getAcpConversationModelPreference("conv-refuse", "agent-model"),
+    ).toBeUndefined();
+  });
+});
+
+describe("AcpSessionManager: unsolicited model updates", () => {
+  test("a model changed from the transcript updates state, publishes, and is remembered", async () => {
+    const { manager, acpSessionId, sent } = await spawnSwitchable("conv-typed");
+
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("opus")],
+      },
+    });
+
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "opus",
+    );
+    expect(sent).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId,
+        model: "opus",
+        availableModels: MODEL_OPTION_MODELS,
+      },
+    ]);
+    expect(getAcpConversationModelPreference("conv-typed", "agent-model")).toBe(
+      "opus",
+    );
+    // Reporting is not choosing: the adapter is never asked to set it back.
+    expect(setConfigOptionCalls).toEqual([]);
+  });
+
+  test("an update repeating the current model publishes but records no preference", async () => {
+    const { manager, acpSessionId, sent } =
+      await spawnSwitchable("conv-unchanged");
+
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("sonnet")],
+      },
+    });
+
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_model_update"]);
+    expect(
+      getAcpConversationModelPreference("conv-unchanged", "agent-model"),
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -855,4 +855,126 @@ describe("AcpSessionManager: unsolicited model updates", () => {
       getAcpConversationModelPreference("conv-unchanged", "agent-model"),
     ).toBeUndefined();
   });
+
+  test("an update landing while the spawn pin is in flight records no preference", async () => {
+    config.setConfig({ defaultModel: "sonnet" });
+    scriptedConfigOptions = [[modelOption("default")]];
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    setConfigOptionResponder = async (value) => {
+      await held;
+      return [modelOption(String(value))];
+    };
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const spawning = manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-pin-race",
+      (msg: AssistantEvent) => sent.push(msg),
+    );
+    await waitForConfigOptionCalls(1);
+    const acpSessionId = (manager.getStatus() as AcpSessionState[])[0].id;
+
+    // The adapter reports the pin it is still answering.
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("sonnet")],
+      },
+    });
+    release();
+    await spawning;
+
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "sonnet",
+    );
+    expect(sent.map((e) => e.type)).toEqual([
+      "acp_session_model_update",
+      "acp_session_spawned",
+      "acp_session_model_update",
+    ]);
+    expect(
+      getAcpConversationModelPreference("conv-pin-race", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("an update echoing the spawn pin after it resolved records no preference", async () => {
+    // The adapter answers the pin with the snapshot it had, then reports the
+    // value it moved to through a notification of its own.
+    setConfigOptionResponder = async () => [modelOption("default")];
+    const { manager, acpSessionId, sent } =
+      await spawnPinnedToDefault("conv-pin-echo");
+
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("sonnet")],
+      },
+    });
+
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "sonnet",
+    );
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_model_update"]);
+    expect(
+      getAcpConversationModelPreference("conv-pin-echo", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("a different model after the spawn pin is still remembered", async () => {
+    setConfigOptionResult = [modelOption("sonnet")];
+    const { manager, acpSessionId, sent } = await spawnPinnedToDefault(
+      "conv-pin-then-typed",
+    );
+
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("opus")],
+      },
+    });
+
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "opus",
+    );
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_model_update"]);
+    expect(
+      getAcpConversationModelPreference("conv-pin-then-typed", "agent-model"),
+    ).toBe("opus");
+  });
 });
+
+/**
+ * A running session the manager pinned to the global default on its own, with
+ * the spawn events drained. Nothing about the model was an explicit request,
+ * so the spawn wrote no preference. Callers set the adapter's answer to the
+ * pin before calling.
+ */
+async function spawnPinnedToDefault(conversationId: string): Promise<{
+  manager: Manager;
+  acpSessionId: string;
+  sent: AssistantEvent[];
+}> {
+  config.setConfig({ defaultModel: "sonnet" });
+  scriptedConfigOptions = [[modelOption("default")]];
+  const manager = new AcpSessionManager(5);
+  const sent: AssistantEvent[] = [];
+  const { acpSessionId } = await manager.spawn(
+    "agent-model",
+    { command: "echo", args: ["hi"] },
+    "task",
+    "/tmp",
+    conversationId,
+    (msg) => sent.push(msg),
+  );
+  sent.length = 0;
+  return { manager, acpSessionId, sent };
+}

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -40,6 +40,10 @@ const setConfigOptionCalls: Array<{
 }> = [];
 /** What `setConfigOption` answers with; an Error is thrown instead. */
 let setConfigOptionResult: SessionConfigOption[] | Error = [];
+/** Answers per call when set, so one round trip can be slower than the next. */
+let setConfigOptionResponder:
+  | ((value: string | boolean) => Promise<SessionConfigOption[]>)
+  | null = null;
 
 // Stub the agent-process module so spawn() does not actually launch a child
 // process. Each fake instance records the cwd it was spawned in and resolves
@@ -69,6 +73,9 @@ mock.module("../agent-process.js", () => ({
       value: string | boolean,
     ): Promise<SessionConfigOption[]> {
       setConfigOptionCalls.push({ sessionId, configId, value });
+      if (setConfigOptionResponder) {
+        return setConfigOptionResponder(value);
+      }
       if (setConfigOptionResult instanceof Error) {
         throw setConfigOptionResult;
       }
@@ -112,6 +119,7 @@ beforeEach(() => {
   scriptedConfigOptions = [];
   setConfigOptionCalls.length = 0;
   setConfigOptionResult = [];
+  setConfigOptionResponder = null;
   config.setConfig({});
   getSqlite().run("DELETE FROM acp_conversation_model_preference");
 });
@@ -595,6 +603,58 @@ describe("AcpSessionManager: live model switching", () => {
     ).toBeUndefined();
   });
 
+  test("overlapping switches run in order and the later choice wins", async () => {
+    const { manager, acpSessionId, sent } = await spawnSwitchable("conv-race");
+    const confirmed: string[] = [];
+    setConfigOptionResponder = async (value) => {
+      // The first switch answers last if the calls are allowed to overlap.
+      if (value === "opus") {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      confirmed.push(String(value));
+      return [modelOption(String(value))];
+    };
+
+    const first = manager.setModel(acpSessionId, "opus");
+    const second = manager.setModel(acpSessionId, "sonnet");
+    await Promise.all([first, second]);
+
+    expect(confirmed).toEqual(["opus", "sonnet"]);
+    expect(setConfigOptionCalls.map((call) => call.value)).toEqual([
+      "opus",
+      "sonnet",
+    ]);
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "sonnet",
+    );
+    expect(getAcpConversationModelPreference("conv-race", "agent-model")).toBe(
+      "sonnet",
+    );
+    expect(sent).toHaveLength(2);
+    expect(sent[sent.length - 1]).toMatchObject({
+      type: "acp_session_model_update",
+      model: "sonnet",
+    });
+  });
+
+  test("a refused switch leaves the next one free to run", async () => {
+    const { manager, acpSessionId } = await spawnSwitchable("conv-chain");
+    setConfigOptionResponder = async (value) => {
+      if (value === "opus") {
+        throw new Error("Invalid value for config option model: opus");
+      }
+      return [modelOption(String(value))];
+    };
+
+    const refused = manager.setModel(acpSessionId, "opus");
+    const next = manager.setModel(acpSessionId, "sonnet");
+
+    await expect(refused).rejects.toThrow(
+      "Invalid value for config option model: opus",
+    );
+    await expect(next).resolves.toMatchObject({ model: "sonnet" });
+  });
+
   test("an adapter refusal surfaces verbatim and leaves the session as it was", async () => {
     const { manager, acpSessionId, sent } =
       await spawnSwitchable("conv-refuse");
@@ -642,6 +702,42 @@ describe("AcpSessionManager: unsolicited model updates", () => {
       "opus",
     );
     // Reporting is not choosing: the adapter is never asked to set it back.
+    expect(setConfigOptionCalls).toEqual([]);
+  });
+
+  test("a selector that disappears clears the model, the options, and the picker", async () => {
+    const { manager, acpSessionId, sent } =
+      await spawnSwitchable("conv-dropped");
+
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [
+          {
+            type: "select",
+            id: "mode",
+            name: "Mode",
+            currentValue: "default",
+            options: [{ value: "default", name: "Default" }],
+          },
+        ],
+      },
+    });
+
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.model).toBeUndefined();
+    expect(state.availableModels).toEqual([]);
+    expect(sent).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId,
+        availableModels: [],
+      },
+    ]);
+    await expect(manager.setModel(acpSessionId, "opus")).rejects.toBeInstanceOf(
+      AcpModelSelectionUnsupportedError,
+    );
     expect(setConfigOptionCalls).toEqual([]);
   });
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -664,6 +664,10 @@ export class AcpSessionManager {
    * One link of a session's model-switch chain: validates the value against
    * the options the adapter advertised, asks for the switch, then records and
    * publishes what came back.
+   *
+   * A session torn down while the round trip was in flight takes the answer
+   * with it: the caller's request is no longer actionable, so it comes back
+   * as not-found rather than mutating a state nobody reads.
    */
   private async applyModelSwitch(
     acpSessionId: string,
@@ -671,6 +675,9 @@ export class AcpSessionManager {
     model: string,
   ): Promise<AcpSessionState> {
     const { state, modelConfigId } = entry;
+    if (!this.isEntryLive(acpSessionId, entry)) {
+      throw new AcpSessionNotFoundError(acpSessionId);
+    }
     if (!modelConfigId) {
       throw new AcpModelSelectionUnsupportedError(acpSessionId);
     }
@@ -688,10 +695,54 @@ export class AcpSessionManager {
       modelConfigId,
       model,
     );
+    if (!this.isEntryLive(acpSessionId, entry)) {
+      throw new AcpSessionNotFoundError(acpSessionId);
+    }
     this.applyModelInfo(entry, refreshed);
-    this.rememberModelChoice(entry);
-    this.sendModelEvent(acpSessionId, entry);
+    if (!this.clearVanishedModelSelector(acpSessionId, entry, true)) {
+      this.rememberModelChoice(entry);
+      this.sendModelEvent(acpSessionId, entry);
+    }
     return state;
+  }
+
+  /**
+   * Whether `entry` is still this manager's live entry for `acpSessionId`.
+   * A response that lands after close, cancellation, or prompt completion has
+   * nothing left to update: the terminal row is already written, so applying
+   * it would leave history on one model and clients on another.
+   */
+  private isEntryLive(acpSessionId: string, entry: SessionEntry): boolean {
+    return (
+      this.sessions.get(acpSessionId) === entry &&
+      (entry.state.status === "running" ||
+        entry.state.status === "initializing")
+    );
+  }
+
+  /**
+   * Drops the live model snapshot a vanished selector took with it and
+   * publishes the empty picker. `applyModelInfo` keeps the recorded model for
+   * adapters that never had one, which here would leave the client on options
+   * `setModel` now rejects. Returns whether it fired, so callers skip the
+   * publish and the preference write that assume a model is still there.
+   */
+  private clearVanishedModelSelector(
+    acpSessionId: string,
+    entry: SessionEntry,
+    hadSelector: boolean,
+  ): boolean {
+    if (!hadSelector || entry.modelConfigId) {
+      return false;
+    }
+    entry.state.model = undefined;
+    entry.state.availableModels = [];
+    entry.sendToVellum({
+      type: "acp_session_model_update",
+      acpSessionId,
+      availableModels: [],
+    });
+    return true;
   }
 
   /**
@@ -732,17 +783,7 @@ export class AcpSessionManager {
     const hadSelector = entry.modelConfigId !== undefined;
     this.applyModelInfo(entry, configOptions);
 
-    // A selector that disappears mid-session takes the live snapshot with it.
-    // applyModelInfo keeps the recorded model for adapters that never had one,
-    // which here would leave the client on options setModel now rejects.
-    if (hadSelector && !entry.modelConfigId) {
-      entry.state.model = undefined;
-      entry.state.availableModels = [];
-      entry.sendToVellum({
-        type: "acp_session_model_update",
-        acpSessionId,
-        availableModels: [],
-      });
+    if (this.clearVanishedModelSelector(acpSessionId, entry, hadSelector)) {
       return;
     }
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -194,6 +194,9 @@ interface SessionEntry {
    *  none. Both the id to write a model back through and the flag that says
    *  this session has a model to publish at all. */
   modelConfigId?: string;
+  /** Tail of this session's model-switch chain, so overlapping setModel calls
+   *  reach the adapter one at a time and the last choice wins. */
+  modelSwitchQueue: Promise<void>;
 }
 
 /**
@@ -576,6 +579,7 @@ export class AcpSessionManager {
       task: opts.task,
       command: basename(opts.agentConfig.command),
       credentialDigest: opts.agentConfig.credentialDigest,
+      modelSwitchQueue: Promise.resolve(),
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -631,6 +635,11 @@ export class AcpSessionManager {
    * The in-flight prompt is left alone: the adapter applies the new model to
    * the next turn, and cancelling a running turn to change a model would cost
    * the user the work in flight.
+   *
+   * Switches run one at a time per session. A picker changed twice in quick
+   * succession would otherwise have two round trips in flight at once, and a
+   * slow first one landing last would put the state, the preference, and the
+   * client back on the model the user already moved off.
    */
   async setModel(
     acpSessionId: string,
@@ -640,6 +649,27 @@ export class AcpSessionManager {
     if (!entry) {
       throw new AcpSessionNotFoundError(acpSessionId);
     }
+    const switched = entry.modelSwitchQueue.then(() =>
+      this.applyModelSwitch(acpSessionId, entry, model),
+    );
+    // A refusal belongs to its caller alone; the chain carries on either way.
+    entry.modelSwitchQueue = switched.then(
+      () => undefined,
+      () => undefined,
+    );
+    return switched;
+  }
+
+  /**
+   * One link of a session's model-switch chain: validates the value against
+   * the options the adapter advertised, asks for the switch, then records and
+   * publishes what came back.
+   */
+  private async applyModelSwitch(
+    acpSessionId: string,
+    entry: SessionEntry,
+    model: string,
+  ): Promise<AcpSessionState> {
     const { state, modelConfigId } = entry;
     if (!modelConfigId) {
       throw new AcpModelSelectionUnsupportedError(acpSessionId);
@@ -699,7 +729,23 @@ export class AcpSessionManager {
       return;
     }
     const previousModel = entry.state.model;
+    const hadSelector = entry.modelConfigId !== undefined;
     this.applyModelInfo(entry, configOptions);
+
+    // A selector that disappears mid-session takes the live snapshot with it.
+    // applyModelInfo keeps the recorded model for adapters that never had one,
+    // which here would leave the client on options setModel now rejects.
+    if (hadSelector && !entry.modelConfigId) {
+      entry.state.model = undefined;
+      entry.state.availableModels = [];
+      entry.sendToVellum({
+        type: "acp_session_model_update",
+        acpSessionId,
+        availableModels: [],
+      });
+      return;
+    }
+
     this.sendModelEvent(acpSessionId, entry);
 
     if (entry.state.model !== previousModel) {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -128,6 +128,21 @@ export class AcpSessionNotFoundError extends Error {
 }
 
 /**
+ * Thrown when a live model switch is asked of a session whose adapter
+ * advertises no model selector. Distinct from not-found on purpose: the
+ * session exists and is healthy, so callers map this to a conflict rather
+ * than pretending the session is gone.
+ */
+export class AcpModelSelectionUnsupportedError extends Error {
+  constructor(public readonly acpSessionId: string) {
+    super(
+      `ACP session "${acpSessionId}" runs an agent that advertises no model selector`,
+    );
+    this.name = "AcpModelSelectionUnsupportedError";
+  }
+}
+
+/**
  * Wraps failures from the resume-then-steer phase of `steerOrResume` so
  * transport callers can distinguish them (HTTP 424 with the actionable
  * resume hint) from plain steer failures (404). The message mirrors the
@@ -387,12 +402,8 @@ export class AcpSessionManager {
     // once the session is confirmed to be on it. Inherited rungs are already
     // recorded where they came from, and re-recording them here would freeze a
     // config default into the conversation.
-    if (options?.model && !modelWarning && state.model) {
-      rememberConversationModelPreference({
-        parentConversationId,
-        agentId,
-        model: state.model,
-      });
+    if (options?.model && !modelWarning) {
+      this.rememberModelChoice(entry);
     }
 
     this.sendSpawnedEvent(acpSessionId, entry);
@@ -532,6 +543,7 @@ export class AcpSessionManager {
       opts.parentConversationId,
       (configOptions) => {
         agentProcess.applyConfigOptionsUpdate(configOptions);
+        this.applyUnsolicitedConfigOptions(acpSessionId, configOptions);
       },
     );
 
@@ -603,6 +615,96 @@ export class AcpSessionManager {
       model: entry.state.model,
       availableModels: entry.state.availableModels ?? [],
     });
+  }
+
+  /**
+   * Switches a live session onto `model` and publishes what the adapter
+   * confirmed.
+   *
+   * Unlike the spawn pin, the value is checked against the selector the
+   * adapter advertised before the adapter is asked: a live switch comes from
+   * a picker built out of exactly those options, so anything else is a caller
+   * bug worth naming rather than a round trip that would fail. A genuine
+   * adapter refusal propagates verbatim and leaves the session on the model
+   * it was already running.
+   *
+   * The in-flight prompt is left alone: the adapter applies the new model to
+   * the next turn, and cancelling a running turn to change a model would cost
+   * the user the work in flight.
+   */
+  async setModel(
+    acpSessionId: string,
+    model: string,
+  ): Promise<AcpSessionState> {
+    const entry = this.sessions.get(acpSessionId);
+    if (!entry) {
+      throw new AcpSessionNotFoundError(acpSessionId);
+    }
+    const { state, modelConfigId } = entry;
+    if (!modelConfigId) {
+      throw new AcpModelSelectionUnsupportedError(acpSessionId);
+    }
+
+    const available = state.availableModels ?? [];
+    if (!available.some((option) => option.value === model)) {
+      throw new Error(
+        `ACP session "${acpSessionId}" does not offer model "${model}". ` +
+          `Available: ${available.map((option) => option.value).join(", ") || "none"}`,
+      );
+    }
+
+    const refreshed = await entry.process.setConfigOption(
+      state.acpSessionId,
+      modelConfigId,
+      model,
+    );
+    this.applyModelInfo(entry, refreshed);
+    this.rememberModelChoice(entry);
+    this.sendModelEvent(acpSessionId, entry);
+    return state;
+  }
+
+  /**
+   * Records the model a session is confirmed to be on as this conversation's
+   * choice for this agent. The value is the adapter's own, which may have
+   * resolved an alias to a full model id. No-op when the adapter reports no
+   * model, so a session with no selector never writes a preference.
+   */
+  private rememberModelChoice(entry: SessionEntry): void {
+    const { model } = entry.state;
+    if (!model) {
+      return;
+    }
+    rememberConversationModelPreference({
+      parentConversationId: entry.parentConversationId,
+      agentId: entry.state.agentId,
+      model,
+    });
+  }
+
+  /**
+   * Takes in a `config_option_update` the adapter sent unprompted, which is
+   * how a `/model` the user typed straight into the transcript reaches the
+   * daemon. Only a value that actually moved becomes the conversation's
+   * preference: adapters re-report the full option set for unrelated changes,
+   * and re-recording an unchanged model would freeze an inherited default
+   * into the conversation.
+   */
+  private applyUnsolicitedConfigOptions(
+    acpSessionId: string,
+    configOptions: SessionConfigOption[],
+  ): void {
+    const entry = this.sessions.get(acpSessionId);
+    if (!entry) {
+      return;
+    }
+    const previousModel = entry.state.model;
+    this.applyModelInfo(entry, configOptions);
+    this.sendModelEvent(acpSessionId, entry);
+
+    if (entry.state.model !== previousModel) {
+      this.rememberModelChoice(entry);
+    }
   }
 
   /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -197,6 +197,14 @@ interface SessionEntry {
   /** Tail of this session's model-switch chain, so overlapping setModel calls
    *  reach the adapter one at a time and the last choice wins. */
   modelSwitchQueue: Promise<void>;
+  /** Count of this manager's own `setConfigOption` calls in flight, so a
+   *  `config_option_update` the adapter sends as their side effect is not
+   *  read as a user choice. */
+  managerPinsInFlight: number;
+  /** Last model value this manager asked the adapter for, kept because the
+   *  echoing notification can land after the call resolved. Cleared once a
+   *  genuinely different model arrives. */
+  lastManagerPinnedModel?: string;
 }
 
 /**
@@ -461,7 +469,7 @@ export class AcpSessionManager {
     configOptions: SessionConfigOption[],
     resolvedModel: string | undefined,
   ): Promise<string | undefined> {
-    const { state, process: agentProcess } = entry;
+    const { state } = entry;
     const info = this.applyModelInfo(entry, configOptions);
     if (!resolvedModel || resolvedModel === info.model) {
       return undefined;
@@ -475,8 +483,8 @@ export class AcpSessionManager {
     }
 
     try {
-      const refreshed = await agentProcess.setConfigOption(
-        state.acpSessionId,
+      const refreshed = await this.setConfigOptionAsManager(
+        entry,
         info.modelConfigId,
         resolvedModel,
       );
@@ -488,6 +496,31 @@ export class AcpSessionManager {
         "ACP agent refused the requested model; running on its own model",
       );
       return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  /**
+   * Runs one of the manager's own `setConfigOption` calls, marked for the
+   * duration so the unsolicited path does not mistake the adapter's echo of
+   * it for a model the user chose. Spawn, resume, and `setModel` each decide
+   * their own preference write, and a second one from the notification would
+   * freeze an inherited default into the conversation.
+   */
+  private async setConfigOptionAsManager(
+    entry: SessionEntry,
+    configId: string,
+    value: string,
+  ): Promise<SessionConfigOption[]> {
+    entry.managerPinsInFlight += 1;
+    entry.lastManagerPinnedModel = value;
+    try {
+      return await entry.process.setConfigOption(
+        entry.state.acpSessionId,
+        configId,
+        value,
+      );
+    } finally {
+      entry.managerPinsInFlight -= 1;
     }
   }
 
@@ -580,6 +613,7 @@ export class AcpSessionManager {
       command: basename(opts.agentConfig.command),
       credentialDigest: opts.agentConfig.credentialDigest,
       modelSwitchQueue: Promise.resolve(),
+      managerPinsInFlight: 0,
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -690,8 +724,8 @@ export class AcpSessionManager {
       );
     }
 
-    const refreshed = await entry.process.setConfigOption(
-      state.acpSessionId,
+    const refreshed = await this.setConfigOptionAsManager(
+      entry,
       modelConfigId,
       model,
     );
@@ -769,7 +803,9 @@ export class AcpSessionManager {
    * daemon. Only a value that actually moved becomes the conversation's
    * preference: adapters re-report the full option set for unrelated changes,
    * and re-recording an unchanged model would freeze an inherited default
-   * into the conversation.
+   * into the conversation. A move this manager itself asked for is published
+   * like any other but writes no preference, whether the notification lands
+   * while the request is in flight or just after it resolved.
    */
   private applyUnsolicitedConfigOptions(
     acpSessionId: string,
@@ -789,9 +825,17 @@ export class AcpSessionManager {
 
     this.sendModelEvent(acpSessionId, entry);
 
-    if (entry.state.model !== previousModel) {
-      this.rememberModelChoice(entry);
+    if (entry.state.model === previousModel) {
+      return;
     }
+    if (
+      entry.managerPinsInFlight > 0 ||
+      entry.state.model === entry.lastManagerPinnedModel
+    ) {
+      return;
+    }
+    entry.lastManagerPinnedModel = undefined;
+    this.rememberModelChoice(entry);
   }
 
   /**


### PR DESCRIPTION
## Summary
- `AcpSessionManager.setModel(acpSessionId, model)` switches a live session's model: validates against the adapter's advertised options locally (no round trip for unknown values), applies it through `setConfigOption`, re-derives state, remembers the confirmed value as the conversation preference, emits `acp_session_model_update`, and never interrupts the in-flight prompt.
- New `AcpModelSelectionUnsupportedError` for sessions whose adapter advertises no model selector; a genuine adapter refusal propagates verbatim and leaves the session on the model it was running.
- Unsolicited `config_option_update` notifications (a user typing `/model` in the transcript) now re-derive and republish model state, writing the conversation preference only when the value actually changed.

Part of plan: acp-model-control.md (PR 8 of 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D