### PR TITLE
fix(web): restore Go to Conversation on scheduled notification cards

### DIFF
--- a/assistant/src/notifications/__tests__/notification-utils.test.ts
+++ b/assistant/src/notifications/__tests__/notification-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   collapseHorizontalWhitespace,
+  decodeLiteralLineBreaks,
   describeMedia,
   mediaEmbeds,
   sanitizeMultilineMessagePreview,
@@ -276,5 +277,17 @@ describe("describeMedia", () => {
 
   test("returns empty for no labels, leaving the fallback to the caller", () => {
     expect(describeMedia([])).toBe("");
+  });
+});
+
+describe("decodeLiteralLineBreaks", () => {
+  test("turns literal newline escapes into real line breaks", () => {
+    expect(decodeLiteralLineBreaks("Line one\\n\\nLine two")).toBe(
+      "Line one\n\nLine two",
+    );
+  });
+
+  test("leaves ordinary markdown alone", () => {
+    expect(decodeLiteralLineBreaks("**3 new emails**")).toBe("**3 new emails**");
   });
 });

--- a/assistant/src/notifications/__tests__/schedule-result-producer.test.ts
+++ b/assistant/src/notifications/__tests__/schedule-result-producer.test.ts
@@ -190,6 +190,21 @@ describe("emitScheduleResultNotification", () => {
     );
   });
 
+  test("turns literal newline escapes in the run body into real line breaks", async () => {
+    assistantRow = makeAssistantRow([
+      {
+        type: "text",
+        text: "Inbox pass:**\\n\\n•** First item worth review.",
+      },
+    ] as ContentBlock[]);
+
+    await run();
+
+    expect(emitCalls[0].contextPayload.requestedMessage).toBe(
+      "Inbox pass:**\n\n•** First item worth review.",
+    );
+  });
+
   test("stays silent when the run already notified itself", async () => {
     alreadyNotified = true;
 

--- a/assistant/src/notifications/notification-utils.ts
+++ b/assistant/src/notifications/notification-utils.ts
@@ -25,6 +25,21 @@ export function nonEmpty(value: string | null | undefined): string | undefined {
 }
 
 /**
+ * Models sometimes write the two-character sequence `\n` (or `\t`) instead of
+ * a real line break. Turn those into actual newlines so a briefing stored as
+ * a notification body still parses as markdown.
+ *
+ * Real newlines and tabs are left alone. A backslash that is not part of `\n`
+ * or `\t` is left alone too.
+ */
+export function decodeLiteralLineBreaks(text: string): string {
+  if (!text.includes("\\")) {
+    return text;
+  }
+  return text.replace(/\\n/g, "\n").replace(/\\t/g, "\t");
+}
+
+/**
  * Safely read a string property from an unknown-typed payload object.
  * Returns `undefined` when the payload is falsy, not an object, or the
  * key does not hold a string value.

--- a/assistant/src/notifications/schedule-result-producer.ts
+++ b/assistant/src/notifications/schedule-result-producer.ts
@@ -39,6 +39,7 @@ import type { ContentBlock } from "../providers/types.js";
 import { emitNotificationSignal } from "./emit-signal.js";
 import { hasNotifiedSourceContextSince } from "./events-store.js";
 import {
+  decodeLiteralLineBreaks,
   sanitizeNotificationTitle,
   stripMarkdownForPreview,
   truncate,
@@ -143,7 +144,7 @@ function resolveRunOutput(latestRow: MessageRow): string | undefined {
   if (!flattened) {
     return undefined;
   }
-  return truncate(text.trim(), MAX_RESULT_BODY_CHARS);
+  return truncate(decodeLiteralLineBreaks(text.trim()), MAX_RESULT_BODY_CHARS);
 }
 
 /**

--- a/clients/web/src/domains/home/components/notifications-bell-detail.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell-detail.tsx
@@ -51,11 +51,12 @@ export interface NotificationsBellDetailProps {
    */
   contentMaxHeight?: string;
   /**
-   * Ids of the conversations that still exist, merged from the foreground,
-   * background, and scheduled lists.
+   * Ids of conversations the by-id read has vouched for (or is still
+   * vouching for, while pending). Sidebar list membership is not consulted:
+   * scheduled runs are missing from the foreground list even when they exist.
    */
   validConversationIds: Set<string>;
-  /** True while any of those lists has yet to resolve. */
+  /** True while the by-id read for this item's conversation is in flight. */
   areConversationListsPending: boolean;
   /**
    * Links to the entities this notification names (its schedule, the skill it
@@ -113,7 +114,7 @@ export function NotificationsBellDetail({
   // request needs nothing of anyone, so the same name reads as plain text.
   const isTitleAwaitingAction = isPendingGuardianFeedItem(item);
 
-  // The lists start loading when this view opens, so validation has a pending
+  // The by-id read starts when this view opens, so validation has a pending
   // state a warm-cache surface would not have. Every
   // list a candidate link depends on has to land before any link becomes
   // reachable, so the buttons settle together rather than one at a time and a
@@ -122,10 +123,11 @@ export function NotificationsBellDetail({
     (conversationId !== null && areConversationListsPending) ||
     areEntityLinksPending;
 
-  // A link the lists have yet to vouch for still renders, holding the box it
-  // will occupy so the footer keeps its shape once validation resolves. One
-  // whose target turns out to be gone drops out (entity links are dropped by
-  // the resolver itself, the conversation link here).
+  // A link the by-id read (or an entity list) has yet to vouch for still
+  // renders, holding the box it will occupy so the footer keeps its shape
+  // once validation resolves. One whose target turns out to be gone drops
+  // out (entity links are dropped by the resolver itself, the conversation
+  // link here).
   const linkedConversationId =
     conversationId !== null &&
     (isValidationPending || validConversationIds.has(conversationId))

--- a/clients/web/src/domains/home/components/notifications-bell.test.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.test.tsx
@@ -186,6 +186,44 @@ mock.module("@/hooks/conversation-queries", () => ({
   ) => conversationListResult("scheduled", enabled),
 }));
 
+/**
+ * The by-id existence check the detail uses for "Go to Conversation". Default
+ * is that any named conversation still exists, matching production: a
+ * scheduled run is reachable even when it is in none of the sidebar lists.
+ * `missing` is the 404 case; `isPending` is the in-flight case.
+ */
+const conversationLinkRef: {
+  missing: Set<string>;
+  isPending: boolean;
+} = {
+  missing: new Set(),
+  isPending: false,
+};
+
+const conversationLinkEnabledCalls: boolean[] = [];
+
+mock.module("@/domains/home/hooks/use-feed-item-conversation-link", () => ({
+  useFeedItemConversationLink: (
+    conversationId: string | null,
+    assistantId: string | null | undefined,
+    enabled: boolean,
+  ) => {
+    const canFetch =
+      enabled && Boolean(assistantId) && Boolean(conversationId);
+    conversationLinkEnabledCalls.push(canFetch);
+    if (!conversationId || !canFetch) {
+      return { conversationId: null, isPending: false };
+    }
+    if (conversationLinkRef.isPending) {
+      return { conversationId, isPending: true };
+    }
+    if (conversationLinkRef.missing.has(conversationId)) {
+      return { conversationId: null, isPending: false };
+    }
+    return { conversationId, isPending: false };
+  },
+}));
+
 function conversation(conversationId: string): Conversation {
   return { conversationId } as Conversation;
 }
@@ -451,6 +489,9 @@ beforeEach(() => {
   enabledCalls.foreground = [];
   enabledCalls.background = [];
   enabledCalls.scheduled = [];
+  conversationLinkRef.missing = new Set();
+  conversationLinkRef.isPending = false;
+  conversationLinkEnabledCalls.length = 0;
   schedulesRef.list = [];
   schedulesRef.isPending = false;
   schedulesRef.isError = false;
@@ -1218,7 +1259,6 @@ describe("NotificationsBell detail", () => {
 
   test("offers Go to Conversation when the item has a conversation", async () => {
     feedRef.items = [{ ...FIRST, conversationId: "conversation-1" }];
-    conversationListsRef.foreground = [conversation("conversation-1")];
 
     await openDetail("Watcher job failed");
     fireEvent.click(screen.getByRole("button", { name: "Go to Conversation" }));
@@ -1255,10 +1295,27 @@ describe("NotificationsBell detail", () => {
     ).toBeTruthy();
   });
 
+  test("offers Go to Conversation for a scheduled run that is not in the sidebar lists", async () => {
+    feedRef.items = [
+      {
+        ...FIRST,
+        conversationId: "scheduled-1",
+        metadata: { scheduleId: "schedule-1" },
+      },
+    ];
+    schedulesRef.list = [schedule("schedule-1")];
+
+    await openDetail("Watcher job failed");
+
+    expect(screen.getByRole("button", { name: "View schedule" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Go to Conversation" }),
+    ).toBeTruthy();
+  });
+
   test("omits the conversation footer when the conversation is gone", async () => {
     feedRef.items = [{ ...FIRST, conversationId: "deleted-1" }];
-    conversationListsRef.foreground = [conversation("other-1")];
-    conversationListsRef.scheduled = [conversation("other-2")];
+    conversationLinkRef.missing.add("deleted-1");
 
     await openDetail("Watcher job failed");
 
@@ -1267,9 +1324,9 @@ describe("NotificationsBell detail", () => {
     ).toBeNull();
   });
 
-  test("withholds Go to Conversation while the lists are still loading", async () => {
+  test("withholds Go to Conversation while the conversation read is still loading", async () => {
     feedRef.items = [{ ...FIRST, conversationId: "background-1" }];
-    conversationListsRef.isPending = true;
+    conversationLinkRef.isPending = true;
 
     await openDetail("Watcher job failed");
 
@@ -1434,7 +1491,7 @@ describe("NotificationsBell detail", () => {
         metadata: { scheduleId: "schedule-1" },
       },
     ];
-    conversationListsRef.isPending = true;
+    conversationLinkRef.isPending = true;
     schedulesRef.isPending = true;
 
     await openDetail("Watcher job failed");
@@ -1467,7 +1524,7 @@ describe("NotificationsBell detail", () => {
         metadata: { scheduleId: "schedule-1" },
       },
     ];
-    conversationListsRef.isPending = true;
+    conversationLinkRef.isPending = true;
     schedulesRef.isPending = true;
 
     const { rerender } = render(<NotificationsBell />);
@@ -1483,8 +1540,7 @@ describe("NotificationsBell detail", () => {
       "Go to Conversation",
     ]);
 
-    conversationListsRef.isPending = false;
-    conversationListsRef.foreground = [conversation("conversation-1")];
+    conversationLinkRef.isPending = false;
     schedulesRef.isPending = false;
     schedulesRef.list = [schedule("schedule-1")];
     rerender(<NotificationsBell />);
@@ -1514,7 +1570,7 @@ describe("NotificationsBell detail", () => {
         metadata: { scheduleId: "deleted-2" },
       },
     ];
-    conversationListsRef.foreground = [conversation("other-1")];
+    conversationLinkRef.missing.add("deleted-1");
     schedulesRef.list = [schedule("other-2")];
 
     await openDetail("Watcher job failed");
@@ -1605,14 +1661,17 @@ describe("NotificationsBell detail", () => {
     await openBell();
 
     // The list view names its threads off whatever the caches already hold
-    // and fetches nothing for it: each conversation list is a drain of its
-    // whole bucket, and the bell renders on every route. Schedule and skill
-    // ids matter only to a detail's links, so those lists stay untouched
-    // too.
+    // and fetches nothing for it. Conversation lists stay cache-only: the
+    // Go to Conversation link is a by-id read, not a drain of every bucket.
+    // Schedule and skill ids matter only to a detail's links, so those lists
+    // stay untouched too.
     expect(enabledCalls.foreground.length).toBeGreaterThan(0);
     expect(enabledCalls.foreground.some((enabled) => enabled)).toBe(false);
     expect(enabledCalls.background.some((enabled) => enabled)).toBe(false);
     expect(enabledCalls.scheduled.some((enabled) => enabled)).toBe(false);
+    expect(conversationLinkEnabledCalls.some((enabled) => enabled)).toBe(
+      false,
+    );
     expect(skillsEnabledCalls.length).toBeGreaterThan(0);
     expect(skillsEnabledCalls.some((enabled) => enabled)).toBe(false);
     // The recipe gate reads the same list, but only for an empty feed, and
@@ -1623,11 +1682,27 @@ describe("NotificationsBell detail", () => {
     fireEvent.click(screen.getByRole("button", { name: "Watcher job failed" }));
     await act(async () => {});
 
-    expect(enabledCalls.foreground.at(-1)).toBe(true);
-    expect(enabledCalls.background.at(-1)).toBe(true);
-    expect(enabledCalls.scheduled.at(-1)).toBe(true);
+    expect(enabledCalls.foreground.at(-1)).toBe(false);
+    expect(enabledCalls.background.at(-1)).toBe(false);
+    expect(enabledCalls.scheduled.at(-1)).toBe(false);
+    // This item names no conversation, so the by-id read stays off.
+    expect(conversationLinkEnabledCalls.at(-1)).toBe(false);
     expect(skillsEnabledCalls.at(-1)).toBe(true);
     expect(schedulesEnabledCalls.some((enabled) => enabled)).toBe(true);
+  });
+
+  test("reads the conversation by id once a detail that names one is open", async () => {
+    feedRef.items = [{ ...FIRST, conversationId: "scheduled-1" }];
+
+    await openBell();
+    expect(conversationLinkEnabledCalls.some((enabled) => enabled)).toBe(
+      false,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Watcher job failed" }));
+    await act(async () => {});
+
+    expect(conversationLinkEnabledCalls.at(-1)).toBe(true);
   });
 
   test("reopening the bell lands back on the list", async () => {

--- a/clients/web/src/domains/home/components/notifications-bell.tsx
+++ b/clients/web/src/domains/home/components/notifications-bell.tsx
@@ -24,10 +24,11 @@ import {
 import { toast } from "@vellumai/design-library/components/toast";
 
 import type { HomeRecapRowDecision } from "../home-recap-row";
-import { useShouldOfferBriefingRecipe } from "../hooks/use-should-offer-briefing-recipe";
+import { useFeedItemConversationLink } from "../hooks/use-feed-item-conversation-link";
 import { useFeedItemEntityLinks } from "../hooks/use-feed-item-entity-links";
 import { useGuardianDecision } from "../hooks/use-guardian-decision";
 import { useHomeFeedQuery } from "../hooks/use-home-feed-query";
+import { useShouldOfferBriefingRecipe } from "../hooks/use-should-offer-briefing-recipe";
 import {
   clearAllArgs,
   getVisibleFeedItems,
@@ -138,30 +139,25 @@ export function NotificationsBell() {
   );
 
   // A notification can point at a conversation that has since been deleted, so
-  // the detail's "Go to Conversation" link is checked against the foreground,
-  // background, and scheduled lists merged. They load only while a detail is
-  // open: each list is a full drain of its bucket, the bell renders in the top
-  // bar on every route, and the list view has no use for the ids. Disabled,
-  // these stay subscribed to the caches without fetching, so the foreground
-  // list the chat layout already loaded is read for free and opening a
-  // detail costs the background and scheduled lists at most.
+  // the detail's "Go to Conversation" link is checked by id, not against the
+  // sidebar lists. Scheduled and background runs are absent from the
+  // foreground list, and the background drain drops scheduled rows, so list
+  // membership treats a live scheduled inbox-pass as gone. The by-id read is
+  // the same answer the chat route uses.
   //
-  // The rows name their threads off those same caches, and only off the
-  // caches: a title the sidebar has already loaded is shown, and one it has
-  // not is left to the row's source-label fallback rather than paid for with
-  // a drain of every bucket each time the panel opens.
-  const {
-    conversations: foregroundConversations,
-    isPending: isForegroundPending,
-  } = useConversationListQuery(assistantId, isDetailOpen);
-  const {
-    conversations: backgroundConversations,
-    isPending: isBackgroundPending,
-  } = useBackgroundConversationListQuery(assistantId, isDetailOpen);
-  const {
-    conversations: scheduledConversations,
-    isPending: isScheduledPending,
-  } = useScheduledConversationListQuery(assistantId, isDetailOpen);
+  // The rows still name their threads off the conversation-list caches, and
+  // only off the caches: a title the sidebar has already loaded is shown, and
+  // one it has not is left to the row's source-label fallback rather than paid
+  // for with a drain of every bucket. Those lists stay subscribed without
+  // fetching so a cache another surface already filled is read for free.
+  const { conversations: foregroundConversations } = useConversationListQuery(
+    assistantId,
+    false,
+  );
+  const { conversations: backgroundConversations } =
+    useBackgroundConversationListQuery(assistantId, false);
+  const { conversations: scheduledConversations } =
+    useScheduledConversationListQuery(assistantId, false);
   const mergedConversations = useMemo(
     () =>
       mergeConversationLists(
@@ -170,13 +166,6 @@ export function NotificationsBell() {
         scheduledConversations,
       ),
     [foregroundConversations, backgroundConversations, scheduledConversations],
-  );
-  const validConversationIds = useMemo(
-    () =>
-      new Set(
-        mergedConversations.map((conversation) => conversation.conversationId),
-      ),
-    [mergedConversations],
   );
   // Only conversations with a title: an untitled one leaves its row's thread
   // line to the source label, or to nothing.
@@ -189,8 +178,19 @@ export function NotificationsBell() {
     }
     return titles;
   }, [mergedConversations]);
-  const areConversationListsPending =
-    isForegroundPending || isBackgroundPending || isScheduledPending;
+
+  const conversationLink = useFeedItemConversationLink(
+    selectedItem?.conversationId ?? null,
+    assistantId,
+    isDetailOpen,
+  );
+  const validConversationIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (conversationLink.conversationId) {
+      ids.add(conversationLink.conversationId);
+    }
+    return ids;
+  }, [conversationLink.conversationId]);
 
   // A pending approval can be decided from its row, through the same hook
   // the detail card decides with, so every outcome (applied, declined for a
@@ -421,7 +421,7 @@ export function NotificationsBell() {
           contentHeight={contentHeight}
           contentMaxHeight={contentMaxHeight}
           validConversationIds={validConversationIds}
-          areConversationListsPending={areConversationListsPending}
+          areConversationListsPending={conversationLink.isPending}
           entityLinks={entityLinks}
           areEntityLinksPending={areEntityLinksPending}
           isActionPending={feedQuery.triggerAction.isPending}

--- a/clients/web/src/domains/home/decode-literal-line-breaks.test.ts
+++ b/clients/web/src/domains/home/decode-literal-line-breaks.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { decodeLiteralLineBreaks } from "./decode-literal-line-breaks";
+
+describe("decodeLiteralLineBreaks", () => {
+  test("leaves ordinary markdown alone", () => {
+    expect(
+      decodeLiteralLineBreaks("**3 new emails** and a calendar change."),
+    ).toBe("**3 new emails** and a calendar change.");
+  });
+
+  test("turns literal newline escapes into real line breaks", () => {
+    expect(decodeLiteralLineBreaks("Line one\\n\\nLine two")).toBe(
+      "Line one\n\nLine two",
+    );
+  });
+
+  test("turns literal tab escapes into real tabs", () => {
+    expect(decodeLiteralLineBreaks("col a\\tcol b")).toBe("col a\tcol b");
+  });
+
+  test("leaves a lone backslash that is not a line-break escape", () => {
+    expect(decodeLiteralLineBreaks("path\\file")).toBe("path\\file");
+  });
+});

--- a/clients/web/src/domains/home/decode-literal-line-breaks.ts
+++ b/clients/web/src/domains/home/decode-literal-line-breaks.ts
@@ -1,0 +1,14 @@
+/**
+ * Models sometimes write the two-character sequence `\n` (or `\t`) instead of
+ * a real line break. Markdown then treats the briefing as one line, which is
+ * what makes a scheduled-run card unreadable in the notifications bell.
+ *
+ * Real newlines and tabs are left alone. A backslash that is not part of `\n`
+ * or `\t` is left alone too.
+ */
+export function decodeLiteralLineBreaks(text: string): string {
+  if (!text.includes("\\")) {
+    return text;
+  }
+  return text.replace(/\\n/g, "\n").replace(/\\t/g, "\t");
+}

--- a/clients/web/src/domains/home/detail-panel/home-markdown-content.test.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-markdown-content.test.tsx
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
+
+import { HomeMarkdownContent } from "./home-markdown-content";
+
+describe("HomeMarkdownContent", () => {
+  test("renders literal newline escapes as separate paragraphs", () => {
+    render(<HomeMarkdownContent content={"First item.\\n\\nSecond item."} />);
+
+    expect(screen.getByText("First item.")).toBeTruthy();
+    expect(screen.getByText("Second item.")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/home/detail-panel/home-markdown-content.tsx
+++ b/clients/web/src/domains/home/detail-panel/home-markdown-content.tsx
@@ -5,6 +5,8 @@ import remarkGfm from "remark-gfm";
 import { handleNativeAnchorClick } from "@/utils/native-anchor";
 import { cn } from "@vellumai/design-library";
 
+import { decodeLiteralLineBreaks } from "../decode-literal-line-breaks";
+
 interface HomeMarkdownContentProps {
   content: string;
   className?: string;
@@ -167,7 +169,7 @@ export function HomeMarkdownContent({
         remarkPlugins={[remarkGfm]}
         components={markdownComponents}
       >
-        {content}
+        {decodeLiteralLineBreaks(content)}
       </ReactMarkdown>
     </div>
   );

--- a/clients/web/src/domains/home/feed-preview.test.ts
+++ b/clients/web/src/domains/home/feed-preview.test.ts
@@ -518,6 +518,12 @@ describe("flattenSummary", () => {
     ).toBe("Deploy failed The api never came up.");
   });
 
+  test("turns literal newline escapes into markdown line breaks before flattening", () => {
+    expect(flattenSummary("Line one\\n\\n**Line two**")).toBe(
+      "Line one Line two",
+    );
+  });
+
   test("returns an empty string for a summary with nothing renderable", () => {
     expect(flattenSummary("```\nconst a = 1;\n```")).toBe("");
   });

--- a/clients/web/src/domains/home/feed-preview.ts
+++ b/clients/web/src/domains/home/feed-preview.ts
@@ -10,6 +10,8 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 
+import { decodeLiteralLineBreaks } from "./decode-literal-line-breaks";
+
 /** Shortest continuation worth showing after the title's prefix is removed. */
 const MIN_PREVIEW_LENGTH = 12;
 
@@ -347,7 +349,9 @@ function capPreviewLength(value: string): string {
  * as markup by a screen reader.
  */
 export function flattenSummary(summary: string): string {
-  return capPreviewLength(flattenMarkdownBlocks(summary));
+  return capPreviewLength(
+    flattenMarkdownBlocks(decodeLiteralLineBreaks(summary)),
+  );
 }
 
 /**

--- a/clients/web/src/domains/home/hooks/use-feed-item-conversation-link.test.ts
+++ b/clients/web/src/domains/home/hooks/use-feed-item-conversation-link.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveConversationLink } from "./use-feed-item-conversation-link";
+
+describe("resolveConversationLink", () => {
+  test("offers no link when the item names no conversation", () => {
+    expect(
+      resolveConversationLink({
+        itemConversationId: null,
+        enabled: true,
+        isPending: false,
+        isError: false,
+        exists: false,
+      }),
+    ).toEqual({ conversationId: null, isPending: false });
+  });
+
+  test("holds the candidate id while the by-id read is in flight", () => {
+    expect(
+      resolveConversationLink({
+        itemConversationId: "conv-xyz",
+        enabled: true,
+        isPending: true,
+        isError: false,
+        exists: false,
+      }),
+    ).toEqual({ conversationId: "conv-xyz", isPending: true });
+  });
+
+  test("offers the link when the conversation still exists", () => {
+    expect(
+      resolveConversationLink({
+        itemConversationId: "conv-xyz",
+        enabled: true,
+        isPending: false,
+        isError: false,
+        exists: true,
+      }),
+    ).toEqual({ conversationId: "conv-xyz", isPending: false });
+  });
+
+  test("drops the link when the by-id read 404s", () => {
+    expect(
+      resolveConversationLink({
+        itemConversationId: "conv-gone",
+        enabled: true,
+        isPending: false,
+        isError: false,
+        exists: false,
+      }),
+    ).toEqual({ conversationId: null, isPending: false });
+  });
+
+  test("keeps the link when the by-id read fails for any other reason", () => {
+    expect(
+      resolveConversationLink({
+        itemConversationId: "conv-xyz",
+        enabled: true,
+        isPending: false,
+        isError: true,
+        exists: false,
+      }),
+    ).toEqual({ conversationId: "conv-xyz", isPending: false });
+  });
+
+  test("fetches nothing while the detail is closed", () => {
+    expect(
+      resolveConversationLink({
+        itemConversationId: "conv-xyz",
+        enabled: false,
+        isPending: true,
+        isError: false,
+        exists: false,
+      }),
+    ).toEqual({ conversationId: null, isPending: false });
+  });
+});

--- a/clients/web/src/domains/home/hooks/use-feed-item-conversation-link.ts
+++ b/clients/web/src/domains/home/hooks/use-feed-item-conversation-link.ts
@@ -1,0 +1,115 @@
+/**
+ * Resolves the "Go to Conversation" target for one feed item.
+ *
+ * Sidebar list membership is the wrong existence check: scheduled and
+ * background runs are stripped from the foreground list, the background drain
+ * drops scheduled rows, and a conversation that is archived or simply not in
+ * the drained window looks deleted. The by-id read is the same answer the
+ * chat route uses, so a scheduled inbox-pass card can still open its thread.
+ *
+ * A 404 drops the link. Any other failure keeps it: the feed already named
+ * the conversation, and the chat route handles a dead id.
+ */
+import { useQuery } from "@tanstack/react-query";
+
+import { conversationsByIdGet } from "@/generated/daemon/sdk.gen";
+import {
+  ApiError,
+  assertHasResponse,
+  extractErrorMessage,
+} from "@/utils/api-errors";
+
+export interface FeedItemConversationLinkResult {
+  /**
+   * Id to open, or `null` when the item names none or the by-id read 404ed.
+   * While the read is in flight this is the candidate id, so the footer can
+   * hold the button's box until validation lands.
+   */
+  conversationId: string | null;
+  /** True while the by-id read this item actually depends on is in flight. */
+  isPending: boolean;
+}
+
+/**
+ * Map one by-id read onto the footer link. Exported so the pending / 404 /
+ * error cases can be asserted without mounting the query.
+ */
+export function resolveConversationLink(args: {
+  itemConversationId: string | null;
+  enabled: boolean;
+  isPending: boolean;
+  isError: boolean;
+  /** `false` when the by-id read 404ed. `true` when it returned a row. */
+  exists: boolean;
+}): FeedItemConversationLinkResult {
+  const { itemConversationId, enabled, isPending, isError, exists } = args;
+  if (!itemConversationId || !enabled) {
+    return { conversationId: null, isPending: false };
+  }
+  if (isPending) {
+    return { conversationId: itemConversationId, isPending: true };
+  }
+  if (isError || exists) {
+    return { conversationId: itemConversationId, isPending: false };
+  }
+  return { conversationId: null, isPending: false };
+}
+
+/**
+ * Resolve the conversation a feed item opens, validated by id rather than by
+ * sidebar list membership.
+ *
+ * `enabled` gates the fetch. The bell renders in the top bar on every route
+ * and passes `false` until a detail is open, so its list view costs nothing.
+ */
+export function useFeedItemConversationLink(
+  itemConversationId: string | null,
+  assistantId: string | null | undefined,
+  enabled: boolean,
+): FeedItemConversationLinkResult {
+  const conversationId = itemConversationId;
+  const canFetch =
+    enabled && Boolean(assistantId) && Boolean(conversationId);
+
+  // Own cache, not the conversation-detail key: a 404 here is `false`, and
+  // other readers of `conversationsByIdGet` expect a row.
+  const query = useQuery({
+    queryKey: [
+      "feedItemConversationLink",
+      assistantId ?? "",
+      conversationId ?? "",
+    ],
+    enabled: canFetch,
+    staleTime: 30_000,
+    retry: false,
+    queryFn: async ({ signal }) => {
+      const { data, error, response } = await conversationsByIdGet({
+        path: {
+          assistant_id: assistantId ?? "",
+          id: conversationId ?? "",
+        },
+        throwOnError: false,
+        signal,
+      });
+      if (response?.status === 404) {
+        return false;
+      }
+      assertHasResponse(response, error, "Failed to fetch conversation.");
+      if (!response.ok) {
+        throw new ApiError(
+          response.status,
+          extractErrorMessage(error, response, "Failed to fetch conversation."),
+        );
+      }
+      return data?.conversation != null;
+    },
+  });
+
+  return resolveConversationLink({
+    itemConversationId: conversationId,
+    enabled: canFetch,
+    isPending: query.isPending,
+    isError: query.isError,
+    exists: query.data === true,
+  });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

iOS feedback (`01a08303-f586-7313-8564-a4a820d096bf`): a scheduled Inbox pass card in the notifications bell showed **View schedule** but no **Go to Conversation**, so the user could not open the thread to read the briefing or reply. The screenshot also showed literal `\n` sequences in the body instead of line breaks.

The footer required the feed item's `conversationId` to appear in the merged sidebar lists. Scheduled runs are excluded from the foreground list, and the background drain drops scheduled rows, so a live scheduled conversation looked deleted even though View schedule still resolved.

Validate that conversation with `GET /v1/conversations/:id` instead of list membership. A 404 still hides the button. Also decode literal `\n` / `\t` escapes in home-feed markdown (and in the schedule-result producer) so the briefing is readable in the card.

## Summary
- Notifications bell "Go to Conversation" is gated on a by-id existence check, not sidebar list membership.
- Scheduled inbox-pass cards keep the conversation button even when the thread is absent from Recents / Background.
- Literal `\n` escapes in briefing bodies become real line breaks in the detail panel and in new schedule-result notifications.

## Test Plan
- `clients/web`: notifications-bell tests (including a scheduled run that is in no sidebar list), conversation-link resolver, markdown decode, feed preview.
- `assistant`: schedule-result producer and notification-utils decode tests.

## Risk
Low. Conversation buttons that 404 still drop out. Transient by-id failures keep the link and let the chat route handle a dead id. No API contract or migration changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d94bbac-20e9-46b7-b2b7-7babf256500d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d94bbac-20e9-46b7-b2b7-7babf256500d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

