### PR TITLE
fix(acp): keep a model selector the adapter announced during session creation

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -849,6 +849,40 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ).toBeUndefined();
   });
 
+  test("a session/load answering with no config options keeps the replayed selector", async () => {
+    fakeCaps.loadSession = true;
+    seedConversationRow("conv-1");
+    // The selector reaches the manager only through the replayed
+    // notification: the load itself answers with no config options at all.
+    replayConfigOptions = [modelOption("default")];
+    resumeConfigOptions = [];
+    insertHistoryRow({ id: "resume-replay-only", model: "opus" });
+
+    const manager = new AcpSessionManager(4);
+    const sent: AssistantEvent[] = [];
+    await manager.resumeFromHistory("resume-replay-only", (msg) =>
+      sent.push(msg),
+    );
+
+    // The re-pin still reaches the adapter, so the run comes back on the
+    // model its row recorded.
+    expect(setConfigOptionCalls).toEqual([
+      { sessionId: "proto-old", configId: "model", value: "opus" },
+    ]);
+    expect(
+      (manager.getStatus("resume-replay-only") as AcpSessionState).model,
+    ).toBe("opus");
+    // The announced default, then the model the run was put back on.
+    const modelEvents = sent.filter(
+      (m) => m.type === "acp_session_model_update",
+    );
+    expect(modelEvents.map((m) => m.model)).toEqual(["default", "opus"]);
+    expect(modelEvents[1]).toMatchObject({
+      acpSessionId: "resume-replay-only",
+      availableModels: MODEL_OPTION_MODELS,
+    });
+  });
+
   test("a resume the adapter refuses to re-pin runs on the adapter's model and records that on the row", async () => {
     fakeCaps.resume = true;
     seedConversationRow("conv-1");

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -34,6 +34,11 @@ const cancelCalls: string[] = [];
 
 /** Config options each `createSession` reports, one entry per call. */
 let scriptedConfigOptions: SessionConfigOption[][] = [];
+/**
+ * When set, `createSession` stalls on this gate before it answers, so a test
+ * can drive a notification into the still-open call.
+ */
+let createSessionGate: Promise<void> | null = null;
 /** Every `setConfigOption` the manager dispatched to a fake process. */
 const setConfigOptionCalls: Array<{
   sessionId: string;
@@ -64,6 +69,9 @@ mock.module("../agent-process.js", () => ({
     async createSession(
       _cwd: string,
     ): Promise<{ sessionId: string; configOptions: SessionConfigOption[] }> {
+      if (createSessionGate) {
+        await createSessionGate;
+      }
       return {
         sessionId: `proto-${this.agentId}`,
         configOptions: scriptedConfigOptions.shift() ?? [],
@@ -115,6 +123,7 @@ type Manager = InstanceType<typeof AcpSessionManager>;
 
 beforeEach(() => {
   scriptedConfigOptions = [];
+  createSessionGate = null;
   setConfigOptionCalls.length = 0;
   setConfigOptionResult = [];
   setConfigOptionResponder = null;
@@ -1180,6 +1189,90 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     expect(
       getAcpConversationModelPreference("conv-pin-then-typed", "agent-model"),
     ).toBe("opus");
+  });
+
+  test("a selector announced during session/new survives a response that omits it", async () => {
+    seedConversationRow("conv-open-race");
+    config.setConfig({ defaultModel: "opus" });
+    // The adapter answers session/new with no config options at all.
+    scriptedConfigOptions = [[]];
+    setConfigOptionResult = [modelOption("opus")];
+    let release = () => {};
+    createSessionGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const spawning = manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-open-race",
+      (msg: AssistantEvent) => sent.push(msg),
+    );
+    const acpSessionId = (manager.getStatus() as AcpSessionState[])[0].id;
+
+    // The adapter announces its selector while session/new is still open.
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
+    release();
+    await spawning;
+
+    // The selector is still there for the configured default to be pinned
+    // through, and the picker still reaches the client after the spawn.
+    expect(setConfigOptionCalls).toEqual([
+      { sessionId: "proto-agent-model", configId: "model", value: "opus" },
+    ]);
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "opus",
+    );
+    expect(sent.map((e) => e.type)).toEqual([
+      "acp_session_model_update",
+      "acp_session_spawned",
+      "acp_session_model_update",
+    ]);
+    expect(sent[2]).toMatchObject({
+      model: "opus",
+      availableModels: MODEL_OPTION_MODELS,
+    });
+  });
+
+  test("an opening response naming a selector outranks one announced mid-call", async () => {
+    seedConversationRow("conv-open-response");
+    scriptedConfigOptions = [[modelOption("opus")]];
+    let release = () => {};
+    createSessionGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const spawning = manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-open-response",
+      (msg: AssistantEvent) => sent.push(msg),
+    );
+    const acpSessionId = (manager.getStatus() as AcpSessionState[])[0].id;
+
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
+    release();
+    await spawning;
+
+    // Nothing was requested and the response says the session is on opus, so
+    // the adapter is never asked to change.
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "opus",
+    );
+    expect(setConfigOptionCalls).toEqual([]);
+    expect(sent[sent.length - 1]).toMatchObject({
+      type: "acp_session_model_update",
+      model: "opus",
+      availableModels: MODEL_OPTION_MODELS,
+    });
   });
 });
 

--- a/assistant/src/acp/model-config.ts
+++ b/assistant/src/acp/model-config.ts
@@ -41,7 +41,7 @@ export type AcpModelOption = z.infer<
 >["availableModels"][number];
 
 /** What an adapter's config-option set says about the session's model. */
-type AcpModelInfo = {
+export type AcpModelInfo = {
   model?: string;
   availableModels: AcpModelOption[];
   modelConfigId?: string;

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -38,6 +38,7 @@ import {
 import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { deriveFailureError } from "./failure-error.js";
+import type { AcpModelInfo } from "./model-config.js";
 import { deriveModelInfo, resolveAcpModel } from "./model-config.js";
 import { prepareAgentEnv } from "./prepare-agent-env.js";
 import { canonicalAgentId, formatResolveFailure } from "./resolve-agent.js";
@@ -479,18 +480,39 @@ export class AcpSessionManager {
     };
   }
 
-  /**
-   * Records what the adapter says about the session's model. `modelConfigId`
-   * doubles as the "this adapter has a model selector" flag, so state is left
-   * untouched when there is none: a resumed session keeps the model its
-   * history row recorded instead of having it wiped by an adapter that never
-   * reports one.
-   */
+  /** Records what a config-option set says about the session's model. */
   private applyModelInfo(
     entry: SessionEntry,
     configOptions: SessionConfigOption[],
   ): void {
+    this.recordModelInfo(entry, deriveModelInfo(configOptions));
+  }
+
+  /**
+   * Records the model state a `session/new`, `session/load`, or
+   * `session/resume` response reports. The response is authoritative when it
+   * names a selector, or when nothing has announced one yet; otherwise the
+   * selector a `config_option_update` announced while the call was open
+   * stands, because an omitted optional field is not a removal.
+   */
+  private applyOpeningModelInfo(
+    entry: SessionEntry,
+    configOptions: SessionConfigOption[],
+  ): void {
     const info = deriveModelInfo(configOptions);
+    if (info.modelConfigId || entry.modelConfigId === undefined) {
+      this.recordModelInfo(entry, info);
+    }
+  }
+
+  /**
+   * Writes what the adapter reports onto the entry. `modelConfigId` doubles
+   * as the "this adapter has a model selector" flag, so state is left
+   * untouched when there is none: a resumed session keeps the model its
+   * history row recorded instead of having it wiped by an adapter that never
+   * reports one.
+   */
+  private recordModelInfo(entry: SessionEntry, info: AcpModelInfo): void {
     entry.modelConfigId = info.modelConfigId;
     if (info.modelConfigId) {
       entry.state.model = info.model;
@@ -569,7 +591,7 @@ export class AcpSessionManager {
     resolvedModel: string | undefined,
   ): Promise<ModelPinResult> {
     const { state } = entry;
-    this.applyModelInfo(entry, configOptions);
+    this.applyOpeningModelInfo(entry, configOptions);
 
     if (!resolvedModel || resolvedModel === state.model) {
       return { applied: true };


### PR DESCRIPTION
## Summary
- An opening response that names no model selector no longer clears one the adapter announced by config_option_update during session/new, session/load, or session/resume; the response still wins when it names a selector
- Red-green tests for spawn and resume

Part of plan: acp-model-control.md (feature-branch review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D