### PR TITLE
feat(runtime): hand route handlers the raw URL, raw bytes, and verified subject

### DIFF
--- a/assistant/src/runtime/routes/__tests__/http-adapter-passthrough.test.ts
+++ b/assistant/src/runtime/routes/__tests__/http-adapter-passthrough.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for the HTTP adapter's passthrough primitives: wire-exact `rawUrl`,
+ * unparsed `rawBody` under `rawRequestBody`, and the verified
+ * `x-vellum-subject` header.
+ *
+ * A proxy handler forwards what the caller actually sent, so the adapter must
+ * not normalize the URL, parse the body, or trust a caller-supplied subject.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { resolveScopeProfile } from "../../auth/scopes.js";
+import type { AuthContext } from "../../auth/types.js";
+import { routeDefinitionsToHTTPRoutes } from "../http-adapter.js";
+import type { RouteDefinition } from "../types.js";
+
+interface EchoResult {
+  body: Record<string, unknown> | null;
+  rawBody: number[] | null;
+  rawPathname: string | null;
+  rawSearch: string | null;
+  queryParams: Record<string, string>;
+  subject: string | null;
+}
+
+function echoRoute(rawRequestBody?: boolean): RouteDefinition {
+  return {
+    operationId: "echo_passthrough",
+    endpoint: "test/echo-passthrough",
+    method: "POST",
+    policy: null,
+    // Omitted, not `false`, when unset: the adapter's default path is what
+    // the regression guard exercises.
+    ...(rawRequestBody === undefined ? {} : { rawRequestBody }),
+    handler: ({ body, rawBody, rawUrl, queryParams, headers }) => ({
+      body: body ?? null,
+      rawBody: rawBody ? Array.from(rawBody) : null,
+      rawPathname: rawUrl?.pathname ?? null,
+      rawSearch: rawUrl?.search ?? null,
+      queryParams: queryParams ?? {},
+      subject: headers?.["x-vellum-subject"] ?? null,
+    }),
+  };
+}
+
+function buildAuthContext(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    subject: "local:self:abc",
+    principalType: "local",
+    assistantId: "self",
+    scopeProfile: "local_v1",
+    scopes: resolveScopeProfile("local_v1"),
+    policyEpoch: 0,
+    ...overrides,
+  };
+}
+
+async function invokeEcho(params: {
+  rawRequestBody?: boolean;
+  requestUrl?: string;
+  contentType?: string;
+  body?: BodyInit;
+  requestHeaders?: Record<string, string>;
+  authContext?: AuthContext;
+}): Promise<EchoResult> {
+  const [httpRoute] = routeDefinitionsToHTTPRoutes([
+    echoRoute(params.rawRequestBody),
+  ]);
+
+  const headers: Record<string, string> = { ...params.requestHeaders };
+  if (params.contentType) {
+    headers["content-type"] = params.contentType;
+  }
+
+  const req = new Request(
+    params.requestUrl ?? "http://daemon.local/v1/test/echo-passthrough",
+    { method: "POST", headers, body: params.body },
+  );
+
+  const response = await httpRoute.handler({
+    req,
+    url: new URL(req.url),
+    // The echo handler doesn't touch `server`; a stub is fine.
+    server: undefined as never,
+    authContext: params.authContext ?? buildAuthContext(),
+    params: {},
+  });
+
+  return (await response.json()) as EchoResult;
+}
+
+function bytesOf(text: string): number[] {
+  return Array.from(new TextEncoder().encode(text));
+}
+
+describe("http-adapter rawRequestBody", () => {
+  test("delivers unparsed bytes for a JSON content-type with an invalid body", async () => {
+    const payload = "{not: valid json,,,}";
+
+    const result = await invokeEcho({
+      rawRequestBody: true,
+      contentType: "application/json",
+      body: payload,
+    });
+
+    expect(result.rawBody).toEqual(bytesOf(payload));
+    expect(result.body).toBeNull();
+  });
+
+  test("delivers form-encoded bytes untouched", async () => {
+    const payload = "grant_type=client_credentials&scope=a+b";
+
+    const result = await invokeEcho({
+      rawRequestBody: true,
+      contentType: "application/x-www-form-urlencoded",
+      body: payload,
+    });
+
+    expect(result.rawBody).toEqual(bytesOf(payload));
+    expect(result.body).toBeNull();
+  });
+
+  test("delivers binary bytes untouched", async () => {
+    const payload = new Uint8Array([0x00, 0xff, 0x10, 0x7f, 0x80]);
+
+    const result = await invokeEcho({
+      rawRequestBody: true,
+      contentType: "application/octet-stream",
+      body: payload,
+    });
+
+    expect(result.rawBody).toEqual(Array.from(payload));
+    expect(result.body).toBeNull();
+  });
+
+  test("parses JSON as usual when the flag is absent", async () => {
+    const result = await invokeEcho({
+      contentType: "application/json",
+      body: JSON.stringify({ hello: "world" }),
+    });
+
+    expect(result.body).toEqual({ hello: "world" });
+    expect(result.rawBody).toBeNull();
+  });
+});
+
+describe("http-adapter rawUrl", () => {
+  test("keeps percent-encoding and repeated query keys the parsed params collapse", async () => {
+    const result = await invokeEcho({
+      requestUrl:
+        "http://daemon.local/v1/test/echo%2Fpassthrough?x=1&x=2&y=a%20b",
+      contentType: "application/json",
+      body: JSON.stringify({}),
+    });
+
+    expect(result.rawPathname).toBe("/v1/test/echo%2Fpassthrough");
+    expect(result.rawSearch).toBe("?x=1&x=2&y=a%20b");
+    expect(result.queryParams.x).toBe("2");
+    expect(result.queryParams.y).toBe("a b");
+  });
+});
+
+describe("http-adapter subject header", () => {
+  test("replaces a caller-supplied subject with the verified one", async () => {
+    const result = await invokeEcho({
+      contentType: "application/json",
+      body: JSON.stringify({}),
+      requestHeaders: { "x-vellum-subject": "local:self:spoofed" },
+      authContext: buildAuthContext({ subject: "local:self:abc" }),
+    });
+
+    expect(result.subject).toBe("local:self:abc");
+  });
+
+  test("injects the verified subject when the caller sends none", async () => {
+    const result = await invokeEcho({
+      contentType: "application/json",
+      body: JSON.stringify({}),
+      authContext: buildAuthContext({ subject: "local:self:oauth-proxy.demo" }),
+    });
+
+    expect(result.subject).toBe("local:self:oauth-proxy.demo");
+  });
+});

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -86,7 +86,12 @@ export function routeDefinitionsToHTTPRoutes(
           r.method === "PATCH" ||
           r.method === "DELETE"
         ) {
-          if (contentType.includes("application/json") || contentType === "") {
+          if (r.rawRequestBody) {
+            rawBody = new Uint8Array(await req.arrayBuffer());
+          } else if (
+            contentType.includes("application/json") ||
+            contentType === ""
+          ) {
             try {
               const parsed = (await req.json()) as Record<string, unknown>;
               if (parsed && typeof parsed === "object") {
@@ -106,8 +111,9 @@ export function routeDefinitionsToHTTPRoutes(
           headers[key] = value;
         });
 
-        // Strip any caller-supplied identity headers before deriving them
-        // from the verified AuthContext. On the HTTP path the actor identity
+        // Strip the caller-supplied actor-principal, principal-type, and
+        // subject headers before deriving them from the verified AuthContext.
+        // On the HTTP path the actor identity
         // always comes from the validated JWT — never from inbound headers —
         // so a request that carries these headers is either confused or
         // hostile. Without this, a caller whose token carries no
@@ -120,6 +126,7 @@ export function routeDefinitionsToHTTPRoutes(
         // the gateway IPC proxy (gateway/src/http/routes/ipc-runtime-proxy.ts).
         delete headers["x-vellum-actor-principal-id"];
         delete headers["x-vellum-principal-type"];
+        delete headers["x-vellum-subject"];
 
         // Inject auth context fields so transport-agnostic handlers can
         // resolve trust context without importing auth internals.
@@ -129,12 +136,16 @@ export function routeDefinitionsToHTTPRoutes(
         if (authContext?.principalType) {
           headers["x-vellum-principal-type"] = authContext.principalType;
         }
+        if (authContext?.subject) {
+          headers["x-vellum-subject"] = authContext.subject;
+        }
 
         const result = await r.handler({
           pathParams,
           queryParams,
           body,
           rawBody,
+          rawUrl: url,
           headers,
           abortSignal: req.signal,
         });

--- a/assistant/src/runtime/routes/types.ts
+++ b/assistant/src/runtime/routes/types.ts
@@ -102,11 +102,19 @@ export interface RouteHandlerArgs {
   body?: Record<string, unknown>;
   rawBody?: Uint8Array;
   /**
+   * The request URL exactly as received: percent-encoding intact in
+   * `pathname`, repeated keys intact in `search`. Set only by the HTTP
+   * adapter, so a handler that needs wire-exact input treats `undefined` as
+   * "not served over HTTP".
+   */
+  rawUrl?: URL;
+  /**
    * Caller identity headers, including `x-vellum-principal-type` (the verified
-   * principal type) and `x-vellum-actor-principal-id`. Both adapters derive
-   * these from a trusted source — HTTP from the verified `AuthContext`, IPC
-   * from `injectLocalActorHeader` — never from caller-supplied values, so
-   * handlers that elevate trust can gate on the header (e.g. `"local"`).
+   * principal type), `x-vellum-actor-principal-id`, and `x-vellum-subject`
+   * (the verified `AuthContext.subject`). Both adapters derive these from a
+   * trusted source (HTTP from the verified `AuthContext`, IPC from
+   * `injectLocalActorHeader`), never from caller-supplied values, so handlers
+   * that elevate trust can gate on the header (e.g. `"local"`).
    */
   headers?: Record<string, string>;
   /**
@@ -175,6 +183,12 @@ export interface RouteDefinition {
   pathParams?: RoutePathParam[];
   queryParams?: RouteQueryParam[];
   requestBody?: RouteRequestBody;
+  /**
+   * When true, the HTTP adapter skips JSON parsing for POST/PUT/PATCH/DELETE
+   * and delivers the request bytes untouched in `rawBody`, whatever the
+   * Content-Type. `body` stays undefined.
+   */
+  rawRequestBody?: boolean;
   responseBody?: RouteResponseBody;
   /**
    * HTTP status code for the success response. Defaults to "200".


### PR DESCRIPTION
## Summary

- `RouteHandlerArgs.rawUrl` gives HTTP-served handlers the request URL exactly as received: percent-encoding intact in `pathname`, repeated query keys intact in `search`. The IPC adapter never sets it, so `undefined` reads as "not served over HTTP".
- `RouteDefinition.rawRequestBody` opts a route out of JSON parsing for POST/PUT/PATCH/DELETE: the adapter hands over the request bytes untouched in `rawBody` whatever the Content-Type, and `body` stays undefined.
- The adapter now derives `x-vellum-subject` from the verified `AuthContext.subject`, stripping any caller-supplied value alongside the two existing identity headers.

Both new fields are additive and opt-in, so no existing route changes behavior. They are the primitives a transparent OAuth passthrough proxy route needs to forward what the caller actually sent.

Part of plan: oauth-proxy-passthrough.md (PR 1 of 8)