### PR TITLE
test(web): chat-info helper restores its stubs, the mobile fit reads the column width, and the frames row has a story

### DIFF
--- a/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
@@ -4,58 +4,31 @@
  * cannot get, a non-image glyph, a video poster, and a camera frame labelled
  * with when it was captured.
  *
- * `LazyImage` seeds the cache entry the tile reads, under the same
+ * `LazyImage` draws the bytes the shared story client holds, under the same
  * `attachmentContentQueryKey` the preview modal fetches with, so the story
  * shows the fetched path without a daemon behind it.
  */
 
-import { QueryClientProvider } from "@tanstack/react-query";
-import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 import {
   makeDisplayAttachment,
   makeSamplePreview,
-  SAMPLE_PREVIEWS,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
-import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
-import { CHAT_INFO_ASSISTANT_ID } from "@/domains/chat/components/chat-info-story-fixtures";
 import {
-  CHAT_INFO_T0,
-  makeChatInfoQueryClient,
-  makeDocumentAsset,
-  makeDocumentSummary,
+  CHAT_INFO_ASSISTANT_ID,
+  withChatInfoStoryClient,
+} from "@/domains/chat/components/chat-info-story-fixtures";
+import {
+  CHAT_INFO_STORY_FILES,
+  chatInfoStoryFrames,
   makeFileAsset,
-  makeFrameAsset,
 } from "@/domains/chat/components/chat-info.test-helper";
-import { decodeBase64Payload } from "@/utils/base64";
 
 import { ChatInfoFileTile } from "./chat-info-file-tile";
 
-const DOCUMENT_FILE = makeDocumentAsset(
-  makeDocumentSummary({
-    surfaceId: "surface-trip-notes",
-    title: "Trip Notes",
-    wordCount: 842,
-  }),
-);
-
-const INLINE_IMAGE = makeFileAsset(
-  makeDisplayAttachment({
-    id: "harbour-at-dawn",
-    filename: "harbour-at-dawn.png",
-    sizeBytes: 184_320,
-    previewUrl: makeSamplePreview(240, 150),
-  }),
-);
-
-/** Metadata only: the tile has to fetch these bytes before it can draw them. */
-const LAZY_IMAGE_ATTACHMENT = makeDisplayAttachment({
-  id: "ferry-deck",
-  filename: "ferry-deck.png",
-  sizeBytes: 190_464,
-});
-const LAZY_IMAGE = makeFileAsset(LAZY_IMAGE_ATTACHMENT);
+const { tripNotes, inlineImage, lazyImage, pdf } = CHAT_INFO_STORY_FILES;
 
 /** A legacy row: a synthetic id the content endpoint can never resolve. */
 const LAZY_IMAGE_UNAVAILABLE = makeFileAsset(
@@ -63,15 +36,6 @@ const LAZY_IMAGE_UNAVAILABLE = makeFileAsset(
     id: "rehydrated:0",
     filename: "gulls-at-dusk.png",
     sizeBytes: 176_128,
-  }),
-);
-
-const PDF_FILE = makeFileAsset(
-  makeDisplayAttachment({
-    id: "coast-guide",
-    filename: "coast-guide.pdf",
-    mimeType: "application/pdf",
-    sizeBytes: 2_097_152,
   }),
 );
 
@@ -85,37 +49,15 @@ const VIDEO_FILE = makeFileAsset(
   }),
 );
 
-const FRAME_FILE = makeFrameAsset(
-  makeDisplayAttachment({
-    id: "camera-frame-01",
-    filename: "camera-frame-01.jpg",
-    mimeType: "image/jpeg",
-    sizeBytes: 98_304,
-    previewUrl: SAMPLE_PREVIEWS[3]!,
-  }),
-  CHAT_INFO_T0,
-);
-
-const storyClient = makeChatInfoQueryClient();
-// The bytes the daemon would return, decoded from a sample preview data URL.
-storyClient.setQueryData(
-  attachmentContentQueryKey(CHAT_INFO_ASSISTANT_ID, LAZY_IMAGE_ATTACHMENT.id),
-  new Blob([decodeBase64Payload(SAMPLE_PREVIEWS[2]!)!], { type: "image/png" }),
-);
-
-const withSeededBytes: Decorator = (Story) => (
-  <QueryClientProvider client={storyClient}>
-    <Story />
-  </QueryClientProvider>
-);
+const FRAME_FILE = chatInfoStoryFrames(1)[0]!;
 
 const meta: Meta<typeof ChatInfoFileTile> = {
   title: "Chat/ChatInfoFileTile",
   component: ChatInfoFileTile,
   parameters: { layout: "centered" },
-  decorators: [withSeededBytes],
+  decorators: [withChatInfoStoryClient],
   args: {
-    file: DOCUMENT_FILE,
+    file: tripNotes,
     assistantId: CHAT_INFO_ASSISTANT_ID,
     onOpen: fn(),
   },
@@ -129,12 +71,12 @@ export const Document: Story = {};
 
 /** An image the transcript already carries, drawn straight from its data URL. */
 export const InlineImage: Story = {
-  args: { file: INLINE_IMAGE },
+  args: { file: inlineImage },
 };
 
 /** An image whose bytes the tile fetches once it is on screen. */
 export const LazyImage: Story = {
-  args: { file: LAZY_IMAGE },
+  args: { file: lazyImage },
 };
 
 /** A legacy image with no bytes to fetch: the tile settles straight on the glyph. */
@@ -144,7 +86,7 @@ export const LazyImageUnavailable: Story = {
 
 /** A non-image attachment, which is always its kind's glyph. */
 export const Pdf: Story = {
-  args: { file: PDF_FILE },
+  args: { file: pdf },
 };
 
 /** A video, painted from its poster frame rather than an image element. */
@@ -162,9 +104,9 @@ export const Row: Story = {
   parameters: { controls: { disable: true } },
   render: (args) => (
     <div className="flex gap-2">
-      <ChatInfoFileTile {...args} file={DOCUMENT_FILE} />
-      <ChatInfoFileTile {...args} file={INLINE_IMAGE} />
-      <ChatInfoFileTile {...args} file={PDF_FILE} />
+      <ChatInfoFileTile {...args} file={tripNotes} />
+      <ChatInfoFileTile {...args} file={inlineImage} />
+      <ChatInfoFileTile {...args} file={pdf} />
       <ChatInfoFileTile {...args} file={FRAME_FILE} />
     </div>
   ),

--- a/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
@@ -2,13 +2,15 @@
  * A Chat Info row: the category header with its exact total and a See All
  * control, over one line of tiles.
  *
- * The row is tile-agnostic, so these stories feed it the shipped 64px
- * `MessageAttachmentSquare` rather than the panel's own tiles. What they
- * document is the fit rule: on a roomy window the line is truncated to the
- * tiles its measured width holds, and on a phone the same width decides a
- * horizontal strip that runs past the screen edge. See All appears whenever
- * the category's total exceeds that line, which is why the paged story shows
- * it under a row that looks complete.
+ * The row is tile-agnostic, so most of these stories feed it the shipped 64px
+ * `MessageAttachmentSquare`. What they document is the fit rule: on a roomy
+ * window the line is truncated to the tiles its measured width holds, and on a
+ * phone the same width decides a horizontal strip that runs past the screen
+ * edge. See All appears whenever the category's total exceeds that line, which
+ * is why the paged story shows it under a row that looks complete.
+ *
+ * The Frames stories are the exception: they draw the panel's own Camera
+ * Frames row, on its catalog copy and its file tiles.
  *
  * Read the phone stories at the Mobile viewports: the frame draws
  * `DetailShell`'s lift surface and body inset, which the strip cancels.
@@ -23,10 +25,21 @@ import {
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import {
+  CHAT_INFO_FILE_TILE_WIDTH_PX,
+  ChatInfoFileTile,
+} from "@/domains/chat/components/chat-info-file-tile";
+import {
+  CHAT_INFO_ASSISTANT_ID,
+  withChatInfoStoryClient,
+} from "@/domains/chat/components/chat-info-story-fixtures";
+import {
   CHAT_INFO_DRAWER_WIDTH_PX,
   CHAT_INFO_NARROW_PHONE_PX,
+  chatInfoStoryFrames,
 } from "@/domains/chat/components/chat-info.test-helper";
+import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
+import { useTranslation } from "@/i18n";
 
 import {
   ChatInfoSection,
@@ -156,4 +169,55 @@ export const NarrowPhoneStrip: Story = {
     items: makePreviewableImages(8),
     count: 12,
   },
+};
+
+/** One Live session's captures, the set the frames row is shown against. */
+const FRAME_TILES = chatInfoStoryFrames(6);
+
+/** The Camera Frames row the panel draws: its catalog copy, over its file tiles. */
+function FramesRow({
+  count,
+  onSeeAll,
+}: Pick<ChatInfoSectionProps<ConversationFileAsset>, "count" | "onSeeAll">) {
+  const { t } = useTranslation("chat");
+  return (
+    <ChatInfoSection
+      title={t("chatInfoPanel.framesTitle")}
+      count={count}
+      items={FRAME_TILES}
+      tileWidth={CHAT_INFO_FILE_TILE_WIDTH_PX}
+      seeAllAriaLabel={t("chatInfoPanel.seeAllFramesAria")}
+      onSeeAll={onSeeAll}
+      renderTile={(frame) => (
+        <ChatInfoFileTile
+          key={frame.id}
+          file={frame}
+          assistantId={CHAT_INFO_ASSISTANT_ID}
+          onOpen={() => {}}
+        />
+      )}
+    />
+  );
+}
+
+type FramesStory = StoryObj<
+  Pick<ChatInfoSectionProps<ConversationFileAsset>, "count" | "onSeeAll">
+>;
+
+/**
+ * Camera Frames at the drawer width: each tile carries the time its frame was
+ * captured, and the session's total puts See All in the header.
+ */
+export const Frames: FramesStory = {
+  decorators: [withChatInfoStoryClient, inDrawerColumn],
+  args: { count: 240 },
+  render: (args) => <FramesRow {...args} />,
+};
+
+/** The same row on the narrowest phone, where the captures scroll past the edge. */
+export const FramesStrip: FramesStory = {
+  decorators: [withChatInfoStoryClient, inPhonePage],
+  globals: { viewport: { value: "sbNarrowPhone", isRotated: false } },
+  args: { count: 240 },
+  render: (args) => <FramesRow {...args} />,
 };

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -171,24 +171,18 @@ describe("ChatInfoSection", () => {
     expect(seeAll()).not.toBeNull();
   });
 
-  test("counts the strip's reclaimed right inset toward the narrow-window fit", () => {
-    // The strip shows the column plus the inset it reclaims on the right.
+  test("offers See All for two app tiles on the narrowest phone", () => {
+    // Two app tiles and their gap are wider than the column, so the pair
+    // scrolls and the drill-in is the only way to the second one.
     viewport.set({ narrow: true, coarsePointer: false });
     widthRef.value = NARROW_COLUMN_WIDTH;
 
-    const fitted = renderSection({
+    renderSection({
       items: makeItems(2),
       count: 2,
       tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
     });
-    expect(seeAll()).toBeNull();
-    fitted.unmount();
 
-    renderSection({
-      items: makeItems(3),
-      count: 3,
-      tileWidth: CHAT_INFO_APP_TILE_WIDTH_PX,
-    });
     expect(seeAll()).not.toBeNull();
   });
 

--- a/clients/web/src/domains/chat/components/chat-info-section.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.tsx
@@ -67,11 +67,8 @@ export function ChatInfoSection<T>({
   const titleId = useId();
   const { ref, size } = useElementSize();
   const isMobile = useIsMobile();
-  // The strip runs through the body's right inset, so that width counts too.
-  const fit = fitTileCount(
-    isMobile ? size.w + DETAIL_SHELL_BODY_INSET_PX : size.w,
-    tileWidth,
-  );
+  // The strip's bleed is padding, not extra room, so one fit serves both layouts.
+  const fit = fitTileCount(size.w, tileWidth);
   const showSeeAll = count > fit;
 
   return (

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -24,6 +24,7 @@ import {
   makeAppSummary,
   makeChatInfoQueryClient,
   makeDocumentSummary,
+  makeSeededChatInfoStoryClient,
   seedChatInfoConversation,
   seedTranscriptMessages,
 } from "@/domains/chat/components/chat-info.test-helper";
@@ -34,6 +35,18 @@ import { primeAppHtmlCache } from "@/utils/app-html-cache";
 
 export const CHAT_INFO_ASSISTANT_ID = "story-assistant";
 export const CHAT_INFO_CONVERSATION_ID = "story-conversation";
+
+const storyClient = makeSeededChatInfoStoryClient(CHAT_INFO_ASSISTANT_ID);
+
+/**
+ * The client a tile story reads: it answers every query from what
+ * {@link makeSeededChatInfoStoryClient} holds, so no story reaches the daemon.
+ */
+export const withChatInfoStoryClient: Decorator = (Story) => (
+  <QueryClientProvider client={storyClient}>
+    <Story />
+  </QueryClientProvider>
+);
 
 /** Name, icon, and preview lines for each app a story can ask for. */
 const APP_SEEDS: Array<{ name: string; icon: string; lines: string[] }> = [
@@ -100,7 +113,7 @@ const APP_SEEDS: Array<{ name: string; icon: string; lines: string[] }> = [
 ];
 
 /** A small page for the preview iframe, in system colours so it reads in either theme. */
-export function chatInfoPreviewHtml(title: string, lines: string[]): string {
+function chatInfoPreviewHtml(title: string, lines: string[]): string {
   const items = lines.map((line) => `<li>${line}</li>`).join("");
   return `<!doctype html><meta charset="utf-8"><title>${title}</title><style>body{margin:0;padding:24px;font-family:system-ui,sans-serif;background:Canvas;color:CanvasText}h1{margin:0 0 12px;font-size:28px}ul{margin:0;padding-left:22px;font-size:18px;line-height:1.7}</style><h1>${title}</h1><ul>${items}</ul>`;
 }

--- a/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
@@ -23,6 +23,7 @@ import type { ReactElement } from "react";
 
 import {
   CHAT_INFO_OBJECT_URL,
+  CHAT_INFO_TEST_LOCALE,
   chatInfoAppHtmlCacheMock,
   installChatInfoDomStubs,
   makeAppSummary,
@@ -36,7 +37,7 @@ import {
 } from "@/domains/chat/components/chat-info.test-helper";
 import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
 
-installChatInfoDomStubs();
+const restoreDomStubs = installChatInfoDomStubs();
 
 // The app tile's live preview would otherwise call the daemon's open endpoint.
 mock.module("@/utils/app-html-cache", chatInfoAppHtmlCacheMock);
@@ -108,6 +109,7 @@ afterEach(() => {
 });
 
 afterAll(() => {
+  restoreDomStubs();
   mock.restore();
 });
 
@@ -292,9 +294,6 @@ describe("ChatInfoFileTile attachments", () => {
 });
 
 describe("ChatInfoFileTile camera frames", () => {
-  // The suite pins i18next to English, which is the locale the tile formats in.
-  const LOCALE = "en";
-
   function frameAsset(capturedAt: number): ConversationFileAsset {
     return makeFrameAsset(
       makeDisplayAttachment({
@@ -321,7 +320,7 @@ describe("ChatInfoFileTile camera frames", () => {
 
     expect(screen.getByLabelText("Preview camera frame")).toBeDefined();
     expect(
-      screen.getByText(formatCaptureTime(capturedAt, LOCALE)),
+      screen.getByText(formatCaptureTime(capturedAt, CHAT_INFO_TEST_LOCALE)),
     ).toBeDefined();
   });
 
@@ -336,7 +335,7 @@ describe("ChatInfoFileTile camera frames", () => {
     );
 
     expect(
-      screen.getByText(formatCaptureTime(capturedAt, LOCALE)),
+      screen.getByText(formatCaptureTime(capturedAt, CHAT_INFO_TEST_LOCALE)),
     ).toBeDefined();
     expect(screen.getByText(/2001/)).toBeDefined();
   });

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -19,6 +19,12 @@ import { QueryClient } from "@tanstack/react-query";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import {
+  makeDisplayAttachment,
+  makeSamplePreview,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
+import {
   type ConversationFileAsset,
   toConversationFileAssets,
 } from "@/domains/chat/hooks/use-conversation-assets";
@@ -34,6 +40,7 @@ import type { AppSummary } from "@/types/app-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
 import type { DocumentSummary } from "@/types/document-types";
 import * as appHtmlCache from "@/utils/app-html-cache";
+import { decodeBase64Payload } from "@/utils/base64";
 
 /** Fixed epoch ms, so nothing built here depends on the clock. */
 export const CHAT_INFO_T0 = 1_760_000_000_000;
@@ -43,6 +50,9 @@ export const CHAT_INFO_DRAWER_WIDTH_PX = 569;
 
 /** The narrowest phone the app runs on, screen width and all. */
 export const CHAT_INFO_NARROW_PHONE_PX = 402;
+
+/** The suite pins i18next to English, which is the locale the tile formats in. */
+export const CHAT_INFO_TEST_LOCALE = "en";
 
 /** The shared app builder, under the defaults every Chat Info fixture wants. */
 export function makeAppSummary(
@@ -143,7 +153,7 @@ export function attachmentRows(
  * Names the conversation the seeded chat-session snapshot belongs to, which is
  * what `useConversationAttachments` gates on.
  */
-export function seedTranscriptOwner(
+function seedTranscriptOwner(
   assistantId: string,
   conversationId: string,
 ): void {
@@ -171,8 +181,16 @@ export const CHAT_INFO_OBJECT_URL = "blob:chat-info";
  * The two browser APIs the tiles need and happy-dom does not implement: object
  * URLs, and an IntersectionObserver that reports every observed tile on screen
  * straight away so the lazy image fetch runs inside the test.
+ *
+ * Returns a restore fn the caller invokes once done: a suite that leaves the
+ * stubs installed hands them to whatever the runner evaluates next, and
+ * `use-in-view.test.tsx` captures its `IntersectionObserver` at module scope.
  */
-export function installChatInfoDomStubs(): void {
+export function installChatInfoDomStubs(): () => void {
+  const createObjectURL = globalThis.URL.createObjectURL;
+  const revokeObjectURL = globalThis.URL.revokeObjectURL;
+  const intersectionObserver = globalThis.IntersectionObserver;
+
   globalThis.URL.createObjectURL = () => CHAT_INFO_OBJECT_URL;
   globalThis.URL.revokeObjectURL = () => {};
 
@@ -195,6 +213,12 @@ export function installChatInfoDomStubs(): void {
   }
   globalThis.IntersectionObserver =
     ImmediateIntersectionObserver as unknown as typeof IntersectionObserver;
+
+  return () => {
+    globalThis.URL.createObjectURL = createObjectURL;
+    globalThis.URL.revokeObjectURL = revokeObjectURL;
+    globalThis.IntersectionObserver = intersectionObserver;
+  };
 }
 
 /**
@@ -315,4 +339,84 @@ export function seedTranscriptMessages(
 export function clearTranscriptMessages(): void {
   useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
   clearTranscriptOwner();
+}
+
+/** Metadata only: the tile has to fetch these bytes before it can draw them. */
+const STORY_LAZY_ATTACHMENT = makeDisplayAttachment({
+  id: "ferry-deck",
+  filename: "ferry-deck.png",
+  sizeBytes: 190_464,
+});
+
+/**
+ * The files the Chat Info stories are shown against: two daemon documents, an
+ * image the transcript carries inline, one whose bytes the tile fetches, and a
+ * PDF. `Object.values` gives the set as one category's items.
+ */
+export const CHAT_INFO_STORY_FILES = {
+  tripNotes: makeDocumentAsset(
+    makeDocumentSummary({
+      surfaceId: "surface-trip-notes",
+      title: "Trip Notes",
+      wordCount: 842,
+    }),
+  ),
+  packingList: makeDocumentAsset(
+    makeDocumentSummary({
+      surfaceId: "surface-packing-list",
+      title: "Packing List",
+      wordCount: 214,
+    }),
+  ),
+  inlineImage: makeFileAsset(
+    makeDisplayAttachment({
+      id: "harbour-at-dawn",
+      filename: "harbour-at-dawn.png",
+      sizeBytes: 184_320,
+      previewUrl: makeSamplePreview(240, 150),
+    }),
+  ),
+  lazyImage: makeFileAsset(STORY_LAZY_ATTACHMENT),
+  pdf: makeFileAsset(
+    makeDisplayAttachment({
+      id: "coast-guide",
+      filename: "coast-guide.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_097_152,
+    }),
+  ),
+};
+
+/** One Live session: `count` captures three minutes apart, newest first. */
+export function chatInfoStoryFrames(count: number): ConversationFileAsset[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeFrameAsset(
+      makeDisplayAttachment({
+        id: `camera-frame-${index + 1}`,
+        filename: `camera-frame-${index + 1}.jpg`,
+        mimeType: "image/jpeg",
+        sizeBytes: 98_304 + index * 2_048,
+        previewUrl: SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
+      }),
+      CHAT_INFO_T0 - index * 180_000,
+    ),
+  );
+}
+
+/**
+ * A story client holding the bytes the daemon would return for the one story
+ * file with no inline preview, under the same key the preview modal fetches
+ * with, so its tile draws the fetched path with no daemon behind it.
+ */
+export function makeSeededChatInfoStoryClient(
+  assistantId: string,
+): QueryClient {
+  const client = makeChatInfoQueryClient();
+  client.setQueryData(
+    attachmentContentQueryKey(assistantId, STORY_LAZY_ATTACHMENT.id),
+    new Blob([decodeBase64Payload(SAMPLE_PREVIEWS[2]!)!], {
+      type: "image/png",
+    }),
+  );
+  return client;
 }


### PR DESCRIPTION
## Summary
- installChatInfoDomStubs returns a restore function; the story asset sets, seeded client, and test locale live in the helper
- the mobile strip's fit is measured against the column (the strip pays the inset back on both edges), so See All appears when two app tiles scroll on a narrow phone
- ChatInfoSection stories render the Camera Frames row at the drawer width and as a phone strip

Part of plan: chat-info-assets-panel.md (remediation round 6)