### PR TITLE
fix(notifications): stop filing unmapped feed items under the system category

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -919,6 +919,33 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(appendCalls[0]!.noteworthy).toBe(true);
   });
 
+  test("a mapped source event carries its feed category", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      contextPayload: { title: "Nightly briefing", body: "Three things." },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
+
+    expect(item?.category).toBe("scheduling");
+    expect(appendCalls[0]!.category).toBe("scheduling");
+  });
+
+  test("an unmapped source event carries no category instead of falling back to system", async () => {
+    conversationRow = { conversationType: "background" };
+    const signal = makeSignal({
+      sourceChannel: "assistant_tool",
+      sourceEventName: "user.send_notification",
+      contextPayload: { title: "Tool share", body: "Body" },
+    });
+
+    const item = await writeHomeFeedItemForSignal(signal, makeDecision());
+
+    expect(item).not.toBeNull();
+    expect("category" in item!).toBe(false);
+    expect("category" in appendCalls[0]!).toBe(false);
+  });
+
   test("credential.health_alert is noteworthy regardless of source channel", async () => {
     conversationRow = { conversationType: "background" };
     const signal = makeSignal({

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -194,7 +194,7 @@ export async function writeHomeFeedItemForSignal(
     timestamp: now,
     createdAt: now,
     status: "new",
-    category,
+    ...(category ? { category } : {}),
     noteworthy: deriveNoteworthy(signal),
     fromAssistant: signal.sourceChannel === "assistant_tool",
     ...(guardianProjection ? { guardianRequest: guardianProjection } : {}),
@@ -449,8 +449,19 @@ const EVENT_CATEGORY_MAP: Record<string, FeedItemCategory> = {
   "telegram.webhook_health_alert": "system",
 };
 
-function deriveCategory(signal: NotificationSignal): FeedItemCategory {
-  return EVENT_CATEGORY_MAP[signal.sourceEventName] ?? "system";
+/**
+ * Map a signal's source event to a feed category, or nothing when the event
+ * has no entry. An unmapped event used to land in `system`, a bucket named
+ * for our architecture rather than the user's world, and every deliberate
+ * assistant notification (`user.send_notification`) ended up there. The
+ * category is optional on the wire, so an event without a home simply
+ * carries none: readers that filter by category skip it, and nothing has
+ * to guess.
+ */
+function deriveCategory(
+  signal: NotificationSignal,
+): FeedItemCategory | undefined {
+  return EVENT_CATEGORY_MAP[signal.sourceEventName];
 }
 
 function deriveDetailPanelKind(


### PR DESCRIPTION
## Summary

Closes [LUM-3406](https://linear.app/vellum/issue/LUM-3406/rename-the-system-notification-category-to-something-a-user-would-say).

The ticket's user-visible half is already done on main: #41824 retired the Activity page and its filter bar (which defaulted unknown categories to "System"), and #42235 deleted the category chip and the `category.system` string. No client surface renders `FeedItemCategory` any more.

This PR does the "separately, reconsider the fallback" half. `deriveCategory` in the home-feed side effect filed every source event without a map entry under `system`, including the assistant's own deliberate `user.send_notification` shares. That value still reached the feed route's `categories` filter and the CLI, and it described our architecture rather than the user's world.

## Change

- An unmapped source event now carries **no** category. The field is already optional on the wire, so nothing changes shape.
- Explicit mappings are untouched (`watcher.notification` and `telegram.webhook_health_alert` still map to `system`).
- The `system` enum value stays so items already on disk keep validating; no migration.
- Two tests pin the behavior: a mapped event keeps its category, an unmapped one has none.

## Verification

- `bun test src/notifications/__tests__/home-feed-side-effect.test.ts`: 57 pass
- `bun run typecheck:fast`, eslint and prettier on the changed files: clean
- OpenAPI schema is unchanged (enum and optionality untouched), so no regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbDLwNdFrdLqZY19x6GEDv
