### PR TITLE
fix(acp): harden model-preference writes, resume re-pin, and status projection

### DIFF
--- a/assistant/src/acp/__tests__/agent-process.test.ts
+++ b/assistant/src/acp/__tests__/agent-process.test.ts
@@ -15,6 +15,7 @@ import type {
 } from "@agentclientprotocol/sdk";
 
 import { AcpAgentProcess } from "../agent-process.js";
+import { modelOption } from "./helpers/acp-model-option.js";
 
 function makeProcess(): AcpAgentProcess {
   return new AcpAgentProcess(
@@ -165,21 +166,6 @@ describe("AcpAgentProcess loadSession/resumeSession", () => {
 });
 
 describe("AcpAgentProcess config options", () => {
-  /** The model selector shaped the way claude-agent-acp reports it. */
-  function modelOption(currentValue: string): SessionConfigOption {
-    return {
-      type: "select",
-      id: "model",
-      name: "Model",
-      category: "model",
-      currentValue,
-      options: [
-        { value: "sonnet", name: "Sonnet" },
-        { value: "opus", name: "Opus" },
-      ],
-    };
-  }
-
   /** Injects a connection whose session calls report `configOptions`. */
   function stubSessionResponses(
     proc: AcpAgentProcess,
@@ -193,7 +179,7 @@ describe("AcpAgentProcess config options", () => {
     };
   }
 
-  test("createSession returns and caches the reported options", async () => {
+  test("createSession returns the reported options", async () => {
     const proc = makeProcess();
     const options = [modelOption("sonnet")];
     stubSessionResponses(proc, options);
@@ -202,10 +188,9 @@ describe("AcpAgentProcess config options", () => {
       sessionId: "session-1",
       configOptions: options,
     });
-    expect(proc.configOptions).toEqual(options);
   });
 
-  test("loadSession returns and caches the reported options", async () => {
+  test("loadSession returns the reported options", async () => {
     const proc = makeProcess();
     const options = [modelOption("sonnet")];
     stubSessionResponses(proc, options);
@@ -213,10 +198,9 @@ describe("AcpAgentProcess config options", () => {
     await expect(
       proc.loadSession("session-1", "/tmp/project"),
     ).resolves.toEqual({ configOptions: options });
-    expect(proc.configOptions).toEqual(options);
   });
 
-  test("resumeSession returns and caches the reported options", async () => {
+  test("resumeSession returns the reported options", async () => {
     const proc = makeProcess();
     const options = [modelOption("opus")];
     stubSessionResponses(proc, options);
@@ -224,7 +208,6 @@ describe("AcpAgentProcess config options", () => {
     await expect(
       proc.resumeSession("session-1", "/tmp/project"),
     ).resolves.toEqual({ configOptions: options });
-    expect(proc.configOptions).toEqual(options);
   });
 
   test("a null or absent configOptions normalizes to an empty array", async () => {
@@ -234,7 +217,6 @@ describe("AcpAgentProcess config options", () => {
       sessionId: "session-1",
       configOptions: [],
     });
-    expect(created.configOptions).toEqual([]);
 
     const loaded = makeProcess();
     stubSessionResponses(loaded, null);
@@ -249,84 +231,7 @@ describe("AcpAgentProcess config options", () => {
     ).resolves.toEqual({ configOptions: [] });
   });
 
-  test("modelConfigOption is undefined before a session call", () => {
-    const proc = makeProcess();
-
-    expect(proc.modelConfigOption).toBeUndefined();
-    expect(proc.supportsModelSelection).toBe(false);
-  });
-
-  test("modelConfigOption matches a select option by id", async () => {
-    const proc = makeProcess();
-    const option: SessionConfigOption = {
-      ...modelOption("sonnet"),
-      category: undefined,
-    };
-    stubSessionResponses(proc, [option]);
-
-    await proc.createSession("/tmp/project");
-
-    expect(proc.modelConfigOption).toEqual(option);
-    expect(proc.supportsModelSelection).toBe(true);
-  });
-
-  test("modelConfigOption matches a select option by category", async () => {
-    const proc = makeProcess();
-    const option: SessionConfigOption = {
-      ...modelOption("sonnet"),
-      id: "llm",
-    };
-    stubSessionResponses(proc, [option]);
-
-    await proc.createSession("/tmp/project");
-
-    expect(proc.modelConfigOption).toEqual(option);
-  });
-
-  test("modelConfigOption ignores boolean options in the model category", async () => {
-    const proc = makeProcess();
-    stubSessionResponses(proc, [
-      {
-        type: "boolean",
-        id: "model",
-        name: "Extended thinking",
-        category: "model",
-        currentValue: true,
-      },
-    ]);
-
-    await proc.createSession("/tmp/project");
-
-    expect(proc.modelConfigOption).toBeUndefined();
-    expect(proc.supportsModelSelection).toBe(false);
-  });
-
-  test("applyConfigOptionsUpdate replaces the cached set", async () => {
-    const proc = makeProcess();
-    stubSessionResponses(proc, [modelOption("sonnet")]);
-    await proc.createSession("/tmp/project");
-
-    const refreshed = [modelOption("opus")];
-    proc.applyConfigOptionsUpdate(refreshed);
-
-    expect(proc.configOptions).toEqual(refreshed);
-    expect(proc.modelConfigOption).toEqual(refreshed[0]);
-    expect(proc.supportsModelSelection).toBe(true);
-  });
-
-  test("applyConfigOptionsUpdate can drop the model selector", async () => {
-    const proc = makeProcess();
-    stubSessionResponses(proc, [modelOption("sonnet")]);
-    await proc.createSession("/tmp/project");
-
-    proc.applyConfigOptionsUpdate([]);
-
-    expect(proc.configOptions).toEqual([]);
-    expect(proc.modelConfigOption).toBeUndefined();
-    expect(proc.supportsModelSelection).toBe(false);
-  });
-
-  test("setConfigOption forwards the value and caches the refreshed set", async () => {
+  test("setConfigOption forwards the value and returns the refreshed set", async () => {
     const proc = makeProcess();
     const calls: unknown[] = [];
     const refreshed = [modelOption("opus")];
@@ -344,8 +249,6 @@ describe("AcpAgentProcess config options", () => {
     expect(calls).toEqual([
       { sessionId: "session-1", configId: "model", value: "opus" },
     ]);
-    expect(proc.configOptions).toEqual(refreshed);
-    expect(proc.modelConfigOption).toMatchObject({ currentValue: "opus" });
   });
 
   test("setConfigOption sends the boolean request variant", async () => {

--- a/assistant/src/acp/__tests__/client-handler.test.ts
+++ b/assistant/src/acp/__tests__/client-handler.test.ts
@@ -7,6 +7,7 @@ import type {
 
 import type { AssistantEvent } from "../../api/index.js";
 import { VellumAcpClientHandler } from "../client-handler.js";
+import { modelOption } from "./helpers/acp-model-option.js";
 
 const ACP_SESSION_ID = "acp-session-abc";
 const PARENT_CONVERSATION_ID = "conv-xyz";
@@ -792,17 +793,7 @@ describe("VellumAcpClientHandler seq + enriched fields", () => {
 });
 
 describe("VellumAcpClientHandler config_option_update", () => {
-  const MODEL_OPTION: SessionConfigOption = {
-    type: "select",
-    id: "model",
-    name: "Model",
-    category: "model",
-    currentValue: "sonnet",
-    options: [
-      { value: "sonnet", name: "Sonnet" },
-      { value: "opus", name: "Opus" },
-    ],
-  };
+  const MODEL_OPTION = modelOption("sonnet");
 
   const THOUGHT_OPTION: SessionConfigOption = {
     type: "boolean",

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -37,6 +37,14 @@ let promptThrowsSync = false;
 let resumeSessionGate: Promise<void> | null = null;
 /** Config options session/resume and session/load report back. */
 let resumeConfigOptions: SessionConfigOption[] = [];
+/**
+ * When set, session/load announces these through a `config_option_update`
+ * during its replay, the way an adapter reports what the reattached session
+ * is on before the load resolves.
+ */
+let replayConfigOptions: SessionConfigOption[] | null = null;
+/** When set, setConfigOption rejects with it (the adapter refusing a pin). */
+let setConfigOptionError: Error | null = null;
 /** Every `setConfigOption` the manager dispatched during a resume. */
 const setConfigOptionCalls: Array<{
   sessionId: string;
@@ -95,6 +103,9 @@ class FakeAcpAgentProcess {
     for (const text of replayChunks) {
       await this.emitChunk(text);
     }
+    if (replayConfigOptions) {
+      await this.emitConfigOptions(replayConfigOptions);
+    }
     return { configOptions: resumeConfigOptions };
   }
 
@@ -116,9 +127,20 @@ class FakeAcpAgentProcess {
     value: string | boolean,
   ): Promise<SessionConfigOption[]> {
     setConfigOptionCalls.push({ sessionId, configId, value });
+    if (setConfigOptionError) {
+      throw setConfigOptionError;
+    }
     return typeof value === "string"
       ? [modelOption(value)]
       : resumeConfigOptions;
+  }
+
+  /** Drives a config_option_update through the real client handler. */
+  async emitConfigOptions(configOptions: SessionConfigOption[]): Promise<void> {
+    await this.clientFactory(this).sessionUpdate({
+      sessionId: "proto-old",
+      update: { sessionUpdate: "config_option_update", configOptions },
+    });
   }
 
   /** Drives an agent_message_chunk through the real client handler. */
@@ -300,6 +322,8 @@ beforeEach(() => {
   prepareAgentEnvCommands = [];
   resumeSessionGate = null;
   resumeConfigOptions = [];
+  replayConfigOptions = null;
+  setConfigOptionError = null;
   setConfigOptionCalls.length = 0;
   resolveImpl = () => ({
     ok: true,
@@ -798,6 +822,55 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     expect(
       getAcpConversationModelPreference("conv-1", "claude"),
     ).toBeUndefined();
+  });
+
+  test("a config_option_update replayed during session/load records no preference", async () => {
+    fakeCaps.loadSession = true;
+    // The reattached adapter announces its own default mid-replay, before
+    // the pin that puts the run back on what the row recorded.
+    replayConfigOptions = [modelOption("default")];
+    resumeConfigOptions = [modelOption("default")];
+    insertHistoryRow({ id: "resume-replay-model", model: "opus" });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-replay-model", () => {});
+
+    const state = manager.getStatus("resume-replay-model") as AcpSessionState;
+    expect(state.model).toBe("opus");
+    // Announcing a default is not the user choosing one.
+    expect(
+      getAcpConversationModelPreference("conv-1", "claude"),
+    ).toBeUndefined();
+  });
+
+  test("a resume the adapter refuses to re-pin keeps the recorded model on the row", async () => {
+    fakeCaps.resume = true;
+    resumeConfigOptions = [modelOption("default")];
+    setConfigOptionError = new Error(
+      "Invalid value for config option model: claude-opus-4-5",
+    );
+    insertHistoryRow({
+      id: "resume-refused-model",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+      model: "claude-opus-4-5",
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-refused-model", () => {});
+
+    // The adapter's own default replaced it in state; the record wins back.
+    expect(
+      (manager.getStatus("resume-refused-model") as AcpSessionState).model,
+    ).toBe("claude-opus-4-5");
+
+    await manager.steer("resume-refused-model", "keep going");
+    fakeInstances[0]!.resolvePrompt!({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readHistoryRow("resume-refused-model")!.model).toBe(
+      "claude-opus-4-5",
+    );
   });
 
   test("concurrent resumes of the same id: one wins, the loser fails cleanly without leaking a process", async () => {

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -89,10 +89,6 @@ mock.module("../agent-process.js", () => ({
     async cancel(sessionId: string): Promise<void> {
       cancelCalls.push(sessionId);
     }
-    readonly appliedConfigOptions: SessionConfigOption[][] = [];
-    applyConfigOptionsUpdate(configOptions: SessionConfigOption[]): void {
-      this.appliedConfigOptions.push(configOptions);
-    }
     markStderr(): number {
       return 0;
     }
@@ -231,47 +227,6 @@ describe("AcpSessionManager — cancelForParent", () => {
 
     expect(manager.cancelForParent("parent-with-nothing")).toBe(0);
     expect(cancelCalls).toEqual([]);
-  });
-});
-
-describe("AcpSessionManager config option updates", () => {
-  const noopSend = () => {};
-
-  const MODEL_OPTION = modelOption("opus");
-
-  test("a config_option_update notification refreshes the process cache", async () => {
-    const manager = new AcpSessionManager(5);
-
-    const { acpSessionId } = await manager.spawn(
-      "agent-1",
-      { command: "echo", args: ["hi"] },
-      "task",
-      "/tmp",
-      "parent-A",
-      noopSend,
-    );
-
-    const entry = (
-      manager as unknown as {
-        sessions: Map<
-          string,
-          {
-            process: { appliedConfigOptions: SessionConfigOption[][] };
-            clientHandler: VellumAcpClientHandler;
-          }
-        >;
-      }
-    ).sessions.get(acpSessionId);
-
-    await entry?.clientHandler.sessionUpdate({
-      sessionId: "proto-agent-1",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [MODEL_OPTION],
-      },
-    });
-
-    expect(entry?.process.appliedConfigOptions).toEqual([[MODEL_OPTION]]);
   });
 });
 
@@ -473,6 +428,22 @@ describe("AcpSessionManager: model selection at spawn", () => {
     expect(
       getAcpConversationModelPreference("conv-inherit", "agent-model"),
     ).toBeUndefined();
+  });
+
+  test("an inherited model the adapter refuses warns nobody", async () => {
+    config.setConfig({ defaultModel: "nope" });
+    scriptedConfigOptions = [[modelOption("opus")]];
+    setConfigOptionResult = new Error(
+      "Invalid value for config option model: nope",
+    );
+
+    const { modelWarning, state } = await spawnWithModel({
+      conversationId: "conv-refused-inherited",
+    });
+
+    // Logged, not surfaced: nobody typed this model here.
+    expect(modelWarning).toBeUndefined();
+    expect(state.model).toBe("opus");
   });
 
   test("a refused model warns, runs unpinned, and records no preference", async () => {
@@ -952,6 +923,126 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     expect(sent.map((e) => e.type)).toEqual(["acp_session_model_update"]);
     expect(
       getAcpConversationModelPreference("conv-pin-echo", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("a notification after the session went terminal changes nothing", async () => {
+    const { manager, acpSessionId, sent } =
+      await spawnSwitchable("conv-terminal");
+    const handler = clientHandlerFor(manager, acpSessionId);
+    await manager.cancel(acpSessionId);
+    sent.length = 0;
+
+    await handler.sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("opus")],
+      },
+    });
+
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.status).toBe("cancelled");
+    expect(state.model).toBe("sonnet");
+    expect(sent).toEqual([]);
+    expect(
+      getAcpConversationModelPreference("conv-terminal", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("an adapter that first reports its selector by notification records no preference", async () => {
+    // Nothing in the session/new response, so no pin ever ran against a
+    // model the adapter had told us about.
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const { acpSessionId } = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-late-selector",
+      (msg) => sent.push(msg),
+    );
+    sent.length = 0;
+
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("opus")],
+      },
+    });
+
+    // The picker still reaches the client; only the preference is withheld.
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "opus",
+    );
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_model_update"]);
+    expect(
+      getAcpConversationModelPreference("conv-late-selector", "agent-model"),
+    ).toBeUndefined();
+  });
+
+  test("a user picking the value a refused pin asked for is remembered", async () => {
+    scriptedConfigOptions = [[modelOption("opus")]];
+    setConfigOptionResult = new Error(
+      "Invalid value for config option model: sonnet",
+    );
+    const manager = new AcpSessionManager(5);
+    const { acpSessionId } = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-refused-then-typed",
+      () => {},
+      { model: "sonnet" },
+    );
+
+    // Nothing moved when the pin was refused, so this is a genuine choice
+    // rather than that call's echo.
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("sonnet")],
+      },
+    });
+
+    expect(
+      getAcpConversationModelPreference(
+        "conv-refused-then-typed",
+        "agent-model",
+      ),
+    ).toBe("sonnet");
+  });
+
+  test("a preference is keyed on the canonical agent id, not the alias spawned under", async () => {
+    scriptedConfigOptions = [[modelOption("sonnet")]];
+    const manager = new AcpSessionManager(5);
+    const { acpSessionId } = await manager.spawn(
+      "claude code",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-alias",
+      () => {},
+    );
+
+    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+      sessionId: "proto-claude code",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("opus")],
+      },
+    });
+
+    expect(getAcpConversationModelPreference("conv-alias", "claude")).toBe(
+      "opus",
+    );
+    // And a spawn made under the canonical id inherits it.
+    expect(
+      getAcpConversationModelPreference("conv-alias", "claude code"),
     ).toBeUndefined();
   });
 

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -25,7 +25,6 @@ import * as acp from "@agentclientprotocol/sdk";
 
 import { getLogger } from "../util/logger.js";
 import { AcpAuthRequiredError, isAcpAuthRequired } from "./auth-required.js";
-import { findModelConfigOption } from "./model-config.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp");
@@ -36,6 +35,16 @@ const log = getLogger("acp");
  * stays bounded.
  */
 const STDERR_RETENTION_BYTES = 4096;
+
+/**
+ * Normalizes the SDK's optional-and-nullable config-option field to an array,
+ * so every session call hands its caller the same shape.
+ */
+function normalizeConfigOptions(
+  configOptions: SessionConfigOption[] | null | undefined,
+): SessionConfigOption[] {
+  return configOptions ?? [];
+}
 
 function isEnvVarMethod(
   method: AuthMethod,
@@ -62,14 +71,6 @@ export class AcpAgentProcess {
    * afterwards.
    */
   private spawnedEnv: NodeJS.ProcessEnv | null = null;
-
-  /**
-   * Session config options as last reported by the agent: on session
-   * create/load/resume, on every setConfigOption response, and on every
-   * config_option_update notification. Each carries the full refreshed set.
-   * Empty until one of those arrives.
-   */
-  private lastConfigOptions: SessionConfigOption[] = [];
 
   /**
    * Ring of the most recent stderr lines, bounded to ~STDERR_RETENTION_BYTES.
@@ -231,24 +232,6 @@ export class AcpAgentProcess {
     );
   }
 
-  /** Session config options as of the last session or setConfigOption call. */
-  get configOptions(): SessionConfigOption[] {
-    return this.lastConfigOptions;
-  }
-
-  /** The agent's model selector, if it advertises one. */
-  get modelConfigOption(): SessionConfigOption | undefined {
-    return findModelConfigOption(this.lastConfigOptions);
-  }
-
-  /**
-   * Whether the agent exposes a model selector. No capability flag announces
-   * config-option support, so this stays false until a session call reports one.
-   */
-  get supportsModelSelection(): boolean {
-    return this.modelConfigOption != null;
-  }
-
   /**
    * Authentication methods the agent advertised at initialize.
    * Returns an empty array before initialize() resolves.
@@ -385,25 +368,6 @@ export class AcpAgentProcess {
   }
 
   /**
-   * Replaces the cached config options with what the agent just reported,
-   * normalizing the SDK's optional-and-nullable field to an array.
-   */
-  private cacheConfigOptions(
-    configOptions: SessionConfigOption[] | null | undefined,
-  ): SessionConfigOption[] {
-    this.lastConfigOptions = configOptions ?? [];
-    return this.lastConfigOptions;
-  }
-
-  /**
-   * Refreshes the cache from a `config_option_update` notification, which
-   * carries the agent's full option set rather than a delta.
-   */
-  applyConfigOptionsUpdate(configOptions: SessionConfigOption[]): void {
-    this.cacheConfigOptions(configOptions);
-  }
-
-  /**
    * Creates a new ACP session in the specified working directory.
    * Returns the session ID and the config options the agent reported.
    */
@@ -418,7 +382,7 @@ export class AcpAgentProcess {
 
     return {
       sessionId: result.sessionId,
-      configOptions: this.cacheConfigOptions(result.configOptions),
+      configOptions: normalizeConfigOptions(result.configOptions),
     };
   }
 
@@ -440,7 +404,7 @@ export class AcpAgentProcess {
       this.requireConnection().loadSession({ sessionId, cwd, mcpServers: [] }),
     );
 
-    return { configOptions: this.cacheConfigOptions(result.configOptions) };
+    return { configOptions: normalizeConfigOptions(result.configOptions) };
   }
 
   /**
@@ -464,13 +428,13 @@ export class AcpAgentProcess {
       }),
     );
 
-    return { configOptions: this.cacheConfigOptions(result.configOptions) };
+    return { configOptions: normalizeConfigOptions(result.configOptions) };
   }
 
   /**
    * Sets one session config option (e.g. the model selector) via
    * `session/set_config_option`. The agent answers with the full refreshed
-   * option set, which replaces the cached one.
+   * option set, which is returned to the caller.
    *
    * A boolean value sends the `type: "boolean"` request variant; a string
    * sends the value-id variant.
@@ -494,7 +458,7 @@ export class AcpAgentProcess {
       this.requireConnection().setSessionConfigOption(request),
     );
 
-    return this.cacheConfigOptions(response.configOptions);
+    return normalizeConfigOptions(response.configOptions);
   }
 
   /**

--- a/assistant/src/acp/model-config.test.ts
+++ b/assistant/src/acp/model-config.test.ts
@@ -8,29 +8,20 @@ import { describe, expect, test } from "bun:test";
 
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 
+import {
+  MODEL_OPTION_MODELS,
+  modelOption,
+} from "./__tests__/helpers/acp-model-option.js";
 import { deriveModelInfo, resolveAcpModel } from "./model-config.js";
 
-const flatModelOption: SessionConfigOption = {
-  type: "select",
-  id: "model",
-  name: "Model",
-  category: "model",
-  currentValue: "sonnet",
-  options: [
-    { value: "sonnet", name: "Sonnet", description: "Balanced" },
-    { value: "opus", name: "Opus" },
-  ],
-};
+const flatModelOption = modelOption("sonnet");
 
 describe("deriveModelInfo", () => {
   test("flattens flat options and reports the current value", () => {
     expect(deriveModelInfo([flatModelOption])).toEqual({
       model: "sonnet",
       modelConfigId: "model",
-      availableModels: [
-        { value: "sonnet", label: "Sonnet", description: "Balanced" },
-        { value: "opus", label: "Opus" },
-      ],
+      availableModels: MODEL_OPTION_MODELS,
     });
   });
 

--- a/assistant/src/acp/model-config.ts
+++ b/assistant/src/acp/model-config.ts
@@ -27,27 +27,34 @@ import type {
   SessionConfigSelectGroup,
   SessionConfigSelectOption,
 } from "@agentclientprotocol/sdk";
+import type { z } from "zod";
 
-/** A selectable model as reported by the adapter, flattened out of its group. */
-export type AcpModelOption = {
-  value: string;
-  label: string;
-  description?: string;
-  group?: string;
-};
+import type { AcpSessionModelUpdateEventSchema } from "../api/events/acp-session-model-update.js";
 
-export type AcpModelInfo = {
+/**
+ * A selectable model as reported by the adapter, flattened out of its group.
+ * Derived from the event schema so the published wire shape and the shape the
+ * daemon carries in memory cannot drift apart.
+ */
+export type AcpModelOption = z.infer<
+  typeof AcpSessionModelUpdateEventSchema
+>["availableModels"][number];
+
+/** What an adapter's config-option set says about the session's model. */
+type AcpModelInfo = {
   model?: string;
   availableModels: AcpModelOption[];
   modelConfigId?: string;
 };
 
-export type ResolveAcpModelInput = {
+type ResolveAcpModelInput = {
   requestedModel?: string;
   conversationPreference?: string;
   agentModel?: string;
   defaultModel?: string;
 };
+
+type ModelSelectOption = Extract<SessionConfigOption, { type: "select" }>;
 
 function isGroup(
   entry: SessionConfigSelectOption | SessionConfigSelectGroup,
@@ -68,16 +75,6 @@ function toModelOption(
 }
 
 /**
- * Extract current model, selectable models, and the config id to write back.
- * Returns `{ availableModels: [] }` when the adapter advertises no model
- * selector, which is how the whole feature degrades to invisible.
- */
-export type ModelSelectOption = Extract<
-  SessionConfigOption,
-  { type: "select" }
->;
-
-/**
  * The adapter's model selector, if it advertises one. `category` is UX-only
  * per the ACP spec, so a `model` id counts too; non-select options never do.
  */
@@ -91,6 +88,11 @@ export function findModelConfigOption(
   );
 }
 
+/**
+ * Extract current model, selectable models, and the config id to write back.
+ * Returns `{ availableModels: [] }` when the adapter advertises no model
+ * selector, which is how the whole feature degrades to invisible.
+ */
 export function deriveModelInfo(
   configOptions: SessionConfigOption[] | null | undefined,
 ): AcpModelInfo {

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -10,7 +10,8 @@ afterAll(() => {
   which.restore();
 });
 
-const { resolveAcpAgent, listAcpAgents } = await import("./resolve-agent.js");
+const { canonicalAgentId, resolveAcpAgent, listAcpAgents } =
+  await import("./resolve-agent.js");
 
 beforeEach(() => {
   config.setConfig({});
@@ -309,6 +310,29 @@ describe("resolveAcpAgent", () => {
       return;
     }
     expect(fullPath.agent.command).toBe("/opt/bin/claude-agent-acp");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canonicalAgentId
+// ---------------------------------------------------------------------------
+
+describe("canonicalAgentId", () => {
+  test("folds every natural spelling of an alias onto one id", () => {
+    for (const alias of ["Claude Code", "claude-code", "claude_code"]) {
+      expect(canonicalAgentId(alias)).toBe("claude");
+    }
+    expect(canonicalAgentId("OpenAI Codex")).toBe("codex");
+    expect(canonicalAgentId("codex cli")).toBe("codex");
+  });
+
+  test("passes a canonical id through untouched", () => {
+    expect(canonicalAgentId("claude")).toBe("claude");
+    expect(canonicalAgentId("codex")).toBe("codex");
+  });
+
+  test("passes an id that names no alias through untouched", () => {
+    expect(canonicalAgentId("my-custom-agent")).toBe("my-custom-agent");
   });
 });
 

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -144,6 +144,15 @@ function normalizeAgentId(id: string): string {
 }
 
 /**
+ * The bundled id an alias resolves to, or the id itself when it names no
+ * alias. Callers that key durable state on an agent id use this so a spawn
+ * made as "claude code" and one made as "claude" share a single record.
+ */
+export function canonicalAgentId(id: string): string {
+  return AGENT_ID_ALIASES[normalizeAgentId(id)] ?? id;
+}
+
+/**
  * Resolve an id against user config first, then bundled defaults. Returns the
  * resolved entry plus a `source` label so callers can surface "user override
  * vs bundled default" without re-deriving it.

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -38,13 +38,9 @@ import {
 import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { deriveFailureError } from "./failure-error.js";
-import {
-  type AcpModelInfo,
-  deriveModelInfo,
-  resolveAcpModel,
-} from "./model-config.js";
+import { deriveModelInfo, resolveAcpModel } from "./model-config.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
-import { formatResolveFailure } from "./resolve-agent.js";
+import { canonicalAgentId, formatResolveFailure } from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
 import type { AcpAgentConfig, AcpSessionState } from "./types.js";
 
@@ -84,7 +80,10 @@ function readConversationModelPreference(
   agentId: string,
 ): string | undefined {
   try {
-    return getAcpConversationModelPreference(parentConversationId, agentId);
+    return getAcpConversationModelPreference(
+      parentConversationId,
+      canonicalAgentId(agentId),
+    );
   } catch (err) {
     log.warn(
       { parentConversationId, agentId, err },
@@ -105,7 +104,10 @@ function rememberConversationModelPreference(preference: {
   model: string;
 }): void {
   try {
-    upsertAcpConversationModelPreference(preference);
+    upsertAcpConversationModelPreference({
+      ...preference,
+      agentId: canonicalAgentId(preference.agentId),
+    });
   } catch (err) {
     log.warn(
       { ...preference, err },
@@ -213,14 +215,26 @@ interface SessionEntry {
   /** Tail of this session's model-switch chain, so overlapping setModel calls
    *  reach the adapter one at a time and the last choice wins. */
   modelSwitchQueue: Promise<void>;
-  /** Count of this manager's own `setConfigOption` calls in flight, so a
-   *  `config_option_update` the adapter sends as their side effect is not
-   *  read as a user choice. */
-  managerPinsInFlight: number;
-  /** Last model value this manager asked the adapter for, kept because the
-   *  echoing notification can land after the call resolved. Cleared once a
-   *  genuinely different model arrives. */
+  /** Last model value this manager asked the adapter for, so a
+   *  `config_option_update` the adapter sends as that call's side effect is
+   *  not read as a user choice. Set before the call, cleared when the call
+   *  failed (nothing moved, so a later user pick of the same value is a
+   *  genuine choice) and once a genuinely different model arrives. */
   lastManagerPinnedModel?: string;
+  /** Whether a pin has run against the adapter's own reported model. Until it
+   *  has, an unsolicited update is the adapter announcing its default rather
+   *  than the user choosing, and writing it as the conversation's preference
+   *  would freeze that default in. */
+  modelBaselineEstablished: boolean;
+}
+
+/** What a spawn or resume pin did about the model it was asked for. */
+interface ModelPinResult {
+  /** False when the session is not on the model asked for: the adapter
+   *  refused it, or advertises no selector at all. */
+  applied: boolean;
+  /** Message to relay, present only when the caller named the model. */
+  warning?: string;
 }
 
 /**
@@ -420,11 +434,11 @@ export class AcpSessionManager {
       throw err;
     }
 
-    const modelWarning = await this.pinSessionModel(
+    const { warning: modelWarning } = await this.pinSessionModel(
       entry,
       configOptions,
+      requestedModel,
       resolvedModel,
-      requestedModel !== undefined,
     );
 
     // Only an explicit request becomes the conversation's preference, and only
@@ -463,14 +477,13 @@ export class AcpSessionManager {
   private applyModelInfo(
     entry: SessionEntry,
     configOptions: SessionConfigOption[],
-  ): AcpModelInfo {
+  ): void {
     const info = deriveModelInfo(configOptions);
     entry.modelConfigId = info.modelConfigId;
     if (info.modelConfigId) {
       entry.state.model = info.model;
       entry.state.availableModels = info.availableModels;
     }
-    return info;
   }
 
   /**
@@ -482,62 +495,79 @@ export class AcpSessionManager {
    * relay, because a session that is live and working is worth more than one
    * that never started over a model name.
    *
-   * `explicitlyRequested` says the caller named this model rather than
-   * inheriting it, which is what decides whether an adapter with no model
-   * selector is worth a warning: someone who asked for a model is owed the
-   * news that it was not applied, while an inherited rung is only logged.
+   * A caller who named the model is owed the news when it was not applied,
+   * whether the adapter has no selector or refused the value; an inherited
+   * rung (config default, remembered preference) is only logged, so a config
+   * the user never typed here does not surface as a warning on every spawn.
    */
   private async pinSessionModel(
     entry: SessionEntry,
     configOptions: SessionConfigOption[],
+    requestedModel: string | undefined,
     resolvedModel: string | undefined,
-    explicitlyRequested = false,
-  ): Promise<string | undefined> {
+  ): Promise<ModelPinResult> {
     const { state } = entry;
-    const info = this.applyModelInfo(entry, configOptions);
-    if (!resolvedModel || resolvedModel === info.model) {
-      return undefined;
+    this.applyModelInfo(entry, configOptions);
+    // The adapter has reported what it is on, so anything unsolicited from
+    // here is a change rather than its opening announcement.
+    entry.modelBaselineEstablished = entry.modelConfigId !== undefined;
+
+    if (!resolvedModel || resolvedModel === state.model) {
+      return { applied: true };
     }
-    if (!info.modelConfigId) {
+    if (!entry.modelConfigId) {
       log.info(
         { acpSessionId: state.id, agentId: state.agentId, resolvedModel },
         "ACP agent advertises no model selector; running on its own model",
       );
-      return explicitlyRequested
-        ? `Agent "${state.agentId}" does not support model selection, so the session is running on the agent's own model.`
-        : undefined;
+      return {
+        applied: false,
+        ...(requestedModel
+          ? {
+              warning: `Agent "${state.agentId}" does not support model selection, so the session is running on the agent's own model.`,
+            }
+          : {}),
+      };
     }
 
     try {
       const refreshed = await this.setConfigOptionAsManager(
         entry,
-        info.modelConfigId,
+        entry.modelConfigId,
         resolvedModel,
       );
       this.applyModelInfo(entry, refreshed);
-      return undefined;
+      return { applied: true };
     } catch (err) {
       log.warn(
         { acpSessionId: state.id, agentId: state.agentId, resolvedModel, err },
         "ACP agent refused the requested model; running on its own model",
       );
-      return err instanceof Error ? err.message : String(err);
+      return {
+        applied: false,
+        ...(requestedModel
+          ? { warning: err instanceof Error ? err.message : String(err) }
+          : {}),
+      };
     }
   }
 
   /**
-   * Runs one of the manager's own `setConfigOption` calls, marked for the
-   * duration so the unsolicited path does not mistake the adapter's echo of
-   * it for a model the user chose. Spawn, resume, and `setModel` each decide
-   * their own preference write, and a second one from the notification would
-   * freeze an inherited default into the conversation.
+   * Runs one of the manager's own `setConfigOption` calls, marked so the
+   * unsolicited path does not mistake the adapter's echo of it for a model
+   * the user chose. Spawn, resume, and `setModel` each decide their own
+   * preference write, and a second one from the notification would freeze an
+   * inherited default into the conversation. Switches are serialized per
+   * session, so one marker covers every call in flight.
+   *
+   * A refused call clears the marker: nothing moved, so a later `/model` onto
+   * the same value is a genuine choice rather than this call's echo.
    */
   private async setConfigOptionAsManager(
     entry: SessionEntry,
     configId: string,
     value: string,
   ): Promise<SessionConfigOption[]> {
-    entry.managerPinsInFlight += 1;
     entry.lastManagerPinnedModel = value;
     try {
       return await entry.process.setConfigOption(
@@ -545,8 +575,9 @@ export class AcpSessionManager {
         configId,
         value,
       );
-    } finally {
-      entry.managerPinsInFlight -= 1;
+    } catch (err) {
+      entry.lastManagerPinnedModel = undefined;
+      throw err;
     }
   }
 
@@ -597,14 +628,13 @@ export class AcpSessionManager {
       opts.sendToVellum(msg);
     };
 
-    // The callback reads agentProcess, constructed just below, and only runs
-    // once the agent is connected and sending notifications.
+    // The callback runs once the agent is connected and sending
+    // notifications, which is after agentProcess is constructed just below.
     const clientHandler = new VellumAcpClientHandler(
       acpSessionId,
       wrappedSend,
       opts.parentConversationId,
       (configOptions) => {
-        agentProcess.applyConfigOptionsUpdate(configOptions);
         this.applyUnsolicitedConfigOptions(acpSessionId, configOptions);
       },
     );
@@ -639,7 +669,7 @@ export class AcpSessionManager {
       command: basename(opts.agentConfig.command),
       credentialDigest: opts.agentConfig.credentialDigest,
       modelSwitchQueue: Promise.resolve(),
-      managerPinsInFlight: 0,
+      modelBaselineEstablished: false,
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -760,7 +790,7 @@ export class AcpSessionManager {
       throw new AcpSessionNotFoundError(acpSessionId);
     }
     this.applyModelInfo(entry, refreshed);
-    if (!this.clearVanishedModelSelector(acpSessionId, entry, true)) {
+    if (!this.clearVanishedModelSelector(acpSessionId, entry)) {
       this.rememberModelChoice(entry);
       this.sendModelEvent(acpSessionId, entry);
     }
@@ -787,13 +817,17 @@ export class AcpSessionManager {
    * adapters that never had one, which here would leave the client on options
    * `setModel` now rejects. Returns whether it fired, so callers skip the
    * publish and the preference write that assume a model is still there.
+   *
+   * A published picker is what says the selector was there to vanish: only an
+   * adapter that advertised one ever populates it, so an adapter that never
+   * had one publishes nothing. `state.model` would not do: a resume seeds it
+   * from the history row for adapters that report no selector at all.
    */
   private clearVanishedModelSelector(
     acpSessionId: string,
     entry: SessionEntry,
-    hadSelector: boolean,
   ): boolean {
-    if (!hadSelector || entry.modelConfigId) {
+    if (entry.modelConfigId || entry.state.availableModels === undefined) {
       return false;
     }
     entry.state.model = undefined;
@@ -832,21 +866,28 @@ export class AcpSessionManager {
    * and re-recording an unchanged model would freeze an inherited default
    * into the conversation. A move this manager itself asked for is published
    * like any other but writes no preference, whether the notification lands
-   * while the request is in flight or just after it resolved.
+   * while the request is in flight or just after it resolved. Nor does an
+   * update that arrives before any pin has run: an adapter that reports its
+   * options by notification, and a `session/load` replay during a resume, are
+   * both announcing a default rather than relaying a choice.
+   *
+   * A session past its terminal transition takes nothing from a late
+   * notification at all: its history row is already written, so mutating
+   * state or emitting here would leave clients and history disagreeing about
+   * the same run.
    */
   private applyUnsolicitedConfigOptions(
     acpSessionId: string,
     configOptions: SessionConfigOption[],
   ): void {
     const entry = this.sessions.get(acpSessionId);
-    if (!entry) {
+    if (!entry || !this.isEntryLive(acpSessionId, entry)) {
       return;
     }
     const previousModel = entry.state.model;
-    const hadSelector = entry.modelConfigId !== undefined;
     this.applyModelInfo(entry, configOptions);
 
-    if (this.clearVanishedModelSelector(acpSessionId, entry, hadSelector)) {
+    if (this.clearVanishedModelSelector(acpSessionId, entry)) {
       return;
     }
 
@@ -856,8 +897,8 @@ export class AcpSessionManager {
       return;
     }
     if (
-      entry.managerPinsInFlight > 0 ||
-      entry.state.model === entry.lastManagerPinnedModel
+      entry.state.model === entry.lastManagerPinnedModel ||
+      !entry.modelBaselineEstablished
     ) {
       return;
     }
@@ -1104,7 +1145,24 @@ export class AcpSessionManager {
     // A fresh adapter process starts on its own default, so the run the user
     // resumes is put back on the model its history row recorded. No preference
     // is written: resuming is not choosing.
-    await this.pinSessionModel(entry, configOptions, row.model ?? undefined);
+    const recordedModel = row.model ?? undefined;
+    const { applied } = await this.pinSessionModel(
+      entry,
+      configOptions,
+      undefined,
+      recordedModel,
+    );
+    if (recordedModel && !applied) {
+      // `applyModelInfo` has already put the adapter's default on the state,
+      // and the next terminal upsert would write that over the row. Keep the
+      // record instead: the run is the same one, on a model it could not be
+      // put back on.
+      log.warn(
+        { acpSessionId, agentId: row.agentId, model: recordedModel },
+        "ACP resume could not restore the recorded model; keeping the record",
+      );
+      state.model = recordedModel;
+    }
 
     this.sendSpawnedEvent(acpSessionId, entry);
     this.sendModelEvent(acpSessionId, entry);

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -509,8 +509,26 @@ describe("executeAcpSpawn - model selection", () => {
     expect(result.isError).toBe(false);
     const payload = JSON.parse(result.content);
     expect(payload.message).toContain(
-      "The agent refused the requested model and is running on its own default: Unknown model: nope",
+      "The requested model was not applied: Unknown model: nope",
     );
+  });
+
+  test("the note relays a no-selector warning without calling it a refusal", async () => {
+    spawnMock.mockImplementationOnce(async () => ({
+      acpSessionId: "acp-session-test",
+      protocolSessionId: "proto-session-test",
+      modelWarning:
+        'Agent "claude" does not support model selection, so the session is running on the agent\'s own model.',
+    }));
+
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something", model: "opus" },
+      makeContext(),
+    );
+
+    const payload = JSON.parse(result.content);
+    expect(payload.message).toContain("does not support model selection");
+    expect(payload.message).not.toContain("refused");
   });
 
   test("no model note when the spawn reports no warning", async () => {
@@ -521,7 +539,9 @@ describe("executeAcpSpawn - model selection", () => {
 
     expect(result.isError).toBe(false);
     const payload = JSON.parse(result.content);
-    expect(payload.message).not.toContain("refused the requested model");
+    expect(payload.message).not.toContain(
+      "The requested model was not applied",
+    );
   });
 });
 

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -143,8 +143,10 @@ export async function executeAcpSpawn(
     const installNote = autoInstalledPackage
       ? ` Installed ${autoInstalledPackage} automatically.`
       : "";
+    // Relayed verbatim: the warning already distinguishes an adapter with no
+    // selector from one that refused the value.
     const modelNote = modelWarning
-      ? ` The agent refused the requested model and is running on its own default: ${modelWarning}`
+      ? ` The requested model was not applied: ${modelWarning}`
       : "";
     const payload = JSON.stringify({
       acpSessionId,

--- a/assistant/src/tools/acp/status.test.ts
+++ b/assistant/src/tools/acp/status.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the `acp_status` tool's projection of session state.
+ *
+ * The state the manager tracks feeds three surfaces with different budgets:
+ * the HTTP route, the SSE picker, and this tool, whose output is spent on
+ * LLM context. Only the fields an agent can act on belong here.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { AcpSessionState } from "../../acp/types.js";
+import type { ToolContext } from "../types.js";
+
+const RUNNING_STATE: AcpSessionState = {
+  id: "acp-1",
+  agentId: "claude",
+  acpSessionId: "proto-1",
+  parentConversationId: "conv-1",
+  status: "running",
+  startedAt: 1234,
+  task: "refactor the parser",
+  model: "claude-opus-4-5",
+  availableModels: [
+    { value: "sonnet", label: "Sonnet" },
+    { value: "opus", label: "Opus", description: "Most capable" },
+  ],
+};
+
+let statusResult: AcpSessionState | AcpSessionState[] = RUNNING_STATE;
+
+const realAcpModule = await import("../../acp/index.js");
+mock.module("../../acp/index.js", () => ({
+  ...realAcpModule,
+  getAcpSessionManager: () => ({ getStatus: () => statusResult }),
+}));
+
+const { executeAcpStatus } = await import("./status.js");
+
+const context = {
+  conversationId: "conv-1",
+  workingDir: "/tmp",
+} as unknown as ToolContext;
+
+describe("executeAcpStatus", () => {
+  test("a single session reports its model but not the picker", async () => {
+    statusResult = RUNNING_STATE;
+
+    const result = await executeAcpStatus({ acp_session_id: "acp-1" }, context);
+
+    expect(result.isError).toBe(false);
+    const payload = JSON.parse(result.content);
+    expect(payload).toEqual({
+      id: "acp-1",
+      agentId: "claude",
+      acpSessionId: "proto-1",
+      parentConversationId: "conv-1",
+      status: "running",
+      startedAt: 1234,
+      task: "refactor the parser",
+      model: "claude-opus-4-5",
+    });
+    expect(result.content).not.toContain("Most capable");
+  });
+
+  test("the listing drops the picker from every entry", async () => {
+    statusResult = [
+      RUNNING_STATE,
+      { ...RUNNING_STATE, id: "acp-2", model: "sonnet" },
+    ];
+
+    const result = await executeAcpStatus({}, context);
+
+    const payload = JSON.parse(result.content) as Array<
+      Record<string, unknown>
+    >;
+    expect(payload).toHaveLength(2);
+    expect(payload.map((entry) => entry.model)).toEqual([
+      "claude-opus-4-5",
+      "sonnet",
+    ]);
+    for (const entry of payload) {
+      expect(entry).not.toHaveProperty("availableModels");
+    }
+  });
+
+  test("an empty listing says so rather than rendering an empty array", async () => {
+    statusResult = [];
+
+    const result = await executeAcpStatus({}, context);
+
+    expect(result.content).toBe("No ACP sessions found.");
+    expect(result.isError).toBe(false);
+  });
+});

--- a/assistant/src/tools/acp/status.ts
+++ b/assistant/src/tools/acp/status.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { getAcpSessionManager } from "../../acp/index.js";
+import type { AcpSessionState } from "../../acp/types.js";
 import {
   invalidToolInputResult,
   nullAsOmitted,
@@ -16,6 +17,40 @@ export const acpStatusInputSchema = z.looseObject({
   acp_session_id: nullAsOmitted(z.string()),
 });
 
+/**
+ * The session fields worth spending LLM context on. An allowlist rather than
+ * an omission: `availableModels` is a picker for the human surfaces (HTTP and
+ * SSE) that says nothing the agent can act on, and a field added to
+ * `AcpSessionState` for those surfaces should not reach this one by default.
+ * `model` stays: which model a session is running on is answerable.
+ */
+function projectSession(state: AcpSessionState) {
+  return {
+    id: state.id,
+    agentId: state.agentId,
+    acpSessionId: state.acpSessionId,
+    parentConversationId: state.parentConversationId,
+    status: state.status,
+    startedAt: state.startedAt,
+    completedAt: state.completedAt,
+    error: state.error,
+    stopReason: state.stopReason,
+    task: state.task,
+    parentToolUseId: state.parentToolUseId,
+    authErrorCode: state.authErrorCode,
+    authErrorCredential: state.authErrorCredential,
+    latestUsage: state.latestUsage,
+    model: state.model,
+  };
+}
+
+/** Projects either shape `getStatus` answers with. */
+function projectStatus(status: AcpSessionState | AcpSessionState[]): unknown {
+  return Array.isArray(status)
+    ? status.map(projectSession)
+    : projectSession(status);
+}
+
 export async function executeAcpStatus(
   input: Record<string, unknown>,
   _context: ToolContext,
@@ -29,9 +64,8 @@ export async function executeAcpStatus(
 
   try {
     if (acpSessionId) {
-      const state = manager.getStatus(acpSessionId);
       return {
-        content: JSON.stringify(state),
+        content: JSON.stringify(projectStatus(manager.getStatus(acpSessionId))),
         isError: false,
       };
     }
@@ -42,7 +76,10 @@ export async function executeAcpStatus(
       return { content: "No ACP sessions found.", isError: false };
     }
 
-    return { content: JSON.stringify(allStates), isError: false };
+    return {
+      content: JSON.stringify(projectStatus(allStates)),
+      isError: false,
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { content: msg, isError: true };


### PR DESCRIPTION
## Summary
Fixes gaps identified during the plan self-review for acp-model-control.md (session manager and process cluster).

- `applyUnsolicitedConfigOptions` guards on `isEntryLive`, so a `config_option_update` landing during cancel or the prompt-failure teardown window mutates nothing, emits nothing, and writes no preference.
- Dropped the `managerPinsInFlight` counter; `lastManagerPinnedModel` is now cleared when the pin call failed, so a later user pick of that same value is read as a choice rather than an echo.
- Added a per-entry `modelBaselineEstablished` flag: an adapter that first reports its selector by notification, or a `session/load` replay during resume, still updates state and publishes but never records the adapter's own default as the conversation's preference.
- A resume whose re-pin is refused (or whose adapter has no selector) keeps `row.model` on the state and logs at warn, so the next terminal upsert preserves the recorded model instead of overwriting it with the adapter's default.
- `modelWarning` is now gated on an explicit request for refusals as well as the no-selector branch; `acp_spawn` relays the warning text instead of asserting a refusal it cannot vouch for.
- Conversation model preferences are keyed on a new `canonicalAgentId` export, so a spawn made as "claude code" and one made as "claude" share one record.
- `acp_status` projects an explicit field list, keeping `model` and leaving `availableModels` on the HTTP and SSE surfaces only.
- Removed the dead process-side config-option cache (`lastConfigOptions`, `configOptions`, `modelConfigOption`, `supportsModelSelection`, `applyConfigOptionsUpdate`) and the tests that existed only for it.
- Type hygiene in `model-config.ts`: `ModelSelectOption`, `ResolveAcpModelInput`, and `AcpModelInfo` are local, `AcpModelOption` is derived from the event schema, and `deriveModelInfo`'s JSDoc sits on the function.
- Simplifications: `clearVanishedModelSelector` computes its own guard, `applyModelInfo` returns void, and `pinSessionModel` derives `explicitlyRequested` from `requestedModel`.
- Three suites now import the shared `modelOption` fixture instead of hand-rolling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D