### PR TITLE
fix(web): dates keep the browser region under the app language, the share helper returns its callback and reports, and conversation navigation settles the chat-info view

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -299,6 +299,13 @@ const emDashEnforcedPaths = [
   "src/domains/chat/hooks/use-conversation-assets*.{ts,tsx}",
   "src/domains/chat/hooks/use-conversation-attachments*.{ts,tsx}",
   "src/domains/chat/chat-layout-header.stories.tsx",
+  // The attachment preview a tile opens into, and the shared pieces the
+  // panel and its menus draw from.
+  "src/domains/chat/components/chat-attachments/attachment-preview-box.tsx",
+  "src/domains/chat/components/chat-attachments/use-attachment-object-url.ts",
+  "src/components/midline-dot.tsx",
+  "src/hooks/use-share-app.ts",
+  "src/utils/share-app-with-toast.ts",
 ];
 
 const eslintConfig = defineConfig([

--- a/clients/web/src/components/detail-shell.test.tsx
+++ b/clients/web/src/components/detail-shell.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * The two header/body pieces every drawer panel draws from one place: the
+ * quiet centred line an empty or failed body renders, and the "title · N"
+ * cluster the header shows in place of a plain title.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import {
+  DetailShellNotice,
+  DetailShellTitleWithCount,
+} from "@/components/detail-shell";
+
+afterEach(cleanup);
+
+describe("DetailShellNotice", () => {
+  test("renders the copy as a centred paragraph", () => {
+    render(<DetailShellNotice>Nothing here yet</DetailShellNotice>);
+
+    const notice = screen.getByText("Nothing here yet");
+    expect(notice.tagName).toBe("P");
+    expect(notice.className).toContain("text-center");
+  });
+});
+
+describe("DetailShellTitleWithCount", () => {
+  test("renders the title, the dot, and the count", () => {
+    const { container } = render(
+      <DetailShellTitleWithCount title="Thinking" count="6 steps" />,
+    );
+
+    expect(screen.getByText("Thinking")).toBeDefined();
+    expect(screen.getByText("6 steps")).toBeDefined();
+    // The separator is decorative, so it is the one element with no text.
+    expect(container.querySelectorAll('[aria-hidden="true"]')).toHaveLength(1);
+  });
+
+  test("lets the title truncate while the count stays whole", () => {
+    const { container } = render(
+      <DetailShellTitleWithCount
+        title="A title long enough to need truncating"
+        count="12"
+      />,
+    );
+
+    const title = screen.getByText("A title long enough to need truncating");
+    expect(title.className).toContain("truncate");
+    expect(screen.getByText("12").className).toContain("shrink-0");
+    expect(container.firstElementChild?.className).toContain("min-w-0");
+  });
+});

--- a/clients/web/src/components/detail-shell.tsx
+++ b/clients/web/src/components/detail-shell.tsx
@@ -21,7 +21,6 @@ import type { ReactNode } from "react";
 import { Button, Typography } from "@vellumai/design-library";
 
 import { MidlineDot } from "@/components/midline-dot";
-import { cn } from "@/utils/misc";
 
 /**
  * Horizontal inset of `DetailShell`'s header, body, and footer, in px. A host
@@ -30,21 +29,12 @@ import { cn } from "@/utils/misc";
 export const DETAIL_SHELL_BODY_INSET_PX = 20;
 
 /** The quiet centred line a body renders when it is empty or failed to load. */
-export function DetailShellNotice({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
+export function DetailShellNotice({ children }: { children: ReactNode }) {
   return (
     <Typography
       as="p"
       variant="body-small-default"
-      className={cn(
-        "py-4 text-center text-[var(--content-tertiary)]",
-        className,
-      )}
+      className="py-4 text-center text-[var(--content-tertiary)]"
     >
       {children}
     </Typography>

--- a/clients/web/src/components/midline-dot.tsx
+++ b/clients/web/src/components/midline-dot.tsx
@@ -1,7 +1,9 @@
 /**
  * The 3px dot that separates a title from the count or meta beside it. Panel
  * headers, chat chips, card surfaces, and list rows all draw it, so it sits
- * above any one of their shells.
+ * above any one of their shells. `packages/design-library`'s
+ * `list-row.stories.tsx` keeps its own copy of the span, since the package
+ * cannot import from the app.
  */
 
 import { cn } from "@/utils/misc";

--- a/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
+++ b/clients/web/src/domains/chat/components/conversation-asset-actions.tsx
@@ -92,7 +92,7 @@ export const AppAssetActions: FC<AppAssetActionsProps> = ({
   const { togglePin, pinnedAppIds } = usePinnedApps(assistantId);
   const isPinned = pinnedAppIds.has(app.id);
 
-  const { share } = useShareApp(assistantId, app, {
+  const share = useShareApp(assistantId, app, {
     exported: t("chat:appAssetActions.appExported"),
     failed: t("chat:appAssetActions.shareFailed"),
   });

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -163,7 +163,7 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
             while KEEPING the cached skill. Gate the error state on the
             RESOLVED skill being absent, not on `isError` alone: cached data
             degrades to the cached render, while an error with nothing to
-            show surfaces the failure (matching `skill-detail-page`). */}
+            show surfaces the failure. */}
         {skillQuery.isError && !skill ? (
           <DetailShellNotice>
             {t("skillDetailPanel.loadError")}

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -60,7 +60,7 @@ export function LibraryAppCard({
     () => getCachedAppHtml(assistantId, app.id),
     [assistantId, app.id],
   );
-  const { share } = useShareApp(assistantId, app, {
+  const share = useShareApp(assistantId, app, {
     exported: t("libraryAppCard.exported"),
     failed: t("libraryAppCard.shareFailed"),
   });

--- a/clients/web/src/hooks/use-share-app.test.tsx
+++ b/clients/web/src/hooks/use-share-app.test.tsx
@@ -17,6 +17,7 @@ import {
 import { act, cleanup, renderHook } from "@testing-library/react";
 import * as toastModule from "@vellumai/design-library/components/toast";
 
+import * as captureErrorModule from "@/lib/sentry/capture-error";
 import type { AppSummary } from "@/types/app-types";
 
 interface RaisedToast {
@@ -24,8 +25,14 @@ interface RaisedToast {
   description?: string;
 }
 
+interface CapturedError {
+  err: unknown;
+  context?: string;
+}
+
 let successes: RaisedToast[] = [];
 let errors: RaisedToast[] = [];
+let captured: CapturedError[] = [];
 let shareCalls: Array<[string, string, string]> = [];
 let shareResult: Promise<void> = Promise.resolve();
 
@@ -38,6 +45,13 @@ mock.module("@vellumai/design-library/components/toast", () => ({
     error: (title: string, options?: { description?: string }) => {
       errors.push({ title, description: options?.description });
     },
+  },
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  ...captureErrorModule,
+  captureError: (err: unknown, options?: { context?: string }) => {
+    captured.push({ err, context: options?.context });
   },
 }));
 
@@ -61,6 +75,7 @@ function renderShare() {
 beforeEach(() => {
   successes = [];
   errors = [];
+  captured = [];
   shareCalls = [];
   shareResult = Promise.resolve();
 });
@@ -78,7 +93,7 @@ describe("useShareApp", () => {
     const { result } = renderShare();
 
     await act(async () => {
-      await result.current.share();
+      await result.current();
     });
 
     expect(shareCalls).toEqual([[ASSISTANT_ID, "app-1", "Trip Planner"]]);
@@ -93,13 +108,25 @@ describe("useShareApp", () => {
     const { result } = renderShare();
 
     await act(async () => {
-      await result.current.share();
+      await result.current();
     });
 
     expect(errors).toEqual([
       { title: "Export failed", description: "no bundle" },
     ]);
     expect(successes).toHaveLength(0);
+  });
+
+  test("reports the failure to Sentry as well as the toast", async () => {
+    const failure = new Error("no bundle");
+    shareResult = Promise.reject(failure);
+    const { result } = renderShare();
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(captured).toEqual([{ err: failure, context: "shareAppWithToast" }]);
   });
 
   test("ignores a second request while one is still in flight", async () => {
@@ -111,11 +138,11 @@ describe("useShareApp", () => {
 
     let firstShare: Promise<void> = Promise.resolve();
     act(() => {
-      firstShare = result.current.share();
+      firstShare = result.current();
     });
 
     await act(async () => {
-      await result.current.share();
+      await result.current();
     });
     expect(shareCalls).toHaveLength(1);
 
@@ -130,10 +157,10 @@ describe("useShareApp", () => {
     const { result } = renderShare();
 
     await act(async () => {
-      await result.current.share();
+      await result.current();
     });
     await act(async () => {
-      await result.current.share();
+      await result.current();
     });
 
     expect(shareCalls).toHaveLength(2);
@@ -145,17 +172,17 @@ describe("useShareApp", () => {
       release = resolve;
     });
     const { result } = renderShare();
-    const before = result.current.share;
+    const before = result.current;
 
     let firstShare: Promise<void> = Promise.resolve();
     act(() => {
-      firstShare = result.current.share();
+      firstShare = result.current();
     });
     await act(async () => {
       release();
       await firstShare;
     });
 
-    expect(result.current.share).toBe(before);
+    expect(result.current).toBe(before);
   });
 });

--- a/clients/web/src/hooks/use-share-app.ts
+++ b/clients/web/src/hooks/use-share-app.ts
@@ -16,15 +16,11 @@ import {
   type ShareAppCopy,
 } from "@/utils/share-app-with-toast";
 
-export interface ShareAppHandle {
-  share: () => Promise<void>;
-}
-
 export function useShareApp(
   assistantId: string,
   app: Pick<AppSummary, "id" | "name">,
   { exported, failed }: ShareAppCopy,
-): ShareAppHandle {
+): () => Promise<void> {
   const { id, name } = app;
   const isSharingRef = useRef(false);
 
@@ -40,5 +36,5 @@ export function useShareApp(
     }
   }, [assistantId, id, name, exported, failed]);
 
-  return { share };
+  return share;
 }

--- a/clients/web/src/i18n/host-language.test-helper.ts
+++ b/clients/web/src/i18n/host-language.test-helper.ts
@@ -1,0 +1,22 @@
+/**
+ * Swap the host's reported language for the span of one test.
+ *
+ * A property descriptor rather than a module mock: bun applies `mock.module`
+ * process-wide, so a stub of `navigator` would follow every other test file
+ * sharing the process. Returns the restore, which puts back whatever
+ * descriptor was there (including none at all).
+ */
+export function stubHostLanguage(tag: string): () => void {
+  const original = Object.getOwnPropertyDescriptor(navigator, "language");
+  Object.defineProperty(navigator, "language", {
+    value: tag,
+    configurable: true,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(navigator, "language", original);
+    } else {
+      delete (navigator as unknown as { language?: string }).language;
+    }
+  };
+}

--- a/clients/web/src/i18n/i18n.test.ts
+++ b/clients/web/src/i18n/i18n.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { stubHostLanguage } from "@/i18n/host-language.test-helper";
+import type { SupportedLocale } from "@/i18n/supported-locales";
+
 let preferred: string[] = [];
 mock.module("@/i18n/system-locale", () => ({
   systemLocales: () => preferred,
 }));
 
-const { changeLocale, currentLocale, initI18n, resolveInitialLocale } =
-  await import("@/i18n/i18n");
+const {
+  changeLocale,
+  currentLocale,
+  formatLocale,
+  initI18n,
+  resolveInitialLocale,
+} = await import("@/i18n/i18n");
 const { t } = await import("i18next");
 const { deviceKey } = await import("@/utils/device-settings");
 
@@ -127,5 +135,35 @@ describe("ICU message formatting", () => {
     expect(t("notFound.body")).toBe(
       "The page you're looking for doesn't exist or may have moved.",
     );
+  });
+});
+
+describe("formatLocale", () => {
+  async function hostLanguageUnder(
+    host: string,
+    app: SupportedLocale,
+  ): Promise<string> {
+    await initI18n();
+    await changeLocale(app);
+    const restore = stubHostLanguage(host);
+    try {
+      return formatLocale();
+    } finally {
+      restore();
+      await changeLocale("en");
+    }
+  }
+
+  test("keeps the host's region when it speaks the app's language", async () => {
+    expect(await hostLanguageUnder("en-GB", "en")).toBe("en-GB");
+    expect(await hostLanguageUnder("es-MX", "es")).toBe("es-MX");
+  });
+
+  test("keeps a Chinese host tag under either Chinese catalog", async () => {
+    expect(await hostLanguageUnder("zh-TW", "zh")).toBe("zh-TW");
+  });
+
+  test("falls back to the app locale when the host speaks another language", async () => {
+    expect(await hostLanguageUnder("de-DE", "en")).toBe("en");
   });
 });

--- a/clients/web/src/i18n/i18n.ts
+++ b/clients/web/src/i18n/i18n.ts
@@ -214,4 +214,39 @@ export function currentLocale(): SupportedLocale {
   return isSupportedLocale(language) ? language : DEFAULT_LOCALE;
 }
 
+/** The primary language subtag of a BCP 47 tag, lowercased. */
+function primaryLanguage(tag: string): string {
+  return tag.split("-")[0].toLowerCase();
+}
+
+/**
+ * The locale to format dates, times, and numbers in.
+ *
+ * {@link currentLocale} answers with one of the five language tags the app
+ * ships a catalog for, which is the right answer for copy and the wrong one
+ * for formatting: it drops the region, so a UK user reading English copy
+ * would get US date order and 12-hour times. This returns the host's own tag
+ * whenever its primary language subtag is the app locale's, and the app
+ * locale otherwise, so `en-GB` under app locale `en` keeps its region while
+ * `de-DE` under `en` does not format German dates beside English copy.
+ *
+ * Comparison is by primary subtag, so a `zh-TW` host keeps `zh-TW` under
+ * either Chinese catalog.
+ *
+ * References:
+ * - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
+ * - https://www.rfc-editor.org/rfc/rfc5646 (BCP 47 tag structure)
+ */
+export function formatLocale(): string {
+  const app = currentLocale();
+  if (typeof navigator === "undefined") {
+    return app;
+  }
+  const host = navigator.language;
+  if (!host) {
+    return app;
+  }
+  return primaryLanguage(host) === primaryLanguage(app) ? host : app;
+}
+
 export { i18next };

--- a/clients/web/src/i18n/index.ts
+++ b/clients/web/src/i18n/index.ts
@@ -38,6 +38,7 @@ export { Trans, useTranslation } from "react-i18next";
 export {
   changeLocale,
   currentLocale,
+  formatLocale,
   initI18n,
   resolveInitialLocale,
 } from "@/i18n/i18n";

--- a/clients/web/src/utils/conversation-navigation.test.ts
+++ b/clients/web/src/utils/conversation-navigation.test.ts
@@ -155,6 +155,31 @@ describe("navigateToConversation", () => {
     expect(useViewerStore.getState().activeMessageFiles).toBeNull();
   });
 
+  test("chat-info settles back to the app it was opened over, which then keeps the conversation beside it", () => {
+    useConversationStore.getState().setActiveConversationId("conv-1");
+    useViewerStore.setState({
+      mainView: "chat-info",
+      viewBeforeChatInfo: "app",
+      activeAppId: SAMPLE_APP.appId,
+      openedAppState: SAMPLE_APP,
+      activeChatInfo: {
+        assistantId: "asst-1",
+        conversationId: "conv-1",
+        category: null,
+      },
+    });
+    const navigate = mock((_to: string) => {});
+    navigateToConversation(navigate as unknown as NavigateFunction, "conv-2");
+
+    // The payload clear runs before the reveal, so the reveal sees the app
+    // the panel was opened over rather than the panel itself.
+    expect(useViewerStore.getState().activeChatInfo).toBeNull();
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    expect(useConversationStore.getState().editingConversationId).toBe(
+      "conv-2",
+    );
+  });
+
   test("keeps an open app in the side-by-side layout on a wide viewport", () => {
     openAppViewer();
     const navigate = mock((_to: string) => {});

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -83,16 +83,19 @@ export function navigateToConversation(
   if (!options?.silent) {
     haptic.light();
   }
-  revealConversationView(conversationId);
   // Only wipe per-conversation process state on a genuine switch. Wiping on
   // a same-conversation navigation kills the inline cards for subagents
   // that are still running: the store repopulates only from live SSE
   // events, so the spawned entries can't come back mid-run (LUM-2875).
+  //
+  // The clear runs first because it settles the chat-info view back to the
+  // one the panel was opened from, and the reveal below reads that view.
   if (conversationId !== useConversationStore.getState().activeConversationId) {
     useSubagentStore.getState().reset();
     useWorkflowStore.getState().reset();
     useViewerStore.getState().clearTranscriptPanelPayloads();
   }
+  revealConversationView(conversationId);
   useConversationStore.getState().setActiveConversationId(conversationId);
   void navigate(
     options?.messageId

--- a/clients/web/src/utils/format-date.test.ts
+++ b/clients/web/src/utils/format-date.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { currentLocale } from "@/i18n";
+import { formatLocale } from "@/i18n";
+import { stubHostLanguage } from "@/i18n/host-language.test-helper";
 import {
   formatCaptureTime,
   formatCompactLocalDate,
@@ -13,7 +14,7 @@ import {
  * hardcoded "Aug 5, 11:42 AM", so they hold wherever the suite runs. What they
  * pin is the composition: the friendly date, a comma, and the local time.
  */
-function localTime(date: Date, locale: string = currentLocale()): string {
+function localTime(date: Date, locale: string = formatLocale()): string {
   return date.toLocaleTimeString(locale, {
     hour: "numeric",
     minute: "2-digit",
@@ -134,5 +135,35 @@ describe("formatCaptureTime", () => {
     expect(formatCaptureTime(capturedAt, "ru")).not.toBe(
       formatCaptureTime(capturedAt, "en"),
     );
+  });
+});
+
+describe("the default locale", () => {
+  test("keeps the host's region while the app language stays English", () => {
+    const restore = stubHostLanguage("en-GB");
+    try {
+      const date = new Date(2001, 0, 15, 13, 42);
+
+      // en-GB is day-first and 24-hour, so both halves move away from the
+      // bare `en` the app runs its copy in.
+      expect(formatCompactLocalDate(date.toISOString())).toBe(
+        `${formatFriendlyDate(date, { locale: "en-GB" })}, ${localTime(date, "en-GB")}`,
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  test("falls back to the app language when the host speaks another", () => {
+    const restore = stubHostLanguage("de-DE");
+    try {
+      const date = new Date(2001, 0, 15, 13, 42);
+
+      expect(formatCompactLocalDate(date.toISOString())).toBe(
+        `${formatFriendlyDate(date, { locale: "en" })}, ${localTime(date, "en")}`,
+      );
+    } finally {
+      restore();
+    }
   });
 });

--- a/clients/web/src/utils/format-date.ts
+++ b/clients/web/src/utils/format-date.ts
@@ -1,18 +1,19 @@
-import { currentLocale } from "@/i18n";
+import { formatLocale } from "@/i18n";
 
 /**
  * Format a date as a short, human-readable string (e.g., "27 May" or "27 May 2025").
  * Omits the year when it matches the current year, unless `alwaysShowYear` is set.
  *
- * Every formatter in this file defaults to the app's active locale, so one
- * label never pairs an app-locale date with a browser-locale time. Pass
+ * Every formatter in this file defaults to {@link formatLocale}, so one label
+ * never pairs an app-locale date with a browser-locale time and a user whose
+ * region differs from their language keeps their own date order. Pass
  * `locale` to pin the formatting.
  */
 export function formatFriendlyDate(
   date: Date,
   opts?: { alwaysShowYear?: boolean; locale?: string },
 ): string {
-  return date.toLocaleDateString(opts?.locale ?? currentLocale(), {
+  return date.toLocaleDateString(opts?.locale ?? formatLocale(), {
     day: "numeric",
     month: "short",
     year:
@@ -23,7 +24,7 @@ export function formatFriendlyDate(
 }
 
 /** Hour and minute, the shape every inline timestamp here shows. */
-function formatTimeOfDay(date: Date, locale: string = currentLocale()): string {
+function formatTimeOfDay(date: Date, locale: string = formatLocale()): string {
   return date.toLocaleTimeString(locale, {
     hour: "numeric",
     minute: "2-digit",
@@ -37,7 +38,7 @@ function formatTimeOfDay(date: Date, locale: string = currentLocale()): string {
  */
 export function formatCaptureTime(
   ms: number,
-  locale: string = currentLocale(),
+  locale: string = formatLocale(),
 ): string {
   const date = new Date(ms);
   const now = new Date();
@@ -54,10 +55,7 @@ export function formatCaptureTime(
  * Compact relative-time label for inline metadata ("just now", "2h ago").
  * Mirrors the macOS client's `Date.relativeShortString()`.
  */
-export function formatRelativeDate(
-  dateStr: string | null | undefined,
-  locale: string = currentLocale(),
-): string {
+export function formatRelativeDate(dateStr: string | null | undefined): string {
   if (!dateStr) {
     return "—";
   }
@@ -102,7 +100,7 @@ export function formatRelativeDate(
     const weeks = Math.floor(diffDays / 7);
     return `${weeks}w ago`;
   }
-  return date.toLocaleDateString(locale);
+  return date.toLocaleDateString(formatLocale());
 }
 
 /**
@@ -112,7 +110,7 @@ export function formatRelativeDate(
  */
 export function formatCompactLocalDate(
   dateStr: string | null | undefined,
-  locale: string = currentLocale(),
+  locale: string = formatLocale(),
 ): string {
   if (!dateStr) {
     return "";
@@ -127,7 +125,7 @@ export function formatCompactLocalDate(
  */
 export function formatFullLocalDate(
   dateStr: string | null | undefined,
-  locale: string = currentLocale(),
+  locale: string = formatLocale(),
 ): string {
   if (!dateStr) {
     return "";

--- a/clients/web/src/utils/share-app-with-toast.ts
+++ b/clients/web/src/utils/share-app-with-toast.ts
@@ -13,6 +13,7 @@
 
 import { toast } from "@vellumai/design-library";
 
+import { captureError } from "@/lib/sentry/capture-error";
 import type { AppSummary } from "@/types/app-types";
 import { shareApp } from "@/utils/share-app";
 
@@ -32,6 +33,7 @@ export async function shareAppWithToast(
     await shareApp(assistantId, app.id, app.name);
     toast.success(exported, { description: `${app.name}.vellum` });
   } catch (err) {
+    captureError(err, { context: "shareAppWithToast" });
     toast.error(failed, {
       description: err instanceof Error ? err.message : undefined,
     });


### PR DESCRIPTION
## Summary
- formatLocale() keeps the browser locale when its language matches the app locale, so en-GB stays day-first under app language en; every format-date formatter defaults to it
- useShareApp returns the callback; shareAppWithToast reports failures through captureError
- DetailShellNotice drops its unused className and gains tests with the title cluster; navigateToConversation clears the transcript panel payloads before revealing the conversation view; five new files join the em-dash lint scope

Part of plan: chat-info-assets-panel.md (remediation round 6)