### PR TITLE
feat(chat): cap the streaming activity run and pin it to its newest row

### DIFF
--- a/clients/web/src/domains/chat/transcript/assistant-content-disclosure.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/assistant-content-disclosure.stories.tsx
@@ -272,7 +272,7 @@ const CRAWL_POOL: AssistantContentDisclosureItem[] = [
     key: "prose-4",
     node: (
       <CollapsedProse>
-        Comments are in rich_text, authored by Vargas. Re-running the sweep
+        Comments are in rich_text, authored by Alice. Re-running the sweep
         with proper extraction, ordered by time.
       </CollapsedProse>
     ),
@@ -317,7 +317,7 @@ const CRAWL_POOL: AssistantContentDisclosureItem[] = [
     node: (
       <SingleActivity
         variant="thinking"
-        content="Case found: CAS-112, a Discord customer. Now the original message."
+        content="Case found: case-123, a Discord customer. Now the original message."
       />
     ),
   },
@@ -339,7 +339,7 @@ const CRAWL_POOL: AssistantContentDisclosureItem[] = [
         toolCall={makeToolCall({
           id: "tc-case",
           name: "read_file",
-          input: { path: "CAS-112.md", activity: "Reading the case record" },
+          input: { path: "case-123.md", activity: "Reading the case record" },
         })}
       />
     ),

--- a/clients/web/src/domains/chat/transcript/assistant-content-disclosure.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/assistant-content-disclosure.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
 
@@ -197,4 +198,192 @@ export const Streaming: Story = {
     isStreaming: true,
     items: MIXED_RUN,
   },
+};
+
+/**
+ * A long run, one row at a time. Rows land every 900ms from this pool until
+ * it is spent, the way a turn that reads a dozen files does, so the story
+ * shows the crawl filling, hitting its cap, and then pinning to the newest
+ * row while the older ones fade out at the top edge.
+ */
+const CRAWL_POOL: AssistantContentDisclosureItem[] = [
+  {
+    key: "prose-1",
+    node: (
+      <CollapsedProse>
+        Let me find the feedback first. Most likely it&apos;s comments on the
+        Notion doc. Loading the comment-review skill to pull them.
+      </CollapsedProse>
+    ),
+  },
+  {
+    key: "thinking-1",
+    iconName: "brain",
+    node: (
+      <SingleActivity
+        variant="thinking"
+        content="No comments on the page-level anchor. They must be attached to individual blocks instead."
+      />
+    ),
+  },
+  {
+    key: "prose-2",
+    node: (
+      <CollapsedProse>
+        No page-level comments. They&apos;re probably anchored to individual
+        blocks, so I&apos;ll sweep all 52 blocks.
+      </CollapsedProse>
+    ),
+  },
+  {
+    key: "tool-1",
+    iconName: "file",
+    node: (
+      <SingleActivity
+        variant="tool"
+        toolCall={makeToolCall({
+          id: "tc-sweep",
+          name: "read_file",
+          input: { path: "blocks.json", activity: "Sweeping 52 blocks" },
+        })}
+      />
+    ),
+  },
+  {
+    key: "prose-3",
+    node: (
+      <CollapsedProse>
+        Found 20 comments but the markdown field came back empty. The field
+        structure must differ, so I&apos;ll dump one raw comment.
+      </CollapsedProse>
+    ),
+  },
+  {
+    key: "thinking-2",
+    iconName: "brain",
+    node: (
+      <SingleActivity
+        variant="thinking"
+        content="The comment markdown fields printed empty. The body is probably under rich_text."
+      />
+    ),
+  },
+  {
+    key: "prose-4",
+    node: (
+      <CollapsedProse>
+        Comments are in rich_text, authored by Vargas. Re-running the sweep
+        with proper extraction, ordered by time.
+      </CollapsedProse>
+    ),
+  },
+  {
+    key: "multi-1",
+    iconName: "terminal",
+    node: (
+      <div className="w-full">
+        <MultiActivityGroup
+          toolCalls={[
+            makeToolCall({
+              id: "tc-extract",
+              input: {
+                command: "notion comments --all",
+                activity: "Extracting 20 comments",
+              },
+            }),
+            makeToolCall({
+              id: "tc-sort",
+              input: { command: "sort -k time", activity: "Ordering by time" },
+            }),
+          ]}
+        />
+      </div>
+    ),
+  },
+  {
+    key: "prose-5",
+    node: (
+      <CollapsedProse>
+        All 20 comments extracted. Clear split: durable plan-writing rules for
+        the skill, and specific rewrites for the Interactive Tools doc. I need
+        three more inputs: the original customer message, the truth about
+        ui_show persistence, and per-tool token estimates.
+      </CollapsedProse>
+    ),
+  },
+  {
+    key: "thinking-3",
+    iconName: "brain",
+    node: (
+      <SingleActivity
+        variant="thinking"
+        content="Case found: CAS-112, a Discord customer. Now the original message."
+      />
+    ),
+  },
+  {
+    key: "prose-6",
+    node: (
+      <CollapsedProse>
+        Case found. Now the original customer message. Let me get the full case
+        output and check for notes or the linked activity.
+      </CollapsedProse>
+    ),
+  },
+  {
+    key: "tool-2",
+    iconName: "file",
+    node: (
+      <SingleActivity
+        variant="tool"
+        toolCall={makeToolCall({
+          id: "tc-case",
+          name: "read_file",
+          input: { path: "CAS-112.md", activity: "Reading the case record" },
+        })}
+      />
+    ),
+  },
+];
+
+const CRAWL_ROW_INTERVAL_MS = 900;
+
+/** Feeds `CRAWL_POOL` into a streaming disclosure one row at a time. */
+function StreamingCrawlHarness() {
+  const [count, setCount] = useState(2);
+  useEffect(() => {
+    if (count >= CRAWL_POOL.length) {
+      return;
+    }
+    const timer = setTimeout(
+      () => setCount((current) => current + 1),
+      CRAWL_ROW_INTERVAL_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [count]);
+  return (
+    <AssistantContentDisclosure
+      isStreaming
+      items={CRAWL_POOL.slice(0, count)}
+    />
+  );
+}
+
+/**
+ * Streaming, long enough to overflow the cap. The run holds at its capped
+ * height with the newest row pinned to the bottom edge and older rows fading
+ * out at the top. Drag up inside the run to read an earlier row; the crawl
+ * stops following until you scroll back to the bottom.
+ */
+export const StreamingCrawl: Story = {
+  render: () => <StreamingCrawlHarness />,
+};
+
+/**
+ * The same crawl at phone width, where the cap is shorter so the run leaves
+ * room for the composer and the reply below it.
+ */
+export const StreamingCrawlMobile: Story = {
+  render: () => <StreamingCrawlHarness />,
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
 };

--- a/clients/web/src/domains/chat/transcript/assistant-content-disclosure.tsx
+++ b/clients/web/src/domains/chat/transcript/assistant-content-disclosure.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useEffect, useState } from "react";
 import { Bolt, ChevronRight } from "lucide-react";
-import { Collapsible } from "@vellumai/design-library";
+import { Collapsible, ScrollShadow } from "@vellumai/design-library";
 
 import { useTranslation } from "@/i18n";
 
@@ -8,7 +8,18 @@ import type { IconName } from "@/domains/chat/components/tool-progress-card/deri
 import { ICON_MAP } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { cn } from "@/utils/misc";
 
+import { usePinnedToBottom } from "./use-pinned-to-bottom";
+
 const EARLIER_ACTIVITY_VALUE = "earlier-activity";
+
+/**
+ * Height cap on the live run while it streams. Sized in lines of the 13px /
+ * 20px collapsed prose: about six lines on a phone, about nine on a wider
+ * window, where the transcript has room to show more of the run without the
+ * run pushing the reply off screen. Tailwind's `sm` breakpoint keeps the two
+ * sizes in CSS alongside the rest of the transcript's width variants.
+ */
+const STREAMING_RUN_HEIGHT_CLASS = "max-h-[7.5rem] sm:max-h-[11.25rem]";
 
 /** One collapsed group, plus the glyph that marks it on the timeline. */
 export interface AssistantContentDisclosureItem {
@@ -48,6 +59,7 @@ export function AssistantContentDisclosure({
   isStreaming = false,
 }: AssistantContentDisclosureProps) {
   const { t } = useTranslation("chat");
+  const streamingRunRef = usePinnedToBottom();
   const [animateOnSettle] = useState(isStreaming);
   const [value, setValue] = useState(
     isStreaming ? EARLIER_ACTIVITY_VALUE : "",
@@ -101,15 +113,34 @@ export function AssistantContentDisclosure({
           {/* While streaming there is no trigger and nothing has been collapsed
               yet: this is the live turn's own work, which stays flush with the
               response. The timeline arrives with the trigger when the turn
-              settles, under cover of the collapse animation. */}
+              settles, under cover of the collapse animation.
+
+              The live run is capped in height and pinned to its newest row, so
+              a long turn reads as a crawl: new rows arrive at the bottom edge
+              and older ones fade out at the top instead of stacking up until
+              the run fills the viewport. Only the top edge fades, since the
+              bottom is where the newest row sits. The scrollbar is hidden so
+              the crawl reads as prose, and the box still scrolls, so a reader
+              who wants an earlier row can drag back up; `overscroll-contain`
+              stops that drag from bleeding into the transcript once it hits
+              the top. Once the turn settles the cap goes with the streaming
+              branch: the disclosure below shows the whole timeline. */}
           {isStreaming ? (
-            <div className="flex flex-col gap-2">
-              {items.map((item) => (
-                <div key={item.key} className="w-full">
-                  {item.node}
-                </div>
-              ))}
-            </div>
+            <ScrollShadow
+              ref={streamingRunRef}
+              fadeEdges="start"
+              size={32}
+              hideScrollBar
+              className={cn("overscroll-contain", STREAMING_RUN_HEIGHT_CLASS)}
+            >
+              <div className="flex flex-col gap-2">
+                {items.map((item) => (
+                  <div key={item.key} className="w-full">
+                    {item.node}
+                  </div>
+                ))}
+              </div>
+            </ScrollShadow>
           ) : (
             // 2px of daylight between the trigger's text and the glyph column
             // below it, so the timeline reads as nested under the trigger

--- a/clients/web/src/domains/chat/transcript/assistant-content-disclosure.tsx
+++ b/clients/web/src/domains/chat/transcript/assistant-content-disclosure.tsx
@@ -64,20 +64,38 @@ export function AssistantContentDisclosure({
   const [value, setValue] = useState(
     isStreaming ? EARLIER_ACTIVITY_VALUE : "",
   );
+  // Whether the current open state came from the user's own click rather
+  // than the streaming pin. On settle the pin lets go one frame after
+  // `isStreaming` drops, and for that frame the run is still open: it keeps
+  // the capped live treatment until the accordion has actually closed, so the
+  // whole timeline never expands for a painted frame and then animates shut.
+  // A run the user opens afterwards shows the uncapped timeline.
+  const [openedByUser, setOpenedByUser] = useState(false);
 
   useEffect(() => {
-    const frame = requestAnimationFrame(() =>
-      setValue(isStreaming ? EARLIER_ACTIVITY_VALUE : ""),
-    );
+    const frame = requestAnimationFrame(() => {
+      setValue(isStreaming ? EARLIER_ACTIVITY_VALUE : "");
+      if (isStreaming) {
+        setOpenedByUser(false);
+      }
+    });
     return () => cancelAnimationFrame(frame);
   }, [isStreaming]);
+
+  const handleValueChange = (next: string) => {
+    setValue(next);
+    setOpenedByUser(next === EARLIER_ACTIVITY_VALUE);
+  };
+
+  const showsLiveRun =
+    isStreaming || (value === EARLIER_ACTIVITY_VALUE && !openedByUser);
 
   return (
     <Collapsible.Root
       type="single"
       collapsible
       value={isStreaming ? EARLIER_ACTIVITY_VALUE : value}
-      onValueChange={setValue}
+      onValueChange={handleValueChange}
     >
       <Collapsible.Item value={EARLIER_ACTIVITY_VALUE}>
         <Collapsible.Trigger
@@ -123,9 +141,9 @@ export function AssistantContentDisclosure({
               the crawl reads as prose, and the box still scrolls, so a reader
               who wants an earlier row can drag back up; `overscroll-contain`
               stops that drag from bleeding into the transcript once it hits
-              the top. Once the turn settles the cap goes with the streaming
-              branch: the disclosure below shows the whole timeline. */}
-          {isStreaming ? (
+              the top. Once the turn settles and the run has closed, the cap
+              goes with it: a run the user reopens shows the whole timeline. */}
+          {showsLiveRun ? (
             <ScrollShadow
               ref={streamingRunRef}
               fadeEdges="start"

--- a/clients/web/src/domains/chat/transcript/use-pinned-to-bottom.ts
+++ b/clients/web/src/domains/chat/transcript/use-pinned-to-bottom.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Distance from the bottom (px) at or below which the box counts as pinned to
+ * its newest content and auto-follows growth. Generous enough that a
+ * sub-line of overshoot on iOS rubber-banding does not un-pin it, tight
+ * enough that a deliberate drag up does.
+ */
+const PINNED_THRESHOLD_PX = 24;
+
+/**
+ * Keeps a height-capped scroll box pinned to its newest content while that
+ * content grows, the way a credits crawl holds the latest line at the bottom
+ * edge. The moment the user scrolls up the box stops following; scrolling
+ * back to the bottom re-engages it.
+ *
+ * Returns a callback ref to attach to the scroll container. The hook owns the
+ * element via state so its observers attach the moment the container mounts,
+ * which a plain ref object would miss when the box renders conditionally.
+ *
+ * The container's first element child is the observed content: a wrapper the
+ * caller renders inside the scroll box (`ScrollShadow` provides one). Watching
+ * the content rather than the container matters because a `max-height` box
+ * never resizes once its content overflows.
+ */
+export function usePinnedToBottom(): (el: HTMLDivElement | null) => void {
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+  const isPinnedRef = useRef(true);
+
+  const ref = useCallback((el: HTMLDivElement | null) => {
+    setScrollEl((prev) => {
+      if (el !== prev) {
+        isPinnedRef.current = true;
+      }
+      return el;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!scrollEl) {
+      return;
+    }
+    const pin = () => {
+      // Instant rather than smooth: a smooth scroll on every streamed delta
+      // stutters, and its intermediate scroll events would read as the user
+      // dragging away from the bottom.
+      scrollEl.scrollTo({ top: scrollEl.scrollHeight, behavior: "auto" });
+    };
+    const classify = () => {
+      const maxScrollTop = Math.max(
+        0,
+        scrollEl.scrollHeight - scrollEl.clientHeight,
+      );
+      const distanceFromBottom = Math.max(0, maxScrollTop - scrollEl.scrollTop);
+      isPinnedRef.current = distanceFromBottom <= PINNED_THRESHOLD_PX;
+    };
+
+    scrollEl.addEventListener("scroll", classify, { passive: true });
+
+    const content = scrollEl.firstElementChild;
+    const observer =
+      content && typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => {
+            if (isPinnedRef.current) {
+              pin();
+            }
+          })
+        : null;
+    if (content) {
+      observer?.observe(content);
+    }
+    pin();
+
+    return () => {
+      scrollEl.removeEventListener("scroll", classify);
+      observer?.disconnect();
+    };
+  }, [scrollEl]);
+
+  return ref;
+}


### PR DESCRIPTION
## Summary

While a turn streams, the muted "earlier activity" run (interim prose, thinking links, tool links) grew without bound. A turn with a dozen tool calls pushed the composer and the eventual reply off screen, worst on phones.

This caps the live run and turns it into a crawl:

- The streaming branch of `AssistantContentDisclosure` now wraps its rows in the design library's `ScrollShadow` with a height cap, a top-only fade, and a hidden scrollbar.
- A new `usePinnedToBottom` hook watches the content with a ResizeObserver and keeps the box scrolled to the newest row, so rows land at the bottom and older ones fade out at the top. Drag up inside the run and it stops following until you scroll back to the bottom. `overscroll-contain` keeps that drag from bleeding into the transcript.
- The cap only applies while streaming. Once the turn settles the existing collapse into "Earlier activity" takes over, and the expanded timeline is uncapped.

| Width | Cap |
| --- | --- |
| Phone (below `sm`) | 7.5rem, about 6 lines of the 13px prose |
| Desktop | 11.25rem, about 9 lines |

Both live in one constant (`STREAMING_RUN_HEIGHT_CLASS`) so they are easy to tune.

## Stories

`Chat/AssistantContentDisclosure` gains `StreamingCrawl` and `StreamingCrawlMobile`. Each feeds twelve rows in one at a time (900ms apart) so the crawl can be watched filling, hitting the cap, and pinning.

## Verification

- `bunx tsc --noEmit` clean, eslint clean on the touched files
- `bun test src/domains/chat/transcript/transcript-message-body.test.tsx`: 82 pass
- Headless Chromium run of both stories confirmed the box holds at the cap, stays pinned to the bottom as rows land, and applies the top fade mask
- Visually QA'd in Storybook at desktop and phone widths

## Design note

Uses the existing `ScrollShadow` primitive from `@vellumai/design-library` rather than a bespoke fade. Nested scrolling over the crawl scrolls the crawl first and then chains to the transcript, which is standard browser behaviour; if that ever feels grabby the box can be made non-interactive with one class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbDLwNdFrdLqZY19x6GEDv