### PR TITLE
feat(auth): add the oauth.proxy scope and oauth_proxy_v1 profile

### DIFF
--- a/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
+++ b/assistant/src/runtime/auth/__tests__/guard-tests.test.ts
@@ -273,6 +273,7 @@ describe("scope profile contract", () => {
       "internal.write",
     ],
     local_v1: ["local.all"],
+    oauth_proxy_v1: ["oauth.proxy"],
     speech_relay_v1: ["speech.relay"],
     ui_page_v1: ["settings.read"],
   };
@@ -292,16 +293,7 @@ describe("scope profile contract", () => {
     // The type system ensures EXPECTED_PROFILES covers all ScopeProfile
     // values via the Record<ScopeProfile, ...> type. This test verifies
     // that resolveScopeProfile returns a non-empty set for each.
-    const profiles: ScopeProfile[] = [
-      "actor_client_v1",
-      "gateway_ingress_v1",
-      "gateway_service_v1",
-      "local_v1",
-      "speech_relay_v1",
-      "ui_page_v1",
-    ];
-
-    for (const profile of profiles) {
+    for (const profile of Object.keys(EXPECTED_PROFILES) as ScopeProfile[]) {
       const scopes = resolveScopeProfile(profile);
       expect(scopes.size).toBeGreaterThan(0);
     }

--- a/assistant/src/runtime/auth/__tests__/middleware.test.ts
+++ b/assistant/src/runtime/auth/__tests__/middleware.test.ts
@@ -28,6 +28,7 @@ mock.module("../../../config/env.js", () => ({
 
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
 import { authenticateRequest } from "../middleware.js";
+import { CURRENT_POLICY_EPOCH } from "../policy.js";
 import { initAuthSigningKey, mintToken } from "../token-service.js";
 import type { ScopeProfile, TokenAudience } from "../types.js";
 
@@ -322,4 +323,39 @@ describe("authenticateRequest for /v1/host-browser-result", () => {
       expect(result.context.actorPrincipalId).toBe("dev-bypass");
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// oauth_proxy_v1 grants: the narrow bearer a third-party CLI presents to the
+// OAuth passthrough route. Accepted on either audience, and carrying nothing
+// but oauth.proxy.
+// ---------------------------------------------------------------------------
+
+describe("authenticateRequest for oauth_proxy_v1 grants", () => {
+  test.each(["vellum-daemon", "vellum-gateway"] as const)(
+    "accepts an %s-audience grant and grants only oauth.proxy",
+    (aud) => {
+      const token = mintValidToken({
+        aud,
+        sub: "local:self:oauth-proxy.stripe_link",
+        scope_profile: "oauth_proxy_v1",
+        policy_epoch: CURRENT_POLICY_EPOCH,
+        ttlSeconds: 60,
+      });
+
+      const req = new Request(
+        "http://localhost/v1/oauth/proxy/stripe_link/v1/accounts",
+        { method: "GET", headers: { Authorization: `Bearer ${token}` } },
+      );
+
+      const result = authenticateRequest(req);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.context.principalType).toBe("local");
+        expect(result.context.conversationId).toBe("oauth-proxy.stripe_link");
+        expect(result.context.scopes.has("oauth.proxy")).toBe(true);
+        expect(result.context.scopes.has("settings.write")).toBe(false);
+      }
+    },
+  );
 });

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -28,6 +28,7 @@ mock.module("../../../config/env.js", () => ({
 }));
 
 import { enforcePolicy, type RoutePolicy } from "../route-policy.js";
+import { resolveScopeProfile } from "../scopes.js";
 import type { AuthContext, Scope } from "../types.js";
 
 /** Build a synthetic AuthContext for testing. */
@@ -63,6 +64,12 @@ const ACTOR_WRITE_POLICY: RoutePolicy = {
 const GATEWAY_INGRESS_POLICY: RoutePolicy = {
   requiredScopes: ["ingress.write"],
   allowedPrincipalTypes: ["svc_gateway"],
+};
+
+/** Policy guarding the OAuth passthrough route. */
+const OAUTH_PROXY_POLICY: RoutePolicy = {
+  requiredScopes: ["oauth.proxy"],
+  allowedPrincipalTypes: ["local"],
 };
 
 describe("enforcePolicy", () => {
@@ -141,6 +148,41 @@ describe("enforcePolicy", () => {
     // Has chat.write but not approval.write
     const ctx = buildTestContext({ scopes: ["chat.write"] });
     const result = enforcePolicy("compound", multiScopePolicy, ctx);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("allows a local principal holding oauth.proxy", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({
+      principalType: "local",
+      scopes: ["oauth.proxy"],
+    });
+    expect(enforcePolicy("oauth/proxy", OAUTH_PROXY_POLICY, ctx)).toBeNull();
+  });
+
+  test("oauth.proxy opens no other route", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({
+      principalType: "local",
+      scopes: ["oauth.proxy"],
+    });
+    const result = enforcePolicy(
+      "settings",
+      { requiredScopes: ["settings.write"], allowedPrincipalTypes: ["local"] },
+      ctx,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("a fully scoped actor client cannot reach the oauth proxy route", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({
+      principalType: "actor",
+      scopes: [...resolveScopeProfile("actor_client_v1")],
+    });
+    const result = enforcePolicy("oauth/proxy", OAUTH_PROXY_POLICY, ctx);
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
   });

--- a/assistant/src/runtime/auth/__tests__/scopes.test.ts
+++ b/assistant/src/runtime/auth/__tests__/scopes.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, test } from "bun:test";
 import { hasAllScopes, hasScope, resolveScopeProfile } from "../scopes.js";
 import type { AuthContext, Scope, ScopeProfile } from "../types.js";
 
+/** Every profile name; the Record keeps this list exhaustive. */
+const KNOWN_PROFILES = Object.keys({
+  actor_client_v1: true,
+  gateway_ingress_v1: true,
+  gateway_service_v1: true,
+  local_v1: true,
+  oauth_proxy_v1: true,
+  speech_relay_v1: true,
+  ui_page_v1: true,
+} satisfies Record<ScopeProfile, true>) as ScopeProfile[];
+
 /** Utility to create a minimal AuthContext with a given scope profile. */
 function makeCtx(profile: ScopeProfile): AuthContext {
   return {
@@ -88,6 +99,21 @@ describe("resolveScopeProfile", () => {
     const scopes = resolveScopeProfile("local_v1");
     expect(scopes.has("local.all")).toBe(true);
     expect(scopes.size).toBe(1);
+  });
+
+  test("oauth_proxy_v1 includes only oauth.proxy", () => {
+    const scopes = resolveScopeProfile("oauth_proxy_v1");
+    expect(scopes.has("oauth.proxy")).toBe(true);
+    expect(scopes.size).toBe(1);
+  });
+
+  test("no other profile grants oauth.proxy", () => {
+    for (const profile of KNOWN_PROFILES) {
+      if (profile === "oauth_proxy_v1") {
+        continue;
+      }
+      expect(resolveScopeProfile(profile).has("oauth.proxy")).toBe(false);
+    }
   });
 });
 

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -38,6 +38,9 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
     "internal.write",
   ]),
   local_v1: new Set<Scope>(["local.all"]),
+  // A grant minted for a third-party CLI to reach the OAuth passthrough
+  // route; it opens no other route.
+  oauth_proxy_v1: new Set<Scope>(["oauth.proxy"]),
   // Managed speech relay only (ATL-1033): the daemon's relay-dial token must
   // not open any other edge-scoped route.
   speech_relay_v1: new Set<Scope>(["speech.relay"]),

--- a/assistant/src/runtime/auth/types.ts
+++ b/assistant/src/runtime/auth/types.ts
@@ -14,6 +14,7 @@ export type ScopeProfile =
   | "gateway_ingress_v1"
   | "gateway_service_v1"
   | "local_v1"
+  | "oauth_proxy_v1"
   | "speech_relay_v1"
   | "ui_page_v1";
 
@@ -37,7 +38,8 @@ export type Scope =
   | "feature_flags.read"
   | "feature_flags.write"
   | "speech.relay"
-  | "local.all";
+  | "local.all"
+  | "oauth.proxy";
 
 // ---------------------------------------------------------------------------
 // Principal types — derived from the sub pattern


### PR DESCRIPTION
## Summary

- Adds the `oauth.proxy` scope and the `oauth_proxy_v1` profile that grants it and nothing else, the narrow bearer a third-party CLI will present to the OAuth passthrough route.
- Covers the grant end to end: profile resolution, route-policy enforcement (a local principal holding `oauth.proxy` passes, the same context is denied `settings.write`, and a fully scoped actor client is denied the proxy policy), and a `mintToken` -> `authenticateRequest` round trip on both the daemon and gateway audiences.
- Extends the exhaustive scope-profile contract in `guard-tests.test.ts` for the new profile, and derives its coverage loop from the same Record instead of a second hand-maintained list.

Part of plan: oauth-proxy-passthrough.md (PR 2 of 8)