### PR TITLE
fix(web): every attachment gallery opens at an explicit index, the preview modal's copy is translated, and missing attachments are not reported

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
@@ -129,7 +129,7 @@ describe("AttachmentPreviewModal content loading", () => {
 
     expect(
       screen.getByText(
-        "Preview unavailable — file content was not preserved in chat history.",
+        "Preview unavailable. The file content was not preserved in chat history.",
       ),
     ).toBeDefined();
     expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
@@ -142,7 +142,9 @@ describe("AttachmentPreviewModal content loading", () => {
     renderModal(ATTACHMENT, () => undefined, null);
 
     expect(
-      screen.queryByText(/file content was not preserved in chat history/),
+      screen.queryByText(
+        "Preview unavailable. The file content was not preserved in chat history.",
+      ),
     ).toBeNull();
     expect(screen.queryByText("Failed to load preview.")).toBeNull();
     expect(screen.getAllByText("photo.png").length).toBeGreaterThan(0);

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -135,9 +135,9 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   // what `unavailable` covers still has a file behind it, so it falls through
   // to the card that names it.
   const previewError = legacyId
-    ? "Preview unavailable — file content was not preserved in chat history."
+    ? t("attachmentPreviewModal.legacyUnavailable")
     : isError && !unavailable
-      ? "Failed to load preview."
+      ? t("attachmentPreviewModal.loadFailed")
       : null;
 
   const currentIndex = useMemo(() => {

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-test-helpers.tsx
@@ -27,9 +27,9 @@ export {
 
 /**
  * Replace the preview modal with a probe exposing the opened attachment, its
- * preview URL, and its gallery siblings - enough for both the gallery-size
- * assertions and the failed-decode assertions. Call this at module scope,
- * above the import of the component under test.
+ * preview URL, its gallery position, and its gallery siblings - enough for the
+ * gallery-size, gallery-position and failed-decode assertions. Call this at
+ * module scope, above the import of the component under test.
  */
 export function mockAttachmentPreviewModal(): void {
   mock.module(
@@ -38,13 +38,16 @@ export function mockAttachmentPreviewModal(): void {
       AttachmentPreviewModal: ({
         attachment,
         siblingAttachments,
+        currentIndex,
       }: {
         attachment: { id: string; previewUrl: string | null };
         siblingAttachments?: Array<{ id: string; previewUrl: string | null }>;
+        currentIndex?: number;
       }) => (
         <div
           data-testid="preview-modal"
           data-attachment-id={attachment.id}
+          data-current-index={String(currentIndex)}
           data-preview-url={String(attachment.previewUrl)}
           data-sibling-count={String((siblingAttachments ?? []).length)}
           data-sibling-preview-urls={JSON.stringify(

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -79,6 +79,29 @@ describe("BubbleAttachments", () => {
     ).toBe("img-1");
   });
 
+  test("opens the gallery at the clicked image's position when two share an id", () => {
+    // The text-parsing history fallback can rehydrate two rows under one
+    // synthetic id, which the modal's id lookup cannot tell apart.
+    const rehydrated = (filename: string): DisplayAttachment => ({
+      id: "rehydrated:0",
+      filename,
+      mimeType: "image/png",
+      sizeBytes: 1_024,
+      previewUrl: `https://example.com/${filename}`,
+    });
+    const { getByRole, getByTestId } = render(
+      <BubbleAttachments
+        attachments={[rehydrated("first.png"), rehydrated("second.png")]}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "second.png" }));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("rehydrated:0");
+    expect(modal.getAttribute("data-current-index")).toBe("1");
+  });
+
   test("preserves the original attachment order for a mixed list", () => {
     const { getByText, getByRole } = render(
       <BubbleAttachments attachments={[pdf, imageWithPreview]} />,

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -50,18 +50,18 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
           if (isInlineImage) {
             return (
               <img
-                key={att.id}
+                key={`${index}:${att.id}`}
                 src={att.previewUrl ?? undefined}
                 alt={att.filename}
                 role="button"
                 aria-label={att.filename}
                 title={att.filename}
                 tabIndex={0}
-                onClick={() => openPreview(att)}
+                onClick={() => openPreview(att, index)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    openPreview(att);
+                    openPreview(att, index);
                   }
                 }}
                 onError={() => markImageFailed(att.id)}

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
@@ -121,6 +121,17 @@ describe("fetchAttachmentContentBlob", () => {
     expect((only?.err as ApiError).status).toBe(503);
   });
 
+  test("answers null for a missing attachment without reporting it", async () => {
+    contentResponse = async () => ({
+      data: undefined,
+      error: { message: "Attachment not found" },
+      response: new Response(null, { status: 404 }),
+    });
+
+    expect(await fetchAttachmentContentBlob("asst-1", "att-gone")).toBeNull();
+    expect(captured).toEqual([]);
+  });
+
   test("never fetches, and never reports, for a synthetic history id", async () => {
     expect(
       await fetchAttachmentContentBlob("asst-1", "rehydrated:0"),

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
@@ -38,7 +38,11 @@ export async function fetchAttachmentContentBlob(
     // `throwOnError: false` hands HTTP failures back as a value, so the status
     // has to be attached here for the transient filter to read it.
     if (response && !response.ok) {
-      reportAttachmentFetchFailure(toApiError(error, response));
+      // A deleted or unknown attachment is a state the surfaces render, not a
+      // fault to report.
+      if (response.status !== 404) {
+        reportAttachmentFetchFailure(toApiError(error, response));
+      }
     } else {
       reportAttachmentFetchFailure(
         error ?? new Error("Attachment content response carried no blob"),

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
@@ -10,6 +10,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactElement } from "react";
 
 import * as daemonSdk from "@/generated/daemon/sdk.gen";
+import { mockAttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
 
@@ -47,6 +48,10 @@ const saveFileMock = mock(
 mock.module("@/runtime/native-file", () => ({
   saveFile: saveFileMock,
 }));
+
+// The strip's own wiring is what is under test, so the modal is a probe
+// reporting which attachment it was handed and at which position.
+mockAttachmentPreviewModal();
 
 const imagesModule =
   await import("@/domains/chat/components/chat-attachments/tool-result-images");
@@ -156,6 +161,36 @@ describe("ToolResultImages referenced media", () => {
     // Saved from the fetched blob (referenced media has no inline data URL).
     expect(saveFileMock.mock.calls[0]![0]).toBeInstanceOf(Blob);
     expect(saveFileMock.mock.calls[0]![1]).toBe("file-read.png");
+  });
+
+  test("opens the gallery at the clicked image's position when two calls name one id", () => {
+    // A turn that reads the same image twice yields two entries under one
+    // attachment id, which the modal's id lookup cannot tell apart.
+    const calls: ChatMessageToolCall[] = [
+      {
+        id: "tc-first",
+        name: "media_generate_image",
+        input: {},
+        result: "Generated 1 image",
+        imageAttachmentIds: ["att-same"],
+        completedAt: 1,
+      },
+      {
+        id: "tc-second",
+        name: "file_read",
+        input: {},
+        result: "Read 1 image",
+        imageAttachmentIds: ["att-same"],
+        completedAt: 2,
+      },
+    ];
+    renderStrip(calls);
+
+    fireEvent.click(screen.getByRole("button", { name: "file-read.png" }));
+
+    const modal = screen.getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("att-same");
+    expect(modal.getAttribute("data-current-index")).toBe("1");
   });
 
   /** A message attachment chip carrying `id`. */

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -426,18 +426,18 @@ export const ToolResultImages: FC<ToolResultImagesProps> = ({
   return (
     <>
       <div className="flex w-full flex-wrap gap-2">
-        {attachments.map((att) => (
+        {attachments.map((att, index) => (
           <div
-            key={att.id}
+            key={`${index}:${att.id}`}
             role="button"
             aria-label={att.filename}
             title={att.filename}
             tabIndex={0}
-            onClick={() => openPreview(att)}
+            onClick={() => openPreview(att, index)}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
-                openPreview(att);
+                openPreview(att, index);
               }
             }}
             data-reveal-row=""

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * The hook every attachment surface reads its bytes through: the transcript
+ * squares, the user bubble, the tool-result strip, the Chat Info tiles and the
+ * full-screen preview. Each of them draws a picture, waits, or falls back on
+ * what it settles on, so every one of those answers is pinned here.
+ *
+ * Driven from the query cache rather than the daemon, since the cache is the
+ * seam the five surfaces already share.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { client as daemonClient } from "@/generated/daemon/client.gen";
+import {
+  attachmentContentQueryKey,
+  useAttachmentObjectUrl,
+} from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
+import type { DisplayAttachment } from "@/types/attachment-types";
+
+type Attachment = Pick<DisplayAttachment, "id" | "previewUrl">;
+
+// happy-dom implements neither half of the object-URL API.
+const realCreateObjectURL = globalThis.URL.createObjectURL;
+const realRevokeObjectURL = globalThis.URL.revokeObjectURL;
+let minted: string[] = [];
+let revoked: string[] = [];
+
+globalThis.URL.createObjectURL = (_blob: Blob | MediaSource): string => {
+  const url = `blob:attachment-${minted.length}`;
+  minted.push(url);
+  return url;
+};
+globalThis.URL.revokeObjectURL = (url: string): void => {
+  revoked.push(url);
+};
+
+// A request the runner would really send is the one thing a pending fetch must
+// not depend on. 404 because it is the one status the fetch helper leaves
+// unreported, so a test that lets a request through stays quiet.
+const realFetch = daemonClient.getConfig().fetch;
+let requests = 0;
+const stubFetch: typeof fetch = Object.assign(
+  async (): Promise<Response> => {
+    requests += 1;
+    return new Response(null, { status: 404 });
+  },
+  { preconnect: () => undefined },
+);
+daemonClient.setConfig({ fetch: stubFetch });
+
+beforeEach(() => {
+  minted = [];
+  revoked = [];
+  requests = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  globalThis.URL.createObjectURL = realCreateObjectURL;
+  globalThis.URL.revokeObjectURL = realRevokeObjectURL;
+  daemonClient.setConfig({ fetch: realFetch });
+});
+
+function renderObjectUrl(
+  attachment: Attachment | null,
+  opts: {
+    assistantId?: string | null;
+    enabled?: boolean;
+    seed?: (client: QueryClient) => void;
+  } = {},
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, retryOnMount: false } },
+  });
+  opts.seed?.(client);
+  const assistantId: string | null =
+    "assistantId" in opts ? (opts.assistantId ?? null) : "asst-1";
+  const rendered = renderHook(
+    ({ on }: { on: boolean }) =>
+      useAttachmentObjectUrl(assistantId, attachment, on),
+    {
+      initialProps: { on: opts.enabled ?? true },
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    },
+  );
+  return { ...rendered, client };
+}
+
+/** Park a failed fetch in the cache, the state a remounting surface reads. */
+function seedFailure(client: QueryClient, queryKey: readonly unknown[]): void {
+  client
+    .getQueryCache()
+    .build(client, { queryKey })
+    .setState({
+      status: "error",
+      error: new Error("Failed to load attachment content"),
+      errorUpdatedAt: Date.now(),
+      fetchStatus: "idle",
+    });
+}
+
+const STORED: Attachment = { id: "att-1", previewUrl: null };
+
+describe("useAttachmentObjectUrl", () => {
+  test("hands back an inline preview URL without touching the cache", () => {
+    const inline = "data:image/png;base64,AAAA";
+    const { result, client } = renderObjectUrl({
+      id: "att-inline",
+      previewUrl: inline,
+    });
+
+    expect(result.current.url).toBe(inline);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(
+      client.getQueryState(attachmentContentQueryKey("asst-1", "att-inline"))
+        ?.fetchStatus,
+    ).toBe("idle");
+    expect(requests).toBe(0);
+    expect(minted).toEqual([]);
+  });
+
+  test("mints an object URL for cached bytes and revokes it on unmount", () => {
+    const { result, unmount } = renderObjectUrl(STORED, {
+      seed: (client) =>
+        client.setQueryData(
+          attachmentContentQueryKey("asst-1", "att-1"),
+          new Blob(["bytes"]),
+        ),
+    });
+
+    expect(result.current.url).toBe("blob:attachment-0");
+    expect(result.current.isPending).toBe(false);
+
+    unmount();
+
+    expect(revoked).toEqual(["blob:attachment-0"]);
+  });
+
+  test("revokes the object URL as soon as the caller stops drawing it", () => {
+    const { result, rerender } = renderObjectUrl(STORED, {
+      seed: (client) =>
+        client.setQueryData(
+          attachmentContentQueryKey("asst-1", "att-1"),
+          new Blob(["bytes"]),
+        ),
+    });
+
+    expect(result.current.url).toBe("blob:attachment-0");
+
+    rerender({ on: false });
+
+    expect(revoked).toEqual(["blob:attachment-0"]);
+    expect(result.current.url).toBeNull();
+  });
+
+  test("calls a synthetic history id a legacy one, whose bytes were never kept", () => {
+    const { result } = renderObjectUrl({
+      id: "rehydrated:2",
+      previewUrl: null,
+    });
+
+    expect(result.current.legacyId).toBe(true);
+    expect(result.current.unavailable).toBe(true);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isPending).toBe(false);
+  });
+
+  test("calls a real id with no assistant unavailable, not legacy", () => {
+    // The composer strip opens the gallery with no assistant behind it. The
+    // file still exists; it is only out of this caller's reach.
+    const { result } = renderObjectUrl(STORED, { assistantId: null });
+
+    expect(result.current.legacyId).toBe(false);
+    expect(result.current.unavailable).toBe(true);
+    expect(result.current.isError).toBe(true);
+  });
+
+  test("stays pending while the bytes are still on their way", () => {
+    const { result } = renderObjectUrl(STORED);
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.url).toBeNull();
+    expect(result.current.isError).toBe(false);
+  });
+
+  test("reports a failed fetch as an error the caller can fall back from", () => {
+    const { result } = renderObjectUrl(STORED, {
+      seed: (client) =>
+        seedFailure(client, attachmentContentQueryKey("asst-1", "att-1")),
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.unavailable).toBe(false);
+    expect(result.current.isPending).toBe(false);
+    expect(result.current.url).toBeNull();
+  });
+
+  test("resolves to nothing at all for a caller with no attachment", () => {
+    const { result } = renderObjectUrl(null);
+
+    expect(result.current.url).toBeNull();
+    expect(result.current.unavailable).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isPending).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * The square renderer every message-attachment surface shares. A legacy
+ * transcript can carry two rows under one synthetic `rehydrated:` id, so a
+ * square hands the gallery its own position rather than leaving the modal to
+ * resolve an id that names both of them.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { mockAttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-test-helpers";
+
+mockAttachmentPreviewModal();
+
+import type { DisplayAttachment } from "@/domains/chat/types/types";
+
+import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
+
+afterAll(() => {
+  mock.restore();
+});
+afterEach(() => {
+  cleanup();
+});
+
+/** The layout every caller writes for itself, reduced to the squares. */
+function Squares({ attachments }: { attachments: DisplayAttachment[] }) {
+  const { displayAttachments, renderSquare, previewModal } =
+    useAttachmentSquares({ attachments });
+
+  return (
+    <>
+      {displayAttachments.map((att, index) => renderSquare(att, index))}
+      {previewModal}
+    </>
+  );
+}
+
+/** Two rows the text-parsing history fallback rehydrated under one id. */
+const SHARED_ID: DisplayAttachment[] = [
+  {
+    id: "rehydrated:0",
+    filename: "first.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 1_024,
+    previewUrl: null,
+  },
+  {
+    id: "rehydrated:0",
+    filename: "second.pdf",
+    mimeType: "application/pdf",
+    sizeBytes: 2_048,
+    previewUrl: null,
+  },
+];
+
+describe("useAttachmentSquares", () => {
+  test("opens the gallery at the clicked square's position, not its id", () => {
+    const { getByRole, getByTestId } = render(
+      <Squares attachments={SHARED_ID} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "second.pdf" }));
+
+    const modal = getByTestId("preview-modal");
+    expect(modal.getAttribute("data-attachment-id")).toBe("rehydrated:0");
+    expect(modal.getAttribute("data-current-index")).toBe("1");
+  });
+
+  test("keys each square on its position, so a shared id is still unique", () => {
+    const logged: unknown[] = [];
+    const realError = console.error;
+    console.error = (...args: unknown[]) => {
+      logged.push(...args);
+    };
+    try {
+      render(<Squares attachments={SHARED_ID} />);
+    } finally {
+      console.error = realError;
+    }
+
+    expect(logged.map(String).join("\n")).not.toContain("same key");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
@@ -45,8 +45,10 @@ interface UseAttachmentSquaresResult {
    *  {@link displayAttachments}. */
   renderSquare: (attachment: DisplayAttachment, index: number) => ReactNode;
   /** Opens the preview modal, for call sites that render their own affordance
-   *  alongside the squares (the bubble's large inline images). */
-  openPreview: (attachment: DisplayAttachment) => void;
+   *  alongside the squares (the bubble's large inline images). Pass the
+   *  attachment's position in {@link displayAttachments}, which resolves a list
+   *  holding two attachments with the same id. */
+  openPreview: (attachment: DisplayAttachment, index?: number) => void;
   /** Records an attachment id whose preview the browser could not decode. */
   markImageFailed: (id: string) => void;
   /** The rendered preview modal, or `null`. Render it somewhere stable. */
@@ -77,9 +79,9 @@ export function useAttachmentSquares({
   const renderSquare = useCallback(
     (attachment: DisplayAttachment, index: number) => (
       <MessageAttachmentSquare
-        key={attachment.id}
+        key={`${index}:${attachment.id}`}
         attachment={attachment}
-        onPreview={() => openPreview(attachment)}
+        onPreview={() => openPreview(attachment, index)}
         // Download falls back to previewUrl when the daemon content fetch is
         // unavailable, so it takes the UNSANITIZED attachment - a blob that
         // can't be rendered is still valid bytes to save.

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
@@ -39,7 +39,7 @@ export function ChatInfoFileTile({
   const { t } = useTranslation("chat");
   const boxRef = useRef<HTMLButtonElement>(null);
 
-  const isOnScreen = useInView(boxRef, { rootMargin: "200px" });
+  const isOnScreen = useInView(boxRef);
   // A browser without IntersectionObserver loads every tile rather than none:
   // the picture is the tile's content here, not an enhancement of it.
   const isVisible = isOnScreen || typeof IntersectionObserver === "undefined";

--- a/clients/web/src/domains/chat/components/chat-markdown-message.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-markdown-message.test.tsx
@@ -103,13 +103,11 @@ const openWorkspaceFile = mock(async (_path: string) => {});
 
 mock.module("@/utils/open-workspace-file", () => ({ openWorkspaceFile }));
 
-const { ChatMarkdownMessage, isVellumLink } = await import(
-  "@/domains/chat/components/chat-markdown-message"
-);
+const { ChatMarkdownMessage, isVellumLink } =
+  await import("@/domains/chat/components/chat-markdown-message");
 const { useViewerStore } = await import("@/stores/viewer-store");
-const { attachmentContentQueryKey } = await import(
-  "@/domains/chat/components/chat-attachments/use-attachment-object-url"
-);
+const { attachmentContentQueryKey } =
+  await import("@/domains/chat/components/chat-attachments/use-attachment-object-url");
 
 function makeAttachment(
   overrides: Pick<DisplayAttachment, "filename" | "mimeType"> &
@@ -428,6 +426,26 @@ describe("ChatMarkdownMessage (image dispatch)", () => {
     ).toBeTruthy();
     expect(attachmentsByIdContentGet).toHaveBeenCalledTimes(1);
     expect(workspaceFileContentGet).not.toHaveBeenCalled();
+  });
+
+  test("a rehydrated attachment falls back rather than loading forever", () => {
+    // A synthetic `rehydrated:` id has no bytes behind it and never will, so
+    // the inline image settles on the fallback instead of a loading chip.
+    const { container } = renderMarkdown({
+      content: "![alt](vellum://workspace/scratch/chart.png)",
+      attachments: [
+        makeAttachment({
+          id: "rehydrated:0",
+          filename: "chart.png",
+          mimeType: "image/png",
+        }),
+      ],
+      assistantId: "asst-1",
+    });
+
+    expect(screen.getByText("Image failed to load (alt)")).toBeTruthy();
+    expect(container.querySelector("img")).toBeNull();
+    expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
   });
 
   test("an image draws bytes another reader already cached, with no fetch of its own", async () => {

--- a/clients/web/src/hooks/use-in-view.test.tsx
+++ b/clients/web/src/hooks/use-in-view.test.tsx
@@ -68,13 +68,14 @@ function report(index: number, isIntersecting: boolean): void {
   });
 }
 
-function renderInView(rootMargin?: string) {
+function renderInView(threshold = 0) {
   const ref: RefObject<Element | null> = {
     current: document.createElement("div"),
   };
   return renderHook(
-    ({ margin }: { margin?: string }) => useInView(ref, { rootMargin: margin }),
-    { initialProps: { margin: rootMargin } },
+    ({ fraction }: { fraction: number }) =>
+      useInView(ref, { threshold: fraction }),
+    { initialProps: { fraction: threshold } },
   );
 }
 
@@ -93,11 +94,11 @@ afterAll(() => {
 });
 
 describe("useInView", () => {
-  test("hands rootMargin to the observer it builds", () => {
-    renderInView("200px");
+  test("observes the element against the threshold it was given", () => {
+    renderInView(0.5);
 
     expect(observers).toHaveLength(1);
-    expect(observers[0]!.options?.rootMargin).toBe("200px");
+    expect(observers[0]!.options?.threshold).toBe(0.5);
     expect(observers[0]!.observed).toHaveLength(1);
   });
 
@@ -114,13 +115,13 @@ describe("useInView", () => {
   });
 
   test("forgets its last answer when the observation ends", () => {
-    const { result, rerender } = renderInView("200px");
+    const { result, rerender } = renderInView(0);
     report(0, true);
     expect(result.current).toBe(true);
 
     // A changed option tears the observer down and builds another, which is
     // the same cleanup an unmount runs.
-    rerender({ margin: "400px" });
+    rerender({ fraction: 0.5 });
 
     expect(observers[0]!.disconnects).toBe(1);
     expect(observers).toHaveLength(2);
@@ -134,5 +135,18 @@ describe("useInView", () => {
     unmount();
 
     expect(observers[0]!.disconnects).toBe(1);
+  });
+
+  test("stays false, and observes nothing, without IntersectionObserver", () => {
+    // A caller that must draw regardless (the Chat Info tile's picture is its
+    // content) reads `typeof IntersectionObserver` itself rather than waiting
+    // on an answer this hook can never give.
+    delete (globalThis as { IntersectionObserver?: unknown })
+      .IntersectionObserver;
+
+    const { result } = renderInView();
+
+    expect(result.current).toBe(false);
+    expect(observers).toHaveLength(0);
   });
 });

--- a/clients/web/src/hooks/use-in-view.ts
+++ b/clients/web/src/hooks/use-in-view.ts
@@ -20,7 +20,6 @@ export function useInView(
   ref: RefObject<Element | null>,
   {
     threshold = 0,
-    rootMargin,
   }: {
     /**
      * Fraction of the element that must be showing to count as visible. The
@@ -28,8 +27,6 @@ export function useInView(
      * already see this, so don't show them a second copy of it".
      */
     threshold?: number;
-    /** Grows the viewport the element is tested against, e.g. `"200px"` to start loading just before it scrolls in. */
-    rootMargin?: string;
   } = {},
 ): boolean {
   const [inView, setInView] = useState(false);
@@ -47,7 +44,7 @@ export function useInView(
         }
         setInView(entry.isIntersecting);
       },
-      { threshold, rootMargin },
+      { threshold },
     );
     observer.observe(el);
     return () => {
@@ -57,7 +54,7 @@ export function useInView(
       // last "visible" answer behind and suppress the floating copy forever.
       setInView(false);
     };
-  }, [ref, threshold, rootMargin]);
+  }, [ref, threshold]);
 
   return inView;
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -137,6 +137,8 @@
     "closePreviewAria": "Close preview",
     "downloadAria": "Download {filename}",
     "downloadLabel": "Download",
+    "legacyUnavailable": "Preview unavailable. The file content was not preserved in chat history.",
+    "loadFailed": "Failed to load preview.",
     "nextAttachmentAria": "Next attachment",
     "pdfLoadFailed": "Couldn't display this PDF",
     "previewAria": "Preview of {filename}",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -133,6 +133,8 @@
     "closePreviewAria": "Cerrar vista previa",
     "downloadAria": "Descargar {filename}",
     "downloadLabel": "Descargar",
+    "legacyUnavailable": "Vista previa no disponible. El contenido del archivo no se conservó en el historial del chat.",
+    "loadFailed": "No se pudo cargar la vista previa.",
     "nextAttachmentAria": "Adjunto siguiente",
     "pdfLoadFailed": "No se pudo mostrar este PDF",
     "previewAria": "Vista previa de {filename}",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -55,6 +55,8 @@
     "unnamedAssistant": "Безымянный ассистент"
   },
   "attachmentPreviewModal": {
+    "legacyUnavailable": "Предпросмотр недоступен. Содержимое файла не сохранилось в истории чата.",
+    "loadFailed": "Не удалось загрузить предпросмотр.",
     "pdfLoadFailed": "Не удалось показать этот PDF"
   },
   "attachmentTile": {

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -132,6 +132,8 @@
     "closePreviewAria": "關閉預覽",
     "downloadAria": "下載 {filename}",
     "downloadLabel": "下載",
+    "legacyUnavailable": "預覽無法使用。檔案內容未保存於聊天記錄中。",
+    "loadFailed": "無法載入預覽。",
     "nextAttachmentAria": "下一個附件",
     "pdfLoadFailed": "無法顯示此 PDF",
     "previewAria": "{filename} 的預覽",

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -132,6 +132,8 @@
     "closePreviewAria": "关闭预览",
     "downloadAria": "下载 {filename}",
     "downloadLabel": "下载",
+    "legacyUnavailable": "预览不可用。文件内容未保存在聊天记录中。",
+    "loadFailed": "无法加载预览。",
     "nextAttachmentAria": "下一个附件",
     "pdfLoadFailed": "无法显示此 PDF",
     "previewAria": "{filename} 的预览",


### PR DESCRIPTION
## Summary
- the transcript squares, bubble attachments, and tool-result images pass the clicked index to the gallery, so rows sharing a legacy id open at the right position; squares key on position and id
- attachmentPreviewModal.legacyUnavailable and loadFailed replace two hardcoded strings in all five catalogs
- useInView drops the inert rootMargin option and gains a no-observer test; useAttachmentObjectUrl gains a suite; a 404 attachment is rendered as unavailable, not reported

Part of plan: chat-info-assets-panel.md (remediation round 6)