### PR TITLE
fix(acp): hold the model baseline until the opening pin finishes

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -41,11 +41,11 @@ let resumeSessionGate: Promise<void> | null = null;
 /** Config options session/resume and session/load report back. */
 let resumeConfigOptions: SessionConfigOption[] = [];
 /**
- * When set, session/load announces these through a `config_option_update`
- * during its replay, the way an adapter reports what the reattached session
- * is on before the load resolves.
+ * One `config_option_update` per entry, announced during session/load's
+ * replay, the way an adapter reports what the reattached session moved
+ * through before the load resolves.
  */
-let replayConfigOptions: SessionConfigOption[] | null = null;
+let replayConfigOptionUpdates: SessionConfigOption[][] = [];
 /** When set, setConfigOption rejects with it (the adapter refusing a pin). */
 let setConfigOptionError: Error | null = null;
 /** Every `setConfigOption` the manager dispatched during a resume. */
@@ -106,8 +106,8 @@ class FakeAcpAgentProcess {
     for (const text of replayChunks) {
       await this.emitChunk(text);
     }
-    if (replayConfigOptions) {
-      await this.emitConfigOptions(replayConfigOptions);
+    for (const configOptions of replayConfigOptionUpdates) {
+      await this.emitConfigOptions(configOptions);
     }
     return { configOptions: resumeConfigOptions };
   }
@@ -326,7 +326,7 @@ beforeEach(() => {
   prepareAgentEnvCommands = [];
   resumeSessionGate = null;
   resumeConfigOptions = [];
-  replayConfigOptions = null;
+  replayConfigOptionUpdates = [];
   setConfigOptionError = null;
   setConfigOptionCalls.length = 0;
   resolveImpl = () => ({
@@ -834,7 +834,7 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     seedConversationRow("conv-1");
     // The reattached adapter announces its own default mid-replay, before
     // the pin that puts the run back on what the row recorded.
-    replayConfigOptions = [modelOption("default")];
+    replayConfigOptionUpdates = [[modelOption("default")]];
     resumeConfigOptions = [modelOption("default")];
     insertHistoryRow({ id: "resume-replay-model", model: "opus" });
 
@@ -849,12 +849,39 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ).toBeUndefined();
   });
 
+  test("the model switches a session/load replays record no preference", async () => {
+    fakeCaps.loadSession = true;
+    seedConversationRow("conv-1");
+    // A transcript the user typed two `/model` commands into: the replay
+    // reports each of them before the load resolves.
+    replayConfigOptionUpdates = [
+      [modelOption("sonnet")],
+      [modelOption("opus")],
+    ];
+    resumeConfigOptions = [modelOption("opus")];
+    insertHistoryRow({ id: "resume-replay-switches", model: "opus" });
+
+    const manager = new AcpSessionManager(4);
+    await manager.resumeFromHistory("resume-replay-switches", () => {});
+
+    expect(
+      getAcpConversationModelPreference("conv-1", "claude"),
+    ).toBeUndefined();
+
+    // The pin latched the baseline, so the next change is the user's own.
+    await fakeInstances[0]!.emitConfigOptions([modelOption("sonnet")]);
+
+    expect(getAcpConversationModelPreference("conv-1", "claude")).toBe(
+      "sonnet",
+    );
+  });
+
   test("a session/load answering with no config options keeps the replayed selector", async () => {
     fakeCaps.loadSession = true;
     seedConversationRow("conv-1");
     // The selector reaches the manager only through the replayed
     // notification: the load itself answers with no config options at all.
-    replayConfigOptions = [modelOption("default")];
+    replayConfigOptionUpdates = [[modelOption("default")]];
     resumeConfigOptions = [];
     insertHistoryRow({ id: "resume-replay-only", model: "opus" });
 

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -1274,6 +1274,47 @@ describe("AcpSessionManager: unsolicited model updates", () => {
       availableModels: MODEL_OPTION_MODELS,
     });
   });
+
+  test("several updates announced while session/new is open record no preference", async () => {
+    seedConversationRow("conv-open-updates");
+    // The response carries nothing, so the announcements are everything the
+    // manager hears about the selector before the pin latches.
+    scriptedConfigOptions = [[]];
+    let release = () => {};
+    createSessionGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const manager = new AcpSessionManager(5);
+    const spawning = manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-open-updates",
+      () => {},
+    );
+    const acpSessionId = (manager.getStatus() as AcpSessionState[])[0].id;
+
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
+    await emitConfigOptions(manager, acpSessionId, [modelOption("opus")]);
+    release();
+    await spawning;
+
+    expect((manager.getStatus(acpSessionId) as AcpSessionState).model).toBe(
+      "opus",
+    );
+    expect(
+      getAcpConversationModelPreference("conv-open-updates", "agent-model"),
+    ).toBeUndefined();
+
+    // The pin latched the baseline, so the next change is the user's own.
+    await emitConfigOptions(manager, acpSessionId, [modelOption("sonnet")]);
+
+    expect(
+      getAcpConversationModelPreference("conv-open-updates", "agent-model"),
+    ).toBe("sonnet");
+  });
 });
 
 /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -239,6 +239,11 @@ interface SessionEntry {
    *  than the user choosing, and writing it as the conversation's preference
    *  would freeze that default in. */
   modelBaselineEstablished: boolean;
+  /** Whether the session is still opening: `session/new`, `session/load` or
+   *  `session/resume` and the pin that follows it. Every notification until
+   *  the pin latches reports what the session opens on, so the baseline
+   *  belongs to the pin alone. */
+  modelOpeningInFlight: boolean;
 }
 
 /** What a spawn or resume pin did about the model it was asked for. */
@@ -547,10 +552,12 @@ export class AcpSessionManager {
         requestedModel,
         resolvedModel,
       );
-      // Latched only once the round trip is done. The window while it is in
-      // flight belongs to `managerPinInFlight`, and by now the adapter has
-      // reported what the session is on, so anything unsolicited after this is
-      // a change rather than an opening announcement.
+      // The opening ends here, which makes this the one place an opening
+      // arms the baseline. The window while the pin is in flight belongs to
+      // `managerPinInFlight`, and by now the adapter has reported what the
+      // session is on, so anything unsolicited after this is a change rather
+      // than an opening announcement.
+      entry.modelOpeningInFlight = false;
       entry.modelBaselineEstablished = entry.modelConfigId !== undefined;
       return result;
     });
@@ -762,6 +769,7 @@ export class AcpSessionManager {
       modelSwitchQueue: Promise.resolve(),
       managerPinInFlight: false,
       modelBaselineEstablished: false,
+      modelOpeningInFlight: true,
     };
 
     this.sessions.set(acpSessionId, entry);
@@ -957,10 +965,10 @@ export class AcpSessionManager {
    * options by notification, and a `session/load` replay during a resume, are
    * both announcing a default rather than relaying a choice.
    *
-   * That first announcement is also what arms the baseline for an adapter
-   * whose selector never appeared in a `session/new` or `session/resume`
-   * response, so a `/model` the user types after it is remembered instead of
-   * being swallowed as another opening announcement forever.
+   * An adapter whose selector appears only once the opening is over arms the
+   * baseline on that first announcement, so a `/model` the user types after
+   * it is remembered instead of being swallowed forever. Announcements made
+   * during an opening, however many, belong to the pin that ends it.
    *
    * A session past its terminal transition takes nothing from a late
    * notification at all: its history row is already written, so mutating
@@ -982,10 +990,14 @@ export class AcpSessionManager {
     if (this.clearVanishedModelSelector(acpSessionId, entry)) {
       return;
     }
-    // A selector seen here for the first time arms the baseline, so the next
+    // A selector first seen after the opening arms the baseline, so the next
     // change the adapter reports is read as a choice rather than swallowed as
     // another opening announcement.
-    if (!hadBaseline && entry.modelConfigId !== undefined) {
+    if (
+      !hadBaseline &&
+      !entry.modelOpeningInFlight &&
+      entry.modelConfigId !== undefined
+    ) {
       entry.modelBaselineEstablished = true;
     }
 


### PR DESCRIPTION
## Summary
- Opening config_option_update notifications, however many, no longer arm the model baseline; the pin at the end of session/new, session/load, and session/resume is the one place an opening establishes it, so a replayed or progressive opening update is never written as the conversation's preference
- A selector first announced after opening still arms the baseline on that announcement
- Red-green tests for the spawn and load paths

Part of plan: acp-model-control.md (feature-branch review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D