### PR TITLE
fix(web): the Chat Info panel renders what it knows, the trigger stays for a failed load, and the category grid is its own tested piece

### DIFF
--- a/clients/web/src/domains/chat/components/chat-info-category-grid.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-category-grid.stories.tsx
@@ -1,0 +1,127 @@
+/**
+ * The Chat Info panel's second level: one category's whole set, wrapped into a
+ * grid, with the paging control the daemon-backed categories offer.
+ *
+ * Every asset carries its own preview, so the grid draws real pictures with no
+ * daemon behind it. The tile's fetched and unavailable states are the file
+ * tile's own story.
+ */
+
+import { QueryClientProvider } from "@tanstack/react-query";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import {
+  makeDisplayAttachment,
+  makeSamplePreview,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { CHAT_INFO_ASSISTANT_ID } from "@/domains/chat/components/chat-info-story-fixtures";
+import {
+  CHAT_INFO_T0,
+  makeChatInfoQueryClient,
+  makeDocumentAsset,
+  makeDocumentSummary,
+  makeFileAsset,
+  makeFrameAsset,
+} from "@/domains/chat/components/chat-info.test-helper";
+
+import { ChatInfoCategoryGrid } from "./chat-info-category-grid";
+
+/** One Live session: six captures a few minutes apart, newest first. */
+const FRAMES = Array.from({ length: 6 }, (_, index) =>
+  makeFrameAsset(
+    makeDisplayAttachment({
+      id: `camera-frame-${index + 1}`,
+      filename: `camera-frame-${index + 1}.jpg`,
+      mimeType: "image/jpeg",
+      sizeBytes: 98_304 + index * 2_048,
+      previewUrl: SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
+    }),
+    CHAT_INFO_T0 - index * 180_000,
+  ),
+);
+
+const FILES = [
+  makeDocumentAsset(
+    makeDocumentSummary({
+      surfaceId: "surface-trip-notes",
+      title: "Trip Notes",
+      wordCount: 842,
+    }),
+  ),
+  makeDocumentAsset(
+    makeDocumentSummary({
+      surfaceId: "surface-packing-list",
+      title: "Packing List",
+      wordCount: 214,
+    }),
+  ),
+  makeFileAsset(
+    makeDisplayAttachment({
+      id: "harbour-at-dawn",
+      filename: "harbour-at-dawn.png",
+      sizeBytes: 184_320,
+      previewUrl: makeSamplePreview(240, 150),
+    }),
+  ),
+  makeFileAsset(
+    makeDisplayAttachment({
+      id: "ferry-deck",
+      filename: "ferry-deck.png",
+      sizeBytes: 190_464,
+      previewUrl: SAMPLE_PREVIEWS[2]!,
+    }),
+  ),
+  makeFileAsset(
+    makeDisplayAttachment({
+      id: "coast-guide",
+      filename: "coast-guide.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_097_152,
+    }),
+  ),
+];
+
+const storyClient = makeChatInfoQueryClient();
+
+const inPanelBody: Decorator = (Story) => (
+  <QueryClientProvider client={storyClient}>
+    <div className="max-w-[560px] p-5">
+      <Story />
+    </div>
+  </QueryClientProvider>
+);
+
+const meta: Meta<typeof ChatInfoCategoryGrid> = {
+  title: "Chat/ChatInfoCategoryGrid",
+  component: ChatInfoCategoryGrid,
+  parameters: { layout: "fullscreen" },
+  decorators: [inPanelBody],
+  args: {
+    items: FRAMES,
+    assistantId: CHAT_INFO_ASSISTANT_ID,
+    hasMore: false,
+    onLoadMore: fn(),
+    onOpen: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatInfoCategoryGrid>;
+
+/**
+ * Camera Frames with more to come: each tile is labelled by capture time, and
+ * the control under the grid fetches the next page.
+ */
+export const Frames: Story = {
+  args: { hasMore: true },
+};
+
+/**
+ * Documents & Images, the whole category loaded: documents and attachments
+ * side by side, and no paging control.
+ */
+export const Files: Story = {
+  args: { items: FILES },
+};

--- a/clients/web/src/domains/chat/components/chat-info-category-grid.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-category-grid.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * `ChatInfoCategoryGrid`: the panel's second level, given one category's
+ * items.
+ *
+ * The real tiles render here, since what the grid owns is the set of them and
+ * the paging control under it. Bytes are never fetched: the frames carry their
+ * preview inline and the query client serves only what a test seeds.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  installChatInfoDomStubs,
+  makeChatInfoQueryClient,
+  makeFileAsset,
+  makeFrameAsset,
+} from "@/domains/chat/components/chat-info.test-helper";
+import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
+
+installChatInfoDomStubs();
+
+const { ChatInfoCategoryGrid } =
+  await import("@/domains/chat/components/chat-info-category-grid");
+const { makeDisplayAttachment, SAMPLE_PREVIEWS } =
+  await import("@/domains/chat/components/chat-attachments/attachment-fixtures");
+const { formatCaptureTime } = await import("@/utils/format-date");
+
+const ASSISTANT_ID = "asst-1";
+/** The suite pins i18next to English, which is the locale the tile formats in. */
+const LOCALE = "en";
+
+const FRAME_CAPTURED_AT = new Date(2001, 4, 27, 10, 30).getTime();
+
+const FRAME = makeFrameAsset(
+  makeDisplayAttachment({
+    id: "frame-1",
+    filename: "frame-01.jpg",
+    mimeType: "image/jpeg",
+    previewUrl: SAMPLE_PREVIEWS[1]!,
+  }),
+  FRAME_CAPTURED_AT,
+);
+
+const FILE = makeFileAsset(
+  makeDisplayAttachment({
+    id: "att-1",
+    filename: "itinerary.pdf",
+    mimeType: "application/pdf",
+  }),
+);
+
+function renderGrid({
+  items = [FRAME],
+  hasMore = false,
+  onLoadMore = () => {},
+  onOpen = () => {},
+}: {
+  items?: ConversationFileAsset[];
+  hasMore?: boolean;
+  onLoadMore?: () => void;
+  onOpen?: (file: ConversationFileAsset) => void;
+} = {}): void {
+  render(
+    <QueryClientProvider client={makeChatInfoQueryClient()}>
+      <ChatInfoCategoryGrid
+        items={items}
+        assistantId={ASSISTANT_ID}
+        hasMore={hasMore}
+        onLoadMore={onLoadMore}
+        onOpen={onOpen}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function loadMore(): HTMLElement | null {
+  return screen.queryByRole("button", { name: "Load more" });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ChatInfoCategoryGrid", () => {
+  test("labels a camera frame by when it was captured", () => {
+    renderGrid();
+
+    expect(screen.getByLabelText("Preview camera frame")).toBeDefined();
+    expect(
+      screen.getByText(formatCaptureTime(FRAME_CAPTURED_AT, LOCALE)),
+    ).toBeDefined();
+  });
+
+  test("gives every item its own tile", () => {
+    renderGrid({ items: [FRAME, FILE] });
+
+    expect(screen.getByLabelText("Preview camera frame")).toBeDefined();
+    expect(screen.getByLabelText("Preview itinerary.pdf")).toBeDefined();
+  });
+
+  test("opens the tile that was activated", () => {
+    const opened: string[] = [];
+    renderGrid({ items: [FILE], onOpen: (file) => opened.push(file.id) });
+
+    fireEvent.click(screen.getByLabelText("Preview itinerary.pdf"));
+
+    expect(opened).toEqual([FILE.id]);
+  });
+
+  test("fetches the next page from the Load more control", () => {
+    const onLoadMore = mock(() => {});
+    renderGrid({ hasMore: true, onLoadMore });
+
+    expect(loadMore()).not.toBeNull();
+    fireEvent.click(loadMore()!);
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  test("offers no Load more for a category that holds everything", () => {
+    renderGrid({ hasMore: false });
+
+    expect(loadMore()).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-info-category-grid.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-category-grid.tsx
@@ -1,0 +1,53 @@
+/**
+ * The Chat Info panel's second level: one category's whole set as a wrapping
+ * grid of tiles, with the control that fetches the next page under it.
+ *
+ * Presentational: the panel owns the category, its items, and what opening a
+ * tile does.
+ */
+
+import { Button } from "@vellumai/design-library";
+
+import { ChatInfoFileTile } from "@/domains/chat/components/chat-info-file-tile";
+import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
+import { useTranslation } from "@/i18n";
+
+export interface ChatInfoCategoryGridProps {
+  items: ConversationFileAsset[];
+  assistantId: string;
+  /** Whether the category holds more than the loaded page. */
+  hasMore: boolean;
+  onLoadMore: () => void;
+  /** Opens a document, or previews an attachment or camera frame. */
+  onOpen: (file: ConversationFileAsset) => void;
+}
+
+export function ChatInfoCategoryGrid({
+  items,
+  assistantId,
+  hasMore,
+  onLoadMore,
+  onOpen,
+}: ChatInfoCategoryGridProps) {
+  const { t } = useTranslation("chat");
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap gap-2">
+        {items.map((file) => (
+          <ChatInfoFileTile
+            key={file.id}
+            file={file}
+            assistantId={assistantId}
+            onOpen={onOpen}
+          />
+        ))}
+      </div>
+      {hasMore && (
+        <Button variant="outlined" onClick={onLoadMore} className="self-start">
+          {t("chatInfoPanel.loadMore")}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
@@ -5,11 +5,11 @@
  * The conversation's assets arrive through the real hook, seeded at both of
  * its sources: the query cache holds the apps and documents, the chat-session
  * store holds the transcript rows the attachments come from. Only the row's
- * measured width and the window-size axis are mocked, since happy-dom reports
- * a zero box for everything. What is left is what this component owns: which
- * sections exist, where See All appears, which level renders, what it says
- * while the sources are unresolved, and the sequence each tile runs when it is
- * opened.
+ * measured width is mocked, since happy-dom reports a zero box for everything,
+ * and the window-size axis comes from a `matchMedia` stub. What is left is
+ * what this component owns: which sections exist, where See All appears, which
+ * level renders, what it says while the sources are unresolved, and the
+ * sequence each tile runs when it is opened.
  *
  * Camera frames and paged categories are not exercised here: the transcript is
  * the hook's only source today and it can produce neither.
@@ -33,22 +33,25 @@ import {
   screen,
 } from "@testing-library/react";
 
-import * as appHtmlCache from "@/utils/app-html-cache";
 import {
+  attachmentRows,
+  CHAT_INFO_DRAWER_WIDTH_PX,
   CHAT_INFO_T0,
+  chatInfoAppHtmlCacheMock,
   clearTranscriptMessages,
   installChatInfoDomStubs,
   makeAppSummary,
   makeChatInfoQueryClient,
   makeDocumentSummary,
+  makeElementSizeMock,
   makePendingChatInfoQueryClient,
+  makeTranscriptRow,
   seedChatInfoConversation,
   seedQueryFailure,
   seedTranscriptMessages,
 } from "@/domains/chat/components/chat-info.test-helper";
 import type { DisplayMessage } from "@/domains/chat/types/types";
-import type * as ElementSizeModule from "@/hooks/use-element-size";
-import type * as IsMobileModule from "@/hooks/use-is-mobile";
+import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
 import type { ChatInfoCategory } from "@/stores/viewer-store";
@@ -56,34 +59,15 @@ import type { ChatInfoCategory } from "@/stores/viewer-store";
 const ASSISTANT_ID = "asst-1";
 const CONVERSATION_ID = "conv-1";
 const OTHER_CONVERSATION_ID = "conv-2";
-/** The drawer's body width on the desktop mock: 3 app tiles, 4 file tiles. */
-const DRAWER_WIDTH = 569;
 
 installChatInfoDomStubs();
 
-mock.module(
-  "@/hooks/use-element-size",
-  (): Partial<typeof ElementSizeModule> => ({
-    useElementSize: () => ({ ref: () => {}, size: { w: DRAWER_WIDTH, h: 0 } }),
-  }),
-);
-
-mock.module(
-  "@/hooks/use-is-mobile",
-  (): Partial<typeof IsMobileModule> => ({
-    useIsMobile: () => false,
-    MOBILE_MEDIA_QUERY: "(max-width: 767px)",
-  }),
+mock.module("@/hooks/use-element-size", () =>
+  makeElementSizeMock(() => CHAT_INFO_DRAWER_WIDTH_PX),
 );
 
 // The app tile's live preview would otherwise call the daemon's open endpoint.
-mock.module(
-  "@/utils/app-html-cache",
-  (): Partial<typeof appHtmlCache> => ({
-    ...appHtmlCache,
-    getCachedAppHtml: async () => "<!doctype html><title>App</title>",
-  }),
-);
+mock.module("@/utils/app-html-cache", chatInfoAppHtmlCacheMock);
 
 const calls: string[] = [];
 
@@ -124,31 +108,20 @@ const PACKING_LIST = makeDocumentSummary({
 });
 const DOCUMENTS = [TRIP_NOTES, PACKING_LIST];
 
-function imageRow(id: string, index: number, timestamp: number) {
-  return {
-    id,
-    role: "user" as const,
-    timestamp,
-    attachments: [
-      makeDisplayAttachment({
-        id: `img-${index}`,
-        filename: `photo-${index}.png`,
-        previewUrl: SAMPLE_PREVIEWS[index]!,
-      }),
-    ],
-  };
-}
-
-const IMAGE_ROWS: DisplayMessage[] = [
-  imageRow("msg-1", 0, CHAT_INFO_T0),
-  imageRow("msg-2", 1, CHAT_INFO_T0 + 1_000),
-];
+const IMAGE_ROWS: DisplayMessage[] = attachmentRows(
+  [0, 1].map((index) =>
+    makeDisplayAttachment({
+      id: `img-${index}`,
+      filename: `photo-${index}.png`,
+      previewUrl: SAMPLE_PREVIEWS[index]!,
+    }),
+  ),
+);
 
 /** Two legacy rows whose attachments carry the same synthetic id. */
 const LEGACY_ROWS: DisplayMessage[] = [
-  {
+  makeTranscriptRow({
     id: "msg-old",
-    role: "user",
     timestamp: CHAT_INFO_T0,
     attachments: [
       makeDisplayAttachment({
@@ -156,10 +129,9 @@ const LEGACY_ROWS: DisplayMessage[] = [
         filename: "legacy-old.png",
       }),
     ],
-  },
-  {
+  }),
+  makeTranscriptRow({
     id: "msg-new",
-    role: "user",
     timestamp: CHAT_INFO_T0 + 1_000,
     attachments: [
       makeDisplayAttachment({
@@ -167,7 +139,7 @@ const LEGACY_ROWS: DisplayMessage[] = [
         filename: "legacy-new.png",
       }),
     ],
-  },
+  }),
 ];
 
 // ---------------------------------------------------------------------------
@@ -187,6 +159,8 @@ const loadDocument = mock(
     calls.push("loadDocument");
   },
 );
+
+const viewport = viewportAxesStub();
 
 const onClose = mock((): void => undefined);
 const onSelectCategory = mock(
@@ -254,6 +228,7 @@ async function renderChatInfo(
 
 beforeEach(() => {
   calls.length = 0;
+  viewport.set({ narrow: false, coarsePointer: false });
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
   loadApp.mockClear();
   closeChatInfo.mockClear();
@@ -265,6 +240,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  viewport.restore();
   clearTranscriptMessages();
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
 });
@@ -433,10 +409,32 @@ describe("ChatInfoPanel See All level", () => {
 });
 
 describe("ChatInfoPanel unsettled sources", () => {
+  const DOCUMENTS_KEY = documentsGetQueryKey({
+    path: { assistant_id: ASSISTANT_ID },
+    query: { conversationId: CONVERSATION_ID },
+  });
+
+  /** Leaves the documents source failed with nothing cached under it. */
+  function failDocuments(client: QueryClient): void {
+    client.removeQueries({ queryKey: DOCUMENTS_KEY });
+    seedQueryFailure(client, DOCUMENTS_KEY);
+  }
+
   test("says nothing at all while the sources are loading", async () => {
-    await renderChatInfo(null, { client: makePendingChatInfoQueryClient() });
+    await renderChatInfo(null, {
+      client: makePendingChatInfoQueryClient(),
+      messages: [],
+    });
 
     expect(screen.getByText("Chat Info")).toBeDefined();
+    expect(screen.queryByText("No assets in this chat yet")).toBeNull();
+    expect(screen.queryByText("Assets could not be loaded")).toBeNull();
+  });
+
+  test("lists the transcript's files while the sources are loading", async () => {
+    await renderChatInfo(null, { client: makePendingChatInfoQueryClient() });
+
+    expect(screen.getByLabelText("Preview photo-0.png")).toBeDefined();
     expect(screen.queryByText("No assets in this chat yet")).toBeNull();
     expect(screen.queryByText("Assets could not be loaded")).toBeNull();
   });
@@ -454,18 +452,24 @@ describe("ChatInfoPanel unsettled sources", () => {
     expect(screen.getByText("No assets in this chat yet")).toBeDefined();
   });
 
-  test("says so when a source could not be loaded", async () => {
+  test("keeps listing documents a failed refetch left cached", async () => {
     await renderChatInfo(null, {
-      afterSeed: (client) =>
-        seedQueryFailure(
-          client,
-          documentsGetQueryKey({
-            path: { assistant_id: ASSISTANT_ID },
-            query: { conversationId: CONVERSATION_ID },
-          }),
-        ),
+      afterSeed: (client) => seedQueryFailure(client, DOCUMENTS_KEY),
     });
 
-    expect(screen.getByText("Assets could not be loaded")).toBeDefined();
+    expect(screen.getByLabelText("Open Trip Notes")).toBeDefined();
+    expect(screen.queryByText("Assets could not be loaded")).toBeNull();
+  });
+
+  test("heads the categories it does have with the failure", async () => {
+    await renderChatInfo(null, { apps: [], afterSeed: failDocuments });
+
+    const notice = screen.getByText("Assets could not be loaded");
+    const filesTitle = screen.getByText("Documents & Images");
+    expect(screen.getByLabelText("Preview photo-0.png")).toBeDefined();
+    expect(
+      notice.compareDocumentPosition(filesTitle) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeGreaterThan(0);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-info-panel.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.tsx
@@ -13,12 +13,13 @@ import { ChevronLeft, Layers } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo } from "react";
 
-import { Button, Typography } from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library";
 
 import { DeleteAppDialog } from "@/components/delete-app-dialog";
 import {
   DetailShell,
   type DetailShellHeaderProps,
+  DetailShellNotice,
   DetailShellTitleWithCount,
 } from "@/components/detail-shell";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
@@ -26,6 +27,7 @@ import {
   CHAT_INFO_APP_TILE_WIDTH_PX,
   ChatInfoAppTile,
 } from "@/domains/chat/components/chat-info-app-tile";
+import { ChatInfoCategoryGrid } from "@/domains/chat/components/chat-info-category-grid";
 import {
   CHAT_INFO_FILE_TILE_WIDTH_PX,
   ChatInfoFileTile,
@@ -48,19 +50,6 @@ import {
   useViewerStore,
 } from "@/stores/viewer-store";
 import type { DisplayAttachment } from "@/types/attachment-types";
-
-/** The body when there is nothing to list: one quiet centred line. */
-function ChatInfoNotice({ children }: { children: ReactNode }) {
-  return (
-    <Typography
-      as="p"
-      variant="body-small-default"
-      className="py-10 text-center text-[var(--content-tertiary)]"
-    >
-      {children}
-    </Typography>
-  );
-}
 
 export interface ChatInfoPanelProps {
   payload: ChatInfoPayload;
@@ -207,15 +196,7 @@ export function ChatInfoPanel({
   };
 
   let body: ReactNode;
-  if (status === "pending") {
-    // Nothing at all rather than a line the loaded panel will replace: the
-    // sources land in a frame or two and a flash of copy reads as an answer.
-    body = null;
-  } else if (status === "error") {
-    body = <ChatInfoNotice>{t("chatInfoPanel.loadFailed")}</ChatInfoNotice>;
-  } else if (count === 0) {
-    body = <ChatInfoNotice>{t("chatInfoPanel.empty")}</ChatInfoNotice>;
-  } else if (level === "apps") {
+  if (level === "apps") {
     body = (
       <div
         className="grid gap-2"
@@ -236,31 +217,28 @@ export function ChatInfoPanel({
       </div>
     );
   } else if (level !== null) {
-    const items = categoryLists[level];
-    const hasMore = level === "files" ? hasMoreFiles : hasMoreFrames;
-    const loadMore = level === "files" ? loadMoreFiles : loadMoreFrames;
     body = (
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-wrap gap-2">
-          {items.map((file) => (
-            <ChatInfoFileTile
-              key={file.id}
-              file={file}
-              assistantId={assistantId}
-              onOpen={handleOpenFile}
-            />
-          ))}
-        </div>
-        {hasMore && (
-          <Button variant="outlined" onClick={loadMore} className="self-start">
-            {t("chatInfoPanel.loadMore")}
-          </Button>
-        )}
-      </div>
+      <ChatInfoCategoryGrid
+        items={categoryLists[level]}
+        assistantId={assistantId}
+        hasMore={level === "files" ? hasMoreFiles : hasMoreFrames}
+        onLoadMore={level === "files" ? loadMoreFiles : loadMoreFrames}
+        onOpen={handleOpenFile}
+      />
     );
   } else {
+    // Every category holding anything is listed whatever the sources are
+    // doing, since the transcript attachments are on screen from the first
+    // paint. A source still loading says nothing at all: a flash of copy reads
+    // as an answer the loaded panel then replaces.
     body = (
       <div className="flex flex-col gap-8">
+        {status === "error" && (
+          <DetailShellNotice>{t("chatInfoPanel.loadFailed")}</DetailShellNotice>
+        )}
+        {status === "ready" && count === 0 && (
+          <DetailShellNotice>{t("chatInfoPanel.empty")}</DetailShellNotice>
+        )}
         {apps.length > 0 && (
           <ChatInfoSection
             title={categoryTitles.apps}

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -1,7 +1,7 @@
 /**
  * `ChatInfoSection` decides how many tiles a row shows from one number: the
- * row's measured width. The suite drives that width and the window-size axis
- * through module mocks rather than a layout engine, since happy-dom reports a
+ * row's measured width. The suite drives that width through a module mock and
+ * the window-size axis through a `matchMedia` stub, since happy-dom reports a
  * zero box for everything.
  *
  * Tiles are plain elements here. The section is generic over its item type and
@@ -26,19 +26,16 @@ import {
   CHAT_INFO_DRAWER_WIDTH_PX,
   CHAT_INFO_NARROW_PHONE_PX,
   makeElementSizeMock,
-  makeIsMobileMock,
 } from "@/domains/chat/components/chat-info.test-helper";
+import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
 const widthRef = { value: CHAT_INFO_DRAWER_WIDTH_PX };
-const isMobileRef = { value: false };
 
 mock.module("@/hooks/use-element-size", () =>
   makeElementSizeMock(() => widthRef.value),
 );
 
-mock.module("@/hooks/use-is-mobile", () =>
-  makeIsMobileMock(() => isMobileRef.value),
-);
+const viewport = viewportAxesStub();
 
 const { ChatInfoSection, fitTileCount } =
   await import("@/domains/chat/components/chat-info-section");
@@ -98,11 +95,12 @@ function seeAll(): HTMLElement | null {
 
 beforeEach(() => {
   widthRef.value = CHAT_INFO_DRAWER_WIDTH_PX;
-  isMobileRef.value = false;
+  viewport.set({ narrow: false, coarsePointer: false });
 });
 
 afterEach(() => {
   cleanup();
+  viewport.restore();
 });
 
 afterAll(() => {
@@ -156,7 +154,7 @@ describe("ChatInfoSection", () => {
   });
 
   test("scrolls the whole fetched set on a narrow window", () => {
-    isMobileRef.value = true;
+    viewport.set({ narrow: true, coarsePointer: false });
     const { container } = renderSection({
       items: makeItems(5),
       tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
@@ -175,7 +173,7 @@ describe("ChatInfoSection", () => {
 
   test("counts the strip's reclaimed right inset toward the narrow-window fit", () => {
     // The strip shows the column plus the inset it reclaims on the right.
-    isMobileRef.value = true;
+    viewport.set({ narrow: true, coarsePointer: false });
     widthRef.value = NARROW_COLUMN_WIDTH;
 
     const fitted = renderSection({
@@ -197,7 +195,7 @@ describe("ChatInfoSection", () => {
   test("pays the reclaimed inset back on both edges of the strip", () => {
     // A strip that fits is then exactly as wide as its scroller, and one that
     // runs past the column stops with the inset showing past its last tile.
-    isMobileRef.value = true;
+    viewport.set({ narrow: true, coarsePointer: false });
     widthRef.value = NARROW_COLUMN_WIDTH;
 
     for (const itemCount of [2, 8]) {

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -29,7 +29,6 @@ import {
   documentsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import type * as ElementSizeModule from "@/hooks/use-element-size";
-import type * as IsMobileModule from "@/hooks/use-is-mobile";
 import { makeAppSummary as makeSharedAppSummary } from "@/types/app-summary.test-helper";
 import type { AppSummary } from "@/types/app-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
@@ -218,16 +217,6 @@ export function makeElementSizeMock(
 ): Partial<typeof ElementSizeModule> {
   return {
     useElementSize: () => ({ ref: () => {}, size: { w: readWidth(), h: 0 } }),
-  };
-}
-
-/** The `@/hooks/use-is-mobile` module body a suite installs. */
-export function makeIsMobileMock(
-  readIsMobile: () => boolean,
-): Partial<typeof IsMobileModule> {
-  return {
-    useIsMobile: () => readIsMobile(),
-    MOBILE_MEDIA_QUERY: "(max-width: 767px)",
   };
 }
 

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.test.tsx
@@ -27,18 +27,20 @@ import * as motionReact from "motion/react";
 
 import {
   clearTranscriptMessages,
+  installChatInfoDomStubs,
   makeChatInfoQueryClient,
   makeDocumentSummary,
+  makePendingChatInfoQueryClient,
   seedChatInfoConversation,
+  seedQueryFailure,
 } from "@/domains/chat/components/chat-info.test-helper";
+import { documentsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 import type { DocumentSummary } from "@/types/document-types";
 
-const isMobileRef = { value: false };
+installChatInfoDomStubs();
 
-mock.module("@/hooks/use-is-mobile", () => ({
-  useIsMobile: () => isMobileRef.value,
-  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
-}));
+const viewport = viewportAxesStub();
 
 // `useReducedMotion` reads a cached media-query singleton, so a per-test
 // `matchMedia` stub can't flip it. Override just that export and drive it
@@ -54,6 +56,8 @@ const {
   ASSETS_PILL_UNSEEN_DOT_TESTID,
   ASSETS_PILL_UNSEEN_DOT_PULSE_CLASS,
 } = await import("@/domains/chat/components/conversation-assets-pill");
+const { ChatInfoPanel } =
+  await import("@/domains/chat/components/chat-info-panel");
 const { useUnseenDocumentChangesStore } =
   await import("@/domains/chat/unseen-document-changes-store");
 const { useViewerStore } = await import("@/stores/viewer-store");
@@ -128,6 +132,44 @@ function renderPill({ withAssets = true }: { withAssets?: boolean } = {}) {
   };
 }
 
+/**
+ * The trigger and the panel together, hosted the way the chat layout hosts
+ * them: both read the real viewer store, so what one does the other sees.
+ */
+function ComposedChatInfo({ client }: { client: QueryClient }) {
+  const mainView = useViewerStore.use.mainView();
+  const activeChatInfo = useViewerStore.use.activeChatInfo();
+  const { closeChatInfo, setChatInfoCategory } = useViewerStore.getState();
+  return (
+    <QueryClientProvider client={client}>
+      <ConversationAssetsPill
+        assistantId={ASSISTANT_ID}
+        conversationId={CONVERSATION_ID}
+      />
+      {mainView === "chat-info" && activeChatInfo !== null ? (
+        <ChatInfoPanel
+          payload={activeChatInfo}
+          onClose={closeChatInfo}
+          onSelectCategory={setChatInfoCategory}
+        />
+      ) : null}
+    </QueryClientProvider>
+  );
+}
+
+function renderComposed() {
+  const client = makeChatInfoQueryClient();
+  seedConversation(client, [makeDocument()], CONVERSATION_ID);
+  render(<ComposedChatInfo client={client} />);
+
+  return {
+    /** Drop the conversation's last asset, as a delete would. */
+    emptyAssets: () => {
+      seedConversation(client, [], CONVERSATION_ID);
+    },
+  };
+}
+
 function markUnseen(conversationId = CONVERSATION_ID, surfaceId = SURFACE_ID) {
   useUnseenDocumentChangesStore
     .getState()
@@ -145,6 +187,7 @@ function chatInfoState() {
 
 beforeEach(() => {
   clearTranscriptMessages();
+  viewport.set({ narrow: false, coarsePointer: false });
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
   useViewerStore.getState().reset();
 });
@@ -152,7 +195,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   clearTranscriptMessages();
-  isMobileRef.value = false;
+  viewport.restore();
   reducedMotion = false;
   useUnseenDocumentChangesStore.setState({ changedDocuments: {} });
   useViewerStore.getState().reset();
@@ -240,7 +283,7 @@ describe("narrow window with a mouse", () => {
   // Room decides whether the count fits in the header cluster: a narrow window
   // gets the compact trigger and the same panel.
   beforeEach(() => {
-    isMobileRef.value = true;
+    viewport.set({ narrow: true, coarsePointer: false });
   });
 
   test("trigger is icon-only and keeps its accessible name", () => {
@@ -289,7 +332,9 @@ describe("conversation switch while the panel is open", () => {
 });
 
 describe("the last asset leaving while the panel is open", () => {
-  test("hides the trigger and takes the panel with it", async () => {
+  // The panel says it is empty and carries its own close control, so the
+  // trigger going does not have to take it down.
+  test("hides the trigger and leaves the panel open", async () => {
     const { emptyAssets } = renderPill();
 
     fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
@@ -301,9 +346,30 @@ describe("the last asset leaving while the panel is open", () => {
       expect(screen.queryByRole("button")).toBeNull();
     });
     expect(chatInfoState()).toEqual({
-      mainView: "chat",
-      activeChatInfo: null,
+      mainView: "chat-info",
+      activeChatInfo: {
+        assistantId: ASSISTANT_ID,
+        conversationId: CONVERSATION_ID,
+        category: null,
+      },
     });
+  });
+
+  test("leaves the panel showing the empty copy, trigger gone", async () => {
+    const { emptyAssets } = renderComposed();
+
+    fireEvent.click(screen.getByRole("button", { name: SEEN_LABEL }));
+    expect(screen.getByLabelText(`Open ${DOC_TITLE}`)).toBeTruthy();
+
+    emptyAssets();
+
+    await waitFor(() => {
+      expect(screen.getByText("No assets in this chat yet")).toBeTruthy();
+    });
+    expect(screen.queryByRole("button", { name: /^Conversation assets/ })).toBe(
+      null,
+    );
+    expect(chatInfoState().mainView).toBe("chat-info");
   });
 });
 
@@ -355,5 +421,31 @@ describe("empty asset list", () => {
     expect(screen.queryByRole("button")).toBeNull();
     expect(screen.queryByTestId(ASSETS_PILL_UNSEEN_DOT_TESTID)).toBeNull();
     expect(unseenConversations()).toEqual([CONVERSATION_ID]);
+  });
+
+  // A first load that failed also counts nothing, and hiding the trigger there
+  // would leave the user no way to reach the panel that reports the failure.
+  test("keeps the trigger when a source could not be loaded", () => {
+    const client = makePendingChatInfoQueryClient();
+    seedQueryFailure(
+      client,
+      documentsGetQueryKey({
+        path: { assistant_id: ASSISTANT_ID },
+        query: { conversationId: CONVERSATION_ID },
+      }),
+    );
+
+    render(
+      <QueryClientProvider client={client}>
+        <ConversationAssetsPill
+          assistantId={ASSISTANT_ID}
+          conversationId={CONVERSATION_ID}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Conversation assets, 0 items" }),
+    ).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -10,7 +10,7 @@
 
 import { Layers } from "lucide-react";
 import { useReducedMotion } from "motion/react";
-import { useCallback, useEffect, useLayoutEffect } from "react";
+import { useCallback, useLayoutEffect } from "react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -50,7 +50,7 @@ export function ConversationAssetsPill({
   conversationId,
   refreshKey,
 }: ConversationAssetsPillProps) {
-  const { count } = useConversationAssets({
+  const { count, status } = useConversationAssets({
     assistantId,
     conversationId,
     refreshKey,
@@ -76,14 +76,6 @@ export function ConversationAssetsPill({
     };
   }, [targetKey]);
 
-  // Zero assets hides the trigger, and a panel with no control to dismiss it
-  // is a trap; the last asset leaving takes the panel with it.
-  useEffect(() => {
-    if (count === 0) {
-      closeOwnedChatInfo(targetKey);
-    }
-  }, [count, targetKey]);
-
   // The header cluster only has room for a labelled pill on a roomy window.
   const isMobile = useIsMobile();
   const { t } = useTranslation("chat");
@@ -94,7 +86,9 @@ export function ConversationAssetsPill({
     useViewerStore.getState().toggleChatInfo({ assistantId, conversationId });
   }, [assistantId, conversationId]);
 
-  if (count === 0) {
+  // A conversation with nothing to show has no trigger, but one whose sources
+  // failed keeps it: the panel is where the user finds out why.
+  if (status === "ready" && count === 0) {
     return null;
   }
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
@@ -223,7 +223,7 @@ describe("useConversationAssets status", () => {
     expect(result.current.status).toBe("pending");
   });
 
-  test("is error when either source failed", () => {
+  test("is error when either source failed with nothing cached", () => {
     const client = makePendingChatInfoQueryClient();
     client.setQueryData(appsGetQueryKey(QUERY_ARGS), { apps: [] });
     seedQueryFailure(client, documentsGetQueryKey(QUERY_ARGS));
@@ -231,6 +231,28 @@ describe("useConversationAssets status", () => {
     const { result } = renderAssets({ client });
 
     expect(result.current.status).toBe("error");
+  });
+
+  // A refetch that fails leaves the last documents in the cache, and those are
+  // still the conversation's files: reporting an error would discard them.
+  test("stays ready when a failed refetch left its data behind", () => {
+    const { result, client } = renderSeeded({
+      documents: [makeDocument("doc-1", 1_000)],
+    });
+    seedQueryFailure(client, documentsGetQueryKey(QUERY_ARGS));
+
+    expect(result.current.status).toBe("ready");
+    expect(result.current.files.map((file) => file.id)).toEqual(["doc-doc-1"]);
+  });
+
+  test("is ready once both sources hold data", () => {
+    const client = makePendingChatInfoQueryClient();
+    client.setQueryData(appsGetQueryKey(QUERY_ARGS), { apps: [] });
+    client.setQueryData(documentsGetQueryKey(QUERY_ARGS), { documents: [] });
+
+    const { result } = renderAssets({ client });
+
+    expect(result.current.status).toBe("ready");
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
@@ -161,10 +161,20 @@ export function useConversationAssets({
   const apps = appsQuery.data ?? NO_APPS;
   const docs = documentsQuery.data ?? NO_DOCUMENTS;
 
+  // A failed background refetch keeps the last data, so a source is failed or
+  // unresolved only while it has nothing to show.
+  const appsUnresolved = appsQuery.data === undefined;
+  const documentsUnresolved = documentsQuery.data === undefined;
   let status: ConversationAssetsStatus = "ready";
-  if (appsQuery.isError || documentsQuery.isError) {
+  if (
+    (appsQuery.isError && appsUnresolved) ||
+    (documentsQuery.isError && documentsUnresolved)
+  ) {
     status = "error";
-  } else if (appsQuery.isPending || documentsQuery.isPending) {
+  } else if (
+    (appsQuery.isPending && appsUnresolved) ||
+    (documentsQuery.isPending && documentsUnresolved)
+  ) {
     status = "pending";
   }
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -13,20 +13,14 @@ import { makeDisplayAttachment } from "@/domains/chat/components/chat-attachment
 import {
   clearTranscriptMessages,
   clearTranscriptOwner,
+  makeTranscriptRow,
   seedTranscriptMessages,
 } from "@/domains/chat/components/chat-info.test-helper";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
-import {
-  countEntryTotals,
-  useConversationAttachments,
-} from "@/domains/chat/hooks/use-conversation-attachments";
+import { useConversationAttachments } from "@/domains/chat/hooks/use-conversation-attachments";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 
 const TARGET = { assistantId: "asst-1", conversationId: "conv-1" };
-
-function makeMessage(overrides: Partial<DisplayMessage>): DisplayMessage {
-  return { id: "msg-1", role: "user", ...overrides };
-}
 
 /** Seeds `messages` as the transcript the target conversation owns. */
 function seed(messages: DisplayMessage[]): void {
@@ -45,12 +39,12 @@ afterEach(() => {
 describe("useConversationAttachments", () => {
   test("walks the transcript newest first", () => {
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-1",
         timestamp: 1_000,
         attachments: [makeDisplayAttachment({ id: "old" })],
       }),
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-2",
         timestamp: 2_000,
         attachments: [makeDisplayAttachment({ id: "new" })],
@@ -77,7 +71,7 @@ describe("useConversationAttachments", () => {
 
   test("lists an optimistic send's files alongside the snapshot's", () => {
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-sent",
         timestamp: 1_000,
         attachments: [makeDisplayAttachment({ id: "sent" })],
@@ -85,7 +79,7 @@ describe("useConversationAttachments", () => {
     ]);
     useChatSessionStore.setState({
       optimisticSends: [
-        makeMessage({
+        makeTranscriptRow({
           id: "msg-sending",
           timestamp: 2_000,
           attachments: [makeDisplayAttachment({ id: "sending" })],
@@ -105,12 +99,12 @@ describe("useConversationAttachments", () => {
     // An optimistic send and its confirmed echo carry the same attachment.
     const attachment = makeDisplayAttachment({ id: "shared" });
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-echo",
         timestamp: 1_000,
         attachments: [attachment],
       }),
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-optimistic",
         timestamp: 2_000,
         attachments: [attachment],
@@ -128,14 +122,14 @@ describe("useConversationAttachments", () => {
   test("keeps legacy rehydrated ids from different rows apart", () => {
     // Rows reloaded without structured metadata synthesize ids per message.
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-old",
         timestamp: 1_000,
         attachments: [
           makeDisplayAttachment({ id: "rehydrated:0", filename: "old.pdf" }),
         ],
       }),
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-new",
         timestamp: 2_000,
         attachments: [
@@ -154,10 +148,11 @@ describe("useConversationAttachments", () => {
   });
 
   test("keeps two rehydrated ids inside one folded row apart", () => {
-    // Adjacent assistant rows fold across a page boundary and concatenate
-    // their attachments under one message id.
+    // A row carrying `mergedMessageIds` is walked like any other: the field is
+    // stamped for stream-id reconciliation too, so it cannot mark a row whose
+    // attachments were concatenated.
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-folded",
         role: "assistant",
         mergedMessageIds: ["msg-donor"],
@@ -174,15 +169,14 @@ describe("useConversationAttachments", () => {
     expect(new Set(result.current.entries.map((entry) => entry.key)).size).toBe(
       2,
     );
-    // The donor's file was appended last, so it is the newer of the two.
     expect(
       result.current.entries.map((entry) => entry.attachment.filename),
-    ).toEqual(["b.pdf", "a.pdf"]);
+    ).toEqual(["a.pdf", "b.pdf"]);
   });
 
   test("keeps one row's uploads in the order they were sent", () => {
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-upload",
         attachments: [
           makeDisplayAttachment({ id: "first", filename: "first.pdf" }),
@@ -200,14 +194,14 @@ describe("useConversationAttachments", () => {
 
   test("skips a channel-deleted row's files", () => {
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-gone",
         deletedAt: 3_000,
         attachments: [
           makeDisplayAttachment({ id: "gone", filename: "gone.pdf" }),
         ],
       }),
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-kept",
         attachments: [
           makeDisplayAttachment({ id: "kept", filename: "kept.pdf" }),
@@ -224,7 +218,9 @@ describe("useConversationAttachments", () => {
 
   test("reports a null capture time for a row with no timestamp", () => {
     seed([
-      makeMessage({ attachments: [makeDisplayAttachment({ id: "att-1" })] }),
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "att-1" })],
+      }),
     ]);
 
     const { result } = renderHook(() => useConversationAttachments(TARGET));
@@ -233,7 +229,7 @@ describe("useConversationAttachments", () => {
   });
 
   test("hands back the same empty array across renders", () => {
-    seed([makeMessage({})]);
+    seed([makeTranscriptRow({})]);
 
     const { result, rerender } = renderHook(() =>
       useConversationAttachments(TARGET),
@@ -250,12 +246,16 @@ describe("useConversationAttachments", () => {
   // a text-only update leaves those shallow-equal.
   test("holds its entries through a text-only stream update", () => {
     seed([
-      makeMessage({
+      makeTranscriptRow({
         id: "msg-upload",
         timestamp: 1_000,
         attachments: [makeDisplayAttachment({ id: "att-1" })],
       }),
-      makeMessage({ id: "msg-reply", role: "assistant", timestamp: 2_000 }),
+      makeTranscriptRow({
+        id: "msg-reply",
+        role: "assistant",
+        timestamp: 2_000,
+      }),
     ]);
 
     let renders = 0;
@@ -283,7 +283,9 @@ describe("useConversationAttachments", () => {
 
   test("lists the loaded transcript when the target owns the snapshot", () => {
     seed([
-      makeMessage({ attachments: [makeDisplayAttachment({ id: "mine" })] }),
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "mine" })],
+      }),
     ]);
 
     const { result } = renderHook(() => useConversationAttachments(TARGET));
@@ -295,7 +297,9 @@ describe("useConversationAttachments", () => {
 
   test("lists nothing when another conversation owns the snapshot", () => {
     seedTranscriptMessages(TARGET.assistantId, "conv-2", [
-      makeMessage({ attachments: [makeDisplayAttachment({ id: "theirs" })] }),
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "theirs" })],
+      }),
     ]);
 
     const { result } = renderHook(() => useConversationAttachments(TARGET));
@@ -306,7 +310,9 @@ describe("useConversationAttachments", () => {
 
   test("lists nothing when another assistant owns the snapshot", () => {
     seedTranscriptMessages("asst-2", TARGET.conversationId, [
-      makeMessage({ attachments: [makeDisplayAttachment({ id: "theirs" })] }),
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "theirs" })],
+      }),
     ]);
 
     const { result } = renderHook(() => useConversationAttachments(TARGET));
@@ -317,7 +323,9 @@ describe("useConversationAttachments", () => {
 
   test("lists nothing when no conversation owns the snapshot", () => {
     seed([
-      makeMessage({ attachments: [makeDisplayAttachment({ id: "draft" })] }),
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "draft" })],
+      }),
     ]);
     clearTranscriptOwner();
 
@@ -336,26 +344,5 @@ describe("useConversationAttachments", () => {
 
     expect(result.current.loadMoreFiles).toBe(loadMoreFiles);
     expect(result.current.loadMoreFrames).toBe(loadMoreFrames);
-  });
-});
-
-describe("countEntryTotals", () => {
-  // The transcript cannot produce a frame, so the split is asserted directly:
-  // it is what keeps the daemon path from counting one capture twice.
-  test("counts a camera frame as a frame and not as a file", () => {
-    const entry = (key: string, sightFrame: boolean) => ({
-      key,
-      attachment: makeDisplayAttachment({ id: key }),
-      capturedAt: null,
-      sightFrame,
-    });
-
-    expect(
-      countEntryTotals([entry("a", false), entry("b", true), entry("c", true)]),
-    ).toEqual({ totalFiles: 1, totalFrames: 2 });
-  });
-
-  test("counts nothing for no entries", () => {
-    expect(countEntryTotals([])).toEqual({ totalFiles: 0, totalFrames: 0 });
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -87,7 +87,7 @@ function selectAttachmentRows(state: ChatSessionStore): DisplayMessage[] {
  * Files and frames partition the entries: one captured by the camera gate
  * counts as a frame and nowhere else, so the two totals cannot double-count it.
  */
-export function countEntryTotals(entries: ConversationAttachmentEntry[]): {
+function countEntryTotals(entries: ConversationAttachmentEntry[]): {
   totalFiles: number;
   totalFrames: number;
 } {
@@ -131,12 +131,9 @@ export function useConversationAttachments(target: {
         continue;
       }
       const attachments = message.attachments ?? [];
-      // A folded row appends the newer donor's files after the survivor's, so
-      // only those are walked from the end; one upload keeps the order it was
-      // sent in.
-      const folded = (message.mergedMessageIds?.length ?? 0) > 0;
-      for (let step = 0; step < attachments.length; step += 1) {
-        const position = folded ? attachments.length - 1 - step : step;
+      // Send order within a row: `mergedMessageIds` is also stamped for
+      // stream-id reconciliation, so it cannot mark a concatenated row.
+      for (let position = 0; position < attachments.length; position += 1) {
         const attachment = attachments[position]!;
         const key = entryKey(message.id, attachment.id, position);
         if (seen.has(key)) {

--- a/clients/web/src/stores/viewer-store.test.ts
+++ b/clients/web/src/stores/viewer-store.test.ts
@@ -626,7 +626,8 @@ describe("closeActiveOverlay", () => {
   });
 
   it("pops the chat-info drill-in before closing the panel", () => {
-    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().setChatInfoCategory("apps");
 
     expect(getState().closeActiveOverlay()).toBe(true);
     expect(getState().mainView).toBe("chat-info");
@@ -912,11 +913,6 @@ describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", 
     expect(state.viewBeforeChatInfo).toBe("chat");
   });
 
-  it("opens the panel drilled into a category", () => {
-    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
-    expect(getState().activeChatInfo?.category).toBe("apps");
-  });
-
   it("close restores the prior view and clears the payload", () => {
     useViewerStore.setState({ mainView: "app" });
     getState().openChatInfo(SAMPLE_CHAT_INFO);
@@ -936,7 +932,8 @@ describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", 
   });
 
   it("toggle switches to a DIFFERENT conversation at the top level", () => {
-    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "files" });
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().setChatInfoCategory("files");
     getState().toggleChatInfo({ ...SAMPLE_CHAT_INFO, conversationId: "c2" });
     const state = getState();
     expect(state.mainView).toBe("chat-info");
@@ -949,7 +946,8 @@ describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", 
 
   it("clearTranscriptPanelPayloads settles the chat-info view on a conversation switch", () => {
     useViewerStore.setState({ mainView: "app" });
-    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().setChatInfoCategory("apps");
 
     getState().clearTranscriptPanelPayloads();
 
@@ -989,7 +987,8 @@ describe("openChatInfo / toggleChatInfo / closeChatInfo / setChatInfoCategory", 
   });
 
   it("setChatInfoCategory does not notify when the category is unchanged", () => {
-    getState().openChatInfo({ ...SAMPLE_CHAT_INFO, category: "apps" });
+    getState().openChatInfo(SAMPLE_CHAT_INFO);
+    getState().setChatInfoCategory("apps");
     const before = getState().activeChatInfo;
     getState().setChatInfoCategory("apps");
     expect(getState().activeChatInfo).toBe(before);

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -653,10 +653,10 @@ export interface ViewerActions {
   closeMessageFiles: () => void;
 
   // --- Chat info panel ---
+  /** Open the chat-info panel for `target`, at the top level. */
   openChatInfo: (target: {
     assistantId: string;
     conversationId: string;
-    category?: ChatInfoCategory | null;
   }) => void;
   /**
    * Open the chat-info panel for `target`, or close it when it is already
@@ -1284,7 +1284,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       activeChatInfo: {
         assistantId: target.assistantId,
         conversationId: target.conversationId,
-        category: target.category ?? null,
+        category: null,
       },
       viewBeforeChatInfo: resolveViewBefore(get(), "viewBeforeChatInfo"),
     });


### PR DESCRIPTION
## Summary
- useConversationAssets reports error or pending only when a source has nothing cached; the panel renders every category it has, puts the failure notice above them, and shows the empty copy only when every source is ready and empty
- the header trigger stays visible on a failed load and no longer force-closes the panel at zero; one composed test mounts trigger and panel together
- ChatInfoCategoryGrid renders the second level with tests and stories for camera frames and Load more; attachments within a row keep send order; openChatInfo no longer takes a category; the suites use the shared helper and the viewport stub

Part of plan: chat-info-assets-panel.md (remediation round 5)