### PR TITLE
feat(gateway): mirror oauth_proxy_v1 and forward the verified subject over IPC

### DIFF
--- a/gateway/src/__tests__/scopes.test.ts
+++ b/gateway/src/__tests__/scopes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { resolveScopeProfile } from "../auth/scopes.js";
+import type { ScopeProfile } from "../auth/types.js";
 
 describe("resolveScopeProfile", () => {
   test("known profiles resolve to their scopes", () => {
@@ -11,6 +12,25 @@ describe("resolveScopeProfile", () => {
     expect(
       resolveScopeProfile("gateway_service_v1").has("settings.write"),
     ).toBe(true);
+  });
+
+  test("oauth_proxy_v1 grants oauth.proxy and nothing else", () => {
+    expect([...resolveScopeProfile("oauth_proxy_v1")]).toEqual(["oauth.proxy"]);
+  });
+
+  test("no other profile grants oauth.proxy", () => {
+    // Keyed by Exclude<...> so a new profile fails typecheck until listed.
+    const others: Record<Exclude<ScopeProfile, "oauth_proxy_v1">, true> = {
+      actor_client_v1: true,
+      gateway_ingress_v1: true,
+      gateway_service_v1: true,
+      local_v1: true,
+      speech_relay_v1: true,
+      ui_page_v1: true,
+    };
+    for (const profile of Object.keys(others) as ScopeProfile[]) {
+      expect(resolveScopeProfile(profile).has("oauth.proxy")).toBe(false);
+    }
   });
 
   test("unknown profiles resolve to no scopes, including prototype keys", () => {

--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -39,6 +39,9 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
     "internal.write",
   ]),
   local_v1: new Set<Scope>(["local.all"]),
+  // Mirrors the daemon profile a short-lived OAuth passthrough grant is
+  // minted with; the gateway resolves it on the IPC fast path.
+  oauth_proxy_v1: new Set<Scope>(["oauth.proxy"]),
   // Managed speech relay only (ATL-1033): the daemon's relay-dial token must
   // not open any other edge-scoped route.
   speech_relay_v1: new Set<Scope>(["speech.relay"]),

--- a/gateway/src/auth/token-exchange.ts
+++ b/gateway/src/auth/token-exchange.ts
@@ -47,6 +47,31 @@ export function validateEdgeToken(
 // ---------------------------------------------------------------------------
 
 /**
+ * Rewrite an edge sub's assistant segment to 'self', the daemon's internal
+ * scope constant. Service and unparseable subs become the gateway service sub.
+ */
+export function toDaemonSubject(edgeSub: string): string {
+  const parsed = parseSub(edgeSub);
+
+  if (!parsed.ok) {
+    log.warn(
+      { sub: edgeSub, reason: parsed.reason },
+      "Failed to parse edge token sub, using gateway service sub",
+    );
+    return "svc:gateway:self";
+  }
+
+  switch (parsed.principalType) {
+    case "actor":
+      return `actor:self:${parsed.actorPrincipalId}`;
+    case "local":
+      return `local:self:${parsed.conversationId}`;
+    default:
+      return "svc:gateway:self";
+  }
+}
+
+/**
  * Mint a short-lived exchange token (aud=vellum-daemon) from validated
  * edge claims. The sub claim's assistant segment is rewritten to 'self'
  * so the daemon always uses its internal scope constant.
@@ -55,36 +80,9 @@ export function mintExchangeToken(
   edgeClaims: TokenClaims,
   targetScopeProfile: ScopeProfile,
 ): string {
-  const parsed = parseSub(edgeClaims.sub);
-  let exchangeSub: string;
-
-  if (!parsed.ok) {
-    // If sub parsing fails, log and use a gateway service sub as fallback
-    log.warn(
-      { sub: edgeClaims.sub, reason: parsed.reason },
-      "Failed to parse edge token sub, using gateway service sub",
-    );
-    exchangeSub = "svc:gateway:self";
-  } else {
-    // Rewrite the assistant segment to 'self'
-    switch (parsed.principalType) {
-      case "actor":
-        exchangeSub = `actor:self:${parsed.actorPrincipalId}`;
-        break;
-      case "svc_gateway":
-        exchangeSub = "svc:gateway:self";
-        break;
-      case "local":
-        exchangeSub = `local:self:${parsed.conversationId}`;
-        break;
-      default:
-        exchangeSub = "svc:gateway:self";
-    }
-  }
-
   return mintToken({
     aud: "vellum-daemon",
-    sub: exchangeSub,
+    sub: toDaemonSubject(edgeClaims.sub),
     scope_profile: targetScopeProfile,
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: EXCHANGE_TOKEN_TTL_SECONDS,

--- a/gateway/src/auth/types.ts
+++ b/gateway/src/auth/types.ts
@@ -14,6 +14,7 @@ export type ScopeProfile =
   | "gateway_ingress_v1"
   | "gateway_service_v1"
   | "local_v1"
+  | "oauth_proxy_v1"
   | "speech_relay_v1"
   | "ui_page_v1";
 
@@ -38,7 +39,8 @@ export type Scope =
   | "feature_flags.read"
   | "feature_flags.write"
   | "speech.relay"
-  | "local.all";
+  | "local.all"
+  | "oauth.proxy";
 
 // ---------------------------------------------------------------------------
 // Principal types — derived from the sub pattern

--- a/gateway/src/http/routes/ipc-runtime-proxy.test.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.test.ts
@@ -86,7 +86,12 @@ mock.module("../../ipc/assistant-client.js", () => ({
   ipcCallAssistant: ipcCallAssistantMock,
 }));
 
-// Stub validateEdgeToken — default: auth passes
+// Stub validateEdgeToken — default: auth passes. The rest of the module
+// (notably toDaemonSubject, which the proxy uses to derive the forwarded
+// subject header) keeps its real implementation.
+const actualTokenExchange = await import("../../auth/token-exchange.js");
+const { toDaemonSubject } = actualTokenExchange;
+
 const validateEdgeTokenMock = mock(
   (
     _token: string,
@@ -99,6 +104,7 @@ const validateEdgeTokenMock = mock(
 );
 
 mock.module("../../auth/token-exchange.js", () => ({
+  ...actualTokenExchange,
   validateEdgeToken: validateEdgeTokenMock,
 }));
 
@@ -348,6 +354,52 @@ describe("tryIpcProxy", () => {
     expect(result!.status).toBe(502);
   });
 
+  test("replaces a spoofed x-vellum-subject with the verified subject", async () => {
+    validateEdgeTokenMock.mockImplementation(() => ({
+      ok: true,
+      claims: {
+        iss: "vellum-auth",
+        aud: "vellum-gateway",
+        sub: "local:asst_1:oauth-proxy.stripe_link",
+        scope_profile: "oauth_proxy_v1",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        policy_epoch: 1,
+      },
+    }));
+
+    const config = makeConfig({ runtimeProxyRequireAuth: true });
+    const req = makeRequest("/v1/health", {
+      headers: {
+        authorization: "Bearer valid",
+        "x-vellum-subject": "local:self:oauth-proxy.attacker",
+      },
+    });
+    await tryIpcProxy(req, config);
+
+    const [, params] = ipcCallAssistantMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const headers = params.headers as Record<string, string>;
+    expect(headers["x-vellum-subject"]).toBe(
+      "local:self:oauth-proxy.stripe_link",
+    );
+  });
+
+  test("strips x-vellum-subject when the request is unauthenticated", async () => {
+    const req = makeRequest("/v1/health", {
+      headers: { "x-vellum-subject": "local:self:oauth-proxy.attacker" },
+    });
+    await tryIpcProxy(req, makeConfig());
+
+    const [, params] = ipcCallAssistantMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const headers = params.headers as Record<string, string>;
+    expect(headers["x-vellum-subject"]).toBeUndefined();
+  });
+
   test("passes query params to IPC", async () => {
     const req = makeRequest("/v1/acp/sessions?limit=10&offset=5");
     await tryIpcProxy(req, makeConfig());
@@ -529,5 +581,22 @@ describe("policy enforcement", () => {
 
     const body = (await result!.json()) as { error: { message: string } };
     expect(body.error.message).toContain("Unable to determine principal type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: toDaemonSubject
+// ---------------------------------------------------------------------------
+
+describe("toDaemonSubject", () => {
+  test("rewrites the assistant segment to self", () => {
+    expect(toDaemonSubject("actor:asst_1:user_1")).toBe("actor:self:user_1");
+    expect(toDaemonSubject("svc:gateway:asst_1")).toBe("svc:gateway:self");
+    expect(toDaemonSubject("local:asst_1:conv_1")).toBe("local:self:conv_1");
+  });
+
+  test("falls back to the gateway service sub for unparseable subs", () => {
+    expect(toDaemonSubject("garbage")).toBe("svc:gateway:self");
+    expect(toDaemonSubject("")).toBe("svc:gateway:self");
   });
 });

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -15,7 +15,10 @@
 import { admitActorToken } from "../../auth/actor-token-revocation.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
-import { validateEdgeToken } from "../../auth/token-exchange.js";
+import {
+  toDaemonSubject,
+  validateEdgeToken,
+} from "../../auth/token-exchange.js";
 import type { TokenClaims } from "../../auth/types.js";
 import type { GatewayConfig } from "../../config.js";
 import {
@@ -147,15 +150,19 @@ export async function tryIpcProxy(
     }
   });
 
-  // Override caller-supplied identity headers with values derived from the
-  // verified JWT claims. The daemon's IPC adapter (`injectLocalActorHeader`)
-  // preserves any inbound `x-vellum-actor-principal-id`, so without this
-  // step a malicious client could spoof another user's principal id by
-  // setting the header explicitly. Mirrors the HTTP adapter's behavior in
+  // Override caller-supplied identity headers (`x-vellum-actor-principal-id`,
+  // `x-vellum-principal-type`, `x-vellum-subject`) with values derived from
+  // the verified JWT claims. The daemon's IPC adapter
+  // (`injectLocalActorHeader`) preserves any inbound
+  // `x-vellum-actor-principal-id`, so without this step a malicious client
+  // could spoof another user's principal id by setting the header explicitly.
+  // Mirrors the HTTP adapter's behavior in
   // `assistant/src/runtime/routes/http-adapter.ts`.
   delete headers["x-vellum-actor-principal-id"];
   delete headers["x-vellum-principal-type"];
+  delete headers["x-vellum-subject"];
   if (claims) {
+    headers["x-vellum-subject"] = toDaemonSubject(claims.sub);
     const sub = parseSub(claims.sub);
     if (sub.ok) {
       headers["x-vellum-principal-type"] = sub.principalType;


### PR DESCRIPTION
## Summary

- Mirror the daemon's new auth vocabulary in the gateway: `oauth.proxy` scope and `oauth_proxy_v1` profile (`{oauth.proxy}`). The gateway never enforces the daemon's proxy policy over HTTP, but its IPC fast path resolves profiles via `resolveScopeProfile`, where an unknown profile resolves to no scopes.
- Extract `toDaemonSubject(edgeSub)` out of `mintExchangeToken` (assistant segment rewritten to `self`, unparseable subs fall back to `svc:gateway:self` with the existing warn log). Minted token output is unchanged for every sub shape.
- The IPC runtime proxy now strips a caller-supplied `x-vellum-subject` and re-derives it from the verified claims, alongside the two identity headers it already overrode, so the daemon's proxy route can bind a grant to one provider.

Part of plan: oauth-proxy-passthrough.md (PR 3 of 8)