### PR TITLE
feat(skills): walk the user through several steps in screen-annotation (JARVIS-1770)

### DIFF
--- a/assistant/src/config/bundled-skills/screen-annotation/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-annotation/SKILL.md
@@ -8,10 +8,9 @@ metadata:
     display-name: "Screen Annotation"
     category: "system"
     activation-hints:
-      - "User asks where something is, or how to do something, in an app they are sharing on a call"
-      - "User wants to be shown how rather than have it done for them"
-      - "The answer to a question is a place on the user's screen"
-      - "User wants to be walked through something in an app, step by step"
+      - "User asks where something is, how to do it, or to be walked through it, in an app they share on a call"
+      - "User wants to be shown, not have it done for them"
+      - "The answer is a place on the user's screen"
     avoid-when:
       - "User wants the assistant to do the thing rather than be shown it (use computer-use)"
       - "Nothing is being shared, so there is no surface to point at"

--- a/assistant/src/config/bundled-skills/screen-annotation/SKILL.md
+++ b/assistant/src/config/bundled-skills/screen-annotation/SKILL.md
@@ -11,6 +11,7 @@ metadata:
       - "User asks where something is, or how to do something, in an app they are sharing on a call"
       - "User wants to be shown how rather than have it done for them"
       - "The answer to a question is a place on the user's screen"
+      - "User wants to be walked through something in an app, step by step"
     avoid-when:
       - "User wants the assistant to do the thing rather than be shown it (use computer-use)"
       - "Nothing is being shared, so there is no surface to point at"
@@ -71,6 +72,39 @@ the step is done, when the user has moved on, or when the conversation has
 left the screen behind. Marks come down on their own if the share ends or
 moves, but a ring left standing over a finished step is one the user has to
 work out is stale.
+
+## Walking someone through several steps
+
+Sometimes the answer is one pointer. Sometimes it is a route: four places to
+click, in order, before the thing they asked about happens. Decide which it is
+before you draw anything, because the two are paced differently.
+
+**Say the route before you start it.** "There are three steps. First the
+Share menu, then the format, then Export." If they asked how and you inferred
+they want to be walked through it rather than told, this is where they wave it
+off and just want the answer. Keep it to the count and the landmarks; the
+detail belongs to each step as you reach it.
+
+**One step, then stop.** Point at it, say what to do, and then wait. The
+temptation is to narrate the next step while the ring for this one is still
+up, and that leaves them doing step one with instructions for step two in
+their ear. Silence is the cue that it is their turn.
+
+**Advance on evidence, not on time.** Move to the next step when a fresh
+picture shows this one done, or when they tell you it is. Do not move on
+because a plausible amount of time has passed. If the next picture shows the
+step not done, or done to the wrong thing, point at the same place again with
+a shorter caption and say what you saw. Pointing at the next step while the
+previous one is still open is how someone ends up two steps behind a ring.
+
+**Going back is just pointing again.** There is no undo. If they went past
+something, or want to see step two again, point at step two. Say which step
+it is, so the words and the ring agree about where you both are.
+
+**Close it out.** When the last step is done, clear the marks and say so, in a
+word. A ring left on the final button is a ring the user has to work out is
+stale, and a walkthrough that ends without an ending leaves them waiting for
+step five of four.
 
 ## Shapes
 


### PR DESCRIPTION
## Summary

The screen-annotation skill knew how to point at one thing but said nothing about pacing a route of several. This adds a "Walking someone through several steps" section to its SKILL.md and a matching activation hint. Prose only, no tool shape change.

What the section teaches:
- Say the route first, as a count plus landmarks, so an inferred walkthrough can be waved off.
- Point at one step, say what to do, then stop talking.
- Advance on a fresh frame or the user's word, never on elapsed time. If the frame shows the step not done, re-point at the same place with a shorter caption.
- Going back is pointing at the earlier step again, naming it.
- Clear the marks at the end and say so.

Today a fresh frame arrives only when the user speaks, so in practice the model advances on the user's word. Silent advancement depends on the between-turns frame poll left open in JARVIS-1739, tracked separately. The wording here is written so that work slots in without a change.

## Test plan

- [x] `bun test src/__tests__/skill-docs-sync-guard.test.ts src/__tests__/available-skills.test.ts src/config/bundled-skills/screen-annotation/tools/screen-annotation.test.ts` passes (skill has no public docs page, so no fingerprint bump)
- [ ] On a call with a screen share, ask to be walked through a multi-step task and confirm the assistant announces the route, points at one step at a time, and clears at the end

Closes JARVIS-1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9nKpq6S1TaXbtU4wFjh3t