### PR TITLE
feat(cli): assistant oauth proxy-url mints a passthrough grant for third-party CLIs

### DIFF
--- a/assistant/src/cli/commands/oauth/index.help.ts
+++ b/assistant/src/cli/commands/oauth/index.help.ts
@@ -31,6 +31,7 @@ Examples:
   assistant oauth status google
   assistant oauth ping google
   assistant oauth request --provider google /gmail/v1/users/me/messages
+  assistant oauth proxy-url stripe_link --export
   assistant oauth disconnect google`,
   subcommands: [
     {
@@ -867,6 +868,55 @@ Examples:
   $ assistant oauth token twitter --json
   $ assistant oauth token google --account user@gmail.com
   $ assistant oauth token google --client-id abc123`,
+    },
+    {
+      name: "proxy-url",
+      args: "<provider>",
+      description:
+        "Mint a short-lived grant that points a third-party CLI at the OAuth passthrough proxy",
+      options: [
+        {
+          flags: "--account <account>",
+          description:
+            "Pin one connected account (required when several are connected)",
+        },
+        {
+          flags: "--ttl <seconds>",
+          description: "Grant lifetime in seconds, 60 to 3600 (default: 900)",
+        },
+        {
+          flags: "--export",
+          description: "Print `export` lines for `eval` instead of JSON",
+        },
+      ],
+      helpText: `
+Arguments:
+  provider   Provider name (e.g. stripe_link, google).
+             Run 'assistant oauth providers list' to see all available
+             providers.
+
+Stock third-party CLIs expect to be handed an API base URL and an access
+token. This command produces both without ever revealing the provider
+credential: the grant it mints can reach only /v1/oauth/proxy/<provider>,
+and it expires. The third-party CLI attaches the grant as its own bearer
+token, and the proxy strips it and substitutes the real credential before
+forwarding the request to the provider. The printed base URL is
+gateway-based, so the CLI talks to the proxy rather than to the provider
+directly.
+
+Environment variables (printed as \`export\` lines with --export):
+  VELLUM_OAUTH_PROXY_BASE_URL     Proxy base URL to point the CLI at
+  VELLUM_OAUTH_PROXY_TOKEN        Short-lived grant to use as the bearer token
+  VELLUM_OAUTH_PROXY_ACCOUNT      Account the grant resolved to (omitted when
+                                  the connection carries no account)
+  VELLUM_OAUTH_PROXY_EXPIRES_AT   When the grant stops working
+
+Use 'assistant oauth status <provider>' to find account identifiers for
+--account.
+
+Examples:
+  $ assistant oauth proxy-url stripe_link
+  $ eval "$(assistant oauth proxy-url stripe_link --export)" && LINK_API_BASE_URL="$VELLUM_OAUTH_PROXY_BASE_URL" LINK_ACCESS_TOKEN="$VELLUM_OAUTH_PROXY_TOKEN" LINK_NO_REFRESH=1 link-cli payment-methods list --format json`,
     },
   ],
 };

--- a/assistant/src/cli/commands/oauth/index.ts
+++ b/assistant/src/cli/commands/oauth/index.ts
@@ -9,6 +9,7 @@ import { oauthHelp } from "./index.help.js";
 import { registerModeCommand } from "./mode.js";
 import { registerPingCommand } from "./ping.js";
 import { registerProviderCommands } from "./providers.js";
+import { registerProxyUrlCommand } from "./proxy-url.js";
 import { registerRequestCommand } from "./request.js";
 import { registerStatusCommand } from "./status.js";
 import { registerTokenCommand } from "./token.js";
@@ -74,6 +75,12 @@ export function registerOAuthCommand(program: Command): void {
       // -----------------------------------------------------------------------
 
       registerTokenCommand(oauth);
+
+      // -----------------------------------------------------------------------
+      // proxy-url: mint a passthrough-proxy grant for a third-party CLI
+      // -----------------------------------------------------------------------
+
+      registerProxyUrlCommand(oauth);
     },
   });
 }

--- a/assistant/src/cli/commands/oauth/proxy-url.test.ts
+++ b/assistant/src/cli/commands/oauth/proxy-url.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ipcCalls: Array<{ method: string; params: unknown }> = [];
+
+let ipcResult: {
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  statusCode?: number;
+} = { ok: true };
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params: unknown) => {
+    ipcCalls.push({ method, params });
+    return ipcResult;
+  },
+  exitFromIpcResult: (r: { error?: string }) => {
+    throw new Error(r.error ?? "IPC error");
+  },
+}));
+
+import { Command } from "commander";
+
+import { applyCommandHelp } from "../../lib/cli-command-help.js";
+import { oauthHelp } from "./index.help.js";
+import { registerProxyUrlCommand } from "./proxy-url.js";
+
+const GRANT = {
+  ok: true,
+  provider: "stripe_link",
+  account: "user@example.com",
+  baseUrl: "https://gateway.example.com/v1/oauth/proxy/stripe_link",
+  path: "/v1/oauth/proxy/stripe_link",
+  token: "grant-abc123",
+  expiresAt: "2026-01-01T00:15:00.000Z",
+  ttlSeconds: 900,
+};
+
+beforeEach(() => {
+  ipcCalls.length = 0;
+  process.exitCode = 0;
+  ipcResult = { ok: true, result: { ...GRANT } };
+});
+
+async function runProxyUrl(args: string[]): Promise<{
+  stdout: string;
+  exitCode: number;
+  error?: Error;
+}> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+    );
+    return true;
+  }) as typeof process.stdout.write;
+
+  let error: Error | undefined;
+  try {
+    const program = new Command();
+    program.exitOverride();
+    const oauth = program.command("oauth").description(oauthHelp.description);
+    applyCommandHelp(oauth, oauthHelp);
+    registerProxyUrlCommand(oauth);
+    const proxyUrl = oauth.commands.find((c) => c.name() === "proxy-url");
+    proxyUrl?.option("--json");
+    await program.parseAsync(["node", "test", "oauth", "proxy-url", ...args]);
+  } catch (err) {
+    error = err instanceof Error ? err : new Error(String(err));
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  return {
+    stdout: chunks.join(""),
+    exitCode: Number(process.exitCode ?? 0),
+    error,
+  };
+}
+
+describe("assistant oauth proxy-url", () => {
+  test("sends only the provider when no options are given", async () => {
+    await runProxyUrl(["stripe_link"]);
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "oauth_proxy_grant",
+        params: { body: { provider: "stripe_link" } },
+      },
+    ]);
+  });
+
+  test("forwards --account and --ttl in the request body", async () => {
+    await runProxyUrl([
+      "stripe_link",
+      "--account",
+      "user@example.com",
+      "--ttl",
+      "120",
+    ]);
+
+    expect(ipcCalls).toEqual([
+      {
+        method: "oauth_proxy_grant",
+        params: {
+          body: {
+            provider: "stripe_link",
+            account: "user@example.com",
+            ttlSeconds: 120,
+          },
+        },
+      },
+    ]);
+  });
+
+  test("prints the grant as pretty JSON by default", async () => {
+    const { stdout, exitCode } = await runProxyUrl(["stripe_link"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe(JSON.stringify(GRANT, null, 2) + "\n");
+  });
+
+  test("prints compact JSON with --json", async () => {
+    const { stdout } = await runProxyUrl(["--json", "stripe_link"]);
+
+    expect(stdout).toBe(JSON.stringify(GRANT) + "\n");
+  });
+
+  test("prints four export lines with --export, escaping single quotes", async () => {
+    ipcResult = {
+      ok: true,
+      result: { ...GRANT, account: "o'brien@example.com" },
+    };
+
+    const { stdout } = await runProxyUrl(["stripe_link", "--export"]);
+
+    expect(stdout.split("\n")).toEqual([
+      `export VELLUM_OAUTH_PROXY_BASE_URL='${GRANT.baseUrl}'`,
+      `export VELLUM_OAUTH_PROXY_TOKEN='${GRANT.token}'`,
+      `export VELLUM_OAUTH_PROXY_EXPIRES_AT='${GRANT.expiresAt}'`,
+      `export VELLUM_OAUTH_PROXY_ACCOUNT='o'\\''brien@example.com'`,
+      "",
+    ]);
+  });
+
+  test("omits the account export line when the grant carries no account", async () => {
+    ipcResult = { ok: true, result: { ...GRANT, account: null } };
+
+    const { stdout } = await runProxyUrl(["stripe_link", "--export"]);
+
+    expect(stdout).not.toContain("VELLUM_OAUTH_PROXY_ACCOUNT");
+    expect(stdout.trimEnd().split("\n")).toHaveLength(3);
+  });
+
+  test("--export ignores --json", async () => {
+    const { stdout } = await runProxyUrl(["--json", "stripe_link", "--export"]);
+
+    expect(stdout.startsWith("export VELLUM_OAUTH_PROXY_BASE_URL=")).toBe(true);
+  });
+
+  test("rejects a non-integer --ttl without calling IPC", async () => {
+    const { exitCode } = await runProxyUrl(["stripe_link", "--ttl", "abc"]);
+
+    expect(ipcCalls).toEqual([]);
+    expect(exitCode).toBe(2);
+  });
+
+  test("surfaces an IPC error through exitFromIpcResult", async () => {
+    ipcResult = {
+      ok: false,
+      error: "Unknown provider: nope",
+      statusCode: 404,
+    };
+
+    const { error } = await runProxyUrl(["nope"]);
+
+    expect(error?.message).toBe("Unknown provider: nope");
+  });
+});

--- a/assistant/src/cli/commands/oauth/proxy-url.ts
+++ b/assistant/src/cli/commands/oauth/proxy-url.ts
@@ -1,0 +1,96 @@
+import type { Command } from "commander";
+
+import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { subcommand } from "../../lib/cli-command-help.js";
+import { writeError, writeOutput } from "../../output.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire shape of the daemon's `oauth_proxy_grant` result. Declared here so the
+ * CLI stays off the daemon module graph.
+ */
+interface OAuthProxyGrantResponse {
+  ok: true;
+  provider: string;
+  account: string | null;
+  baseUrl: string;
+  path: string;
+  token: string;
+  expiresAt: string;
+  ttlSeconds: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Single-quote a value for `eval`, escaping embedded single quotes. */
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function formatExportLines(result: OAuthProxyGrantResponse): string {
+  const lines = [
+    `export VELLUM_OAUTH_PROXY_BASE_URL=${shellQuote(result.baseUrl)}`,
+    `export VELLUM_OAUTH_PROXY_TOKEN=${shellQuote(result.token)}`,
+    `export VELLUM_OAUTH_PROXY_EXPIRES_AT=${shellQuote(result.expiresAt)}`,
+  ];
+  if (result.account) {
+    lines.push(
+      `export VELLUM_OAUTH_PROXY_ACCOUNT=${shellQuote(result.account)}`,
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+export function registerProxyUrlCommand(oauth: Command): void {
+  subcommand(oauth, "proxy-url").action(
+    async (
+      provider: string,
+      opts: { account?: string; ttl?: string; export?: boolean },
+      cmd: Command,
+    ) => {
+      let ttlSeconds: number | undefined;
+      if (opts.ttl !== undefined) {
+        const parsed = Number.parseInt(opts.ttl, 10);
+        if (!Number.isInteger(parsed) || String(parsed) !== opts.ttl.trim()) {
+          writeError(
+            cmd,
+            `Invalid --ttl "${opts.ttl}": expected a whole number of seconds.`,
+          );
+          process.exitCode = 2;
+          return;
+        }
+        ttlSeconds = parsed;
+      }
+
+      const r = await cliIpcCall<OAuthProxyGrantResponse>("oauth_proxy_grant", {
+        body: {
+          provider,
+          ...(opts.account && { account: opts.account }),
+          ...(ttlSeconds !== undefined && { ttlSeconds }),
+        },
+      });
+
+      if (!r.ok) {
+        return exitFromIpcResult(r);
+      }
+
+      const result = r.result!;
+
+      if (opts.export) {
+        process.stdout.write(formatExportLines(result));
+        return;
+      }
+
+      writeOutput(cmd, result);
+    },
+  );
+}

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -922,6 +922,23 @@ describe("assistant subcommand classification", () => {
     expect(result.riskLevel).toBe("low");
   });
 
+  // The grant reaches a live provider API, so it must resolve to its own
+  // registry node rather than falling back to the low-risk bare `oauth` node.
+  test("assistant oauth proxy-url → medium", async () => {
+    const bare = await classifier.classify({
+      command: "assistant oauth",
+      toolName: "bash",
+    });
+    expect(bare.riskLevel).toBe("low");
+
+    const result = await classifier.classify({
+      command: "assistant oauth proxy-url stripe_link --export",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+    expect(result.reason).toContain("passthrough proxy");
+  });
+
   test("assistant credentials reveal → high", async () => {
     const result = await classifier.classify({
       command: "assistant credentials reveal",

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -427,6 +427,10 @@ describe("command-registry", () => {
       test("assistant oauth disconnect is medium risk", () => {
         expect(oauthSpec.subcommands!.disconnect.baseRisk).toBe("medium");
       });
+
+      test("assistant oauth proxy-url is medium risk", () => {
+        expect(oauthSpec.subcommands!["proxy-url"].baseRisk).toBe("medium");
+      });
     });
 
     // ── credentials subcommand ────────────────────────────────────────────
@@ -509,6 +513,7 @@ describe("command-registry", () => {
       expect(oauthSubs).toContain("request");
       expect(oauthSubs).toContain("connect");
       expect(oauthSubs).toContain("disconnect");
+      expect(oauthSubs).toContain("proxy-url");
     });
 
     test("credentials has all expected sub-subcommands", () => {

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -235,6 +235,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "oauth request",
   "oauth disconnect",
   "oauth token",
+  "oauth proxy-url",
   "platform",
   "platform connect",
   "platform status",
@@ -843,6 +844,12 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "oauth providers update", risk: "medium" },
   { path: "oauth providers delete", risk: "medium" },
   { path: "oauth apps delete", risk: "medium" },
+  {
+    path: "oauth proxy-url",
+    risk: "medium",
+    reason:
+      "Mints a scoped, expiring grant a third-party CLI presents to reach a provider API through the passthrough proxy",
+  },
   { path: "platform connect", risk: "low" },
   { path: "platform disconnect", risk: "medium" },
   { path: "platform callback-routes register", risk: "low" },


### PR DESCRIPTION
## Summary

- Adds `assistant oauth proxy-url <provider>`, which mints a short-lived grant over the `oauth_proxy_grant` IPC method and prints the gateway-based proxy base URL plus the grant a stock third-party CLI can consume. The grant can reach only `/v1/oauth/proxy/<provider>`, expires, and is swapped for the real credential by the proxy, so the third-party CLI never sees the provider token.
- `--export` prints shell-quoted `export` lines (`VELLUM_OAUTH_PROXY_BASE_URL`, `_TOKEN`, `_EXPIRES_AT`, and `_ACCOUNT` when the connection carries one) for `eval`; the default output is the JSON grant, compact under the global `--json`. `--account` pins one connected account and `--ttl` sets the grant lifetime.
- Declarative help lands in `oauth/index.help.ts` (including the `link-cli` one-liner example), and the CLI declares the wire result shape locally so it stays off the daemon module graph.

Part of plan: oauth-proxy-passthrough.md (PR 7 of 8)