### PR TITLE
chore(plugins): bump imessage marketplace pin to 41b8e9a

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -219,7 +219,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/imessage",
-        "ref": "01701eb1be4074f99371af90fc4340fdd1674efb"
+        "ref": "41b8e9ad87b4975bf3fbdc9a8e46deda489d3d51"
       },
       "description": "iMessage and SMS channel for the Vellum assistant, backed by a Photon line.",
       "category": "productivity",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Repin the curated iMessage plugin to the latest `vellum-ai/imessage` `main` commit so catalog installs pick up the merged conversational setup path.

## Summary

- Bump `plugins/marketplace.json` `imessage.source.ref` from `01701eb1be4074f99371af90fc4340fdd1674efb` to `41b8e9ad87b4975bf3fbdc9a8e46deda489d3d51`.
- That SHA is current `main` on [`vellum-ai/imessage`](https://github.com/vellum-ai/imessage): [Keep iMessage setup on the conversational path (#51)](https://github.com/vellum-ai/imessage/pull/51).
- Photon connect now prints a single approval URL and tells the assistant to send it in chat before `--finish`. Missing project id and secret are collected with `credentials prompt`. Setup never restarts the assistant or sends the user to the settings app.

This is a pin-only change. Catalog metadata (name, description, category, homepage, license, icon) is unchanged.

## Test plan

- Manifest JSON parses; `imessage.source.ref` is a full 40-hex SHA.
- `node scripts/check-marketplace-prefix.mjs` passes.
- Confirmed `41b8e9ad87b4975bf3fbdc9a8e46deda489d3d51` is `origin/main` on `vellum-ai/imessage`.
- After merge, `assistant plugins install imessage` (or upgrade of an existing install) should resolve this pin.

## Risk

Low. Catalog pin only. Existing installs stay on the old SHA until a user upgrades.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f615f42-2130-49f7-be5e-ab4f865ecabd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f615f42-2130-49f7-be5e-ab4f865ecabd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

