### PR TITLE
chore(acp): final review cleanups for the model-control feature branch

### DIFF
--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -108,11 +108,6 @@ const pinChecks = new Map<string, Promise<AdapterInstallResult>>();
 /** In-flight global installs, keyed by command alone. */
 const installRuns = new Map<string, Promise<AdapterInstallResult>>();
 
-/** Composite map key over fields that may contain any character. */
-function joinKey(first: string, second: string): string {
-  return `${first}\u0000${second}`;
-}
-
 /**
  * Stands in for an agent that names no `env.PATH` and inherits the daemon's.
  * A real PATH string cannot contain NUL, so this never collides with one,
@@ -128,7 +123,7 @@ const INHERITED_SEARCH_PATH = "\u0000inherit";
  * the pin, and must not unpin the agents whose path can.
  */
 function pinScope(command: string, searchPath: string | undefined): string {
-  return joinKey(command, searchPath ?? INHERITED_SEARCH_PATH);
+  return `${command}\u0000${searchPath ?? INHERITED_SEARCH_PATH}`;
 }
 
 /**

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-model-stat-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-model-stat-card.tsx
@@ -262,7 +262,6 @@ export function AcpModelStatCard({
                   label={option.label}
                   description={option.description}
                   selected={selected}
-                  disabled={pending}
                   onSelect={() => handleSelect(option.value)}
                 />
               );

--- a/clients/web/src/domains/settings/ai/coding-agents-card.tsx
+++ b/clients/web/src/domains/settings/ai/coding-agents-card.tsx
@@ -104,8 +104,7 @@ function CodingAgentsCardBody({ assistantId }: { assistantId: string }) {
     }
   }
 
-  const hasCustomValue = isCustomModel(defaultModel);
-  const showsCustomInput = customPicked || hasCustomValue;
+  const showsCustomInput = customPicked;
   const selectValue = showsCustomInput ? CUSTOM_SENTINEL : defaultModel;
 
   const nextDefaultModel = defaultModel?.trim() || null;
@@ -137,7 +136,7 @@ function CodingAgentsCardBody({ assistantId }: { assistantId: string }) {
     (value: string) => {
       if (value === CUSTOM_SENTINEL) {
         setCustomPicked(true);
-        if (!hasCustomValue) {
+        if (!isCustomModel(defaultModel)) {
           setDraftDefaultModel("");
         }
         return;
@@ -145,7 +144,7 @@ function CodingAgentsCardBody({ assistantId }: { assistantId: string }) {
       setCustomPicked(false);
       setDraftDefaultModel(value);
     },
-    [hasCustomValue, setDraftDefaultModel],
+    [defaultModel, setDraftDefaultModel],
   );
 
   const handleSelectNone = useCallback(() => {

--- a/packages/design-library/src/components/action-menu.tsx
+++ b/packages/design-library/src/components/action-menu.tsx
@@ -294,10 +294,7 @@ function Item({
   const { presentation, close } = useActionMenuContext("Item");
   const isDestructive = tone === "destructive";
   const check = selected ? (
-    <Check
-      className="h-3.5 w-3.5 shrink-0 text-[var(--content-default)]"
-      aria-hidden
-    />
+    <Check className="h-3.5 w-3.5 shrink-0 text-inherit" aria-hidden />
   ) : null;
   const ariaCurrent = selected ? ("true" as const) : undefined;
 
@@ -357,6 +354,9 @@ function Item({
       disabled={disabled}
       className={cn(
         "whitespace-nowrap",
+        // The trailing slot paints its contents tertiary, which the mark has
+        // to opt out of to take the row's colour like the leading glyph does.
+        selected && "[&_[data-slot=menu-item-trailing]]:text-inherit",
         isDestructive && actionMenuDestructiveClasses.anchored,
         className,
       )}

--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -245,6 +245,19 @@ describe("PanelItem asChild", () => {
     expect(html).toContain('aria-current="page"');
   });
 
+  /* `active` is the row's own statement of currentness, so it wins over a
+     caller's `aria-current` on this path too. */
+  test("outranks a caller's aria-current when active", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        PanelItem,
+        { asChild: true, active: true, "aria-current": "true" as const },
+        createElement("a", { href: "/pinned" }, "Pinned"),
+      ),
+    );
+    expect(html).toContain('aria-current="page"');
+  });
+
   /* Radix `Slot` skips both the prop merge and the ref composition for a
      fragment, so a fragment child renders a row with none of the above and
      holds no ref. The type cannot express that, so it is reported. */

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -440,6 +440,7 @@ function PanelItemSlotRow({
   activeVariant = "default",
   className,
   "aria-label": ariaLabel,
+  "aria-current": ariaCurrentProp,
   children,
   ref,
   ...rest
@@ -456,9 +457,9 @@ function PanelItemSlotRow({
         interactive: true,
         className,
       })}
-      aria-current={active ? "page" : undefined}
       aria-label={ariaLabel}
       {...rest}
+      aria-current={active ? "page" : ariaCurrentProp}
     >
       {children}
     </Slot>


### PR DESCRIPTION
## Summary
Five mechanical cleanups from the final self-review round for acp-model-control.md: an unreachable disabled prop on menu rows, a redundant custom-row flag, an inlined one-caller key helper, a selected check that now inherits the row color, and aria-current precedence on PanelItem's slot row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D