### PR TITLE
fix(acp): close the in-flight echo window, re-arm the model baseline, and keep resumed state honest

### DIFF
--- a/assistant/src/acp/__tests__/helpers/acp-model-option.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-model-option.ts
@@ -21,6 +21,20 @@ export function modelOption(currentValue: string): SessionConfigOption {
   };
 }
 
+/**
+ * A selector that is not the model one, so a set carrying only this reads as
+ * an adapter that advertises no model selection.
+ */
+export function nonModelOption(): SessionConfigOption {
+  return {
+    type: "select",
+    id: "mode",
+    name: "Mode",
+    currentValue: "default",
+    options: [{ value: "default", name: "Default" }],
+  };
+}
+
 /** `modelOption`'s options as `deriveModelInfo` flattens them. */
 export const MODEL_OPTION_MODELS = [
   { value: "sonnet", label: "Sonnet" },

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -14,7 +14,10 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 
-import { modelOption } from "./helpers/acp-model-option.js";
+import {
+  MODEL_OPTION_MODELS,
+  modelOption,
+} from "./helpers/acp-model-option.js";
 
 // ---------------------------------------------------------------------------
 // Fake AcpAgentProcess with scriptable capabilities and history replay.
@@ -273,6 +276,7 @@ import {
   clearHistory,
   insertHistoryRow,
   readHistoryRow,
+  seedConversationRow,
 } from "./helpers/acp-history-db.js";
 
 const { AcpResumeError, AcpSessionManager, AcpSessionNotFoundError } =
@@ -800,6 +804,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
 
   test("resume puts the fresh adapter process back on the recorded model", async () => {
     fakeCaps.resume = true;
+    seedConversationRow("conv-1");
     // A new adapter process starts on its own default, not the model the
     // original run was pinned to.
     resumeConfigOptions = [modelOption("default")];
@@ -826,6 +831,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
 
   test("a config_option_update replayed during session/load records no preference", async () => {
     fakeCaps.loadSession = true;
+    seedConversationRow("conv-1");
     // The reattached adapter announces its own default mid-replay, before
     // the pin that puts the run back on what the row recorded.
     replayConfigOptions = [modelOption("default")];
@@ -843,8 +849,9 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ).toBeUndefined();
   });
 
-  test("a resume the adapter refuses to re-pin keeps the recorded model on the row", async () => {
+  test("a resume the adapter refuses to re-pin runs on the adapter's model and keeps the record on the row", async () => {
     fakeCaps.resume = true;
+    seedConversationRow("conv-1");
     resumeConfigOptions = [modelOption("default")];
     setConfigOptionError = new Error(
       "Invalid value for config option model: claude-opus-4-5",
@@ -856,21 +863,73 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     });
 
     const manager = new AcpSessionManager(4);
-    await manager.resumeFromHistory("resume-refused-model", () => {});
+    const sent: AssistantEvent[] = [];
+    await manager.resumeFromHistory("resume-refused-model", (msg) =>
+      sent.push(msg),
+    );
 
-    // The adapter's own default replaced it in state; the record wins back.
+    // State and the published event name the model the run is really on, not
+    // the one it could not be put back on.
     expect(
       (manager.getStatus("resume-refused-model") as AcpSessionState).model,
-    ).toBe("claude-opus-4-5");
+    ).toBe("default");
+    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId: "resume-refused-model",
+        model: "default",
+        availableModels: MODEL_OPTION_MODELS,
+      },
+    ]);
+
+    // The adapter re-announcing the model it chose for itself is not the user
+    // choosing it.
+    await fakeInstances[0]!.emitConfigOptions([modelOption("default")]);
+    expect(
+      getAcpConversationModelPreference("conv-1", "claude"),
+    ).toBeUndefined();
 
     await manager.steer("resume-refused-model", "keep going");
     fakeInstances[0]!.resolvePrompt!({ stopReason: "end_turn" });
     await Promise.resolve();
     await Promise.resolve();
 
+    // The row is still the record of the run it belongs to.
     expect(readHistoryRow("resume-refused-model")!.model).toBe(
       "claude-opus-4-5",
     );
+  });
+
+  test("a model chosen after a refused resume re-pin replaces the record on the row", async () => {
+    fakeCaps.resume = true;
+    seedConversationRow("conv-1");
+    resumeConfigOptions = [modelOption("default")];
+    setConfigOptionError = new Error(
+      "Invalid value for config option model: claude-opus-4-5",
+    );
+    insertHistoryRow({
+      id: "resume-then-typed",
+      model: "claude-opus-4-5",
+    });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-then-typed", () => {});
+
+    // The selector announcement re-arms the baseline the refused re-pin took
+    // down; the change after it is the user's own.
+    await fakeInstances[0]!.emitConfigOptions([modelOption("default")]);
+    await fakeInstances[0]!.emitConfigOptions([modelOption("sonnet")]);
+
+    expect(getAcpConversationModelPreference("conv-1", "claude")).toBe(
+      "sonnet",
+    );
+
+    await manager.steer("resume-then-typed", "keep going");
+    fakeInstances[0]!.resolvePrompt!({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readHistoryRow("resume-then-typed")!.model).toBe("sonnet");
   });
 
   test("concurrent resumes of the same id: one wins, the loser fails cleanly without leaking a process", async () => {

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -25,6 +25,7 @@ import { seedConversationRow } from "./helpers/acp-history-db.js";
 import {
   MODEL_OPTION_MODELS,
   modelOption,
+  nonModelOption,
 } from "./helpers/acp-model-option.js";
 
 // Records every `cancel(protocolSessionId)` the manager dispatches to a fake
@@ -451,6 +452,7 @@ describe("AcpSessionManager: model selection at spawn", () => {
   });
 
   test("a refused model warns, runs unpinned, and records no preference", async () => {
+    seedConversationRow("conv-refused");
     scriptedConfigOptions = [[modelOption("opus")]];
     setConfigOptionResult = new Error(
       "Invalid value for config option model: nope",
@@ -499,6 +501,22 @@ function clientHandlerFor(
     throw new Error(`No ACP session registered for "${acpSessionId}"`);
   }
   return entry.clientHandler;
+}
+
+/**
+ * Drives a `config_option_update` through a session's real client handler,
+ * the way an adapter reports a model change it made on its own.
+ */
+async function emitConfigOptions(
+  manager: Manager,
+  acpSessionId: string,
+  options: SessionConfigOption[],
+  sessionId = "proto-agent-model",
+): Promise<void> {
+  await clientHandlerFor(manager, acpSessionId).sessionUpdate({
+    sessionId,
+    update: { sessionUpdate: "config_option_update", configOptions: options },
+  });
 }
 
 /**
@@ -669,15 +687,7 @@ describe("AcpSessionManager: live model switching", () => {
     const { manager, acpSessionId, sent } = await spawnSwitchable(
       "conv-switch-dropped",
     );
-    setConfigOptionResult = [
-      {
-        type: "select",
-        id: "mode",
-        name: "Mode",
-        currentValue: "default",
-        options: [{ value: "default", name: "Default" }],
-      },
-    ];
+    setConfigOptionResult = [nonModelOption()];
 
     const state = await manager.setModel(acpSessionId, "opus");
 
@@ -779,13 +789,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
   test("a model changed from the transcript updates state, publishes, and is remembered", async () => {
     const { manager, acpSessionId, sent } = await spawnSwitchable("conv-typed");
 
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("opus")],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [modelOption("opus")]);
 
     expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
       "opus",
@@ -809,21 +813,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     const { manager, acpSessionId, sent } =
       await spawnSwitchable("conv-dropped");
 
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [
-          {
-            type: "select",
-            id: "mode",
-            name: "Mode",
-            currentValue: "default",
-            options: [{ value: "default", name: "Default" }],
-          },
-        ],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [nonModelOption()]);
 
     const state = manager.getStatus(acpSessionId) as AcpSessionState;
     expect(state.model).toBeUndefined();
@@ -845,13 +835,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     const { manager, acpSessionId, sent } =
       await spawnSwitchable("conv-unchanged");
 
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("sonnet")],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
 
     expect(sent.map((e) => e.type)).toEqual(["acp_session_model_update"]);
     expect(
@@ -860,6 +844,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
   });
 
   test("an update landing while the spawn pin is in flight records no preference", async () => {
+    seedConversationRow("conv-pin-race");
     config.setConfig({ defaultModel: "sonnet" });
     scriptedConfigOptions = [[modelOption("default")]];
     let release = () => {};
@@ -884,13 +869,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     const acpSessionId = (manager.getStatus() as AcpSessionState[])[0].id;
 
     // The adapter reports the pin it is still answering.
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("sonnet")],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
     release();
     await spawning;
 
@@ -907,6 +886,38 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     ).toBeUndefined();
   });
 
+  test("an update landing while a switch is in flight writes no preference", async () => {
+    const { manager, acpSessionId } = await spawnSwitchable(
+      "conv-switch-in-flight",
+    );
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // The adapter resolves the alias it was handed to a full model id, so the
+    // marker holding what the manager asked for cannot recognize the echo.
+    setConfigOptionResponder = async () => {
+      await held;
+      return [modelOption("claude-opus-4-5")];
+    };
+
+    const switching = manager.setModel(acpSessionId, "opus");
+    await waitForConfigOptionCalls(1);
+    // The adapter reports the move it is still answering.
+    await emitConfigOptions(manager, acpSessionId, [
+      modelOption("claude-opus-4-5"),
+    ]);
+    // Terminal before the answer lands, so the switch itself writes nothing
+    // and only the notification could have.
+    manager.close(acpSessionId);
+    release();
+
+    await expect(switching).rejects.toBeInstanceOf(AcpSessionNotFoundError);
+    expect(
+      getAcpConversationModelPreference("conv-switch-in-flight", "agent-model"),
+    ).toBeUndefined();
+  });
+
   test("an update echoing the spawn pin after it resolved records no preference", async () => {
     // The adapter answers the pin with the snapshot it had, then reports the
     // value it moved to through a notification of its own.
@@ -914,13 +925,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     const { manager, acpSessionId, sent } =
       await spawnPinnedToDefault("conv-pin-echo");
 
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("sonnet")],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
 
     expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
       "sonnet",
@@ -958,6 +963,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
   test("an adapter that first reports its selector by notification records no preference", async () => {
     // Nothing in the session/new response, so no pin ever ran against a
     // model the adapter had told us about.
+    seedConversationRow("conv-late-selector");
     const manager = new AcpSessionManager(5);
     const sent: AssistantEvent[] = [];
     const { acpSessionId } = await manager.spawn(
@@ -970,13 +976,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     );
     sent.length = 0;
 
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("opus")],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [modelOption("opus")]);
 
     // The picker still reaches the client; only the preference is withheld.
     expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
@@ -988,7 +988,73 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     ).toBeUndefined();
   });
 
+  test("a selector first seen by notification arms the baseline for later changes", async () => {
+    seedConversationRow("conv-selector-armed");
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const { acpSessionId } = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-selector-armed",
+      (msg) => sent.push(msg),
+    );
+    sent.length = 0;
+
+    // First appearance: published, but announcing is not choosing.
+    await emitConfigOptions(manager, acpSessionId, [modelOption("opus")]);
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_model_update"]);
+    expect(
+      getAcpConversationModelPreference("conv-selector-armed", "agent-model"),
+    ).toBeUndefined();
+
+    // The user then picks a different model from the transcript.
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
+
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "sonnet",
+    );
+    expect(
+      getAcpConversationModelPreference("conv-selector-armed", "agent-model"),
+    ).toBe("sonnet");
+  });
+
+  test("a selector appearing mid-run publishes the picker", async () => {
+    seedConversationRow("conv-selector-midrun");
+    scriptedConfigOptions = [[nonModelOption()]];
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const { acpSessionId } = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-selector-midrun",
+      (msg) => sent.push(msg),
+    );
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_spawned"]);
+    sent.length = 0;
+
+    await emitConfigOptions(manager, acpSessionId, [modelOption("opus")]);
+
+    expect(sent).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId,
+        model: "opus",
+        availableModels: MODEL_OPTION_MODELS,
+      },
+    ]);
+    // The picker is live from here, so a switch is accepted.
+    setConfigOptionResult = [modelOption("sonnet")];
+    await expect(
+      manager.setModel(acpSessionId, "sonnet"),
+    ).resolves.toMatchObject({ model: "sonnet" });
+  });
+
   test("a user picking the value a refused pin asked for is remembered", async () => {
+    seedConversationRow("conv-refused-then-typed");
     scriptedConfigOptions = [[modelOption("opus")]];
     setConfigOptionResult = new Error(
       "Invalid value for config option model: sonnet",
@@ -1006,13 +1072,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
 
     // Nothing moved when the pin was refused, so this is a genuine choice
     // rather than that call's echo.
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("sonnet")],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
 
     expect(
       getAcpConversationModelPreference(
@@ -1023,6 +1083,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
   });
 
   test("a preference is keyed on the canonical agent id, not the alias spawned under", async () => {
+    seedConversationRow("conv-alias");
     scriptedConfigOptions = [[modelOption("sonnet")]];
     const manager = new AcpSessionManager(5);
     const { acpSessionId } = await manager.spawn(
@@ -1034,13 +1095,12 @@ describe("AcpSessionManager: unsolicited model updates", () => {
       () => {},
     );
 
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-claude code",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("opus")],
-      },
-    });
+    await emitConfigOptions(
+      manager,
+      acpSessionId,
+      [modelOption("opus")],
+      "proto-claude code",
+    );
 
     expect(getAcpConversationModelPreference("conv-alias", "claude")).toBe(
       "opus",
@@ -1057,13 +1117,7 @@ describe("AcpSessionManager: unsolicited model updates", () => {
       "conv-pin-then-typed",
     );
 
-    await clientHandlerFor(manager, acpSessionId).sessionUpdate({
-      sessionId: "proto-agent-model",
-      update: {
-        sessionUpdate: "config_option_update",
-        configOptions: [modelOption("opus")],
-      },
-    });
+    await emitConfigOptions(manager, acpSessionId, [modelOption("opus")]);
 
     expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
       "opus",

--- a/assistant/src/acp/model-config.ts
+++ b/assistant/src/acp/model-config.ts
@@ -78,7 +78,7 @@ function toModelOption(
  * The adapter's model selector, if it advertises one. `category` is UX-only
  * per the ACP spec, so a `model` id counts too; non-select options never do.
  */
-export function findModelConfigOption(
+function findModelConfigOption(
   configOptions: SessionConfigOption[] | null | undefined,
 ): ModelSelectOption | undefined {
   return configOptions?.find(

--- a/assistant/src/acp/resolve-agent.test.ts
+++ b/assistant/src/acp/resolve-agent.test.ts
@@ -334,6 +334,22 @@ describe("canonicalAgentId", () => {
   test("passes an id that names no alias through untouched", () => {
     expect(canonicalAgentId("my-custom-agent")).toBe("my-custom-agent");
   });
+
+  test("a config entry keyed as the alias keeps its own id", () => {
+    config.setConfig({
+      agents: { "claude code": { command: "my-claude", args: [] } },
+    });
+
+    // The resolver runs this entry rather than the bundled claude, so its
+    // durable state is its own.
+    expect(canonicalAgentId("claude code")).toBe("claude code");
+  });
+
+  test("an alias with no config entry of its own still folds", () => {
+    config.setConfig({ agents: { other: { command: "other", args: [] } } });
+
+    expect(canonicalAgentId("claude code")).toBe("claude");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -147,8 +147,16 @@ function normalizeAgentId(id: string): string {
  * The bundled id an alias resolves to, or the id itself when it names no
  * alias. Callers that key durable state on an agent id use this so a spawn
  * made as "claude code" and one made as "claude" share a single record.
+ *
+ * A user config entry keyed literally as the alias is a different agent, and
+ * `lookupAgent` resolves it ahead of the alias table. Mirror that order here,
+ * or a spawn on the user's own "claude code" would key its state on the
+ * bundled "claude".
  */
 export function canonicalAgentId(id: string): string {
+  if (getConfig().acp.agents[id]) {
+    return id;
+  }
   return AGENT_ID_ALIASES[normalizeAgentId(id)] ?? id;
 }
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -173,6 +173,20 @@ export class AcpResumeError extends Error {
   }
 }
 
+/**
+ * Statuses a session is still live in. One list for every place that asks the
+ * question: the boot sweep over persisted rows, the in-memory liveness guard,
+ * and close().
+ */
+const ACP_LIVE_STATUSES = ["running", "initializing"] as const;
+
+/** Whether a status is one a session can still move from. */
+function isLiveAcpStatus(
+  status: AcpSessionState["status"],
+): status is (typeof ACP_LIVE_STATUSES)[number] {
+  return ACP_LIVE_STATUSES.some((live) => live === status);
+}
+
 /** Maximum number of update events kept in a session's ring buffer. */
 const MAX_BUFFER_EVENTS = 200;
 /** Maximum aggregate JSON size of a session's ring buffer, in bytes. */
@@ -221,11 +235,21 @@ interface SessionEntry {
    *  failed (nothing moved, so a later user pick of the same value is a
    *  genuine choice) and once a genuinely different model arrives. */
   lastManagerPinnedModel?: string;
+  /** Whether one of this manager's own `setConfigOption` calls is awaiting the
+   *  adapter. `lastManagerPinnedModel` cannot answer for that window: the
+   *  adapter may resolve the alias it was handed to a full model id, so an
+   *  echo landing mid-flight carries a value the manager never named. A
+   *  boolean suffices because switches are serialized per session. */
+  managerPinInFlight: boolean;
   /** Whether a pin has run against the adapter's own reported model. Until it
    *  has, an unsolicited update is the adapter announcing its default rather
    *  than the user choosing, and writing it as the conversation's preference
    *  would freeze that default in. */
   modelBaselineEstablished: boolean;
+  /** Model this run's history row recorded, kept only when a resume could not
+   *  put the adapter back on it. Read by `persistTerminal` alone, so the row
+   *  preserves the record while state stays on the model the run is really on. */
+  recordedModel?: string;
 }
 
 /** What a spawn or resume pin did about the model it was asked for. */
@@ -300,7 +324,7 @@ export class AcpSessionManager {
           stopReason: "daemon_restarted",
           completedAt: Date.now(),
         })
-        .where(inArray(acpSessionHistory.status, ["running", "initializing"]))
+        .where(inArray(acpSessionHistory.status, [...ACP_LIVE_STATUSES]))
         .run();
     } catch (err) {
       log.error(
@@ -481,6 +505,11 @@ export class AcpSessionManager {
     const info = deriveModelInfo(configOptions);
     entry.modelConfigId = info.modelConfigId;
     if (info.modelConfigId) {
+      if (info.model !== entry.state.model) {
+        // The run has moved off whatever a resume could not restore it to, so
+        // the row's record no longer describes it.
+        entry.recordedModel = undefined;
+      }
       entry.state.model = info.model;
       entry.state.availableModels = info.availableModels;
     }
@@ -506,11 +535,33 @@ export class AcpSessionManager {
     requestedModel: string | undefined,
     resolvedModel: string | undefined,
   ): Promise<ModelPinResult> {
+    const result = await this.applyModelPin(
+      entry,
+      configOptions,
+      requestedModel,
+      resolvedModel,
+    );
+    // Latched only once the round trip is done. The window while it is in
+    // flight belongs to `managerPinInFlight`, and by now the adapter has
+    // reported what the session is on, so anything unsolicited after this is
+    // a change rather than an opening announcement.
+    entry.modelBaselineEstablished = entry.modelConfigId !== undefined;
+    return result;
+  }
+
+  /**
+   * The pin itself: report what the adapter says, then put it on
+   * `resolvedModel` if that is somewhere else. Split from the baseline latch
+   * above so the latch cannot be reached before the round trip settles.
+   */
+  private async applyModelPin(
+    entry: SessionEntry,
+    configOptions: SessionConfigOption[],
+    requestedModel: string | undefined,
+    resolvedModel: string | undefined,
+  ): Promise<ModelPinResult> {
     const { state } = entry;
     this.applyModelInfo(entry, configOptions);
-    // The adapter has reported what it is on, so anything unsolicited from
-    // here is a change rather than its opening announcement.
-    entry.modelBaselineEstablished = entry.modelConfigId !== undefined;
 
     if (!resolvedModel || resolvedModel === state.model) {
       return { applied: true };
@@ -558,10 +609,17 @@ export class AcpSessionManager {
    * the user chose. Spawn, resume, and `setModel` each decide their own
    * preference write, and a second one from the notification would freeze an
    * inherited default into the conversation. Switches are serialized per
-   * session, so one marker covers every call in flight.
+   * session, so one flag covers every call in flight.
    *
-   * A refused call clears the marker: nothing moved, so a later `/model` onto
-   * the same value is a genuine choice rather than this call's echo.
+   * Two markers, because the echo can land on either side of the answer. The
+   * in-flight flag covers the round trip whatever the notification carries:
+   * the adapter may resolve `opus` to `claude-opus-4-5` and report that,
+   * which the value marker would never match. The value marker then covers
+   * the echo that arrives after the call resolved.
+   *
+   * A refused call clears the value marker: nothing moved, so a later
+   * `/model` onto the same value is a genuine choice rather than this call's
+   * echo.
    */
   private async setConfigOptionAsManager(
     entry: SessionEntry,
@@ -569,6 +627,7 @@ export class AcpSessionManager {
     value: string,
   ): Promise<SessionConfigOption[]> {
     entry.lastManagerPinnedModel = value;
+    entry.managerPinInFlight = true;
     try {
       return await entry.process.setConfigOption(
         entry.state.acpSessionId,
@@ -578,6 +637,8 @@ export class AcpSessionManager {
     } catch (err) {
       entry.lastManagerPinnedModel = undefined;
       throw err;
+    } finally {
+      entry.managerPinInFlight = false;
     }
   }
 
@@ -669,6 +730,7 @@ export class AcpSessionManager {
       command: basename(opts.agentConfig.command),
       credentialDigest: opts.agentConfig.credentialDigest,
       modelSwitchQueue: Promise.resolve(),
+      managerPinInFlight: false,
       modelBaselineEstablished: false,
     };
 
@@ -806,8 +868,7 @@ export class AcpSessionManager {
   private isEntryLive(acpSessionId: string, entry: SessionEntry): boolean {
     return (
       this.sessions.get(acpSessionId) === entry &&
-      (entry.state.status === "running" ||
-        entry.state.status === "initializing")
+      isLiveAcpStatus(entry.state.status)
     );
   }
 
@@ -871,6 +932,11 @@ export class AcpSessionManager {
    * options by notification, and a `session/load` replay during a resume, are
    * both announcing a default rather than relaying a choice.
    *
+   * That first announcement is also what arms the baseline for an adapter
+   * whose selector never appeared in a `session/new` or `session/resume`
+   * response, so a `/model` the user types after it is remembered instead of
+   * being swallowed as another opening announcement forever.
+   *
    * A session past its terminal transition takes nothing from a late
    * notification at all: its history row is already written, so mutating
    * state or emitting here would leave clients and history disagreeing about
@@ -885,10 +951,17 @@ export class AcpSessionManager {
       return;
     }
     const previousModel = entry.state.model;
+    const hadBaseline = entry.modelBaselineEstablished;
     this.applyModelInfo(entry, configOptions);
 
     if (this.clearVanishedModelSelector(acpSessionId, entry)) {
       return;
+    }
+    // A selector seen here for the first time arms the baseline, so the next
+    // change the adapter reports is read as a choice rather than swallowed as
+    // another opening announcement.
+    if (!hadBaseline && entry.modelConfigId !== undefined) {
+      entry.modelBaselineEstablished = true;
     }
 
     this.sendModelEvent(acpSessionId, entry);
@@ -897,8 +970,9 @@ export class AcpSessionManager {
       return;
     }
     if (
-      entry.state.model === entry.lastManagerPinnedModel ||
-      !entry.modelBaselineEstablished
+      !hadBaseline ||
+      entry.managerPinInFlight ||
+      entry.state.model === entry.lastManagerPinnedModel
     ) {
       return;
     }
@@ -1153,15 +1227,23 @@ export class AcpSessionManager {
       recordedModel,
     );
     if (recordedModel && !applied) {
-      // `applyModelInfo` has already put the adapter's default on the state,
-      // and the next terminal upsert would write that over the row. Keep the
-      // record instead: the run is the same one, on a model it could not be
-      // put back on.
+      // State keeps the adapter's own answer, so the model event, the status
+      // projection and the panel all name the model the run is really on.
+      // Only the terminal upsert keeps the record, and only until something
+      // moves the run off it. The baseline goes back down with it: the
+      // manager just failed to control this session's model, so the adapter's
+      // next announcement is a report rather than a choice the user made.
+      entry.recordedModel = recordedModel;
+      entry.modelBaselineEstablished = false;
       log.warn(
-        { acpSessionId, agentId: row.agentId, model: recordedModel },
-        "ACP resume could not restore the recorded model; keeping the record",
+        {
+          acpSessionId,
+          agentId: row.agentId,
+          recordedModel,
+          model: state.model,
+        },
+        "ACP resume could not restore the recorded model; running on the agent's own model",
       );
-      state.model = recordedModel;
     }
 
     this.sendSpawnedEvent(acpSessionId, entry);
@@ -1399,10 +1481,7 @@ export class AcpSessionManager {
     if (!entry) {
       throw new AcpSessionNotFoundError(acpSessionId);
     }
-    if (
-      entry.state.status === "running" ||
-      entry.state.status === "initializing"
-    ) {
+    if (isLiveAcpStatus(entry.state.status)) {
       entry.state.status = "cancelled";
       entry.state.completedAt = Date.now();
     }
@@ -1518,7 +1597,9 @@ export class AcpSessionManager {
       parentToolUseId: entry.state.parentToolUseId ?? null,
       authErrorCode: entry.state.authErrorCode ?? null,
       authErrorCredential: entry.state.authErrorCredential ?? null,
-      model: entry.state.model ?? null,
+      // The record wins only while a resume could not put the run back on it;
+      // anything that moves the model afterwards clears it.
+      model: entry.recordedModel ?? entry.state.model ?? null,
       usedTokens: usage?.usedTokens ?? null,
       contextSize: usage?.contextSize ?? null,
       costAmount: usage?.costAmount ?? null,

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -4,22 +4,15 @@
 
 import type { StopReason } from "@agentclientprotocol/sdk";
 
+import type { AcpAgentConfig as ConfiguredAcpAgent } from "../config/acp-schema.js";
 import type { AcpModelOption } from "./model-config.js";
 
 /**
- * Configuration for a single ACP agent process.
+ * A configured ACP agent plus what the daemon learns about it at spawn time.
+ * The configured half is the schema's own inferred type, so a new config leaf
+ * is declared once, in `config/acp-schema.ts`.
  */
-export interface AcpAgentConfig {
-  command: string;
-  args: string[];
-  description?: string;
-  env?: Record<string, string>;
-  /**
-   * Model this agent's sessions start on, from `acp.agents.<id>.model`. An
-   * adapter-reported alias, outranked only by an explicit request and the
-   * conversation's own preference.
-   */
-  model?: string;
+export interface AcpAgentConfig extends ConfiguredAcpAgent {
   /**
    * Identity of the Claude token `prepareAgentEnv` resolved into `env`,
    * whichever source it came from. Recorded on the history row when Claude


### PR DESCRIPTION
## Summary
Fixes gaps identified during the second self-review round for acp-model-control.md (daemon ACP core).

- **CI is green again.** The preference table's FK to `conversations` meant the round's new session-manager tests spawned into conversation ids with no row, so the best-effort upsert failed silently and the assertions read `undefined`. Every direct `manager.spawn` in those tests (and in the three "records no preference" ones, which were vacuous for the same reason) now calls `seedConversationRow` first.
- **The in-flight echo hole is closed.** `lastManagerPinnedModel` holds the value the manager asked for (`opus`) while an adapter can answer with a resolved id (`claude-opus-4-5"`), so a `config_option_update` landing mid-round-trip slipped past it. A per-entry `managerPinInFlight` flag is set in `setConfigOptionAsManager` before the await and cleared in `finally`; `applyUnsolicitedConfigOptions` writes no preference while it is up. The value marker still covers the echo that arrives after the call resolved.
- **The baseline latch re-arms.** An adapter whose selector first appears in a `config_option_update` never got a baseline, so every later user `/model` was swallowed forever. That first announcement now arms the baseline (publishing as usual, writing nothing), and the spawn/resume latch moved to after the pin's awaited call settles so the in-flight window is covered by the flag rather than by the baseline.
- **A resumed session's state stays honest.** A refused resume re-pin no longer forces `state.model` back to the recorded value: the model event, `acp_status` and the panel now name the model the run is really on. `entry.recordedModel` carries the historical value to `persistTerminal` alone, and clears as soon as anything moves the run off it.
- **`canonicalAgentId` respects direct config entries.** `lookupAgent` resolves a user entry keyed literally `claude code` ahead of the alias table; the canonicalizer now mirrors that order instead of folding it onto the bundled `claude` and sharing its preference row.
- **Hygiene.** `findModelConfigOption` loses its unused `export`; `acp/types.ts` `AcpAgentConfig` extends the schema-inferred config type so a new config leaf is declared once; one `ACP_LIVE_STATUSES` constant plus a predicate replaces three spellings of "non-terminal status"; a local `emitConfigOptions` helper collapses nine copies of the same `config_option_update` emission, and a `nonModelOption()` fixture collapses three copies of the non-model selector literal.

## Test plan
`src/acp/__tests__/session-manager.test.ts` (42), `src/acp/session-manager.test.ts` (16), `session-manager-resume.test.ts` (32), `session-manager-persistence.test.ts` (14), `session-manager-usage.test.ts` (2), `session-manager-startup.test.ts` (5), `resolve-agent.test.ts` (34), `model-config.test.ts` (17), `agent-process.test.ts` (31+11), `tools/acp/{spawn,status,steer,list-agents}.test.ts`, `runtime/routes/**/acp-*` and `persistence/acp-model-preference.test.ts` all pass; `bunx tsc --noEmit` is clean. The two new guards were verified load-bearing by reverting each fix in turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D