### PR TITLE
feat(oauth): pure helpers for the OAuth passthrough route

### DIFF
--- a/assistant/src/runtime/http-errors.ts
+++ b/assistant/src/runtime/http-errors.ts
@@ -19,8 +19,10 @@ export type HttpErrorCode =
   | "BAD_REQUEST"
   | "CREDENTIAL_IN_USE"
   | "UNAUTHORIZED"
+  | "PAYMENT_REQUIRED"
   | "FORBIDDEN"
   | "NOT_FOUND"
+  | "METHOD_NOT_ALLOWED"
   | "CONFLICT"
   | "GONE"
   | "RATE_LIMITED"
@@ -28,6 +30,7 @@ export type HttpErrorCode =
   | "FAILED_DEPENDENCY"
   | "INTERNAL_ERROR"
   | "NOT_IMPLEMENTED"
+  | "BAD_GATEWAY"
   | "SERVICE_UNAVAILABLE";
 
 // ── Response type ────────────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/errors.ts
+++ b/assistant/src/runtime/routes/errors.ts
@@ -55,6 +55,13 @@ export class TooManyRequestsError extends RouteError {
   }
 }
 
+export class PaymentRequiredError extends RouteError {
+  constructor(message: string, details?: unknown) {
+    super(message, "PAYMENT_REQUIRED", 402, details);
+    this.name = "PaymentRequiredError";
+  }
+}
+
 export class ForbiddenError extends RouteError {
   constructor(message: string) {
     super(message, "FORBIDDEN", 403);
@@ -66,6 +73,13 @@ export class NotFoundError extends RouteError {
   constructor(message: string) {
     super(message, "NOT_FOUND", 404);
     this.name = "NotFoundError";
+  }
+}
+
+export class MethodNotAllowedError extends RouteError {
+  constructor(message: string, details?: unknown) {
+    super(message, "METHOD_NOT_ALLOWED", 405, details);
+    this.name = "MethodNotAllowedError";
   }
 }
 

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CredentialRequiredError,
+  InsufficientBalanceError,
+  ProviderUnreachableError,
+} from "../../oauth/platform-connection.js";
+import { BackendError } from "../../util/errors.js";
+import { BadRequestError, ForbiddenError, RouteError } from "./errors.js";
+import {
+  ambiguousConnectionError,
+  encodeProxyProviderSegment,
+  extractProxyRemainder,
+  mapProxyRequestError,
+  mapProxyResolveError,
+  materializeProxyResponse,
+  normalizeProxyPath,
+  parseProxyProviderSegment,
+  parseProxyQuery,
+  PROXY_PATH_PREFIX,
+  PROXY_ROUTE_ENDPOINT,
+  proxyGrantSubject,
+  sanitizeInboundHeaders,
+} from "./oauth-proxy-passthrough.js";
+
+const proxyUrl = (path: string): URL =>
+  new URL(`http://127.0.0.1:7821${PROXY_PATH_PREFIX}${path}`);
+
+const bodyText = async (body: BodyInit | null): Promise<string> =>
+  await new Response(body).text();
+
+describe("route constants", () => {
+  test("the endpoint pattern and the prefix agree", () => {
+    expect(PROXY_ROUTE_ENDPOINT).toBe("oauth/proxy/:provider/:path*");
+    expect(PROXY_PATH_PREFIX).toBe("/v1/oauth/proxy/");
+  });
+});
+
+describe("provider segment", () => {
+  test("round-trips a provider with an email account", () => {
+    const segment = encodeProxyProviderSegment("stripe_link", "a@example.com");
+    expect(segment).toBe("stripe_link@a%40example.com");
+    // The router percent-decodes before the handler sees the segment.
+    expect(parseProxyProviderSegment(decodeURIComponent(segment))).toEqual({
+      provider: "stripe_link",
+      account: "a@example.com",
+    });
+  });
+
+  test("omits the account when there is none", () => {
+    expect(encodeProxyProviderSegment("stripe_link")).toBe("stripe_link");
+    expect(parseProxyProviderSegment("stripe_link")).toEqual({
+      provider: "stripe_link",
+    });
+  });
+
+  test("splits at the first @ so accounts keep theirs", () => {
+    expect(parseProxyProviderSegment("google@a@b.example.com")).toEqual({
+      provider: "google",
+      account: "a@b.example.com",
+    });
+  });
+
+  test("an empty trailing account is treated as absent", () => {
+    expect(parseProxyProviderSegment("stripe_link@")).toEqual({
+      provider: "stripe_link",
+    });
+  });
+
+  test("rejects an empty provider or one carrying a slash", () => {
+    expect(() => parseProxyProviderSegment("")).toThrow(BadRequestError);
+    expect(() => parseProxyProviderSegment("@a@example.com")).toThrow(
+      BadRequestError,
+    );
+    expect(() => parseProxyProviderSegment("a/b")).toThrow(BadRequestError);
+  });
+});
+
+describe("proxyGrantSubject", () => {
+  test("names the provider the grant is bound to", () => {
+    expect(proxyGrantSubject("stripe_link")).toBe(
+      "local:self:oauth-proxy.stripe_link",
+    );
+  });
+});
+
+describe("extractProxyRemainder", () => {
+  test("preserves percent-encoding and a trailing slash", () => {
+    expect(
+      extractProxyRemainder(proxyUrl("stripe_link/v1/a%2Fb/items/?x=1")),
+    ).toBe("v1/a%2Fb/items/");
+  });
+
+  test("returns the remainder for a single-segment path", () => {
+    expect(extractProxyRemainder(proxyUrl("stripe_link/v1"))).toBe("v1");
+  });
+
+  test("is null when the provider segment is the whole path", () => {
+    expect(extractProxyRemainder(proxyUrl("stripe_link"))).toBeNull();
+    expect(extractProxyRemainder(proxyUrl("stripe_link/"))).toBeNull();
+  });
+});
+
+describe("normalizeProxyPath", () => {
+  test("prefixes a slash and keeps segments verbatim", () => {
+    expect(normalizeProxyPath("v1/a%2Fb/items")).toBe("/v1/a%2Fb/items");
+  });
+
+  test("keeps a trailing slash", () => {
+    expect(normalizeProxyPath("v1/items/")).toBe("/v1/items/");
+  });
+
+  test("resolves . and .. inside the path", () => {
+    expect(normalizeProxyPath("v1/items/../charges")).toBe("/v1/charges");
+    expect(normalizeProxyPath("v1/./items")).toBe("/v1/items");
+  });
+
+  test("a .. that consumes the path leaves the root", () => {
+    expect(normalizeProxyPath("v1/..")).toBe("/");
+    expect(normalizeProxyPath("v1/../")).toBe("/");
+  });
+
+  test("rejects a .. that climbs above the root", () => {
+    expect(() => normalizeProxyPath("../secrets")).toThrow(BadRequestError);
+    expect(() => normalizeProxyPath("v1/../../secrets")).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects a protocol-relative or absolute URL", () => {
+    expect(() => normalizeProxyPath("//evil.example")).toThrow(BadRequestError);
+    expect(() => normalizeProxyPath("/evil.example")).toThrow(BadRequestError);
+    expect(() => normalizeProxyPath("https://evil.example/x")).toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("rejects an empty interior segment", () => {
+    expect(() => normalizeProxyPath("a//b")).toThrow(BadRequestError);
+    expect(() => normalizeProxyPath("a//")).toThrow(BadRequestError);
+  });
+});
+
+describe("parseProxyQuery", () => {
+  test("collapses repeated keys into arrays in wire order", () => {
+    expect(parseProxyQuery("?x=1&q=a%20b&x=2")).toEqual({
+      x: ["1", "2"],
+      q: "a b",
+    });
+  });
+
+  test("a third repeat extends the array", () => {
+    expect(parseProxyQuery("?x=1&x=2&x=3")).toEqual({ x: ["1", "2", "3"] });
+  });
+
+  test("is undefined when there is no query", () => {
+    expect(parseProxyQuery("")).toBeUndefined();
+    expect(parseProxyQuery("?")).toBeUndefined();
+  });
+});
+
+describe("sanitizeInboundHeaders", () => {
+  test("strips every hop-by-hop, credential, and edge header", () => {
+    const stripped = [
+      "Authorization",
+      "proxy-authorization",
+      "proxy-authenticate",
+      "Host",
+      "content-length",
+      "keep-alive",
+      "transfer-encoding",
+      "te",
+      "trailer",
+      "upgrade",
+      "expect",
+      "accept-encoding",
+      "cookie",
+      "forwarded",
+      "x-real-ip",
+      "x-forwarded-for",
+      "x-forwarded-proto",
+      "x-vellum-subject",
+      "x-vellum-principal-type",
+    ];
+    const headers = Object.fromEntries(
+      stripped.map((name) => [name, "dropped"]),
+    );
+
+    expect(sanitizeInboundHeaders(headers)).toEqual({});
+  });
+
+  test("strips the connection header and everything it names", () => {
+    expect(
+      sanitizeInboundHeaders({
+        Connection: "keep-alive, X-Custom-Hop",
+        "x-custom-hop": "dropped",
+        "x-request-id": "req-1",
+      }),
+    ).toEqual({ "x-request-id": "req-1" });
+  });
+
+  test("passes content, negotiation, and custom headers through", () => {
+    const headers = {
+      "content-type": "application/json",
+      accept: "application/json",
+      "user-agent": "link-cli/1.2.3",
+      "x-request-id": "req-1",
+      "Stripe-Version": "2024-06-20",
+    };
+
+    expect(sanitizeInboundHeaders(headers)).toEqual(headers);
+  });
+});
+
+describe("materializeProxyResponse", () => {
+  const upstream = (
+    overrides: Partial<{
+      status: number;
+      headers: Record<string, string>;
+      body: unknown;
+    }> = {},
+  ) => ({
+    status: overrides.status ?? 200,
+    headers: overrides.headers ?? {},
+    body: "body" in overrides ? overrides.body : null,
+  });
+
+  test("drops framing headers and keeps the rest", () => {
+    const response = materializeProxyResponse(
+      upstream({
+        status: 201,
+        headers: {
+          "content-type": "application/json",
+          "x-rate-limit-remaining": "9",
+          "Content-Length": "999",
+          "content-encoding": "gzip",
+          "transfer-encoding": "chunked",
+          connection: "keep-alive",
+          "keep-alive": "timeout=5",
+          trailer: "Expires",
+          upgrade: "h2c",
+        },
+        body: { id: "pm_1" },
+      }),
+      "POST",
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.headers).toEqual({
+      "content-type": "application/json",
+      "x-rate-limit-remaining": "9",
+    });
+  });
+
+  test("serializes an object body and defaults its content type", async () => {
+    const response = materializeProxyResponse(
+      upstream({ body: { id: "pm_1" } }),
+      "GET",
+    );
+
+    expect(response.headers["content-type"]).toBe("application/json");
+    expect(await bodyText(response.body)).toBe(JSON.stringify({ id: "pm_1" }));
+  });
+
+  test("keeps an upstream content type over the JSON default", () => {
+    const response = materializeProxyResponse(
+      upstream({
+        headers: { "Content-Type": "application/vnd.api+json" },
+        body: { id: "pm_1" },
+      }),
+      "GET",
+    );
+
+    expect(response.headers).toEqual({
+      "Content-Type": "application/vnd.api+json",
+    });
+  });
+
+  test("encodes a string body as UTF-8 without touching the content type", async () => {
+    const response = materializeProxyResponse(
+      upstream({ headers: { "content-type": "text/plain" }, body: "héllo" }),
+      "GET",
+    );
+
+    expect(response.headers).toEqual({ "content-type": "text/plain" });
+    expect(await bodyText(response.body)).toBe("héllo");
+  });
+
+  test("passes a Uint8Array body through byte for byte", async () => {
+    const bytes = new Uint8Array([0, 1, 2, 253, 254, 255]);
+    const response = materializeProxyResponse(upstream({ body: bytes }), "GET");
+
+    expect(
+      new Uint8Array(await new Response(response.body).arrayBuffer()),
+    ).toEqual(bytes);
+  });
+
+  test("a null or undefined body becomes no body", () => {
+    expect(materializeProxyResponse(upstream({ body: null }), "GET").body).toBe(
+      null,
+    );
+    expect(
+      materializeProxyResponse(upstream({ body: undefined }), "GET").body,
+    ).toBe(null);
+  });
+
+  test("HEAD, 204, and 304 carry no body but keep their headers", () => {
+    const headers = { "content-type": "application/json", etag: 'W/"1"' };
+
+    for (const [status, method] of [
+      [200, "HEAD"],
+      [204, "DELETE"],
+      [304, "GET"],
+    ] as const) {
+      const response = materializeProxyResponse(
+        upstream({ status, headers, body: { id: "pm_1" } }),
+        method,
+      );
+      expect(response.body).toBeNull();
+      expect(response.status).toBe(status);
+      expect(response.headers).toEqual(headers);
+    }
+  });
+});
+
+describe("mapProxyResolveError", () => {
+  test("wraps a plain resolver error as a failed dependency", () => {
+    const mapped = mapProxyResolveError(
+      new Error("No active connection for stripe_link"),
+      "stripe_link",
+    );
+
+    expect(mapped.statusCode).toBe(424);
+    expect(mapped.code).toBe("FAILED_DEPENDENCY");
+    expect(mapped.message).toBe("No active connection for stripe_link");
+    expect(mapped.details).toEqual({
+      provider: "stripe_link",
+      reconnect: "assistant oauth connect stripe_link",
+    });
+  });
+
+  test("stringifies a non-Error throw", () => {
+    expect(mapProxyResolveError("missing scopes", "stripe_link").message).toBe(
+      "missing scopes",
+    );
+  });
+
+  test("returns a RouteError unchanged", () => {
+    const original = new ForbiddenError("nope");
+    expect(mapProxyResolveError(original, "stripe_link")).toBe(original);
+  });
+});
+
+describe("mapProxyRequestError", () => {
+  test("an expired credential asks the caller to reconnect", () => {
+    const mapped = mapProxyRequestError(
+      new CredentialRequiredError("Token revoked"),
+      "stripe_link",
+    );
+
+    expect(mapped.statusCode).toBe(424);
+    expect(mapped.message).toBe("Token revoked");
+    expect(mapped.details).toEqual({
+      provider: "stripe_link",
+      reconnect: "assistant oauth connect stripe_link",
+    });
+  });
+
+  test("an insufficient balance is payment required", () => {
+    const mapped = mapProxyRequestError(
+      new InsufficientBalanceError("Add funds"),
+      "stripe_link",
+    );
+
+    expect(mapped.statusCode).toBe(402);
+    expect(mapped.code).toBe("PAYMENT_REQUIRED");
+    expect(mapped.message).toBe("Add funds");
+  });
+
+  test("an unreachable provider is a bad gateway", () => {
+    const mapped = mapProxyRequestError(
+      new ProviderUnreachableError("Upstream 502"),
+      "stripe_link",
+    );
+
+    expect(mapped.statusCode).toBe(502);
+    expect(mapped.code).toBe("BAD_GATEWAY");
+    expect(mapped.message).toBe("Upstream 502");
+  });
+
+  test("returns a RouteError unchanged", () => {
+    const original = new RouteError("teapot", "TEAPOT", 418);
+    expect(mapProxyRequestError(original, "stripe_link")).toBe(original);
+  });
+
+  test("any other failure is a bad gateway carrying the message", () => {
+    expect(
+      mapProxyRequestError(
+        new BackendError("Platform proxy returned unexpected status 500"),
+        "stripe_link",
+      ),
+    ).toMatchObject({
+      statusCode: 502,
+      message: "Platform proxy returned unexpected status 500",
+    });
+    expect(
+      mapProxyRequestError(new TypeError("fetch failed"), "stripe_link"),
+    ).toMatchObject({ statusCode: 502, message: "fetch failed" });
+  });
+});
+
+describe("ambiguousConnectionError", () => {
+  test("names both accounts and how to pin one", () => {
+    const err = ambiguousConnectionError("stripe_link", [
+      "a@example.com",
+      "b@example.com",
+    ]);
+
+    expect(err.statusCode).toBe(409);
+    expect(err.message).toContain("a@example.com");
+    expect(err.message).toContain("b@example.com");
+    expect(err.message).toContain("stripe_link@a%40example.com");
+    expect(err.details).toEqual({
+      provider: "stripe_link",
+      accounts: ["a@example.com", "b@example.com"],
+      providerSegments: [
+        "stripe_link@a%40example.com",
+        "stripe_link@b%40example.com",
+      ],
+    });
+  });
+});

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
@@ -74,6 +74,21 @@ describe("provider segment", () => {
     );
     expect(() => parseProxyProviderSegment("a/b")).toThrow(BadRequestError);
   });
+
+  test("refuses to encode a provider key that would parse back wrong", () => {
+    // "vendor@region" would encode unchanged and parse back as provider
+    // "vendor" pinned to account "region".
+    expect(() => encodeProxyProviderSegment("vendor@region")).toThrow(
+      BadRequestError,
+    );
+    expect(() =>
+      encodeProxyProviderSegment("vendor@region", "a@example.com"),
+    ).toThrow(BadRequestError);
+    expect(() => encodeProxyProviderSegment("vendor/region")).toThrow(
+      BadRequestError,
+    );
+    expect(() => encodeProxyProviderSegment("")).toThrow(BadRequestError);
+  });
 });
 
 describe("proxyGrantSubject", () => {
@@ -157,6 +172,26 @@ describe("parseProxyQuery", () => {
     expect(parseProxyQuery("")).toBeUndefined();
     expect(parseProxyQuery("?")).toBeUndefined();
   });
+
+  test("a key naming an Object.prototype member is an ordinary key", () => {
+    const query = parseProxyQuery(
+      "?__proto__=polluted&constructor=c&toString=t",
+    );
+
+    expect(Object.entries(query ?? {})).toEqual([
+      ["__proto__", "polluted"],
+      ["constructor", "c"],
+      ["toString", "t"],
+    ]);
+    // The literal-object build would have mutated this prototype instead.
+    expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+  });
+
+  test("a repeated __proto__ collapses into an array like any other key", () => {
+    expect(
+      Object.entries(parseProxyQuery("?__proto__=a&__proto__=b") ?? {}),
+    ).toEqual([["__proto__", ["a", "b"]]]);
+  });
 });
 
 describe("sanitizeInboundHeaders", () => {
@@ -165,6 +200,7 @@ describe("sanitizeInboundHeaders", () => {
       "Authorization",
       "proxy-authorization",
       "proxy-authenticate",
+      "Proxy-Connection",
       "Host",
       "content-length",
       "keep-alive",
@@ -363,6 +399,54 @@ describe("mapProxyRequestError", () => {
     expect(mapped.details).toEqual({
       provider: "stripe_link",
       reconnect: "assistant oauth connect stripe_link",
+    });
+  });
+
+  // Stands in for `TokenExpiredError` from security/token-manager.js, which
+  // this pure module deliberately does not import.
+  const tokenExpiredError = (message: string): Error => {
+    const err = new Error(message);
+    err.name = "TokenExpiredError";
+    return err;
+  };
+
+  test("a BYO token expiry asks the caller to reconnect", () => {
+    const mapped = mapProxyRequestError(
+      tokenExpiredError(
+        'No access token found for "stripe_link". Authorization required.',
+      ),
+      "stripe_link",
+    );
+
+    expect(mapped.statusCode).toBe(424);
+    expect(mapped.details).toEqual({
+      provider: "stripe_link",
+      reconnect: "assistant oauth connect stripe_link",
+    });
+  });
+
+  test("a BYO 401 that survived a refresh asks the caller to reconnect", () => {
+    const err = new Error("HTTP 401 from stripe_link");
+    (err as Error & { status: number }).status = 401;
+
+    const mapped = mapProxyRequestError(err, "stripe_link");
+
+    expect(mapped.statusCode).toBe(424);
+    expect(mapped.message).toBe("HTTP 401 from stripe_link");
+    expect(mapped.details).toEqual({
+      provider: "stripe_link",
+      reconnect: "assistant oauth connect stripe_link",
+    });
+  });
+
+  test("another upstream status is still a bad gateway", () => {
+    const err = new Error("HTTP 403 from stripe_link");
+    (err as Error & { status: number }).status = 403;
+
+    expect(mapProxyRequestError(err, "stripe_link")).toMatchObject({
+      statusCode: 502,
+      code: "BAD_GATEWAY",
+      message: "HTTP 403 from stripe_link",
     });
   });
 

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
@@ -1,0 +1,338 @@
+/**
+ * Pure helpers for the OAuth passthrough proxy route
+ * (`/v1/oauth/proxy/:provider/:path*`).
+ *
+ * No DB, no network, no logging: the route and the grant command both build on
+ * these, and keeping them side-effect free keeps the wire semantics (path
+ * fidelity, header stripping, error mapping) testable in isolation.
+ */
+
+import {
+  isBinaryOAuthBody,
+  type OAuthConnectionResponse,
+} from "../../oauth/connection.js";
+import {
+  CredentialRequiredError,
+  InsufficientBalanceError,
+  ProviderUnreachableError,
+} from "../../oauth/platform-connection.js";
+import {
+  BadGatewayError,
+  BadRequestError,
+  ConflictError,
+  FailedDependencyError,
+  PaymentRequiredError,
+  RouteError,
+} from "./errors.js";
+import { RouteResponse } from "./types.js";
+
+/** Route pattern registered for every proxied HTTP method. */
+export const PROXY_ROUTE_ENDPOINT = "oauth/proxy/:provider/:path*";
+
+/** Everything after this prefix is the provider segment plus the upstream path. */
+export const PROXY_PATH_PREFIX = "/v1/oauth/proxy/";
+
+/**
+ * Number of leading `/`-separated pieces before the upstream path: the empty
+ * piece before the leading slash, then `v1`, `oauth`, `proxy`, and the
+ * provider segment.
+ */
+const PROXY_PATH_SEGMENT_COUNT = 5;
+
+/** Request headers that must never reach the provider. */
+const STRIPPED_REQUEST_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "proxy-authenticate",
+  "host",
+  "content-length",
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "te",
+  "trailer",
+  "upgrade",
+  "expect",
+  "accept-encoding",
+  "cookie",
+  "forwarded",
+  "x-real-ip",
+]);
+
+const TEXT_ENCODER = new TextEncoder();
+
+/** Response headers describing a framing this daemon re-does itself. */
+const STRIPPED_RESPONSE_HEADERS = new Set([
+  "content-length",
+  "content-encoding",
+  "transfer-encoding",
+  "connection",
+  "keep-alive",
+  "trailer",
+  "upgrade",
+]);
+
+/**
+ * Provider segment for a base URL. An account pins one connection when the
+ * provider has several.
+ */
+export function encodeProxyProviderSegment(
+  provider: string,
+  account?: string,
+): string {
+  return account ? `${provider}@${encodeURIComponent(account)}` : provider;
+}
+
+/**
+ * Inverse of {@link encodeProxyProviderSegment}. The router has already
+ * percent-decoded the segment, so an account containing `@` still parses:
+ * the split is at the first `@`.
+ */
+export function parseProxyProviderSegment(segment: string): {
+  provider: string;
+  account?: string;
+} {
+  const at = segment.indexOf("@");
+  const provider = at === -1 ? segment : segment.slice(0, at);
+  const account = at === -1 ? "" : segment.slice(at + 1);
+
+  if (!provider || provider.includes("/")) {
+    throw new BadRequestError(
+      `Invalid OAuth proxy provider segment: "${segment}"`,
+    );
+  }
+
+  return account ? { provider, account } : { provider };
+}
+
+/**
+ * Subject a proxy grant is minted with, and the value the route requires in
+ * `x-vellum-subject`, so a grant for one provider cannot reach another.
+ */
+export function proxyGrantSubject(provider: string): string {
+  return `local:self:oauth-proxy.${provider}`;
+}
+
+/**
+ * Upstream path as the caller wrote it, taken from the raw pathname so
+ * percent-encoding survives. Null when the provider segment is the whole path.
+ */
+export function extractProxyRemainder(rawUrl: URL): string | null {
+  const remainder = rawUrl.pathname
+    .split("/")
+    .slice(PROXY_PATH_SEGMENT_COUNT)
+    .join("/");
+  return remainder === "" ? null : remainder;
+}
+
+/**
+ * Resolve `.` and `..` and reject anything that could retarget the request
+ * (an absolute URL, `//host`, an empty segment). Segments are never decoded or
+ * re-encoded, so `%2F` reaches the provider as the caller wrote it.
+ */
+export function normalizeProxyPath(remainder: string): string {
+  const segments = remainder.split("/");
+  const trailingSlash = segments.length > 1 && segments.at(-1) === "";
+  if (trailingSlash) {
+    segments.pop();
+  }
+
+  const resolved: string[] = [];
+  for (const segment of segments) {
+    if (segment === "") {
+      throw new BadRequestError(
+        "Absolute URLs and empty path segments are not allowed",
+      );
+    }
+    if (segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      if (resolved.length === 0) {
+        throw new BadRequestError(
+          "The proxied path may not climb above the provider API base",
+        );
+      }
+      resolved.pop();
+      continue;
+    }
+    resolved.push(segment);
+  }
+
+  const path = `/${resolved.join("/")}`;
+  return trailingSlash && !path.endsWith("/") ? `${path}/` : path;
+}
+
+/**
+ * Decoded query parameters, repeated keys collapsed into arrays in wire order.
+ * Both connection classes re-encode these.
+ */
+export function parseProxyQuery(
+  search: string,
+): Record<string, string | string[]> | undefined {
+  const query: Record<string, string | string[]> = {};
+  for (const [key, value] of new URLSearchParams(search)) {
+    const existing = query[key];
+    if (existing === undefined) {
+      query[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      query[key] = [existing, value];
+    }
+  }
+  return Object.keys(query).length > 0 ? query : undefined;
+}
+
+/**
+ * Caller headers minus the daemon's own credential, hop-by-hop framing, and
+ * anything the edge injected. Content type, accept, user agent, and custom
+ * `x-*` headers pass through untouched.
+ */
+export function sanitizeInboundHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  const stripped = new Set(STRIPPED_REQUEST_HEADERS);
+  for (const token of findHeader(headers, "connection")?.split(",") ?? []) {
+    const listed = token.trim().toLowerCase();
+    if (listed) {
+      stripped.add(listed);
+    }
+  }
+
+  const sanitized: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    const lower = name.toLowerCase();
+    if (
+      stripped.has(lower) ||
+      lower.startsWith("x-forwarded-") ||
+      lower.startsWith("x-vellum-")
+    ) {
+      continue;
+    }
+    sanitized[name] = value;
+  }
+  return sanitized;
+}
+
+/**
+ * Turn a connection response into the bytes and headers the caller sees. The
+ * provider's status is preserved; framing headers are dropped because this
+ * response is re-framed on the way out.
+ */
+export function materializeProxyResponse(
+  upstream: OAuthConnectionResponse,
+  method: string,
+): RouteResponse {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(upstream.headers ?? {})) {
+    if (!STRIPPED_RESPONSE_HEADERS.has(name.toLowerCase())) {
+      headers[name] = value;
+    }
+  }
+
+  const bodyless =
+    method.toUpperCase() === "HEAD" ||
+    upstream.status === 204 ||
+    upstream.status === 304;
+  if (bodyless) {
+    return new RouteResponse(null, headers, upstream.status);
+  }
+
+  const body = upstream.body;
+  let bytes: BodyInit | null;
+  if (isBinaryOAuthBody(body)) {
+    // Re-wrapped because `BodyInit` rejects a `Uint8Array<ArrayBufferLike>`.
+    bytes = new Uint8Array(body);
+  } else if (typeof body === "string") {
+    bytes = TEXT_ENCODER.encode(body);
+  } else if (body === null || body === undefined) {
+    bytes = null;
+  } else {
+    bytes = TEXT_ENCODER.encode(JSON.stringify(body));
+    if (findHeader(headers, "content-type") === undefined) {
+      headers["content-type"] = "application/json";
+    }
+  }
+
+  return new RouteResponse(bytes, headers, upstream.status);
+}
+
+/**
+ * The resolver throws plain `Error`s for "no active connection", "missing
+ * prerequisites", and "missing scopes". All of them mean the caller's
+ * dependency is unavailable until they reconnect.
+ */
+export function mapProxyResolveError(
+  err: unknown,
+  provider: string,
+): RouteError {
+  if (err instanceof RouteError) {
+    return err;
+  }
+  return new FailedDependencyError(
+    errorMessage(err),
+    reconnectDetails(provider),
+  );
+}
+
+/** Map a connection-layer failure onto the status the caller should see. */
+export function mapProxyRequestError(
+  err: unknown,
+  provider: string,
+): RouteError {
+  if (err instanceof CredentialRequiredError) {
+    return new FailedDependencyError(err.message, reconnectDetails(provider));
+  }
+  if (err instanceof InsufficientBalanceError) {
+    return new PaymentRequiredError(err.message);
+  }
+  if (err instanceof ProviderUnreachableError) {
+    return new BadGatewayError(err.message);
+  }
+  if (err instanceof RouteError) {
+    return err;
+  }
+  return new BadGatewayError(errorMessage(err));
+}
+
+/**
+ * Several connections match the provider and the caller pinned none. The CLI
+ * prints only the message, so it names the accounts and how to pick one.
+ */
+export function ambiguousConnectionError(
+  provider: string,
+  accounts: string[],
+): ConflictError {
+  const providerSegments = accounts.map((account) =>
+    encodeProxyProviderSegment(provider, account),
+  );
+  const example = providerSegments[0] ?? provider;
+  return new ConflictError(
+    `Multiple ${provider} connections are available (${accounts.join(", ")}). ` +
+      `Pin one by putting its account in the provider segment of the base URL, for example "${example}".`,
+    { provider, accounts, providerSegments },
+  );
+}
+
+function reconnectDetails(provider: string): {
+  provider: string;
+  reconnect: string;
+} {
+  return { provider, reconnect: `assistant oauth connect ${provider}` };
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Case-insensitive lookup, since inbound header casing is the caller's. */
+function findHeader(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const target = name.toLowerCase();
+  return Object.entries(headers).find(
+    ([header]) => header.toLowerCase() === target,
+  )?.[1];
+}

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
@@ -16,6 +16,7 @@ import {
   InsufficientBalanceError,
   ProviderUnreachableError,
 } from "../../oauth/platform-connection.js";
+import type { TokenExpiredError } from "../../security/token-manager.js";
 import {
   BadGatewayError,
   BadRequestError,
@@ -44,6 +45,7 @@ const STRIPPED_REQUEST_HEADERS = new Set([
   "authorization",
   "proxy-authorization",
   "proxy-authenticate",
+  "proxy-connection",
   "host",
   "content-length",
   "connection",
@@ -75,11 +77,20 @@ const STRIPPED_RESPONSE_HEADERS = new Set([
 /**
  * Provider segment for a base URL. An account pins one connection when the
  * provider has several.
+ *
+ * A provider key carrying `@` or `/` would parse back as a different provider,
+ * so it is rejected here, where a grant is minted, rather than silently
+ * misrouting a request later.
  */
 export function encodeProxyProviderSegment(
   provider: string,
   account?: string,
 ): string {
+  if (!provider || provider.includes("@") || provider.includes("/")) {
+    throw new BadRequestError(
+      `An OAuth proxy provider key may not be empty or contain "@" or "/": "${provider}"`,
+    );
+  }
   return account ? `${provider}@${encodeURIComponent(account)}` : provider;
 }
 
@@ -166,11 +177,16 @@ export function normalizeProxyPath(remainder: string): string {
 /**
  * Decoded query parameters, repeated keys collapsed into arrays in wire order.
  * Both connection classes re-encode these.
+ *
+ * The record has a null prototype so a caller's `__proto__`, `constructor`, or
+ * `toString` parameter is a plain key rather than an inherited value.
  */
 export function parseProxyQuery(
   search: string,
 ): Record<string, string | string[]> | undefined {
-  const query: Record<string, string | string[]> = {};
+  const query: Record<string, string | string[]> = Object.create(
+    null,
+  ) as Record<string, string | string[]>;
   for (const [key, value] of new URLSearchParams(search)) {
     const existing = query[key];
     if (existing === undefined) {
@@ -281,8 +297,11 @@ export function mapProxyRequestError(
   err: unknown,
   provider: string,
 ): RouteError {
-  if (err instanceof CredentialRequiredError) {
-    return new FailedDependencyError(err.message, reconnectDetails(provider));
+  if (err instanceof CredentialRequiredError || isBYOCredentialFailure(err)) {
+    return new FailedDependencyError(
+      errorMessage(err),
+      reconnectDetails(provider),
+    );
   }
   if (err instanceof InsufficientBalanceError) {
     return new PaymentRequiredError(err.message);
@@ -312,6 +331,33 @@ export function ambiguousConnectionError(
     `Multiple ${provider} connections are available (${accounts.join(", ")}). ` +
       `Pin one by putting its account in the provider segment of the base URL, for example "${example}".`,
     { provider, accounts, providerSegments },
+  );
+}
+
+/**
+ * A BYO connection reports a dead credential either as `TokenExpiredError`
+ * (no token, or a refresh that cannot succeed) or, when a refreshed request
+ * still comes back 401, as an error carrying `status: 401`. Both mean the same
+ * thing the platform's `CredentialRequiredError` does: reconnect.
+ */
+function isBYOCredentialFailure(err: unknown): boolean {
+  return isTokenExpiredError(err) || hasUnauthorizedStatus(err);
+}
+
+/**
+ * Matched by name rather than `instanceof`: importing the class would pull the
+ * token manager's DB and secure-key graph into this side-effect-free module.
+ */
+function isTokenExpiredError(err: unknown): err is TokenExpiredError {
+  return err instanceof Error && err.name === "TokenExpiredError";
+}
+
+function hasUnauthorizedStatus(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    (err as { status: unknown }).status === 401
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds `oauth-proxy-passthrough.ts`, the dependency-free helper layer the OAuth passthrough route (`/v1/oauth/proxy/:provider/:path*`) and the grant route both build on: provider-segment encode/parse, grant subject, raw-path remainder extraction and normalization, query parsing, inbound header sanitization, upstream response materialization, and the resolve/request error mappings.
- Adds `PaymentRequiredError` (402) and `MethodNotAllowedError` (405) to the route error set, and catches `HttpErrorCode` up with `PAYMENT_REQUIRED`, `METHOD_NOT_ALLOWED`, and `BAD_GATEWAY` (the adapter already casts `BadGatewayError.code`).
- Colocated tests cover every helper: percent-encoding and trailing-slash fidelity, `..` resolution and root-escape rejection, protocol-relative and absolute URL rejection, repeated query keys, every stripped header plus the `connection`-listed case, response materialization across string/object/binary/null/HEAD/204, and each error mapping.

No DB, no network, no logging, so the wire semantics stay trivially testable ahead of the route itself.

Part of plan: oauth-proxy-passthrough.md (PR 4 of 8)