### PR TITLE
test(web): chat-info stories render the real row and every added state, tiles size from their constants, and the fixtures live in one layer

### DIFF
--- a/clients/web/.storybook/viewports.ts
+++ b/clients/web/.storybook/viewports.ts
@@ -29,6 +29,17 @@ export const SB_VIEWPORTS = {
     type: "mobile" as const,
   },
   /**
+   * The narrowest phone the app's own designs are drawn for. `sbNarrowPhone`
+   * is a smaller legacy screen; this is the width a current phone layout
+   * assumes, and it is 12px wider than `sbMobile`, which is enough to change
+   * how many fixed-width tiles fit on one line.
+   */
+  sbCompactPhone: {
+    name: "Mobile (compact)",
+    styles: { width: "402px", height: "874px" },
+    type: "mobile" as const,
+  },
+  /**
    * A desktop window too short for what it holds. Height is the whole point:
    * a dialog that keeps room for an open menu has to give that room back
    * here, and a story pinned to it shows whether the footer survives.

--- a/clients/web/src/domains/chat/chat-layout-header.stories.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.stories.tsx
@@ -17,10 +17,11 @@
  * on ids of this file's own so a panel opened here can only be this header's.
  *
  * The states covered are the composition's, not a per-component matrix: the
- * desktop and mobile baselines, a channel-bound header, and the desktop header
- * with the Chat Info panel open, where the Assets trigger reads as selected.
- * The mobile trigger carries the same `active` fill open or closed, so there is
- * no second open state to show.
+ * desktop and mobile baselines, a channel-bound header, the desktop header
+ * with the Chat Info panel open, where the Assets trigger reads as selected,
+ * and the header of a chat whose assets could not be loaded. The mobile
+ * trigger carries the same `active` fill open or closed, so there is no second
+ * open state to show.
  */
 
 import { useEffect, useState } from "react";
@@ -32,7 +33,10 @@ import { Button } from "@vellumai/design-library";
 import { ChannelSourceLinkPill } from "@/domains/chat/components/channel-source-link-pill";
 import { ChatLayoutHeader } from "@/domains/chat/chat-layout-header";
 import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
-import { inChatInfoConversation } from "@/domains/chat/components/chat-info-story-fixtures";
+import {
+  failChatInfoDocuments,
+  inChatInfoConversation,
+} from "@/domains/chat/components/chat-info-story-fixtures";
 import { ConversationAssetsPill } from "@/domains/chat/components/conversation-assets-pill";
 import { MOBILE_MEDIA_QUERY } from "@/hooks/use-is-mobile";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -227,4 +231,21 @@ export const AssetsPanelOpen: Story = {
   args: { isMobile: false },
   parameters: { chatInfo: { attachments: makePreviewableImages(2) } },
   decorators: [withChatInfoOpen],
+};
+
+/**
+ * A chat whose documents source is down with nothing cached. The trigger stays
+ * in the cluster with nothing counted, since the panel is where the user finds
+ * out why.
+ */
+export const TriggerUnavailable: Story = {
+  args: { isMobile: false },
+  parameters: {
+    chatInfo: {
+      appCount: 0,
+      documentCount: 0,
+      attachments: [],
+      afterSeed: failChatInfoDocuments,
+    },
+  },
 };

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.stories.tsx
@@ -6,7 +6,7 @@
  * Geometry, surface, and border belong to the caller, so every story wears the
  * Chat Info file tile's box and they differ only in what the box has to draw.
  */
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import { Loader2 } from "lucide-react";
 import { fn } from "storybook/test";
 
@@ -15,14 +15,23 @@ import {
   SAMPLE_PREVIEWS,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { AttachmentPreviewBox } from "@/domains/chat/components/chat-attachments/attachment-preview-box";
+import { CHAT_INFO_FILE_TILE_WIDTH_PX } from "@/domains/chat/components/chat-info-file-tile";
 
-/** The Chat Info file tile's box: 135x84 on the panel's own surface. */
-const TILE_CLASS = "h-[84px] w-[135px] rounded-lg bg-[var(--surface-base)]";
+/** The Chat Info file tile's box, at its 84px height on the panel's surface. */
+const TILE_CLASS = "h-[84px] w-full rounded-lg bg-[var(--surface-base)]";
+
+/** The tile's width, which the box fills; only the tile's height is a literal. */
+const atTileWidth: Decorator = (Story) => (
+  <div style={{ width: CHAT_INFO_FILE_TILE_WIDTH_PX }}>
+    <Story />
+  </div>
+);
 
 const meta: Meta<typeof AttachmentPreviewBox> = {
   title: "Chat/AttachmentPreviewBox",
   component: AttachmentPreviewBox,
   parameters: { layout: "centered" },
+  decorators: [atTileWidth],
   args: {
     className: TILE_CLASS,
     kind: "image",

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-box.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/domains/chat/components/chat-attachments/utils";
 import { cn } from "@/utils/misc";
 
-export interface AttachmentPreviewBoxProps {
+interface AttachmentPreviewBoxProps {
   /** Geometry, surface, and border classes for the box. */
   className?: string;
   /** Picks the fallback glyph. */

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-object-url.test.tsx
@@ -20,6 +20,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 
+import { seedQueryFailure } from "@/domains/chat/components/chat-info.test-helper";
 import { client as daemonClient } from "@/generated/daemon/client.gen";
 import {
   attachmentContentQueryKey,
@@ -99,19 +100,6 @@ function renderObjectUrl(
     },
   );
   return { ...rendered, client };
-}
-
-/** Park a failed fetch in the cache, the state a remounting surface reads. */
-function seedFailure(client: QueryClient, queryKey: readonly unknown[]): void {
-  client
-    .getQueryCache()
-    .build(client, { queryKey })
-    .setState({
-      status: "error",
-      error: new Error("Failed to load attachment content"),
-      errorUpdatedAt: Date.now(),
-      fetchStatus: "idle",
-    });
 }
 
 const STORED: Attachment = { id: "att-1", previewUrl: null };
@@ -202,7 +190,11 @@ describe("useAttachmentObjectUrl", () => {
   test("reports a failed fetch as an error the caller can fall back from", () => {
     const { result } = renderObjectUrl(STORED, {
       seed: (client) =>
-        seedFailure(client, attachmentContentQueryKey("asst-1", "att-1")),
+        seedQueryFailure(
+          client,
+          attachmentContentQueryKey("asst-1", "att-1"),
+          "Failed to load attachment content",
+        ),
     });
 
     expect(result.current.isError).toBe(true);

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
@@ -7,8 +7,7 @@
  * tile to see the options menu appear; on a touch device it is always visible.
  */
 
-import { QueryClientProvider } from "@tanstack/react-query";
-import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
 import {
@@ -16,6 +15,7 @@ import {
   CHAT_INFO_CONVERSATION_ID,
   chatInfoApps,
   primeChatInfoAppPreviews,
+  withChatInfoStoryClient,
 } from "@/domains/chat/components/chat-info-story-fixtures";
 import {
   CHAT_INFO_DRAWER_WIDTH_PX,
@@ -54,17 +54,11 @@ seedChatInfoConversation(storyClient, {
   apps: [...PRIMED, NO_PREVIEW],
 });
 
-const withPrimedPreviews: Decorator = (Story) => (
-  <QueryClientProvider client={storyClient}>
-    <Story />
-  </QueryClientProvider>
-);
-
 const meta: Meta<typeof ChatInfoAppTile> = {
   title: "Chat/ChatInfoAppTile",
   component: ChatInfoAppTile,
   parameters: { layout: "centered" },
-  decorators: [withPrimedPreviews],
+  decorators: [withChatInfoStoryClient(storyClient)],
   args: {
     app: TRIP_PLANNER,
     assistantId: CHAT_INFO_ASSISTANT_ID,

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
@@ -3,6 +3,7 @@
  * options menu revealed over it, and the app's name underneath.
  */
 
+import type { CSSProperties } from "react";
 import { useCallback } from "react";
 
 import { cn, Typography } from "@vellumai/design-library";
@@ -16,10 +17,12 @@ import { useTranslation } from "@/i18n";
 import type { AppSummary } from "@/types/app-types";
 import { getCachedAppHtml } from "@/utils/app-html-cache";
 
-/** Fixed tile width, and the minimum the section fits a row of them to. Kept in step with `w-[184px]` below. */
+/** Fixed tile width, and the minimum the section fits a row of them to. */
 export const CHAT_INFO_APP_TILE_WIDTH_PX = 184;
 
-export interface ChatInfoAppTileProps {
+const FIXED_WIDTH_STYLE: CSSProperties = { width: CHAT_INFO_APP_TILE_WIDTH_PX };
+
+interface ChatInfoAppTileProps {
   app: AppSummary;
   assistantId: string;
   onOpen: (appId: string) => void;
@@ -49,8 +52,9 @@ export function ChatInfoAppTile({
       data-reveal-row=""
       className={cn(
         "relative flex flex-col gap-1",
-        stretch ? "min-w-0 flex-1" : "w-[184px] shrink-0",
+        stretch ? "min-w-0 flex-1" : "shrink-0",
       )}
+      style={stretch ? undefined : FIXED_WIDTH_STYLE}
     >
       {/* The preview iframe is `pointer-events: none`, so this button takes the click. */}
       <button

--- a/clients/web/src/domains/chat/components/chat-info-file-grid.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-grid.stories.tsx
@@ -12,12 +12,11 @@ import { fn } from "storybook/test";
 
 import {
   CHAT_INFO_ASSISTANT_ID,
-  withChatInfoStoryClient,
-} from "@/domains/chat/components/chat-info-story-fixtures";
-import {
+  CHAT_INFO_STORY_CLIENT,
   CHAT_INFO_STORY_FILES,
   chatInfoStoryFrames,
-} from "@/domains/chat/components/chat-info.test-helper";
+  withChatInfoStoryClient,
+} from "@/domains/chat/components/chat-info-story-fixtures";
 
 import { ChatInfoFileGrid } from "./chat-info-file-grid";
 
@@ -31,7 +30,7 @@ const meta: Meta<typeof ChatInfoFileGrid> = {
   title: "Chat/ChatInfoFileGrid",
   component: ChatInfoFileGrid,
   parameters: { layout: "fullscreen" },
-  decorators: [inPanelBody, withChatInfoStoryClient],
+  decorators: [inPanelBody, withChatInfoStoryClient(CHAT_INFO_STORY_CLIENT)],
   args: {
     items: chatInfoStoryFrames(6),
     assistantId: CHAT_INFO_ASSISTANT_ID,

--- a/clients/web/src/domains/chat/components/chat-info-file-row.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-row.stories.tsx
@@ -1,0 +1,76 @@
+/**
+ * The Chat Info panel's file row, on the category the panel's own suite cannot
+ * reach: Camera Frames. Documents and images render through this same row, so
+ * what these stories document is the category's own copy over its file tiles,
+ * and the fit rule the row inherits from `ChatInfoSection`.
+ *
+ * The title and the See All label come from the catalog through `t()`, the way
+ * the panel supplies them, so the row is read on the copy that ships.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ComponentProps } from "react";
+import { fn } from "storybook/test";
+
+import {
+  CHAT_INFO_ASSISTANT_ID,
+  CHAT_INFO_STORY_CLIENT,
+  chatInfoStoryFrames,
+  inChatInfoDrawerColumn,
+  inChatInfoPhonePage,
+  withChatInfoStoryClient,
+} from "@/domains/chat/components/chat-info-story-fixtures";
+import { useTranslation } from "@/i18n";
+
+import { ChatInfoFileRow } from "./chat-info-file-row";
+
+/** Everything but the copy, which the catalog supplies through the hook below. */
+type FramesRowArgs = Omit<
+  ComponentProps<typeof ChatInfoFileRow>,
+  "title" | "seeAllAriaLabel"
+>;
+
+/** The real row, on the two catalog keys the panel hands the frames category. */
+function FramesRow(args: FramesRowArgs) {
+  const { t } = useTranslation("chat");
+  return (
+    <ChatInfoFileRow
+      {...args}
+      title={t("chatInfoPanel.framesTitle")}
+      seeAllAriaLabel={t("chatInfoPanel.seeAllFramesAria")}
+    />
+  );
+}
+
+const meta = {
+  title: "Chat/ChatInfoFileRow",
+  component: FramesRow,
+  parameters: { layout: "fullscreen" },
+  decorators: [withChatInfoStoryClient(CHAT_INFO_STORY_CLIENT)],
+  args: {
+    category: "frames",
+    count: 240,
+    items: chatInfoStoryFrames(6),
+    assistantId: CHAT_INFO_ASSISTANT_ID,
+    onSeeAll: fn(),
+    onOpen: fn(),
+  },
+} satisfies Meta<typeof FramesRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Camera Frames at the drawer width: each tile carries the time its frame was
+ * captured, the line is cut to what the column holds, and the session's total
+ * puts See All in the header.
+ */
+export const Frames: Story = {
+  decorators: [inChatInfoDrawerColumn],
+};
+
+/** The same row on a phone, where the whole session scrolls past the screen edge. */
+export const FramesStrip: Story = {
+  decorators: [inChatInfoPhonePage],
+  globals: { viewport: { value: "sbCompactPhone", isRotated: false } },
+};

--- a/clients/web/src/domains/chat/components/chat-info-file-row.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-row.test.tsx
@@ -1,13 +1,17 @@
 /**
  * `ChatInfoFileRow`: the top-level row both file categories render through.
  *
+ * What this row owns is the category binding, that the drill-in it offers
+ * carries the category it was given. Its header and its tiles belong to
+ * `ChatInfoSection` and `ChatInfoFileTile`, which have suites of their own.
+ *
  * Camera frames are the case worth pinning, because the panel's own suite
  * cannot reach them: the transcript never carries the frame tag, so the frames
- * row has no source there. What is asserted is the wiring, that the row hands
- * the frames category its own copy, its own drill-in, and frame tiles.
+ * row has no source there.
  *
  * The row's measured width is mocked, since happy-dom reports a zero box for
- * everything, and the window-size axis comes from a `matchMedia` stub.
+ * everything, and the window-size axis comes from a `matchMedia` stub. Copy
+ * comes from the catalog through `t()`, on the locale pinned below.
  */
 
 import {
@@ -36,9 +40,11 @@ import {
   makeFrameAsset,
 } from "@/domains/chat/components/chat-info.test-helper";
 import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
-import { formatCaptureTime } from "@/utils/format-date";
+import { t } from "@/i18n";
+import { stubHostLanguage } from "@/i18n/host-language.test-helper";
 
 const restoreDomStubs = installChatInfoDomStubs();
+const restoreHostLanguage = stubHostLanguage(CHAT_INFO_TEST_LOCALE);
 
 mock.module("@/hooks/use-element-size", () =>
   makeElementSizeMock(() => CHAT_INFO_DRAWER_WIDTH_PX),
@@ -49,7 +55,7 @@ const { ChatInfoFileRow } =
 
 const ASSISTANT_ID = "asst-1";
 
-// A day apart, so the two tiles carry labels that can be told from each other.
+// Two captures, so the row draws a tile per frame rather than a single one.
 const CAPTURED_AT = [CHAT_INFO_T0, CHAT_INFO_T0 - 86_400_000];
 
 const FRAMES = CAPTURED_AT.map((capturedAt, index) =>
@@ -74,10 +80,10 @@ function renderFramesRow(onSeeAll: (category: "files" | "frames") => void) {
     <QueryClientProvider client={makeChatInfoQueryClient()}>
       <ChatInfoFileRow
         category="frames"
-        title="Camera Frames"
+        title={t("chat:chatInfoPanel.framesTitle")}
         count={FRAMES_TOTAL}
         items={FRAMES}
-        seeAllAriaLabel="See all camera frames"
+        seeAllAriaLabel={t("chat:chatInfoPanel.seeAllFramesAria")}
         onSeeAll={onSeeAll}
         onOpen={() => {}}
         assistantId={ASSISTANT_ID}
@@ -97,36 +103,19 @@ afterEach(() => {
 
 afterAll(() => {
   restoreDomStubs();
+  restoreHostLanguage();
   mock.restore();
 });
 
 describe("ChatInfoFileRow for camera frames", () => {
-  test("heads the row with the frames title and the category's total", () => {
-    renderFramesRow(() => {});
-
-    expect(screen.getByText("Camera Frames")).toBeDefined();
-    expect(screen.getByText(String(FRAMES_TOTAL))).toBeDefined();
-  });
-
   test("drills into frames from the See All control", () => {
     const drilled: string[] = [];
     renderFramesRow((category) => drilled.push(category));
 
-    fireEvent.click(screen.getByLabelText("See all camera frames"));
+    fireEvent.click(
+      screen.getByLabelText(t("chat:chatInfoPanel.seeAllFramesAria")),
+    );
 
     expect(drilled).toEqual(["frames"]);
-  });
-
-  test("labels each tile by when it was captured", () => {
-    renderFramesRow(() => {});
-
-    expect(screen.getAllByLabelText("Preview camera frame")).toHaveLength(
-      FRAMES.length,
-    );
-    for (const capturedAt of CAPTURED_AT) {
-      expect(
-        screen.getByText(formatCaptureTime(capturedAt, CHAT_INFO_TEST_LOCALE)),
-      ).toBeDefined();
-    }
   });
 });

--- a/clients/web/src/domains/chat/components/chat-info-file-row.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-row.tsx
@@ -17,7 +17,7 @@ import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversatio
 
 export type ChatInfoFileCategory = "files" | "frames";
 
-export interface ChatInfoFileRowProps {
+interface ChatInfoFileRowProps {
   category: ChatInfoFileCategory;
   title: string;
   /** The category's exact total, which may exceed `items.length` when paged. */

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.stories.tsx
@@ -18,13 +18,12 @@ import {
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import {
   CHAT_INFO_ASSISTANT_ID,
-  withChatInfoStoryClient,
-} from "@/domains/chat/components/chat-info-story-fixtures";
-import {
+  CHAT_INFO_STORY_CLIENT,
   CHAT_INFO_STORY_FILES,
   chatInfoStoryFrames,
-  makeFileAsset,
-} from "@/domains/chat/components/chat-info.test-helper";
+  withChatInfoStoryClient,
+} from "@/domains/chat/components/chat-info-story-fixtures";
+import { makeFileAsset } from "@/domains/chat/components/chat-info.test-helper";
 
 import { ChatInfoFileTile } from "./chat-info-file-tile";
 
@@ -55,7 +54,7 @@ const meta: Meta<typeof ChatInfoFileTile> = {
   title: "Chat/ChatInfoFileTile",
   component: ChatInfoFileTile,
   parameters: { layout: "centered" },
-  decorators: [withChatInfoStoryClient],
+  decorators: [withChatInfoStoryClient(CHAT_INFO_STORY_CLIENT)],
   args: {
     file: tripNotes,
     assistantId: CHAT_INFO_ASSISTANT_ID,

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Loader2 } from "lucide-react";
+import type { CSSProperties } from "react";
 import { useRef, useState } from "react";
 
 import { Typography } from "@vellumai/design-library";
@@ -22,10 +23,12 @@ import { useInView } from "@/hooks/use-in-view";
 import { useTranslation } from "@/i18n";
 import { formatCaptureTime } from "@/utils/format-date";
 
-/** Fixed tile width, and what the section fits a row of them to. Kept in step with `w-[135px]` below. */
+/** Fixed tile width, and what the section fits a row of them to. */
 export const CHAT_INFO_FILE_TILE_WIDTH_PX = 135;
 
-export interface ChatInfoFileTileProps {
+const TILE_STYLE: CSSProperties = { width: CHAT_INFO_FILE_TILE_WIDTH_PX };
+
+interface ChatInfoFileTileProps {
   file: ConversationFileAsset;
   assistantId: string;
   onOpen: (file: ConversationFileAsset) => void;
@@ -85,7 +88,8 @@ export function ChatInfoFileTile({
     <div
       data-slot="chat-info-file-tile"
       data-reveal-row=""
-      className="relative flex w-[135px] shrink-0 flex-col gap-1"
+      className="relative flex shrink-0 flex-col gap-1"
+      style={TILE_STYLE}
     >
       <button
         ref={boxRef}

--- a/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
@@ -13,6 +13,9 @@
  * so that row has nothing to build from until frames come from the daemon's
  * attachment list.
  *
+ * The last three stories are the states the sources put the panel in: still
+ * loading, loaded and empty, and one source down.
+ *
  * The frame is the shipped drawer, so a story opens at its 400px default and
  * the rows fit what that width holds. Drag the drawer's left edge to walk the
  * fit rule out to the mock's wider column.
@@ -33,6 +36,7 @@ import {
   CHAT_INFO_ASSISTANT_ID,
   CHAT_INFO_CONVERSATION_ID,
   type ChatInfoStoryConversation,
+  failChatInfoDocuments,
   inChatInfoConversation,
 } from "@/domains/chat/components/chat-info-story-fixtures";
 import { DetailPanelStoryFrame } from "@/domains/chat/components/detail-panel-story-frame";
@@ -131,6 +135,37 @@ export const Mobile: Story = {
 /** The same strips on the narrowest phone the app runs on. */
 export const NarrowPhone: Story = {
   globals: { viewport: { value: "sbNarrowPhone", isRotated: false } },
+};
+
+/**
+ * The sources have not answered yet. The transcript's own files are on screen
+ * from the first paint, and the panel says nothing about what it is missing:
+ * a notice here reads as an answer the loaded panel then replaces.
+ */
+export const Loading: Story = {
+  parameters: { chatInfo: { pendingSources: true } },
+};
+
+/** A conversation that really holds nothing, once every source has said so. */
+export const Empty: Story = {
+  parameters: {
+    chatInfo: { appCount: 0, documentCount: 0, attachments: [] },
+  },
+};
+
+/**
+ * The documents source is down with nothing cached under it. The notice heads
+ * the body, above the categories that did load.
+ */
+export const LoadFailed: Story = {
+  parameters: {
+    chatInfo: {
+      appCount: 3,
+      documentCount: 0,
+      attachments: [],
+      afterSeed: failChatInfoDocuments,
+    },
+  },
 };
 
 /**

--- a/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.stories.tsx
@@ -2,44 +2,30 @@
  * A Chat Info row: the category header with its exact total and a See All
  * control, over one line of tiles.
  *
- * The row is tile-agnostic, so most of these stories feed it the shipped 64px
+ * The row is tile-agnostic, so these stories feed it the shipped 64px
  * `MessageAttachmentSquare`. What they document is the fit rule: on a roomy
  * window the line is truncated to the tiles its measured width holds, and on a
  * phone the same width decides a horizontal strip that runs past the screen
  * edge. See All appears whenever the category's total exceeds that line, which
- * is why the paged story shows it under a row that looks complete.
- *
- * The Frames stories are the exception: they draw the panel's own Camera
- * Frames row, on its catalog copy and its file tiles.
+ * is why the paged story shows it under a row that looks complete. The panel's
+ * own rows over its own tiles are `ChatInfoFileRow`'s stories.
  *
  * Read the phone stories at the Mobile viewports: the frame draws
  * `DetailShell`'s lift surface and body inset, which the strip cancels.
  */
-import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
-import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
 import {
   makeMixedAttachments,
   makePreviewableImages,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import {
-  CHAT_INFO_FILE_TILE_WIDTH_PX,
-  ChatInfoFileTile,
-} from "@/domains/chat/components/chat-info-file-tile";
-import {
-  CHAT_INFO_ASSISTANT_ID,
-  withChatInfoStoryClient,
+  inChatInfoDrawerColumn,
+  inChatInfoPhonePage,
 } from "@/domains/chat/components/chat-info-story-fixtures";
-import {
-  CHAT_INFO_DRAWER_WIDTH_PX,
-  CHAT_INFO_NARROW_PHONE_PX,
-  chatInfoStoryFrames,
-} from "@/domains/chat/components/chat-info.test-helper";
-import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
-import { useTranslation } from "@/i18n";
 
 import {
   ChatInfoSection,
@@ -57,35 +43,6 @@ const FITTING_SET: DisplayAttachment[] = [
   ...makePreviewableImages(2),
   ...makeMixedAttachments().filter((file) => file.previewUrl === null),
 ];
-
-/** The drawer body's column on the desktop mock, inside `DetailShell`'s lift surface and body inset. */
-const inDrawerColumn: Decorator = (Story) => (
-  <div
-    className="bg-[var(--surface-lift)]"
-    style={{ padding: DETAIL_SHELL_BODY_INSET_PX }}
-  >
-    <div style={{ width: CHAT_INFO_DRAWER_WIDTH_PX }}>
-      <Story />
-    </div>
-  </div>
-);
-
-/**
- * A phone page at the shell's body inset, which the strip's negative margin
- * cancels so the tiles run to the screen edge and the last one is cut off, as
- * in the mobile mock.
- */
-const inPhonePage: Decorator = (Story) => (
-  <div
-    className="bg-[var(--surface-lift)]"
-    style={{
-      maxWidth: CHAT_INFO_NARROW_PHONE_PX,
-      padding: DETAIL_SHELL_BODY_INSET_PX,
-    }}
-  >
-    <Story />
-  </div>
-);
 
 function renderSquare(attachment: DisplayAttachment) {
   return (
@@ -115,7 +72,7 @@ type Story = StoryObj<typeof meta>;
  * no See All, because the count and the fitted line agree.
  */
 export const Fit: Story = {
-  decorators: [inDrawerColumn],
+  decorators: [inChatInfoDrawerColumn],
   args: {
     items: FITTING_SET,
     count: FITTING_SET.length,
@@ -127,7 +84,7 @@ export const Fit: Story = {
  * takes the right edge of the header.
  */
 export const Overflow: Story = {
-  decorators: [inDrawerColumn],
+  decorators: [inChatInfoDrawerColumn],
   args: {
     items: makePreviewableImages(12),
     count: 12,
@@ -140,7 +97,7 @@ export const Overflow: Story = {
  * offered.
  */
 export const PagedCount: Story = {
-  decorators: [inDrawerColumn],
+  decorators: [inChatInfoDrawerColumn],
   args: {
     items: makePreviewableImages(4),
     count: 240,
@@ -153,7 +110,7 @@ export const PagedCount: Story = {
  * the screen edge.
  */
 export const MobileStrip: Story = {
-  decorators: [inPhonePage],
+  decorators: [inChatInfoPhonePage],
   globals: { viewport: { value: "sbMobile", isRotated: false } },
   args: {
     items: makePreviewableImages(8),
@@ -161,63 +118,12 @@ export const MobileStrip: Story = {
   },
 };
 
-/** The same strip on the narrowest phone the app runs on. */
+/** The same strip at the width the phone page is drawn for, where its own cap binds. */
 export const NarrowPhoneStrip: Story = {
-  decorators: [inPhonePage],
-  globals: { viewport: { value: "sbNarrowPhone", isRotated: false } },
+  decorators: [inChatInfoPhonePage],
+  globals: { viewport: { value: "sbCompactPhone", isRotated: false } },
   args: {
     items: makePreviewableImages(8),
     count: 12,
   },
-};
-
-/** One Live session's captures, the set the frames row is shown against. */
-const FRAME_TILES = chatInfoStoryFrames(6);
-
-/** The Camera Frames row the panel draws: its catalog copy, over its file tiles. */
-function FramesRow({
-  count,
-  onSeeAll,
-}: Pick<ChatInfoSectionProps<ConversationFileAsset>, "count" | "onSeeAll">) {
-  const { t } = useTranslation("chat");
-  return (
-    <ChatInfoSection
-      title={t("chatInfoPanel.framesTitle")}
-      count={count}
-      items={FRAME_TILES}
-      tileWidth={CHAT_INFO_FILE_TILE_WIDTH_PX}
-      seeAllAriaLabel={t("chatInfoPanel.seeAllFramesAria")}
-      onSeeAll={onSeeAll}
-      renderTile={(frame) => (
-        <ChatInfoFileTile
-          key={frame.id}
-          file={frame}
-          assistantId={CHAT_INFO_ASSISTANT_ID}
-          onOpen={() => {}}
-        />
-      )}
-    />
-  );
-}
-
-type FramesStory = StoryObj<
-  Pick<ChatInfoSectionProps<ConversationFileAsset>, "count" | "onSeeAll">
->;
-
-/**
- * Camera Frames at the drawer width: each tile carries the time its frame was
- * captured, and the session's total puts See All in the header.
- */
-export const Frames: FramesStory = {
-  decorators: [withChatInfoStoryClient, inDrawerColumn],
-  args: { count: 240 },
-  render: (args) => <FramesRow {...args} />,
-};
-
-/** The same row on the narrowest phone, where the captures scroll past the edge. */
-export const FramesStrip: FramesStory = {
-  decorators: [withChatInfoStoryClient, inPhonePage],
-  globals: { viewport: { value: "sbNarrowPhone", isRotated: false } },
-  args: { count: 240 },
-  render: (args) => <FramesRow {...args} />,
 };

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -172,8 +172,9 @@ describe("ChatInfoSection", () => {
   });
 
   test("offers See All for two app tiles on the narrowest phone", () => {
-    // Two app tiles and their gap are wider than the column, so the pair
-    // scrolls and the drill-in is the only way to the second one.
+    // Two app tiles and their gap are wider than the column, so the row
+    // scrolls and offers See All even though the bleed leaves the second tile
+    // on screen.
     viewport.set({ narrow: true, coarsePointer: false });
     widthRef.value = NARROW_COLUMN_WIDTH;
 
@@ -184,6 +185,20 @@ describe("ChatInfoSection", () => {
     });
 
     expect(seeAll()).not.toBeNull();
+  });
+
+  test("shows both file tiles and no See All when the phone column holds them", () => {
+    viewport.set({ narrow: true, coarsePointer: false });
+    widthRef.value = NARROW_COLUMN_WIDTH;
+
+    renderSection({
+      items: makeItems(2),
+      count: 2,
+      tileWidth: CHAT_INFO_FILE_TILE_WIDTH_PX,
+    });
+
+    expect(tiles()).toHaveLength(2);
+    expect(seeAll()).toBeNull();
   });
 
   test("pays the reclaimed inset back on both edges of the strip", () => {

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -1,5 +1,7 @@
 /**
- * Fixtures and the seeded-conversation decorator for the Chat Info stories.
+ * Everything the Chat Info stories are built from: the asset sets they show,
+ * the client that answers their queries, the seeded-conversation decorator, and
+ * the two page frames the rows are read inside.
  *
  * The panel reads its assets through the real hooks, so a story has to fill
  * the two sources those hooks go to: the query cache holds the conversation's
@@ -13,39 +15,167 @@
  */
 
 import type { Decorator } from "@storybook/react-vite";
-import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
-import { makePreviewableImages } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
+import {
+  makeDisplayAttachment,
+  makePreviewableImages,
+  makeSamplePreview,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import {
   attachmentRows,
+  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_NARROW_PHONE_PX,
   CHAT_INFO_T0,
   clearTranscriptMessages,
   makeAppSummary,
   makeChatInfoQueryClient,
+  makeDocumentAsset,
   makeDocumentSummary,
-  makeSeededChatInfoStoryClient,
+  makeFileAsset,
+  makeFrameAsset,
+  makePendingChatInfoQueryClient,
   seedChatInfoConversation,
+  seedQueryFailure,
   seedTranscriptMessages,
 } from "@/domains/chat/components/chat-info.test-helper";
+import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
+import { documentsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { AppSummary } from "@/types/app-types";
 import type { DocumentSummary } from "@/types/document-types";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
+import { decodeBase64Payload } from "@/utils/base64";
 
 export const CHAT_INFO_ASSISTANT_ID = "story-assistant";
 export const CHAT_INFO_CONVERSATION_ID = "story-conversation";
 
-const storyClient = makeSeededChatInfoStoryClient(CHAT_INFO_ASSISTANT_ID);
+/** Metadata only: the tile has to fetch these bytes before it can draw them. */
+const STORY_LAZY_ATTACHMENT = makeDisplayAttachment({
+  id: "ferry-deck",
+  filename: "ferry-deck.png",
+  sizeBytes: 190_464,
+});
 
 /**
- * The client a tile story reads: it answers every query from what
- * {@link makeSeededChatInfoStoryClient} holds, so no story reaches the daemon.
+ * The files the Chat Info stories are shown against: two daemon documents, an
+ * image the transcript carries inline, one whose bytes the tile fetches, and a
+ * PDF. `Object.values` gives the set as one category's items.
  */
-export const withChatInfoStoryClient: Decorator = (Story) => (
-  <QueryClientProvider client={storyClient}>
+export const CHAT_INFO_STORY_FILES = {
+  tripNotes: makeDocumentAsset(
+    makeDocumentSummary({
+      surfaceId: "surface-trip-notes",
+      title: "Trip Notes",
+      wordCount: 842,
+    }),
+  ),
+  packingList: makeDocumentAsset(
+    makeDocumentSummary({
+      surfaceId: "surface-packing-list",
+      title: "Packing List",
+      wordCount: 214,
+    }),
+  ),
+  inlineImage: makeFileAsset(
+    makeDisplayAttachment({
+      id: "harbour-at-dawn",
+      filename: "harbour-at-dawn.png",
+      sizeBytes: 184_320,
+      previewUrl: makeSamplePreview(240, 150),
+    }),
+  ),
+  lazyImage: makeFileAsset(STORY_LAZY_ATTACHMENT),
+  pdf: makeFileAsset(
+    makeDisplayAttachment({
+      id: "coast-guide",
+      filename: "coast-guide.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2_097_152,
+    }),
+  ),
+};
+
+/** One Live session: `count` captures three minutes apart, newest first. */
+export function chatInfoStoryFrames(count: number): ConversationFileAsset[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeFrameAsset(
+      makeDisplayAttachment({
+        id: `camera-frame-${index + 1}`,
+        filename: `camera-frame-${index + 1}.jpg`,
+        mimeType: "image/jpeg",
+        sizeBytes: 98_304 + index * 2_048,
+        previewUrl: SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
+      }),
+      CHAT_INFO_T0 - index * 180_000,
+    ),
+  );
+}
+
+function makeSeededChatInfoStoryClient(assistantId: string): QueryClient {
+  const client = makeChatInfoQueryClient();
+  client.setQueryData(
+    attachmentContentQueryKey(assistantId, STORY_LAZY_ATTACHMENT.id),
+    new Blob([decodeBase64Payload(SAMPLE_PREVIEWS[2]!)!], {
+      type: "image/png",
+    }),
+  );
+  return client;
+}
+
+/**
+ * The client the tile, row, and grid stories read. It holds the bytes the
+ * daemon would return for the one story file with no inline preview, under the
+ * same key the preview modal fetches with, so that tile draws the fetched path
+ * with no daemon behind it.
+ */
+export const CHAT_INFO_STORY_CLIENT = makeSeededChatInfoStoryClient(
+  CHAT_INFO_ASSISTANT_ID,
+);
+
+/** Serves every query from `client`, so no story reaches the daemon. */
+export function withChatInfoStoryClient(client: QueryClient): Decorator {
+  return function WithChatInfoStoryClient(Story) {
+    return (
+      <QueryClientProvider client={client}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };
+}
+
+/** The drawer body's column on the desktop mock, inside `DetailShell`'s lift surface and body inset. */
+export const inChatInfoDrawerColumn: Decorator = (Story) => (
+  <div
+    className="bg-[var(--surface-lift)]"
+    style={{ padding: DETAIL_SHELL_BODY_INSET_PX }}
+  >
+    <div style={{ width: CHAT_INFO_DRAWER_WIDTH_PX }}>
+      <Story />
+    </div>
+  </div>
+);
+
+/**
+ * A phone page at the shell's body inset, which the strip's negative margin
+ * cancels so the tiles run to the screen edge and the last one is cut off, as
+ * in the mobile mock. Read it at the `sbCompactPhone` viewport, the width this
+ * page is drawn for.
+ */
+export const inChatInfoPhonePage: Decorator = (Story) => (
+  <div
+    className="bg-[var(--surface-lift)]"
+    style={{
+      maxWidth: CHAT_INFO_NARROW_PHONE_PX,
+      padding: DETAIL_SHELL_BODY_INSET_PX,
+    }}
+  >
     <Story />
-  </QueryClientProvider>
+  </div>
 );
 
 /** Name, icon, and preview lines for each app a story can ask for. */
@@ -160,6 +290,26 @@ export interface ChatInfoStoryConversation {
   appCount: number;
   documentCount: number;
   attachments: DisplayAttachment[];
+  /** Leaves both daemon queries unresolved, on a client whose queries never run. */
+  pendingSources?: boolean;
+  /** Runs on the seeded client, to leave one source in a state the daemon would. */
+  afterSeed?: (
+    client: QueryClient,
+    conversation: ChatInfoStoryConversation,
+  ) => void;
+}
+
+/** An `afterSeed` that leaves the documents source failed with nothing cached. */
+export function failChatInfoDocuments(
+  client: QueryClient,
+  { assistantId, conversationId }: ChatInfoStoryConversation,
+): void {
+  const queryKey = documentsGetQueryKey({
+    path: { assistant_id: assistantId },
+    query: { conversationId },
+  });
+  client.removeQueries({ queryKey });
+  seedQueryFailure(client, queryKey);
 }
 
 /** A worked-in trip conversation, the set most stories are shown against. */
@@ -240,8 +390,14 @@ export const inChatInfoConversation: Decorator =
           | Partial<ChatInfoStoryConversation>
           | undefined),
       };
-      const created = makeChatInfoQueryClient();
-      seedChatInfoQueries(created, conversation);
+      let created: QueryClient;
+      if (conversation.pendingSources) {
+        created = makePendingChatInfoQueryClient();
+      } else {
+        created = makeChatInfoQueryClient();
+        seedChatInfoQueries(created, conversation);
+      }
+      conversation.afterSeed?.(created, conversation);
       seedChatInfoTranscript(conversation);
       return created;
     });

--- a/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-tiles.test.tsx
@@ -36,8 +36,12 @@ import {
   seedQueryFailure,
 } from "@/domains/chat/components/chat-info.test-helper";
 import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversation-assets";
+import { stubHostLanguage } from "@/i18n/host-language.test-helper";
 
 const restoreDomStubs = installChatInfoDomStubs();
+// The capture-time label formats in the host language when it shares a primary
+// language with the app's, so both axes are pinned to read the same strings.
+const restoreHostLanguage = stubHostLanguage(CHAT_INFO_TEST_LOCALE);
 
 // The app tile's live preview would otherwise call the daemon's open endpoint.
 mock.module("@/utils/app-html-cache", chatInfoAppHtmlCacheMock);
@@ -110,6 +114,7 @@ afterEach(() => {
 
 afterAll(() => {
   restoreDomStubs();
+  restoreHostLanguage();
   mock.restore();
 });
 

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -1,29 +1,22 @@
 /**
- * Fixtures and the shared harness for the Chat Info tests and stories: the two
- * daemon summaries the panel lists, the assets it renders as tiles, the
- * transcript rows those assets come from, the query client its hooks read, the
- * modules a suite hands `mock.module`, and the browser APIs happy-dom leaves
- * out.
+ * Fixtures and the shared harness for the Chat Info suites: the two daemon
+ * summaries the panel lists, the assets it renders as tiles, the transcript
+ * rows those assets come from, the query client its hooks read, the modules a
+ * suite hands `mock.module`, and the browser APIs happy-dom leaves out.
  *
  * Every asset goes through `toConversationFileAssets`, the mapping the hook
  * itself runs, so a fixture cannot drift from the ids and shapes the panel
  * receives in the app.
  *
- * Kept free of any test-runner import so `.stories.tsx` files can use it, the
- * way `utils/conversation-list.test-helper.ts` already is. A `mock.module`
- * call is process-global, so it stays in the suite; only the module body it
- * installs lives here.
+ * Kept free of any test-runner import so `chat-info-story-fixtures.tsx` can
+ * build on it, the way `utils/conversation-list.test-helper.ts` already is. A
+ * `mock.module` call is process-global, so it stays in the suite; only the
+ * module body it installs lives here.
  */
 
 import { QueryClient } from "@tanstack/react-query";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
-import {
-  makeDisplayAttachment,
-  makeSamplePreview,
-  SAMPLE_PREVIEWS,
-} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
-import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import {
   type ConversationFileAsset,
   toConversationFileAssets,
@@ -40,7 +33,6 @@ import type { AppSummary } from "@/types/app-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
 import type { DocumentSummary } from "@/types/document-types";
 import * as appHtmlCache from "@/utils/app-html-cache";
-import { decodeBase64Payload } from "@/utils/base64";
 
 /** Fixed epoch ms, so nothing built here depends on the clock. */
 export const CHAT_INFO_T0 = 1_760_000_000_000;
@@ -48,10 +40,17 @@ export const CHAT_INFO_T0 = 1_760_000_000_000;
 /** The drawer body's column on the desktop mock: 3 app tiles, 4 file tiles. */
 export const CHAT_INFO_DRAWER_WIDTH_PX = 569;
 
-/** The narrowest phone the app runs on, screen width and all. */
+/**
+ * The narrowest phone the app's designs are drawn for, screen width and all.
+ * `sbCompactPhone` is the Storybook viewport at the same width.
+ */
 export const CHAT_INFO_NARROW_PHONE_PX = 402;
 
-/** The suite pins i18next to English, which is the locale the tile formats in. */
+/**
+ * The locale a suite pins both of the axes a formatter resolves to: i18next's
+ * active language, and the host language `formatLocale()` prefers over it when
+ * the two share a primary language. Pin the host one with `stubHostLanguage`.
+ */
 export const CHAT_INFO_TEST_LOCALE = "en";
 
 /** The shared app builder, under the defaults every Chat Info fixture wants. */
@@ -277,13 +276,14 @@ export function makePendingChatInfoQueryClient(): QueryClient {
 export function seedQueryFailure(
   client: QueryClient,
   queryKey: readonly unknown[],
+  message = "assistant unreachable",
 ): void {
   client
     .getQueryCache()
     .build(client, { queryKey })
     .setState({
       status: "error",
-      error: new Error("assistant unreachable"),
+      error: new Error(message),
       errorUpdatedAt: Date.now(),
       fetchStatus: "idle",
     });
@@ -339,84 +339,4 @@ export function seedTranscriptMessages(
 export function clearTranscriptMessages(): void {
   useChatSessionStore.setState({ snapshot: null, optimisticSends: [] });
   clearTranscriptOwner();
-}
-
-/** Metadata only: the tile has to fetch these bytes before it can draw them. */
-const STORY_LAZY_ATTACHMENT = makeDisplayAttachment({
-  id: "ferry-deck",
-  filename: "ferry-deck.png",
-  sizeBytes: 190_464,
-});
-
-/**
- * The files the Chat Info stories are shown against: two daemon documents, an
- * image the transcript carries inline, one whose bytes the tile fetches, and a
- * PDF. `Object.values` gives the set as one category's items.
- */
-export const CHAT_INFO_STORY_FILES = {
-  tripNotes: makeDocumentAsset(
-    makeDocumentSummary({
-      surfaceId: "surface-trip-notes",
-      title: "Trip Notes",
-      wordCount: 842,
-    }),
-  ),
-  packingList: makeDocumentAsset(
-    makeDocumentSummary({
-      surfaceId: "surface-packing-list",
-      title: "Packing List",
-      wordCount: 214,
-    }),
-  ),
-  inlineImage: makeFileAsset(
-    makeDisplayAttachment({
-      id: "harbour-at-dawn",
-      filename: "harbour-at-dawn.png",
-      sizeBytes: 184_320,
-      previewUrl: makeSamplePreview(240, 150),
-    }),
-  ),
-  lazyImage: makeFileAsset(STORY_LAZY_ATTACHMENT),
-  pdf: makeFileAsset(
-    makeDisplayAttachment({
-      id: "coast-guide",
-      filename: "coast-guide.pdf",
-      mimeType: "application/pdf",
-      sizeBytes: 2_097_152,
-    }),
-  ),
-};
-
-/** One Live session: `count` captures three minutes apart, newest first. */
-export function chatInfoStoryFrames(count: number): ConversationFileAsset[] {
-  return Array.from({ length: count }, (_, index) =>
-    makeFrameAsset(
-      makeDisplayAttachment({
-        id: `camera-frame-${index + 1}`,
-        filename: `camera-frame-${index + 1}.jpg`,
-        mimeType: "image/jpeg",
-        sizeBytes: 98_304 + index * 2_048,
-        previewUrl: SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
-      }),
-      CHAT_INFO_T0 - index * 180_000,
-    ),
-  );
-}
-
-/**
- * A story client holding the bytes the daemon would return for the one story
- * file with no inline preview, under the same key the preview modal fetches
- * with, so its tile draws the fetched path with no daemon behind it.
- */
-export function makeSeededChatInfoStoryClient(
-  assistantId: string,
-): QueryClient {
-  const client = makeChatInfoQueryClient();
-  client.setQueryData(
-    attachmentContentQueryKey(assistantId, STORY_LAZY_ATTACHMENT.id),
-    new Blob([decodeBase64Payload(SAMPLE_PREVIEWS[2]!)!], {
-      type: "image/png",
-    }),
-  );
-  return client;
 }

--- a/clients/web/src/domains/chat/components/mobile-chat-info-overlay.stories.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-info-overlay.stories.tsx
@@ -65,3 +65,19 @@ export const AppsLevel: Story = {
     },
   },
 };
+
+/** The same drill-in for Documents & Images, where the tiles wrap into a grid. */
+export const FilesLevel: Story = {
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: "files",
+    },
+  },
+};
+
+/** The top level at the width the phone designs are drawn for. */
+export const CompactPhone: Story = {
+  globals: { viewport: { value: "sbCompactPhone", isRotated: false } },
+};


### PR DESCRIPTION
## Summary
- ChatInfoFileRow has its own stories (the section stories no longer re-implement it); the panel, header, and mobile overlay gain Loading, Empty, LoadFailed, TriggerUnavailable, narrow-phone, and files-level stories; a 402px viewport preset makes the mock width reachable
- the tiles apply their width constants directly; the section suite covers the fitting mobile row; the row suite asserts the category binding through the catalog strings
- the story asset sets and seeded client move into the story fixtures with one decorator factory; seedQueryFailure takes a message and the object-URL suite uses it

Part of plan: chat-info-assets-panel.md (remediation round 7)