### PR TITLE
fix(acp): keep the model baseline through a refused resume, queue manager pins, and surface a dead post-install resolution

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -849,7 +849,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ).toBeUndefined();
   });
 
-  test("a resume the adapter refuses to re-pin runs on the adapter's model and keeps the record on the row", async () => {
+  test("a resume the adapter refuses to re-pin runs on the adapter's model and records that on the row", async () => {
     fakeCaps.resume = true;
     seedConversationRow("conv-1");
     resumeConfigOptions = [modelOption("default")];
@@ -894,13 +894,12 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    // The row is still the record of the run it belongs to.
-    expect(readHistoryRow("resume-refused-model")!.model).toBe(
-      "claude-opus-4-5",
-    );
+    // The row records the model the run ended on, so the next resume re-pins
+    // to the one the user was actually working with.
+    expect(readHistoryRow("resume-refused-model")!.model).toBe("default");
   });
 
-  test("a model chosen after a refused resume re-pin replaces the record on the row", async () => {
+  test("a model chosen after a refused resume re-pin is remembered and lands on the row", async () => {
     fakeCaps.resume = true;
     seedConversationRow("conv-1");
     resumeConfigOptions = [modelOption("default")];
@@ -915,9 +914,8 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     const manager = new AcpSessionManager(4);
     await manager.resumeFromHistory("resume-then-typed", () => {});
 
-    // The selector announcement re-arms the baseline the refused re-pin took
-    // down; the change after it is the user's own.
-    await fakeInstances[0]!.emitConfigOptions([modelOption("default")]);
+    // The refused re-pin leaves the baseline armed, so the very next change
+    // the adapter reports is read as the user's own choice.
     await fakeInstances[0]!.emitConfigOptions([modelOption("sonnet")]);
 
     expect(getAcpConversationModelPreference("conv-1", "claude")).toBe(

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -665,6 +665,60 @@ describe("AcpSessionManager: live model switching", () => {
     });
   });
 
+  test("a switch issued during the spawn pin waits for it instead of overlapping it", async () => {
+    seedConversationRow("conv-pin-queue");
+    config.setConfig({ defaultModel: "opus" });
+    scriptedConfigOptions = [[modelOption("default")]];
+    let releasePin = () => {};
+    const pinHeld = new Promise<void>((resolve) => {
+      releasePin = resolve;
+    });
+    let releaseSwitch = () => {};
+    const switchHeld = new Promise<void>((resolve) => {
+      releaseSwitch = resolve;
+    });
+    setConfigOptionResponder = async (value) => {
+      await (value === "opus" ? pinHeld : switchHeld);
+      return [modelOption(String(value))];
+    };
+
+    const manager = new AcpSessionManager(5);
+    const spawned = manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-pin-queue",
+      () => {},
+    );
+    await waitForConfigOptionCalls(1);
+    const acpSessionId = manager.getActiveAndPendingIds()[0]!;
+    const switched = manager.setModel(acpSessionId, "sonnet");
+
+    // The pin holds the adapter until it answers, so the switch has not been
+    // dispatched yet.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(setConfigOptionCalls.map((call) => call.value)).toEqual(["opus"]);
+
+    releasePin();
+    await spawned;
+    await waitForConfigOptionCalls(2);
+
+    // The switch is the only round trip in flight, so its in-flight flag is
+    // still up: the adapter reporting a model now is this manager's own doing
+    // rather than the user picking one.
+    await emitConfigOptions(manager, acpSessionId, [modelOption("haiku")]);
+    expect(
+      getAcpConversationModelPreference("conv-pin-queue", "agent-model"),
+    ).toBeUndefined();
+
+    releaseSwitch();
+    await expect(switched).resolves.toMatchObject({ model: "sonnet" });
+    expect(
+      getAcpConversationModelPreference("conv-pin-queue", "agent-model"),
+    ).toBe("sonnet");
+  });
+
   test("a refused switch leaves the next one free to run", async () => {
     const { manager, acpSessionId } = await spawnSwitchable("conv-chain");
     setConfigOptionResponder = async (value) => {

--- a/assistant/src/acp/auto-install.test.ts
+++ b/assistant/src/acp/auto-install.test.ts
@@ -612,6 +612,37 @@ describe("ensureAdapterInstalled - version pinning", () => {
     ).toHaveLength(1);
   });
 
+  test("an empty agent PATH gets its own pin scope, not the inherited one", async () => {
+    which.setWhich((cmd, options) => {
+      if (cmd === "bun") {
+        return BUN_BIN;
+      }
+      if (cmd !== "codex-acp") {
+        return null;
+      }
+      // An empty PATH reaches nothing; an omitted one inherits the daemon's,
+      // which does reach bun's link.
+      return options?.PATH === "" ? null : bunLinked("codex-acp");
+    });
+    // `bun add` exits 0 without moving the tree off 0.4.0, so the inherited
+    // scope abandons its pin after a single install.
+    stubGlobalTree({ "@agentclientprotocol/codex-acp": "0.4.0" });
+    execScripts.set(BUN_ADD_KEY, { stdout: "" });
+
+    expect(await ensureAdapterInstalled("codex-acp")).toEqual({
+      installed: true,
+    });
+    expect(await ensureAdapterInstalled("codex-acp")).toEqual({
+      installed: false,
+    });
+
+    // The empty PATH never proved that verdict, so it still gets its install.
+    expect(await ensureAdapterInstalled("codex-acp", "")).toEqual({
+      installed: true,
+    });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
   test("two PATHs into the same bun tree run a single install", async () => {
     const BUN_BIN_DIR = `${BUN_ROOT}/bin`;
     const ALIAS_BIN_DIR = `${BUN_ALIAS_ROOT}/bin`;
@@ -1209,7 +1240,7 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
     );
   });
 
-  test("post-install resolution failure keeps the agent resolved before it", async () => {
+  test("post-install resolution failure surfaces the dead resolution, not an unspawnable agent", async () => {
     let onPath = true;
     which.setWhich((cmd) => {
       if (cmd === "bun") {
@@ -1221,8 +1252,8 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
       return null;
     });
     stubGlobalTree({ "@agentclientprotocol/claude-agent-acp": "0.47.0" });
-    // The reinstall unlinks the bin instead of repointing it, so the
-    // re-resolve fails on an agent the caller already had in hand.
+    // The reinstall unlinks the bin instead of repointing it, so the command
+    // the caller held is gone from PATH and nothing there can spawn.
     execScripts.set(BUN_ADD_KEY, {
       stdout: "",
       onCall: () => {
@@ -1232,11 +1263,16 @@ describe("resolveAgentWithAutoInstall - pin enforcement on a resolved binary", (
 
     const result = await resolveAgentWithAutoInstall("claude");
 
-    expect(result.resolved.ok).toBe(true);
-    if (!result.resolved.ok) {
+    expect(result.resolved.ok).toBe(false);
+    if (result.resolved.ok) {
       return;
     }
-    expect(result.resolved.agent.command).toBe("claude-agent-acp");
+    expect(result.resolved.reason).toBe("binary_not_found");
+    if (result.resolved.reason !== "binary_not_found") {
+      return;
+    }
+    expect(result.resolved.command).toBe("claude-agent-acp");
+    expect(result.resolved.hint).toContain(`bun add -g ${CLAUDE_SPEC}`);
     expect(result.autoInstalledPackage).toBeUndefined();
     expect(result.failureMessage).toBeUndefined();
     expect(warnings().join(" ")).toContain("no longer resolves");

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -109,23 +109,26 @@ const pinChecks = new Map<string, Promise<AdapterInstallResult>>();
 const installRuns = new Map<string, Promise<AdapterInstallResult>>();
 
 /** Composite map key over fields that may contain any character. */
-function joinKey(...parts: string[]): string {
-  return parts.join("\u0000");
+function joinKey(first: string, second: string): string {
+  return `${first}\u0000${second}`;
 }
+
+/**
+ * Stands in for an agent that names no `env.PATH` and inherits the daemon's.
+ * A real PATH string cannot contain NUL, so this never collides with one,
+ * including the empty PATH.
+ */
+const INHERITED_SEARCH_PATH = "\u0000inherit";
 
 /**
  * The scope a pin verdict is proven on. Verification asks what a spawn on
  * this search path selects, so a give-up or a spent retry budget belongs to
- * the triple, not to the command: an agent whose `env.PATH` cannot reach
- * bun's global bin dir never satisfies the pin, and must not unpin the agents
- * whose path can.
+ * the command and the search path together, never to the command alone: an
+ * agent whose `env.PATH` cannot reach bun's global bin dir never satisfies
+ * the pin, and must not unpin the agents whose path can.
  */
-function pinScope(
-  command: string,
-  packageSpec: string,
-  searchPath: string | undefined,
-): string {
-  return joinKey(command, packageSpec, searchPath ?? "");
+function pinScope(command: string, searchPath: string | undefined): string {
+  return joinKey(command, searchPath ?? INHERITED_SEARCH_PATH);
 }
 
 /**
@@ -491,8 +494,9 @@ export function ensureAdapterInstalled(
   // Nothing survives the call: the probe is a manifest read plus a realpath,
   // cheap enough to repeat, and caching a no-install decision would pin the
   // daemon to whatever the adapter looked like at first spawn.
-  return coalesce(pinChecks, joinKey(command, searchPath ?? ""), () =>
-    installToPin(bunPath, command, packageSpec, searchPath),
+  const scope = pinScope(command, searchPath);
+  return coalesce(pinChecks, scope, () =>
+    installToPin(bunPath, command, packageSpec, scope, searchPath),
   );
 }
 
@@ -557,9 +561,9 @@ async function installToPin(
   bunPath: string,
   command: string,
   packageSpec: string,
+  scope: string,
   searchPath?: string,
 ): Promise<AdapterInstallResult> {
-  const scope = pinScope(command, packageSpec, searchPath);
   const fields = { command, packageSpec, searchPath };
   const probe = await probePin(command, packageSpec, searchPath);
   if (probe.action === "external") {
@@ -579,8 +583,7 @@ async function installToPin(
     return { installed: false };
   }
   if (probe.action === "unknown") {
-    warnUnverifiable(scope, { ...fields, binaryPath: probe.binaryPath });
-    recordInstallAttempt(scope, fields);
+    noteUnverifiablePin(scope, fields, probe.binaryPath);
     return { installed: false };
   }
   // Probes stay per PATH, but two PATHs spelling the same bun tree reach one
@@ -601,24 +604,30 @@ async function installToPin(
       "ACP adapter install reported success but PATH still does not select the pinned version; leaving it alone for the rest of this process",
     );
   } else if (verified.action === "unknown") {
-    warnUnverifiable(scope, { ...fields, binaryPath: verified.binaryPath });
-    recordInstallAttempt(scope, fields);
+    noteUnverifiablePin(scope, fields, verified.binaryPath);
   } else {
     installAttempts.delete(scope);
   }
   return result;
 }
 
-function warnUnverifiable(
+/**
+ * Report a probe that could not answer, and charge the scope one attempt. The
+ * warning is worth saying once per scope; the attempt is spent every time, so
+ * a filesystem that never answers still lands on the cooldown.
+ */
+function noteUnverifiablePin(
   scope: string,
   fields: Record<string, unknown>,
+  binaryPath: string | undefined,
 ): void {
   warnOnce(
     warnedUnverifiablePins,
     scope,
-    fields,
+    { ...fields, binaryPath },
     "Could not read the installed ACP adapter to check its version pin; leaving it in place and re-checking on the next spawn",
   );
+  recordInstallAttempt(scope, fields);
 }
 
 /**
@@ -733,10 +742,12 @@ export async function resolveAgentWithAutoInstall(
  * A resolution that succeeded still has to satisfy the pin: the adapter on
  * PATH may be an older bun-managed install, or one linked by a different
  * package that owns the same binary name. Reinstall and re-resolve when it
- * does not match. Every path here keeps an agent the caller can spawn: the
- * resolution that came in was already good, so a reinstall that fails, or one
- * that lands but leaves the re-resolve failing, warns and hands back that
- * original agent rather than turning a working spawn into a hard failure.
+ * does not match. A reinstall that fails outright leaves the disk as the
+ * probe found it, so the agent that came in is still spawnable and is handed
+ * back rather than turning a working spawn into a hard failure. A reinstall
+ * that lands and then fails to re-resolve is the opposite: the command is
+ * gone from PATH, so the failed resolution is returned with its actionable
+ * hint instead of an agent no spawn could start.
  * `autoInstalledPackage` is only claimed when the re-resolve confirmed it.
  */
 async function enforcePin(
@@ -761,9 +772,11 @@ async function enforcePin(
       warnedReresolveFailure,
       command,
       { agentId, command, reason: retried.reason },
-      "ACP adapter reinstall landed but the adapter no longer resolves; spawning the one resolved before it",
+      "ACP adapter reinstall landed but the adapter no longer resolves; reporting the resolution failure",
     );
-  } else if (install.error) {
+    return { resolved: retried };
+  }
+  if (install.error) {
     warnOnce(
       warnedInstallFailure,
       command,

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -42,7 +42,12 @@ import { deriveModelInfo, resolveAcpModel } from "./model-config.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
 import { canonicalAgentId, formatResolveFailure } from "./resolve-agent.js";
 import { claudeResumeHint } from "./resume-hint.js";
-import type { AcpAgentConfig, AcpSessionState } from "./types.js";
+import {
+  ACP_LIVE_STATUSES,
+  type AcpAgentConfig,
+  type AcpSessionState,
+  isLiveAcpStatus,
+} from "./types.js";
 
 const log = getLogger("acp:session-manager");
 
@@ -173,20 +178,6 @@ export class AcpResumeError extends Error {
   }
 }
 
-/**
- * Statuses a session is still live in. One list for every place that asks the
- * question: the boot sweep over persisted rows, the in-memory liveness guard,
- * and close().
- */
-const ACP_LIVE_STATUSES = ["running", "initializing"] as const;
-
-/** Whether a status is one a session can still move from. */
-function isLiveAcpStatus(
-  status: AcpSessionState["status"],
-): status is (typeof ACP_LIVE_STATUSES)[number] {
-  return ACP_LIVE_STATUSES.some((live) => live === status);
-}
-
 /** Maximum number of update events kept in a session's ring buffer. */
 const MAX_BUFFER_EVENTS = 200;
 /** Maximum aggregate JSON size of a session's ring buffer, in bytes. */
@@ -226,8 +217,9 @@ interface SessionEntry {
    *  none. Both the id to write a model back through and the flag that says
    *  this session has a model to publish at all. */
   modelConfigId?: string;
-  /** Tail of this session's model-switch chain, so overlapping setModel calls
-   *  reach the adapter one at a time and the last choice wins. */
+  /** Tail of this session's model-switch chain, so the manager's own spawn
+   *  and resume pins and any overlapping setModel calls reach the adapter one
+   *  at a time and the last choice wins. */
   modelSwitchQueue: Promise<void>;
   /** Last model value this manager asked the adapter for, so a
    *  `config_option_update` the adapter sends as that call's side effect is
@@ -246,10 +238,6 @@ interface SessionEntry {
    *  than the user choosing, and writing it as the conversation's preference
    *  would freeze that default in. */
   modelBaselineEstablished: boolean;
-  /** Model this run's history row recorded, kept only when a resume could not
-   *  put the adapter back on it. Read by `persistTerminal` alone, so the row
-   *  preserves the record while state stays on the model the run is really on. */
-  recordedModel?: string;
 }
 
 /** What a spawn or resume pin did about the model it was asked for. */
@@ -505,11 +493,6 @@ export class AcpSessionManager {
     const info = deriveModelInfo(configOptions);
     entry.modelConfigId = info.modelConfigId;
     if (info.modelConfigId) {
-      if (info.model !== entry.state.model) {
-        // The run has moved off whatever a resume could not restore it to, so
-        // the row's record no longer describes it.
-        entry.recordedModel = undefined;
-      }
       entry.state.model = info.model;
       entry.state.availableModels = info.availableModels;
     }
@@ -529,24 +512,49 @@ export class AcpSessionManager {
    * rung (config default, remembered preference) is only logged, so a config
    * the user never typed here does not surface as a warning on every spawn.
    */
-  private async pinSessionModel(
+  private pinSessionModel(
     entry: SessionEntry,
     configOptions: SessionConfigOption[],
     requestedModel: string | undefined,
     resolvedModel: string | undefined,
   ): Promise<ModelPinResult> {
-    const result = await this.applyModelPin(
-      entry,
-      configOptions,
-      requestedModel,
-      resolvedModel,
+    return this.enqueueModelWork(entry, async () => {
+      const result = await this.applyModelPin(
+        entry,
+        configOptions,
+        requestedModel,
+        resolvedModel,
+      );
+      // Latched only once the round trip is done. The window while it is in
+      // flight belongs to `managerPinInFlight`, and by now the adapter has
+      // reported what the session is on, so anything unsolicited after this is
+      // a change rather than an opening announcement.
+      entry.modelBaselineEstablished = entry.modelConfigId !== undefined;
+      return result;
+    });
+  }
+
+  /**
+   * Chains `work` onto this session's model-switch queue, so the manager's
+   * own pins and a client's `setModel` reach the adapter one at a time.
+   * `managerPinInFlight` is a single boolean covering every call in flight,
+   * which only holds while nothing overlaps: two concurrent round trips would
+   * each clear it on their own way out, and whichever answered first would
+   * open the window for the other. The queue is idle when a spawn or resume
+   * pins, so serializing costs those nothing.
+   *
+   * A refusal belongs to its caller alone; the chain carries on either way.
+   */
+  private enqueueModelWork<T>(
+    entry: SessionEntry,
+    work: () => Promise<T>,
+  ): Promise<T> {
+    const queued = entry.modelSwitchQueue.then(work);
+    entry.modelSwitchQueue = queued.then(
+      () => undefined,
+      () => undefined,
     );
-    // Latched only once the round trip is done. The window while it is in
-    // flight belongs to `managerPinInFlight`, and by now the adapter has
-    // reported what the session is on, so anything unsolicited after this is
-    // a change rather than an opening announcement.
-    entry.modelBaselineEstablished = entry.modelConfigId !== undefined;
-    return result;
+    return queued;
   }
 
   /**
@@ -788,7 +796,8 @@ export class AcpSessionManager {
    * the next turn, and cancelling a running turn to change a model would cost
    * the user the work in flight.
    *
-   * Switches run one at a time per session. A picker changed twice in quick
+   * Switches run one at a time per session, on the same queue as the
+   * manager's own spawn and resume pins. A picker changed twice in quick
    * succession would otherwise have two round trips in flight at once, and a
    * slow first one landing last would put the state, the preference, and the
    * client back on the model the user already moved off.
@@ -801,15 +810,9 @@ export class AcpSessionManager {
     if (!entry) {
       throw new AcpSessionNotFoundError(acpSessionId);
     }
-    const switched = entry.modelSwitchQueue.then(() =>
+    return this.enqueueModelWork(entry, () =>
       this.applyModelSwitch(acpSessionId, entry, model),
     );
-    // A refusal belongs to its caller alone; the chain carries on either way.
-    entry.modelSwitchQueue = switched.then(
-      () => undefined,
-      () => undefined,
-    );
-    return switched;
   }
 
   /**
@@ -1228,13 +1231,9 @@ export class AcpSessionManager {
     );
     if (recordedModel && !applied) {
       // State keeps the adapter's own answer, so the model event, the status
-      // projection and the panel all name the model the run is really on.
-      // Only the terminal upsert keeps the record, and only until something
-      // moves the run off it. The baseline goes back down with it: the
-      // manager just failed to control this session's model, so the adapter's
-      // next announcement is a report rather than a choice the user made.
-      entry.recordedModel = recordedModel;
-      entry.modelBaselineEstablished = false;
+      // projection, the panel and the terminal row all name the model the run
+      // is really on. A later resume then re-pins to that, which is the run
+      // the user is coming back to.
       log.warn(
         {
           acpSessionId,
@@ -1597,9 +1596,9 @@ export class AcpSessionManager {
       parentToolUseId: entry.state.parentToolUseId ?? null,
       authErrorCode: entry.state.authErrorCode ?? null,
       authErrorCredential: entry.state.authErrorCredential ?? null,
-      // The record wins only while a resume could not put the run back on it;
-      // anything that moves the model afterwards clears it.
-      model: entry.recordedModel ?? entry.state.model ?? null,
+      // The adapter's own truth: the row records the model the run ended on,
+      // which is what a later resume re-pins to.
+      model: entry.state.model ?? null,
       usedTokens: usage?.usedTokens ?? null,
       contextSize: usage?.contextSize ?? null,
       costAmount: usage?.costAmount ?? null,

--- a/assistant/src/acp/types.ts
+++ b/assistant/src/acp/types.ts
@@ -62,6 +62,20 @@ export interface AcpSessionState {
   availableModels?: AcpModelOption[];
 }
 
+/**
+ * Statuses a session is still live in. One list for every place that asks the
+ * question: the boot sweep over persisted rows, the in-memory liveness guard,
+ * `close()`, and the delete route's conflict guard.
+ */
+export const ACP_LIVE_STATUSES = ["running", "initializing"] as const;
+
+/** Whether a status is one a session can still move from. */
+export function isLiveAcpStatus(
+  status: AcpSessionState["status"],
+): status is (typeof ACP_LIVE_STATUSES)[number] {
+  return ACP_LIVE_STATUSES.some((live) => live === status);
+}
+
 /** Context-window usage snapshot tracked from ACP `usage_update`. */
 export interface AcpUsageSnapshot {
   usedTokens: number;

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -26,7 +26,7 @@ import {
   AcpResumeError,
   AcpSessionNotFoundError,
 } from "../../acp/session-manager.js";
-import type { AcpSessionState } from "../../acp/types.js";
+import { type AcpSessionState, isLiveAcpStatus } from "../../acp/types.js";
 import {
   AcpSessionModelUpdateEventSchema,
   type AssistantEvent,
@@ -654,10 +654,7 @@ function deleteSession({ pathParams }: RouteHandlerArgs) {
 
   try {
     const state = manager.getStatus(id);
-    if (
-      !Array.isArray(state) &&
-      (state.status === "running" || state.status === "initializing")
-    ) {
+    if (!Array.isArray(state) && isLiveAcpStatus(state.status)) {
       throw new ConflictError(
         `ACP session "${id}" is still ${state.status}. Cancel or close it before deleting.`,
       );


### PR DESCRIPTION
## Summary
Fixes gaps identified during the third self-review round for acp-model-control.md (daemon).

- **A refused resume re-pin no longer disarms the model baseline.** `session-manager.ts` cleared `modelBaselineEstablished` after the adapter refused a resume re-pin, so the user's very next `/model` was swallowed as an opening announcement. The `pinSessionModel` latch already leaves the baseline armed, matching the refused-spawn path.
- **Dropped the `recordedModel` sidecar; the history row records the model the run ended on.** It made the terminal row (and the terminal tile after a refetch) name a model the run was never on. The row's `model` is now always `state.model`, the adapter's own truth, and a later resume re-pins to what the run actually ended on.
- **Spawn and resume pins go through the switch queue.** They called `pinSessionModel` directly, off `entry.modelSwitchQueue`, so a `POST set-model` during the initial pin's round trip ran concurrently and whichever call finished first cleared `managerPinInFlight` for both. Both pins and `setModel` now chain through one `enqueueModelWork` helper; the boolean stays, and the queue is idle at spawn so ordering is unchanged.
- **`enforcePin` surfaces a dead post-install resolution.** `auto-install.ts` returned the pre-install resolution when `bun add` reported success but `resolveAcpAgent` then failed. That resolution cannot spawn (the command is gone from PATH) and the caller lost the actionable `binary_not_found` hint; it now returns the failed resolution, keeps the warn, and the doc comment no longer claims every path keeps a spawnable agent.
- **Pin scope key.** `pinScope` keyed on `packageSpec` (a pure function of `command`) and collapsed an omitted PATH into `""`, colliding with an agent whose `env.PATH` is literally empty. The scope is now `command` + search path with a NUL sentinel for an inherited PATH, computed once in `ensureAdapterInstalled` and reused for the `pinChecks` coalesce. `joinKey` is back to two arguments, and the always-paired warn + attempt at the two `unknown` sites is one `noteUnverifiablePin` helper.
- **The live-status predicate is shared with the delete route.** `ACP_LIVE_STATUSES` / `isLiveAcpStatus` moved next to the status union in `acp/types.ts` and are exported; `acp-routes.ts` uses the predicate for its 409 guard instead of re-spelling it.

## Tests
Added a regression test for the queued pin (a `setModel` issued while the spawn pin's adapter response is pending waits for it and does not clear the in-flight flag early), rewrote the two refused-resume-re-pin tests, updated the `enforcePin` test, and added an empty-PATH pin-scope test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D