### PR TITLE
fix(acp): bound adapter reinstalls, probe the agent's PATH on recovery, and document the version pin

### DIFF
--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -58,6 +58,8 @@ function warnings(): string[] {
     .map((record) => record.message);
 }
 
+const { formatResolveFailure } = await import("./resolve-agent.js");
+
 const {
   ensureAdapterInstalled,
   getInstalledAdapterVersion,
@@ -267,9 +269,29 @@ describe("ensureAdapterInstalled", () => {
   });
 
   test("a settled install is not cached: the next call probes again", async () => {
-    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+    let installedVersion = "0.47.0";
+    which.setWhich({
+      bun: BUN_BIN,
+      "claude-agent-acp": bunLinked("claude-agent-acp"),
+    });
+    _setAdapterVersionProbeDepsForTests({
+      bunInstallDir: () => BUN_ROOT,
+      realpath: fakeRealpath({
+        "claude-agent-acp": "@agentclientprotocol/claude-agent-acp",
+      }),
+      readFile: () =>
+        Promise.resolve(JSON.stringify({ version: installedVersion })),
+    });
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        installedVersion = "0.75.1";
+      },
+    });
 
     await ensureAdapterInstalled("claude-agent-acp");
+    // The adapter drifts off the pin again under the running daemon.
+    installedVersion = "0.47.0";
     await ensureAdapterInstalled("claude-agent-acp");
 
     expect(execFileMock).toHaveBeenCalledTimes(2);
@@ -539,6 +561,56 @@ describe("ensureAdapterInstalled - version pinning", () => {
     expect(warnings().join(" ")).not.toContain("managed outside bun");
   });
 
+  test("an install that leaves the pin unsatisfied is never retried", async () => {
+    which.setWhich({ bun: BUN_BIN, "codex-acp": bunLinked("codex-acp") });
+    // `bun add` will exit 0 without moving the tree off 0.4.0, so no number of
+    // reinstalls can satisfy the pin.
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "0.4.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const first = await ensureAdapterInstalled("codex-acp");
+    const second = await ensureAdapterInstalled("codex-acp");
+    const third = await ensureAdapterInstalled("codex-acp");
+
+    expect(first).toEqual({ installed: true });
+    expect(second).toEqual({ installed: false });
+    expect(third).toEqual({ installed: false });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(
+      warnings().filter((message) =>
+        message.includes("does not select the pinned version"),
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("two PATHs into the same bun tree run a single install", async () => {
+    const BUN_BIN_DIR = `${BUN_ROOT}/bin`;
+    const ALIAS_BIN_DIR = `${BUN_ALIAS_ROOT}/bin`;
+    which.setWhich((cmd, options) => {
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (cmd !== "codex-acp") {
+        return null;
+      }
+      return options?.PATH === ALIAS_BIN_DIR
+        ? aliasLinked("codex-acp")
+        : bunLinked("codex-acp");
+    });
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "0.4.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    const [direct, aliased] = await Promise.all([
+      ensureAdapterInstalled("codex-acp", BUN_BIN_DIR),
+      ensureAdapterInstalled("codex-acp", ALIAS_BIN_DIR),
+    ]);
+
+    // Both probes want the pin, and both are served by one `bun add --global`.
+    expect(direct).toEqual({ installed: true });
+    expect(aliased).toEqual({ installed: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
   test("binary missing from PATH: installs without consulting the probe", async () => {
     which.setWhich({ bun: BUN_BIN });
     _setAdapterVersionProbeDepsForTests({
@@ -620,6 +692,47 @@ describe("resolveAgentWithAutoInstall - resolution order", () => {
       "--global",
       CODEX_SPEC,
     ]);
+  });
+
+  test("recovery probes the agent's own PATH, not the daemon's", async () => {
+    const AGENT_PATH = "/opt/agent/bin";
+    config.setConfig({
+      agents: {
+        claude: {
+          command: "claude-agent-acp",
+          args: [],
+          env: { PATH: AGENT_PATH },
+        },
+      },
+    });
+    let installed = false;
+    which.setWhich((cmd, options) => {
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (cmd !== "claude-agent-acp") {
+        return null;
+      }
+      // The daemon's PATH already reaches a pinned adapter; the agent's does
+      // not, which is the failure the resolver reported.
+      if (options?.PATH !== AGENT_PATH) {
+        return bunLinked("claude-agent-acp");
+      }
+      return installed ? `${AGENT_PATH}/claude-agent-acp` : null;
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.75.1" });
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        installed = true;
+      },
+    });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(true);
+    expect(result.autoInstalledPackage).toBe(CLAUDE_SPEC);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 
   test("binary missing + bun absent: no install, plain failure with the hint", async () => {
@@ -805,7 +918,8 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
     const second = await resolveAgentWithAutoInstall("codex");
 
     expect(second.resolved.ok).toBe(true);
-    expect(manifestReads).toBe(2);
+    // One probe per spawn, plus the second spawn's post-install verification.
+    expect(manifestReads).toBe(3);
     expect(execFileMock).toHaveBeenCalledTimes(1);
     expect(execFileMock.mock.calls[0][1]).toEqual([
       "add",
@@ -832,6 +946,39 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
     expect(result.failureMessage).toBeUndefined();
     expect(warnings().join(" ")).toContain(
       "Could not reinstall the ACP adapter",
+    );
+  });
+
+  test("post-install resolution failure surfaces the resolver's hint", async () => {
+    let onPath = true;
+    which.setWhich((cmd) => {
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (cmd === "claude-agent-acp" && onPath) {
+        return bunLinked("claude-agent-acp");
+      }
+      return null;
+    });
+    stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.47.0" });
+    // The reinstall unlinks the bin instead of repointing it, so the adapter
+    // the caller was about to spawn is gone.
+    execScripts.set(BUN_ADD_KEY, {
+      stdout: "",
+      onCall: () => {
+        onPath = false;
+      },
+    });
+
+    const result = await resolveAgentWithAutoInstall("claude");
+
+    expect(result.resolved.ok).toBe(false);
+    if (result.resolved.ok) {
+      return;
+    }
+    expect(result.resolved.reason).toBe("binary_not_found");
+    expect(formatResolveFailure("claude", result.resolved)).toContain(
+      `bun add -g ${CLAUDE_SPEC}`,
     );
   });
 

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -3,7 +3,7 @@
  *
  * When a spawn fails preflight with `binary_not_found`, callers (the
  * `acp_spawn` tool and the `/v1/acp/spawn` route) call
- * `resolveAgentWithAutoInstall(agentId)`, which performs a ONE-TIME global
+ * `resolveAgentWithAutoInstall(agentId)`, which performs a sandboxed global
  * install of the mapped adapter package via `bun`, then re-resolves and
  * continues. After the install the adapter is a normal trusted binary on
  * PATH, and the session manager spawns it the usual way (project cwd, token
@@ -19,6 +19,10 @@
  * or brew is left alone with a warning, since a bun install would not change
  * which binary spawns. The check runs on every resolution, never cached, so
  * an adapter replaced under a running daemon is caught on the next spawn.
+ * Every install is verified by re-probing; one that reports success and still
+ * leaves the pin unsatisfied abandons that pin for the life of the process,
+ * so a state the probe can never satisfy costs one install, not one per
+ * spawn, resume, and tool call.
  *
  * Security boundaries (this is the ATL-808 fix):
  *  - Only commands present in `DEFAULT_AGENT_NPM_PACKAGES` are ever
@@ -50,6 +54,7 @@ import {
 import type { AcpAgentConfig } from "../config/acp-schema.js";
 import { getLogger } from "../util/logger.js";
 import {
+  lookupAcpAgentConfig,
   resolveAcpAgent,
   type ResolveAcpAgentResult,
 } from "./resolve-agent.js";
@@ -72,20 +77,43 @@ export interface AdapterInstallResult {
 }
 
 /**
- * In-flight install promises, keyed by command AND the search path the probe
- * ran on. Concurrent spawns for the same adapter on the same PATH dedupe to a
- * single global install, while two agents whose `env.PATH` selects different
- * binaries each get their own decision: one PATH reaching an externally
- * managed adapter must not exempt another PATH reaching an outdated
- * bun-linked one. Nothing is cached past settle: the adapter on disk can
- * change under a running daemon (a user running the documented `bun add -g
- * ...@latest`), so every spawn re-probes.
+ * In-flight pin checks, keyed by command AND the search path the probe ran
+ * on. Concurrent spawns for the same adapter on the same PATH dedupe to a
+ * single decision, while two agents whose `env.PATH` selects different
+ * binaries each get their own: one PATH reaching an externally managed
+ * adapter must not exempt another PATH reaching an outdated bun-linked one.
+ * Nothing is cached past settle: the adapter on disk can change under a
+ * running daemon, so every spawn re-probes.
  */
-const installPromises = new Map<string, Promise<AdapterInstallResult>>();
+const pinChecks = new Map<string, Promise<AdapterInstallResult>>();
 
-/** Key for `installPromises`: the command plus the PATH the probe will use. */
-function inFlightKey(command: string, searchPath?: string): string {
-  return `${command}\u0000${searchPath ?? ""}`;
+/** In-flight global installs, keyed by command alone. */
+const installRuns = new Map<string, Promise<AdapterInstallResult>>();
+
+/** Composite map key over two fields that may contain any character. */
+function joinKey(first: string, second: string): string {
+  return `${first}\u0000${second}`;
+}
+
+/**
+ * Share one in-flight promise per key. The entry is evicted once the promise
+ * settles, whatever the outcome, so callers coalesce without anything being
+ * cached across calls.
+ */
+function coalesce<T>(
+  inFlight: Map<string, Promise<T>>,
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const existing = inFlight.get(key);
+  if (existing) {
+    return existing;
+  }
+  const promise = fn().finally(() => {
+    inFlight.delete(key);
+  });
+  inFlight.set(key, promise);
+  return promise;
 }
 
 /**
@@ -93,6 +121,31 @@ function inFlightKey(command: string, searchPath?: string): string {
  * spawn; the warning it can emit is worth saying once.
  */
 const warnedOutsideBun = new Set<string>();
+
+/** Commands already reported as unpinnable because `bun` is not on PATH. */
+const warnedMissingBun = new Set<string>();
+
+/**
+ * `command`/`packageSpec` pairs whose install reported success and left the
+ * pin unsatisfied. Nothing the daemon can do reaches the pinned state, so
+ * reinstalling would block every later spawn for the install timeout with no
+ * chance of succeeding. The pair is abandoned for the life of the process.
+ */
+const abandonedPins = new Set<string>();
+
+/** Emit `message` once per key: the pin check runs on every resolution. */
+function warnOnce(
+  seen: Set<string>,
+  key: string,
+  fields: Record<string, unknown>,
+  message: string,
+): void {
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  log.warn(fields, message);
+}
 
 /**
  * Run `execFile` with an AbortController-driven timeout. Returns the stdout
@@ -286,38 +339,70 @@ export function ensureAdapterInstalled(
 
   const bunPath = Bun.which("bun");
   if (!bunPath) {
+    warnOnce(
+      warnedMissingBun,
+      command,
+      { command, packageSpec },
+      "bun is not on PATH; leaving the ACP adapter as-is and skipping the version pin",
+    );
     return Promise.resolve({ installed: false });
   }
 
-  const key = inFlightKey(command, searchPath);
-  const inFlight = installPromises.get(key);
-  if (inFlight) {
-    return inFlight;
-  }
+  // Nothing survives the call: the probe is a manifest read plus a realpath,
+  // cheap enough to repeat, and caching a no-install decision would pin the
+  // daemon to whatever the adapter looked like at first spawn.
+  return coalesce(pinChecks, joinKey(command, searchPath ?? ""), () =>
+    installToPin(bunPath, command, packageSpec, searchPath),
+  );
+}
 
-  // Evicted once settled, whatever the outcome: the probe is a manifest read
-  // plus a realpath, cheap enough to repeat, and caching a no-install decision
-  // would pin the daemon to whatever the adapter looked like at first spawn.
-  const promise = installToPin(
-    bunPath,
-    command,
-    packageSpec,
-    searchPath,
-  ).finally(() => {
-    installPromises.delete(key);
-  });
-  installPromises.set(key, promise);
-  return promise;
+interface PinProbe {
+  /**
+   * `install`: PATH has no adapter, or the bun-linked one is not the pinned
+   * package at the pinned version, which covers an outdated install and one
+   * whose bin another package has taken over.
+   * `external`: PATH selects an adapter bun did not link, so an install would
+   * rewrite the disk without changing which binary spawns.
+   * `satisfied`: the binary a spawn selects is the pin.
+   */
+  action: "install" | "satisfied" | "external";
+  /** The executable a spawn on this search path would select. */
+  binaryPath?: string;
+}
+
+/** What the pin requires of the binary `searchPath` selects right now. */
+async function probePin(
+  command: string,
+  packageSpec: string,
+  searchPath?: string,
+): Promise<PinProbe> {
+  const binaryPath = whichOnPath(command, searchPath);
+  if (!binaryPath) {
+    return { action: "install" };
+  }
+  const { name, version } = splitPackageSpec(packageSpec);
+  if (version === undefined) {
+    return { action: "satisfied", binaryPath };
+  }
+  if (!(await isBunManagedBinary(command, binaryPath))) {
+    return { action: "external", binaryPath };
+  }
+  if (!(await bunLinkOwnedBy(command, name))) {
+    return { action: "install", binaryPath };
+  }
+  const action =
+    (await getInstalledAdapterVersion(command)) === version
+      ? "satisfied"
+      : "install";
+  return { action, binaryPath };
 }
 
 /**
- * A binary missing from PATH always installs, unchanged. One already on PATH
- * skips the install only when bun linked it, the link still resolves into the
- * pinned package, and that package's manifest reports the pinned version. Any
- * other bun-linked case installs, which covers an outdated install and one
- * whose bin another package has taken over. An adapter that came from
- * anywhere else stays put: PATH would keep selecting it, so a bun install
- * would change nothing but the disk.
+ * Install the pin when the probe says PATH does not already select it. The
+ * install is verified by re-probing, since `bun add` exiting 0 does not prove
+ * the pinned binary is what a spawn now runs: a bin link left pointing
+ * elsewhere, or a realpath the daemon may not read, would otherwise reinstall
+ * on every spawn forever.
  */
 async function installToPin(
   bunPath: string,
@@ -325,31 +410,41 @@ async function installToPin(
   packageSpec: string,
   searchPath?: string,
 ): Promise<AdapterInstallResult> {
-  const binaryPath = whichOnPath(command, searchPath);
-  if (!binaryPath) {
-    return runInstall(bunPath, command, packageSpec);
-  }
-  const { name, version } = splitPackageSpec(packageSpec);
-  if (version === undefined) {
+  const probe = await probePin(command, packageSpec, searchPath);
+  if (probe.action === "external") {
+    warnOnce(
+      warnedOutsideBun,
+      command,
+      { command, binaryPath: probe.binaryPath, packageSpec },
+      "ACP adapter is managed outside bun; leaving it in place and skipping the version pin",
+    );
     return { installed: false };
   }
-  if (!(await isBunManagedBinary(command, binaryPath))) {
-    if (!warnedOutsideBun.has(command)) {
-      warnedOutsideBun.add(command);
-      log.warn(
-        { command, binaryPath, packageSpec },
-        "ACP adapter is managed outside bun; leaving it in place and skipping the version pin",
-      );
-    }
+  if (probe.action === "satisfied") {
     return { installed: false };
   }
-  if (!(await bunLinkOwnedBy(command, name))) {
-    return runInstall(bunPath, command, packageSpec);
-  }
-  if ((await getInstalledAdapterVersion(command)) === version) {
+  const pinKey = joinKey(command, packageSpec);
+  if (abandonedPins.has(pinKey)) {
     return { installed: false };
   }
-  return runInstall(bunPath, command, packageSpec);
+  // Probes stay per PATH, but two PATHs spelling the same bun tree reach one
+  // global tree, and racing `bun add --global` against it is the bug.
+  const result = await coalesce(installRuns, command, () =>
+    runInstall(bunPath, command, packageSpec),
+  );
+  if (!result.installed) {
+    return result;
+  }
+  const verified = await probePin(command, packageSpec, searchPath);
+  if (verified.action === "install") {
+    warnOnce(
+      abandonedPins,
+      pinKey,
+      { command, packageSpec, binaryPath: verified.binaryPath },
+      "ACP adapter install reported success but PATH still does not select the pinned version; leaving it alone for the rest of this process",
+    );
+  }
+  return result;
 }
 
 /**
@@ -400,7 +495,10 @@ async function runInstall(
 export interface ResolveWithAutoInstallResult {
   /** The final resolver outcome (post-install re-resolve when applicable). */
   resolved: ResolveAcpAgentResult;
-  /** Set when a missing adapter binary was silently installed via bun. */
+  /**
+   * Set when bun installed the adapter during this resolution, whether it was
+   * missing or merely off the pin, so the caller can explain the delay.
+   */
   autoInstalledPackage?: string;
   /**
    * Set when the auto-install itself failed: the original install hint
@@ -422,14 +520,20 @@ export async function resolveAgentWithAutoInstall(
 ): Promise<ResolveWithAutoInstallResult> {
   const resolved = resolveAcpAgent(agentId);
   if (resolved.ok) {
-    return { resolved: await enforcePin(agentId, resolved.agent) };
+    return enforcePin(agentId, resolved.agent);
   }
   if (resolved.reason !== "binary_not_found") {
     return { resolved };
   }
 
   const { command, hint } = resolved;
-  const install = await ensureAdapterInstalled(command);
+  // The resolver decided `binary_not_found` against the agent's own PATH, so
+  // the recovery probes that PATH too: an adapter the daemon can see and the
+  // agent cannot still needs installing.
+  const install = await ensureAdapterInstalled(
+    command,
+    lookupAcpAgentConfig(agentId)?.env?.PATH,
+  );
   if (install.installed) {
     const retried = resolveAcpAgent(agentId);
     if (retried.ok) {
@@ -455,13 +559,15 @@ export async function resolveAgentWithAutoInstall(
  * A resolution that succeeded still has to satisfy the pin: the adapter on
  * PATH may be an older bun-managed install, or one linked by a different
  * package that owns the same binary name. Reinstall and re-resolve when it
- * does not match. When the reinstall fails, keep the original resolution and
- * warn: a stale adapter still beats no adapter.
+ * does not match, returning the re-resolution even when it failed so the
+ * caller surfaces its actionable hint instead of a bare spawn ENOENT. When
+ * the reinstall fails, keep the original resolution and warn: a stale adapter
+ * still beats no adapter.
  */
 async function enforcePin(
   agentId: string,
   agent: AcpAgentConfig,
-): Promise<ResolveAcpAgentResult> {
+): Promise<ResolveWithAutoInstallResult> {
   const { command } = agent;
   const install = await ensureAdapterInstalled(command, agent.env?.PATH);
   if (install.installed) {
@@ -471,21 +577,28 @@ async function enforcePin(
         { agentId, command },
         "Reinstalled the ACP adapter at its pinned version",
       );
-      return retried;
     }
-  } else if (install.error) {
+    return {
+      resolved: retried,
+      autoInstalledPackage: DEFAULT_AGENT_NPM_PACKAGES[command],
+    };
+  }
+  if (install.error) {
     log.warn(
       { agentId, command, error: install.error },
       "Could not reinstall the ACP adapter at its pinned version; spawning the installed one",
     );
   }
-  return { ok: true, agent };
+  return { resolved: { ok: true, agent } };
 }
 
 /** @internal: exposed for tests only. */
 export function _resetAdapterInstallCacheForTests(): void {
-  installPromises.clear();
+  pinChecks.clear();
+  installRuns.clear();
   warnedOutsideBun.clear();
+  warnedMissingBun.clear();
+  abandonedPins.clear();
   probeDeps = REAL_PROBE_DEPS;
 }
 

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -37,13 +37,15 @@ If they name Claude Code or Codex without asking you to run it here (for example
 
 ACP is always available - default profiles for `claude` and `codex` ship out-of-box, so no config edit is needed to start. First-time setup is just making the adapter binary available, then spawning:
 
-1. Install the adapter binary if it's missing. This happens automatically: when `acp_spawn` finds the agent's binary missing from PATH, the assistant installs it once via a sandboxed bun global install and proceeds in the same call (see "Automatic adapter availability" below).
+1. Install the adapter binary if it's missing. This happens automatically: when `acp_spawn` finds the agent's binary missing from PATH, the assistant installs the pinned version via a sandboxed bun global install and proceeds in the same call (see "Automatic adapter availability" below).
 
 2. Call `acp_spawn`. Do NOT run `vellum sleep && vellum wake` - that kills the conversation.
 
 ## Automatic adapter availability
 
-When `acp_spawn` finds the agent's binary missing from PATH, the assistant installs it once via a sandboxed bun global install and then runs the real installed binary. The install runs in a fresh empty temporary directory (never the task's project directory), with known secrets stripped from the installer environment and the registry pinned to the public npm registry, so a malicious project directory cannot hijack package resolution or capture a token. After this one-time install, the adapter is a normal trusted binary on PATH and every later spawn (and resume) uses it directly.
+The assistant pins the adapter version it was built against and re-checks that pin on every spawn and resume. When the binary is missing from PATH, or the installed one is off the pin, the assistant installs the pinned version via a sandboxed bun global install and then runs the real installed binary. The install runs in a fresh empty temporary directory (never the task's project directory), with known secrets stripped from the installer environment and the registry pinned to the public npm registry, so a malicious project directory cannot hijack package resolution or capture a token. Once the pin holds, the check is a cheap read and the spawn goes straight to the installed binary.
+
+An adapter installed by another package manager (npm, brew) is left alone: PATH would keep selecting it, so the pin is skipped rather than enforced.
 
 Only the allowlisted out-of-box packages are ever installed this way (`@agentclientprotocol/claude-agent-acp`, `@agentclientprotocol/codex-acp`); user-configured agents with custom commands are never installed automatically.
 
@@ -91,15 +93,9 @@ Do NOT put API keys (or any secret) in the workspace config file - secrets never
 
 ## Updating an adapter
 
-Adapters are installed automatically when missing. To update an installed adapter, ask the user first and use its owning package manager. For bun installations:
+The adapter version is pinned by the Assistant, which re-verifies it on every spawn. A manual `bun add -g <adapter>@latest` is therefore reverted to the pin on the next spawn: do not run one, and do not tell the user to. Adapter upgrades ship with Assistant releases.
 
-```bash
-bun add -g @agentclientprotocol/claude-agent-acp@latest
-# or
-bun add -g @agentclientprotocol/codex-acp@latest
-```
-
-Codex uses the adapter's bundled dependency by default, within the version range declared by the adapter. If `CODEX_PATH` selects a separate CLI, update that installation separately. Verify the required model with a fresh `acp_spawn` call after updating.
+Codex uses the adapter's bundled dependency by default, within the version range declared by the adapter. If `CODEX_PATH` selects a separate CLI, update that installation separately.
 
 ## When to use acp_steer vs acp_spawn
 

--- a/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
@@ -33,10 +33,10 @@ export function SkillsReferenceACPContent() {
             Setup required
           </SectionHeading>
           <p className="mb-0 text-zinc-600">
-            The protocol adapter is installed automatically the first time you use an agent. For
-            Claude Code that is everything: sign-in runs through an in-app Connect card, so there is
-            nothing to install yourself. The Codex adapter, @agentclientprotocol/codex-acp,
-            includes Codex and reuses your existing Codex login. Say
+            The protocol adapter is installed automatically and kept at the version your Assistant
+            pins. For Claude Code that is everything: sign-in runs through an in-app Connect card,
+            so there is nothing to install yourself. The Codex adapter,
+            @agentclientprotocol/codex-acp, includes Codex and reuses your existing Codex login. Say
             &ldquo;Set up ACP&rdquo; to walk through authentication. Naming Claude Code or Codex is
             also enough: the assistant offers once to connect it here, then continues.
           </p>

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "c6f1babe93d7d79eec39486eb27fce9b672151383a78572f0b98fc6a32db91ac"
+      "sha256": "602cd2808c59a261a1a7ea01b9783e5eb16ac7edaa49b5fb3a066c03091e2fd9"
     },
     "app-builder": {
       "docsSlug": "app-builder",


### PR DESCRIPTION
## Summary
Fixes gaps identified during the plan self-review for acp-model-control.md (auto-install and skill docs).

- Every install is verified by re-probing the pin. One that exits 0 and still leaves the pin unsatisfied is abandoned for the life of the process (warned once), so a state the probe can never satisfy costs one `bun add --global`, not one on every spawn, resume, and tool call.
- A reinstall reports its package through `autoInstalledPackage`, so the spawn result explains the delay.
- `binary_not_found` recovery probes the failing agent's own `env.PATH` instead of the daemon's, so an adapter the daemon can see and the agent cannot is still installed.
- Probes stay keyed by command plus PATH; the `bun add --global` they agree on is coalesced by command alone, so two PATHs into one bun tree cannot race it.
- `enforcePin` returns the post-install resolver result even when it failed, so the caller surfaces the actionable install hint instead of a bare spawn ENOENT.
- `bun` missing from PATH warns once that the pin is unenforced instead of skipping silently.
- The bundled ACP skill and its public docs page no longer describe the adapter install as one-time or tell the assistant to run `bun add -g <adapter>@latest`: the version is pinned by the Assistant, re-verified on every spawn, and upgraded with Assistant releases. Fingerprint re-recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D