### PR TITLE
fix(acp): cascade model preferences with their conversation and scrub a null default on PATCH

### DIFF
--- a/assistant/src/__tests__/prune-old-conversations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-conversations-job.test.ts
@@ -58,8 +58,7 @@ function seedConversation(id: string, updatedAt: number): void {
       payload: "{}",
     })
     .run();
-  // Conversation-keyed with no foreign key, so only an explicit delete in the
-  // prune transaction reaches it.
+  // Cascades from the conversation, so the prune deletes it without naming it.
   upsertAcpConversationModelPreference({
     parentConversationId: id,
     agentId: "claude",

--- a/assistant/src/acp/__tests__/helpers/acp-history-db.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-history-db.ts
@@ -1,5 +1,5 @@
 /**
- * Shared test helpers for the `acp_session_history` table.
+ * Shared test helpers for the tables the ACP suites read and write directly.
  *
  * Several suites (session-manager resume/persistence, the ACP route
  * handlers) seed and read history rows directly via SQL; this module
@@ -35,8 +35,29 @@ export interface HistoryRow {
   model: string | null;
 }
 
+/**
+ * Clears both ACP tables a suite can leave behind. The model preference is
+ * conversation-keyed rather than session-keyed, so a suite that asserts a
+ * conversation has chosen nothing is order-dependent without it.
+ */
 export function clearHistory(): void {
-  getSqlite().run("DELETE FROM acp_session_history");
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM acp_session_history");
+  sqlite.run("DELETE FROM acp_conversation_model_preference");
+}
+
+/**
+ * Inserts the `conversations` row the model preference's foreign key needs
+ * before a preference can be written for that id. Idempotent, so a suite that
+ * reuses an id across tests can call it every time.
+ */
+export function seedConversationRow(id: string): void {
+  getSqlite()
+    .query(
+      `INSERT OR IGNORE INTO conversations (id, title, created_at, updated_at)
+       VALUES (?, 'acp test', 0, 0)`,
+    )
+    .run(id);
 }
 
 /**

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -21,6 +21,7 @@ import { initializeDb } from "../../persistence/db-init.js";
 import type { VellumAcpClientHandler } from "../client-handler.js";
 import type { AcpSessionState } from "../types.js";
 import { installAcpConfigStub } from "./helpers/acp-config-stub.js";
+import { seedConversationRow } from "./helpers/acp-history-db.js";
 import {
   MODEL_OPTION_MODELS,
   modelOption,
@@ -290,6 +291,7 @@ describe("AcpSessionManager: model selection at spawn", () => {
     sent: AssistantEvent[];
     modelWarning?: string;
   }> {
+    seedConversationRow(opts.conversationId);
     const manager = new AcpSessionManager(5);
     const sent: AssistantEvent[] = [];
     const { acpSessionId, modelWarning } = await manager.spawn(
@@ -378,6 +380,7 @@ describe("AcpSessionManager: model selection at spawn", () => {
 
   test("an explicit request outranks every other rung", async () => {
     config.setConfig({ defaultModel: "haiku" });
+    seedConversationRow("conv-ladder");
     upsertAcpConversationModelPreference({
       parentConversationId: "conv-ladder",
       agentId: "agent-model",
@@ -398,6 +401,7 @@ describe("AcpSessionManager: model selection at spawn", () => {
 
   test("the conversation preference outranks the agent and global defaults", async () => {
     config.setConfig({ defaultModel: "haiku" });
+    seedConversationRow("conv-ladder");
     upsertAcpConversationModelPreference({
       parentConversationId: "conv-ladder",
       agentId: "agent-model",
@@ -537,6 +541,7 @@ async function spawnSwitchable(conversationId: string): Promise<{
   sent: AssistantEvent[];
 }> {
   scriptedConfigOptions = [[modelOption("sonnet")]];
+  seedConversationRow(conversationId);
   const manager = new AcpSessionManager(5);
   const sent: AssistantEvent[] = [];
   const { acpSessionId } = await manager.spawn(
@@ -990,6 +995,7 @@ async function spawnPinnedToDefault(conversationId: string): Promise<{
   acpSessionId: string;
   sent: AssistantEvent[];
 }> {
+  seedConversationRow(conversationId);
   config.setConfig({ defaultModel: "sonnet" });
   scriptedConfigOptions = [[modelOption("default")]];
   const manager = new AcpSessionManager(5);

--- a/assistant/src/persistence/acp-model-preference.test.ts
+++ b/assistant/src/persistence/acp-model-preference.test.ts
@@ -7,7 +7,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
-  deleteAcpConversationModelPreferences,
   getAcpConversationModelPreference,
   upsertAcpConversationModelPreference,
 } from "./acp-model-preference.js";
@@ -22,6 +21,11 @@ import { initializeDb } from "./db-init.js";
 
 await initializeDb();
 
+/** The rows carry a foreign key, so every preference needs a real parent. */
+function newConversationId(title: string): string {
+  return createConversation(title).id;
+}
+
 afterEach(() => {
   getSqlite().run("DELETE FROM acp_conversation_model_preference");
 });
@@ -29,52 +33,50 @@ afterEach(() => {
 describe("getAcpConversationModelPreference", () => {
   test("returns undefined when the conversation has chosen nothing", () => {
     expect(
-      getAcpConversationModelPreference("conv-1", "claude"),
+      getAcpConversationModelPreference(newConversationId("nothing"), "claude"),
     ).toBeUndefined();
   });
 
   test("reads back the recorded choice", () => {
+    const id = newConversationId("recorded choice");
     upsertAcpConversationModelPreference({
-      parentConversationId: "conv-1",
+      parentConversationId: id,
       agentId: "claude",
       model: "opus",
     });
 
-    expect(getAcpConversationModelPreference("conv-1", "claude")).toBe("opus");
+    expect(getAcpConversationModelPreference(id, "claude")).toBe("opus");
   });
 
   test("is scoped to the agent, whose model vocabularies do not overlap", () => {
+    const id = newConversationId("agent scope");
+    const other = newConversationId("agent scope other");
     upsertAcpConversationModelPreference({
-      parentConversationId: "conv-1",
+      parentConversationId: id,
       agentId: "claude",
       model: "opus",
     });
 
-    expect(
-      getAcpConversationModelPreference("conv-1", "codex"),
-    ).toBeUndefined();
-    expect(
-      getAcpConversationModelPreference("conv-2", "claude"),
-    ).toBeUndefined();
+    expect(getAcpConversationModelPreference(id, "codex")).toBeUndefined();
+    expect(getAcpConversationModelPreference(other, "claude")).toBeUndefined();
   });
 });
 
 describe("upsertAcpConversationModelPreference", () => {
   test("a later choice replaces the earlier one for the same pair", () => {
+    const id = newConversationId("replace");
     upsertAcpConversationModelPreference({
-      parentConversationId: "conv-1",
+      parentConversationId: id,
       agentId: "claude",
       model: "opus",
     });
     upsertAcpConversationModelPreference({
-      parentConversationId: "conv-1",
+      parentConversationId: id,
       agentId: "claude",
       model: "sonnet",
     });
 
-    expect(getAcpConversationModelPreference("conv-1", "claude")).toBe(
-      "sonnet",
-    );
+    expect(getAcpConversationModelPreference(id, "claude")).toBe("sonnet");
     const rows = getSqlite()
       .query("SELECT model FROM acp_conversation_model_preference")
       .all();
@@ -82,70 +84,66 @@ describe("upsertAcpConversationModelPreference", () => {
   });
 
   test("moves updated_at forward so the row dates the choice, not the first one", () => {
+    const id = newConversationId("updated at");
     const before = Date.now();
     upsertAcpConversationModelPreference({
-      parentConversationId: "conv-1",
+      parentConversationId: id,
       agentId: "claude",
       model: "opus",
     });
-    const first = updatedAt();
+    const first = updatedAt(id);
     expect(first).toBeGreaterThanOrEqual(before);
 
     upsertAcpConversationModelPreference({
-      parentConversationId: "conv-1",
+      parentConversationId: id,
       agentId: "claude",
       model: "sonnet",
     });
 
-    expect(updatedAt()).toBeGreaterThanOrEqual(first);
+    expect(updatedAt(id)).toBeGreaterThanOrEqual(first);
   });
 });
 
-describe("deleteAcpConversationModelPreferences", () => {
-  test("drops every agent's preference for the conversation, and only that one", () => {
+describe("conversation cascade", () => {
+  test("deleting a conversation takes every agent's preference with it, and only that conversation's", () => {
+    const id = newConversationId("cascade");
+    const other = newConversationId("cascade other");
     for (const agentId of ["claude", "codex"]) {
       upsertAcpConversationModelPreference({
-        parentConversationId: "conv-1",
+        parentConversationId: id,
         agentId,
         model: "opus",
       });
     }
     upsertAcpConversationModelPreference({
-      parentConversationId: "conv-2",
+      parentConversationId: other,
       agentId: "claude",
       model: "opus",
     });
 
-    deleteAcpConversationModelPreferences("conv-1");
+    deleteConversation(id);
 
-    expect(
-      getAcpConversationModelPreference("conv-1", "claude"),
-    ).toBeUndefined();
-    expect(
-      getAcpConversationModelPreference("conv-1", "codex"),
-    ).toBeUndefined();
-    expect(getAcpConversationModelPreference("conv-2", "claude")).toBe("opus");
+    expect(getAcpConversationModelPreference(id, "claude")).toBeUndefined();
+    expect(getAcpConversationModelPreference(id, "codex")).toBeUndefined();
+    expect(getAcpConversationModelPreference(other, "claude")).toBe("opus");
   });
 
-  test("deleting a conversation takes its preferences with it", () => {
-    const conversation = createConversation("acp model preference");
+  test("the gentle delete cascades too", async () => {
+    const id = newConversationId("gently");
     upsertAcpConversationModelPreference({
-      parentConversationId: conversation.id,
+      parentConversationId: id,
       agentId: "claude",
       model: "opus",
     });
 
-    deleteConversation(conversation.id);
+    await deleteConversationGently(id);
 
-    expect(
-      getAcpConversationModelPreference(conversation.id, "claude"),
-    ).toBeUndefined();
+    expect(getAcpConversationModelPreference(id, "claude")).toBeUndefined();
   });
 
   test("clear-all wipes them, so a reused id inherits no one else's choice", async () => {
-    const conversation = createConversation("acp model preference clear all");
     upsertAcpConversationModelPreference({
-      parentConversationId: conversation.id,
+      parentConversationId: newConversationId("clear all"),
       agentId: "claude",
       model: "opus",
     });
@@ -158,29 +156,14 @@ describe("deleteAcpConversationModelPreferences", () => {
         .get(),
     ).toEqual({ c: 0 });
   });
-
-  test("the gentle delete purges them too", async () => {
-    const conversation = createConversation("acp model preference gently");
-    upsertAcpConversationModelPreference({
-      parentConversationId: conversation.id,
-      agentId: "claude",
-      model: "opus",
-    });
-
-    await deleteConversationGently(conversation.id);
-
-    expect(
-      getAcpConversationModelPreference(conversation.id, "claude"),
-    ).toBeUndefined();
-  });
 });
 
-function updatedAt(): number {
+function updatedAt(parentConversationId: string): number {
   const row = getSqlite()
     .query(
       `SELECT updated_at FROM acp_conversation_model_preference
-       WHERE parent_conversation_id = 'conv-1' AND agent_id = 'claude'`,
+       WHERE parent_conversation_id = ? AND agent_id = 'claude'`,
     )
-    .get() as { updated_at: number };
+    .get(parentConversationId) as { updated_at: number };
   return row.updated_at;
 }

--- a/assistant/src/persistence/acp-model-preference.ts
+++ b/assistant/src/persistence/acp-model-preference.ts
@@ -5,21 +5,15 @@
  * given agent should be put on. Written only when the user chooses one, so it
  * never inherits a fallback the user never asked for; `acp_session_history` is
  * the record of what a finished run actually used.
+ *
+ * Nothing here deletes: the row cascades from its conversation, so a
+ * conversation delete takes its preferences with it.
  */
 
 import { and, eq } from "drizzle-orm";
 
-import { type DrizzleDb, getDb } from "./db-connection.js";
+import { getDb } from "./db-connection.js";
 import { acpConversationModelPreference } from "./schema/index.js";
-
-/**
- * Enough of a database handle to delete rows.
- *
- * Named as a slice so the delete can be handed the open transaction of a
- * conversation delete, and the preference rows commit or roll back with the
- * conversation row they belong to.
- */
-type ModelPreferenceWriter = Pick<DrizzleDb, "delete">;
 
 /** The model this conversation prefers for this agent, if it has chosen one. */
 export function getAcpConversationModelPreference(
@@ -59,20 +53,5 @@ export function upsertAcpConversationModelPreference(preference: {
       ],
       set: { model: preference.model, updatedAt },
     })
-    .run();
-}
-
-/** Drop every agent's preference for a conversation that is going away. */
-export function deleteAcpConversationModelPreferences(
-  parentConversationId: string,
-  db: ModelPreferenceWriter = getDb(),
-): void {
-  db.delete(acpConversationModelPreference)
-    .where(
-      eq(
-        acpConversationModelPreference.parentConversationId,
-        parentConversationId,
-      ),
-    )
     .run();
 }

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -54,7 +54,6 @@ import {
   purgeAllWatchTimelines,
   purgeWatchTimelineForConversation,
 } from "../watch/watch-timeline.js";
-import { deleteAcpConversationModelPreferences } from "./acp-model-preference.js";
 import {
   deleteOrphanAttachments,
   linkAttachmentToMessage,
@@ -2243,7 +2242,6 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       .where(eq(toolInvocations.conversationId, id))
       .run();
     tx.delete(messages).where(eq(messages.conversationId, id)).run();
-    deleteAcpConversationModelPreferences(id, tx);
     // Raw SQL on the same bun:sqlite handle Drizzle wraps, so the subagent rows
     // commit or roll back with the conversation row they describe.
     deleteSubagentRecordsByParent(id);
@@ -2394,7 +2392,6 @@ export async function deleteConversationGently(
     tx.delete(toolInvocations)
       .where(eq(toolInvocations.conversationId, id))
       .run();
-    deleteAcpConversationModelPreferences(id, tx);
     // Raw SQL on the same bun:sqlite handle Drizzle wraps, so the subagent rows
     // commit or roll back with the conversation row they describe.
     deleteSubagentRecordsByParent(id);
@@ -3830,9 +3827,10 @@ export async function clearAll(): Promise<{
   // cascade; wipe them explicitly so labels/objectives don't survive (or
   // rehydrate after) a clear-all.
   await runOrThrow("DELETE FROM subagents");
-  // Per-conversation ACP model preferences are conversation-keyed with no FK
-  // cascade either, so a wipe that skipped them would hand a reused id someone
-  // else's model choice.
+  // Per-conversation ACP model preferences cascade from `conversations`, but
+  // these bulk deletes run in a sqlite3 subprocess that does not enable
+  // foreign keys, so nothing above reached them; a wipe that skipped them
+  // would hand a reused id someone else's model choice.
   await runOrThrow("DELETE FROM acp_conversation_model_preference");
   // Watch-session timelines are conversation-keyed rows the cascade does not
   // reach. They come after `conversations` so this statement is the last thing

--- a/assistant/src/persistence/job-handlers/cleanup.ts
+++ b/assistant/src/persistence/job-handlers/cleanup.ts
@@ -4,7 +4,6 @@ import { runHook } from "../../plugins/pipeline.js";
 import { rotateToolInvocations } from "../../telemetry/tool-usage-store.js";
 import { getLogger } from "../../util/logger.js";
 import { getLogsDbPath } from "../../util/logs-db-path.js";
-import { deleteAcpConversationModelPreferences } from "../acp-model-preference.js";
 import { purgeConversationSegments } from "../conversation-crud.js";
 import { runAsyncSqlite } from "../db-async-query.js";
 import { getDb } from "../db-connection.js";
@@ -161,8 +160,8 @@ function parseDeletedCount(stdout: string | undefined): number {
  *
  * Tables with onDelete cascade on conversation FK (memory_segments,
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
- * external_conversation_bindings) are handled automatically. Tables without
- * cascade (messages, tool_invocations, acp_conversation_model_preference,
+ * external_conversation_bindings, acp_conversation_model_preference) are
+ * handled automatically. Tables without cascade (messages, tool_invocations,
  * plus llm_request_logs and conversation-scoped telemetry_events rows on
  * their dedicated connections) are deleted explicitly before removing the
  * conversation row.
@@ -200,7 +199,7 @@ export function pruneOldConversationsJob(
   const db = getDb();
   const prunedIds: string[] = [];
   for (const { id } of stale) {
-    db.transaction((tx) => {
+    db.transaction(() => {
       // Re-check staleness inside the transaction to avoid racing with a conversation
       // that became active again between the initial SELECT and this DELETE.
       const still = rawAll<{ id: string }>(
@@ -240,10 +239,6 @@ export function pruneOldConversationsJob(
         `DELETE FROM messages WHERE conversation_id = ?`,
         id,
       );
-      // Conversation-keyed, no foreign key of its own, so the cascade below
-      // never reaches it. Handed the open transaction so the preference rows
-      // commit or roll back with the conversation row they belong to.
-      deleteAcpConversationModelPreferences(id, tx);
       // Conversation row deletion cascades to remaining dependent tables
       rawRun(
         "cleanup:pruneOldConversations:conv",

--- a/assistant/src/persistence/migrations/378-create-acp-conversation-model-preference.ts
+++ b/assistant/src/persistence/migrations/378-create-acp-conversation-model-preference.ts
@@ -8,7 +8,9 @@ const TABLE = "acp_conversation_model_preference";
  * next run on a given agent starts on.
  *
  * Keyed `(parent_conversation_id, agent_id)` because a conversation can drive
- * more than one coding agent and their model vocabularies do not overlap.
+ * more than one coding agent and their model vocabularies do not overlap. The
+ * conversation column cascades, and no separate index is needed for it: it
+ * leads the composite primary key, so the key's own index serves the cascade.
  *
  * Its own table rather than a column on `acp_session_history`, because history
  * answers a different question. History is written once, when a run reaches a
@@ -24,7 +26,7 @@ export function migrateCreateAcpConversationModelPreference(
 ): void {
   getSqliteFrom(database).exec(
     `CREATE TABLE IF NOT EXISTS ${TABLE} (
-       parent_conversation_id TEXT NOT NULL,
+       parent_conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
        agent_id TEXT NOT NULL,
        model TEXT NOT NULL,
        updated_at INTEGER NOT NULL,

--- a/assistant/src/persistence/migrations/__tests__/378-create-acp-conversation-model-preference.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/378-create-acp-conversation-model-preference.test.ts
@@ -2,7 +2,8 @@
  * Migration 378 creates `acp_conversation_model_preference`, the record of
  * which model a conversation's next run on an agent starts on. Its composite
  * primary key is what makes an explicit choice replace the previous one per
- * agent rather than accumulate.
+ * agent rather than accumulate, and its conversation column cascades so a
+ * preference never outlives the conversation it was chosen for.
  */
 
 import { Database } from "bun:sqlite";
@@ -34,6 +35,27 @@ describe("migrateCreateAcpConversationModelPreference", () => {
     migrateCreateAcpConversationModelPreference(db);
 
     expect(tableNames(db)).toContain("acp_conversation_model_preference");
+  });
+
+  test("the conversation column cascades", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    raw.exec("PRAGMA foreign_keys = ON");
+    raw.exec("CREATE TABLE conversations (id TEXT PRIMARY KEY)");
+    migrateCreateAcpConversationModelPreference(db);
+    raw.exec("INSERT INTO conversations (id) VALUES ('conv-1')");
+    raw.exec(
+      `INSERT INTO acp_conversation_model_preference
+         (parent_conversation_id, agent_id, model, updated_at)
+       VALUES ('conv-1', 'claude', 'opus', 10)`,
+    );
+
+    raw.exec("DELETE FROM conversations WHERE id = 'conv-1'");
+
+    const count = raw
+      .prepare("SELECT COUNT(*) AS n FROM acp_conversation_model_preference")
+      .get() as { n: number };
+    expect(count.n).toBe(0);
   });
 
   test("re-running preserves existing rows", () => {

--- a/assistant/src/persistence/schema/acp.ts
+++ b/assistant/src/persistence/schema/acp.ts
@@ -7,6 +7,8 @@ import {
   text,
 } from "drizzle-orm/sqlite-core";
 
+import { conversations } from "./conversations.js";
+
 /**
  * ACP (Agent Client Protocol) session history. Persists completed ACP
  * sessions so the sessions UI has data across daemon restarts.
@@ -92,12 +94,17 @@ export const acpRefusedCredentials = sqliteTable("acp_refused_credentials", {
  * their model vocabularies do not overlap. Values are adapter aliases (for
  * example "opus"), not Assistant catalog ids.
  *
+ * Cascades from the conversation, so a preference never outlives the
+ * conversation it was chosen for and no delete path has to remember it.
+ *
  * Created by migration 378.
  */
 export const acpConversationModelPreference = sqliteTable(
   "acp_conversation_model_preference",
   {
-    parentConversationId: text("parent_conversation_id").notNull(),
+    parentConversationId: text("parent_conversation_id")
+      .notNull()
+      .references(() => conversations.id, { onDelete: "cascade" }),
     agentId: text("agent_id").notNull(),
     model: text("model").notNull(),
     updatedAt: integer("updated_at").notNull(),

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -53,7 +53,12 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
 }));
 
 import { BACKUP_PROFILE_KEYS } from "../../../config/default-profile-names.js";
-import { getConfig, loadRawConfig } from "../../../config/loader.js";
+import {
+  getConfig,
+  loadConfig,
+  loadRawConfig,
+} from "../../../config/loader.js";
+import { AssistantConfigSchema } from "../../../config/schema.js";
 import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import {
@@ -1327,6 +1332,41 @@ describe("PATCH /v1/config fallbackProfile write protection", () => {
     ).rejects.toThrow(/Automatic fallbacks are code-owned/);
     expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
     expect(initializeProvidersCalls).toBe(0);
+  });
+});
+
+describe("PATCH /v1/config clearing acp.defaultModel", () => {
+  const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
+
+  beforeEach(() => {
+    rawConfigFixture = {
+      acp: {
+        defaultModel: "opus",
+        agents: { claude: { command: "claude-agent-acp", args: [] } },
+      },
+    };
+    seedRawConfig();
+  });
+
+  test("removes the key rather than persisting a schema-invalid null", async () => {
+    await patchRoute.handler({ body: { acp: { defaultModel: null } } });
+
+    const acp = loadRawConfig().acp as Record<string, unknown>;
+    expect("defaultModel" in acp).toBe(false);
+    expect(acp.agents).toEqual({
+      claude: { command: "claude-agent-acp", args: [] },
+    });
+  });
+
+  test("the config it leaves behind loads without a validation warning", async () => {
+    await patchRoute.handler({ body: { acp: { defaultModel: null } } });
+
+    // A persisted `null` fails `acp.defaultModel` and sends every later load
+    // down the salvage ladder, warning each time.
+    expect(AssistantConfigSchema.safeParse(loadRawConfig()).success).toBe(true);
+    const acp = loadConfig().acp;
+    expect(acp.defaultModel).toBeUndefined();
+    expect(Object.keys(acp.agents)).toEqual(["claude"]);
   });
 });
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1566,6 +1566,21 @@ function scrubRemovedServiceModes(raw: Record<string, unknown>): void {
 }
 
 /**
+ * Clearing the default coding-agent model is a PATCH of
+ * `{ acp: { defaultModel: null } }`, and the deep-merge assigns that literal
+ * `null` because the stored value is a scalar. `AcpConfigSchema.defaultModel`
+ * is an optional string, so a persisted `null` makes every later
+ * `loadConfig()` warn and take its salvage path. Clearing means removing the
+ * key, so drop it here.
+ */
+function scrubNulledAcpDefaultModel(raw: Record<string, unknown>): void {
+  const acp = readPlainObject(raw.acp);
+  if (acp && acp.defaultModel === null) {
+    delete acp.defaultModel;
+  }
+}
+
+/**
  * A persisted `services.stt` block must satisfy SttServiceSchema, whose
  * `provider` is required. The services-level default fills the provider only
  * when `services.stt` is wholly absent, so a sparse patch like
@@ -1615,6 +1630,7 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
   }
   deepMergeOverwrite(raw, patch);
   scrubRemovedServiceModes(raw);
+  scrubNulledAcpDefaultModel(raw);
   seedSttProviderForSparseBlock(raw);
 
   await commitConfigWrite(raw, "patch");


### PR DESCRIPTION
## Summary
Fixes gaps identified during the plan self-review for acp-model-control.md (config route and persistence).

- **Clearing the default model no longer persists a schema-invalid `null`.** The settings card clears by PATCHing `{ acp: { defaultModel: null } }`, and `deepMergeOverwrite` assigns that literal null over the stored scalar. Since `AcpConfigSchema.defaultModel` is `z.string().optional()`, every later `loadConfig()` warned and took its salvage path. `handlePatchConfig` now drops the key after the merge, alongside the existing `scrubRemovedServiceModes` post-merge scrub.
- **`acp_conversation_model_preference` cascades from its conversation.** Migration 378 is edited in place (feature-branch only, never shipped) to declare `REFERENCES conversations(id) ON DELETE CASCADE`, matching the schema's dozens of other conversation cascades and the `PRAGMA foreign_keys = ON` every connection runs with. The now-redundant manual purges are gone: both `deleteConversation` and `deleteConversationGently`, the prune job (along with the `(tx)` parameter that existed only to pass a writer), and `deleteAcpConversationModelPreferences` itself with its `ModelPreferenceWriter` type.
- **`clearAll` keeps its explicit delete.** Deviation from the plan: its bulk deletes run through a sqlite3 subprocess that does not enable foreign keys, so the cascade never fires there. That is why clear-all already deletes `messages`, `tool_invocations`, and `subagents` by hand. Removing the preference delete made the clear-all test fail; the delete stays with a corrected rationale.
- **The ACP test helper resets the preference table.** `clearHistory()` cleared only `acp_session_history`, so `session-manager-resume.test.ts`'s "resuming is not choosing" assertion was order-dependent. It now clears both, and a `seedConversationRow` helper gives `session-manager.test.ts` the parent rows the new foreign key requires.
- **No OpenAPI change.** The fix is a post-merge scrub, not a route schema change, so `assistant/openapi.yaml` is untouched.

## Test plan
`bunx tsc --noEmit` clean. Passing, one file per invocation: migration 378, `acp-model-preference`, `prune-old-conversations-job`, `conversation-clear-safety`, `clear-all-lexical`, `schema-contract`, the three `conversation-delete-*` suites, `conversation-query-routes` (84), `acp-routes` (53), and the ACP session-manager suites (spawn/resume/persistence/startup, oauth, auth-marker). The two new PATCH tests were verified to fail with the scrub commented out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D