### PR TITLE
fix(web): report attachment fetch errors the client returns, not only the ones it throws

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
@@ -17,6 +17,7 @@ import {
 
 import * as captureErrorModule from "@/lib/sentry/capture-error";
 import * as daemonSdk from "@/generated/daemon/sdk.gen";
+import { ApiError } from "@/utils/api-errors";
 
 interface CapturedError {
   err: unknown;
@@ -26,8 +27,9 @@ interface CapturedError {
 
 let captured: CapturedError[] = [];
 let contentResponse: () => Promise<{
-  data: Blob | null;
+  data: Blob | null | undefined;
   error: { message: string } | null;
+  response?: Response;
 }> = async () => ({ data: new Blob(["bytes"]), error: null });
 
 const attachmentsByIdContentGet = mock(() => contentResponse());
@@ -87,6 +89,36 @@ describe("fetchAttachmentContentBlob", () => {
       Blob,
     );
     expect(captured).toEqual([]);
+  });
+
+  test("reports an error the request returned, and still answers null", async () => {
+    const returned = { message: "boom" };
+    contentResponse = async () => ({ data: undefined, error: returned });
+
+    expect(await fetchAttachmentContentBlob("asst-1", "att-1")).toBeNull();
+    expect(captured).toEqual([
+      {
+        err: returned,
+        context: "fetchAttachmentContentBlob",
+        bestEffort: true,
+      },
+    ]);
+  });
+
+  test("reports a returned HTTP failure with its status attached", async () => {
+    contentResponse = async () => ({
+      data: undefined,
+      error: { message: "assistant starting" },
+      response: new Response(null, { status: 503 }),
+    });
+
+    expect(await fetchAttachmentContentBlob("asst-1", "att-1")).toBeNull();
+    expect(captured).toHaveLength(1);
+    const [only] = captured;
+    expect(only?.context).toBe("fetchAttachmentContentBlob");
+    expect(only?.bestEffort).toBe(true);
+    expect(only?.err).toBeInstanceOf(ApiError);
+    expect((only?.err as ApiError).status).toBe(503);
   });
 
   test("never fetches, and never reports, for a synthetic history id", async () => {

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
@@ -1,5 +1,17 @@
 import { attachmentsByIdContentGet } from "@/generated/daemon/sdk.gen";
 import { captureError } from "@/lib/sentry/capture-error";
+import { toApiError } from "@/utils/api-errors";
+
+/**
+ * Every reader of the attachment bytes lands here, so this is the one place
+ * an attachment fetch failure is reported.
+ */
+function reportAttachmentFetchFailure(error: unknown): void {
+  captureError(error, {
+    context: "fetchAttachmentContentBlob",
+    bestEffort: true,
+  });
+}
 
 /**
  * Fetch an attachment's stored bytes from the daemon content endpoint.
@@ -15,7 +27,7 @@ export async function fetchAttachmentContentBlob(
   }
 
   try {
-    const { data, error } = await attachmentsByIdContentGet({
+    const { data, error, response } = await attachmentsByIdContentGet({
       path: { assistant_id: assistantId, id: attachmentId },
       parseAs: "blob",
       throwOnError: false,
@@ -23,14 +35,18 @@ export async function fetchAttachmentContentBlob(
     if (!error && data instanceof Blob) {
       return data;
     }
+    // `throwOnError: false` hands HTTP failures back as a value, so the status
+    // has to be attached here for the transient filter to read it.
+    if (response && !response.ok) {
+      reportAttachmentFetchFailure(toApiError(error, response));
+    } else {
+      reportAttachmentFetchFailure(
+        error ?? new Error("Attachment content response carried no blob"),
+      );
+    }
     return null;
   } catch (err) {
-    // Every reader of the attachment bytes lands here, so this is the one
-    // place the failure is reported.
-    captureError(err, {
-      context: "fetchAttachmentContentBlob",
-      bestEffort: true,
-    });
+    reportAttachmentFetchFailure(err);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- fetchAttachmentContentBlob reports the error the generated client returns under throwOnError: false, so offline, 4xx, and 5xx failures reach captureError; the thrown path keeps its report
- a returned HTTP failure is wrapped with toApiError first, so the status is attached and the bestEffort transient filter (503 startup, 502, 401 auth race) reads it the same way it reads a thrown one

Part of plan: chat-info-assets-panel.md (remediation round 5)