### PR TITLE
fix(web): tool-result images keep stable keys and name failures, failed decodes are keyed by position, and the locale resolver validates the host tag

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -300,11 +300,11 @@ const emDashEnforcedPaths = [
   "src/domains/chat/hooks/use-conversation-attachments*.{ts,tsx}",
   "src/domains/chat/chat-layout-header.stories.tsx",
   // The attachment preview a tile opens into, and the shared pieces the
-  // panel and its menus draw from.
-  "src/domains/chat/components/chat-attachments/attachment-preview-box.tsx",
-  "src/domains/chat/components/chat-attachments/use-attachment-object-url.ts",
+  // panel and its menus draw from, with their stories and tests.
+  "src/domains/chat/components/chat-attachments/attachment-preview-box*.{ts,tsx}",
+  "src/domains/chat/components/chat-attachments/use-attachment-object-url*.{ts,tsx}",
   "src/components/midline-dot.tsx",
-  "src/hooks/use-share-app.ts",
+  "src/hooks/use-share-app*.{ts,tsx}",
   "src/utils/share-app-with-toast.ts",
 ];
 

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.test.tsx
@@ -165,6 +165,29 @@ describe("BubbleAttachments", () => {
     expect(modal.getAttribute("data-preview-url")).toBe("null");
   });
 
+  test("keeps the good twin's preview when one of two rows under a shared id fails", () => {
+    // The history fallback rehydrates every row it recovers as `rehydrated:0`,
+    // so a set keyed by id alone would blank both on one dead decode.
+    const rehydrated = (filename: string): DisplayAttachment => ({
+      id: "rehydrated:0",
+      filename,
+      mimeType: "image/png",
+      sizeBytes: 1_024,
+      previewUrl: `https://example.com/${filename}`,
+    });
+    const { getByRole } = render(
+      <BubbleAttachments
+        attachments={[rehydrated("first.png"), rehydrated("second.png")]}
+      />,
+    );
+
+    fireEvent.error(getByRole("button", { name: "first.png" }));
+
+    const twin = getByRole("button", { name: "second.png" });
+    expect(twin.tagName).toBe("IMG");
+    expect(twin.getAttribute("src")).toBe("https://example.com/second.png");
+  });
+
   test("strips a failed sibling's previewUrl in the gallery array so arrow navigation refetches stored bytes", () => {
     const undecodable: DisplayAttachment = {
       id: "img-5",

--- a/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/bubble-attachments.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 
 import { useAttachmentSquares } from "@/domains/chat/components/chat-attachments/use-attachment-squares";
+import { previewEntryKey } from "@/domains/chat/components/chat-attachments/use-failed-preview-ids";
 import { classifyAttachment } from "@/domains/chat/components/chat-attachments/utils";
 
 interface BubbleAttachmentsProps {
@@ -50,7 +51,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
           if (isInlineImage) {
             return (
               <img
-                key={`${index}:${att.id}`}
+                key={previewEntryKey(att.id, index)}
                 src={att.previewUrl ?? undefined}
                 alt={att.filename}
                 role="button"
@@ -64,7 +65,7 @@ export const BubbleAttachments: FC<BubbleAttachmentsProps> = ({
                     openPreview(att, index);
                   }
                 }}
-                onError={() => markImageFailed(att.id)}
+                onError={() => markImageFailed(att.id, index)}
                 className="max-h-[320px] max-w-full cursor-pointer rounded-lg object-contain"
               />
             );

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.test.ts
@@ -39,6 +39,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   attachmentsByIdContentGet,
 }));
 
+const saveFile = mock(
+  async (_source: Blob | string, _filename: string): Promise<void> => undefined,
+);
+mock.module("@/runtime/native-file", () => ({ saveFile }));
+
 mock.module("@/lib/sentry/capture-error", () => ({
   ...captureErrorModule,
   captureError: (
@@ -53,16 +58,23 @@ mock.module("@/lib/sentry/capture-error", () => ({
   },
 }));
 
-const { fetchAttachmentContentBlob } =
+const { downloadAttachment, fetchAttachmentContentBlob } =
   await import("@/domains/chat/components/chat-attachments/download-attachment");
+const { subscribe } = await import("@/lib/event-bus");
+
+/** Terminal download reports the bus carried during the current test. */
+let downloads: { filename: string; state: string }[] = [];
+subscribe("download.done", (payload) => downloads.push(payload));
 
 beforeEach(() => {
   captured = [];
+  downloads = [];
   contentResponse = async () => ({ data: new Blob(["bytes"]), error: null });
 });
 
 afterEach(() => {
   attachmentsByIdContentGet.mockClear();
+  saveFile.mockClear();
 });
 
 afterAll(() => {
@@ -138,5 +150,46 @@ describe("fetchAttachmentContentBlob", () => {
     ).toBeNull();
     expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
     expect(captured).toEqual([]);
+  });
+});
+
+describe("downloadAttachment", () => {
+  test("reports an interrupted download when there are no bytes to save", async () => {
+    // A deleted attachment answers 404, which the fetch reports as null rather
+    // than an error, and it carries no inline preview to fall back to.
+    contentResponse = async () => ({
+      data: undefined,
+      error: { message: "Attachment not found" },
+      response: new Response(null, { status: 404 }),
+    });
+
+    await downloadAttachment(
+      { id: "att-gone", filename: "gone.png", previewUrl: null },
+      "asst-1",
+    );
+
+    expect(saveFile).not.toHaveBeenCalled();
+    expect(downloads).toEqual([{ filename: "gone.png", state: "interrupted" }]);
+  });
+
+  test("stays quiet when the fetched bytes were saved", async () => {
+    await downloadAttachment(
+      { id: "att-1", filename: "photo.png", previewUrl: null },
+      "asst-1",
+    );
+
+    expect(saveFile).toHaveBeenCalledTimes(1);
+    expect(downloads).toEqual([]);
+  });
+
+  test("stays quiet when the inline preview was saved", async () => {
+    await downloadAttachment({
+      id: "rehydrated:0",
+      filename: "legacy.png",
+      previewUrl: "data:image/png;base64,AAAA",
+    });
+
+    expect(saveFile).toHaveBeenCalledTimes(1);
+    expect(downloads).toEqual([]);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/download-attachment.ts
@@ -1,4 +1,5 @@
 import { attachmentsByIdContentGet } from "@/generated/daemon/sdk.gen";
+import { publish } from "@/lib/event-bus";
 import { captureError } from "@/lib/sentry/capture-error";
 import { toApiError } from "@/utils/api-errors";
 
@@ -61,6 +62,10 @@ export async function fetchAttachmentContentBlob(
  * rather than the actual file (e.g. video attachments with `thumbnailData`
  * only). Falls back to `previewUrl` when the daemon endpoint is unavailable
  * (no assistantId, synthetic rehydrated IDs, or fetch failure).
+ *
+ * With neither source `saveFile` never runs, so this publishes the terminal
+ * `download.done` itself. Nothing else would: a deleted attachment answers
+ * 404, which the fetch reports as absence rather than a fault.
  */
 export async function downloadAttachment(
   attachment: {
@@ -82,5 +87,11 @@ export async function downloadAttachment(
 
   if (attachment.previewUrl) {
     await saveFile(attachment.previewUrl, attachment.filename);
+    return;
   }
+
+  publish("download.done", {
+    filename: attachment.filename,
+    state: "interrupted",
+  });
 }

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.test.tsx
@@ -16,6 +16,14 @@ import type { DisplayAttachment } from "@/types/attachment-types";
 
 type ContentResult = { data: Blob | null; error: { message: string } | null };
 
+const respondsWithBytes = async (): Promise<ContentResult> => ({
+  data: new Blob(["image-bytes"]),
+  error: null,
+});
+
+/** What the content endpoint answers, swapped per test. */
+let contentResponse: () => Promise<ContentResult> = respondsWithBytes;
+
 // Mock only the daemon content endpoint; keep the rest of the generated SDK
 // real so any other consumer in the module graph is unaffected.
 const attachmentsByIdContentGet = mock(
@@ -23,10 +31,7 @@ const attachmentsByIdContentGet = mock(
     path: { assistant_id: string; id: string };
     parseAs?: string;
     throwOnError?: boolean;
-  }): Promise<ContentResult> => ({
-    data: new Blob(["image-bytes"]),
-    error: null,
-  }),
+  }): Promise<ContentResult> => contentResponse(),
 );
 
 mock.module("@/generated/daemon/sdk.gen", () => ({
@@ -35,10 +40,12 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 }));
 
 // happy-dom doesn't implement object URLs.
-globalThis.URL.createObjectURL = mock(
+const createObjectUrl = mock(
   (_obj: Blob | MediaSource): string => "blob:tool-image-mock",
 );
-globalThis.URL.revokeObjectURL = mock((_url: string): void => undefined);
+const revokeObjectUrl = mock((_url: string): void => undefined);
+globalThis.URL.createObjectURL = createObjectUrl;
+globalThis.URL.revokeObjectURL = revokeObjectUrl;
 
 // Downloads lazily import the native-file bridge; stub it so clicking Download
 // records the call without touching Capacitor / DOM anchors.
@@ -57,18 +64,22 @@ const imagesModule =
   await import("@/domains/chat/components/chat-attachments/tool-result-images");
 const { ToolResultImages } = imagesModule;
 
-function renderStrip(
+interface StripOptions {
+  messageAttachments?: DisplayAttachment[];
+  assistantId?: string | null;
+  /** Share one client across re-renders so a survivor keeps its cached blob. */
+  client?: QueryClient;
+}
+
+function stripUi(
   toolCalls: ChatMessageToolCall[],
-  opts: {
-    messageAttachments?: DisplayAttachment[];
-    assistantId?: string | null;
-  } = {},
-): void {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
+  opts: StripOptions = {},
+): ReactElement {
+  const client =
+    opts.client ??
+    new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const assistantId = "assistantId" in opts ? opts.assistantId : "asst-1";
-  const ui: ReactElement = (
+  return (
     <QueryClientProvider client={client}>
       <ToolResultImages
         toolCalls={toolCalls}
@@ -77,13 +88,22 @@ function renderStrip(
       />
     </QueryClientProvider>
   );
-  render(ui);
+}
+
+function renderStrip(
+  toolCalls: ChatMessageToolCall[],
+  opts: StripOptions = {},
+): void {
+  render(stripUi(toolCalls, opts));
 }
 
 afterEach(() => {
   cleanup();
+  contentResponse = respondsWithBytes;
   attachmentsByIdContentGet.mockClear();
   saveFileMock.mockClear();
+  createObjectUrl.mockClear();
+  revokeObjectUrl.mockClear();
 });
 
 describe("ToolResultImages referenced media", () => {
@@ -134,9 +154,10 @@ describe("ToolResultImages referenced media", () => {
     renderStrip([toolCall], { assistantId: null });
 
     const placeholder = screen.getByTestId("tool-result-image-placeholder");
-    expect(placeholder).toBeDefined();
-    // Nothing is on its way, so the box stays empty rather than spinning.
+    // Nothing is on its way, so the box names the file with its kind glyph
+    // rather than spinning for bytes that will never arrive.
     expect(placeholder.querySelector(".animate-spin")).toBeNull();
+    expect(placeholder.querySelector("svg")).not.toBeNull();
     expect(screen.queryByTestId("tool-result-image")).toBeNull();
     expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
   });
@@ -218,6 +239,73 @@ describe("ToolResultImages referenced media", () => {
     expect(screen.queryByTestId("tool-result-image")).toBeNull();
     expect(screen.queryByTestId("tool-result-image-placeholder")).toBeNull();
     expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
+  });
+
+  test("names a referenced image whose bytes never arrived", async () => {
+    contentResponse = async () => ({ data: null, error: { message: "gone" } });
+    const toolCall: ChatMessageToolCall = {
+      id: "tc-ref-failed",
+      name: "media_generate_image",
+      input: {},
+      result: "Generated 1 image",
+      imageAttachmentIds: ["att-missing"],
+      completedAt: 1,
+    };
+    renderStrip([toolCall]);
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getByTestId("tool-result-image-placeholder")
+          .querySelector(".animate-spin"),
+      ).toBeNull();
+    });
+    // The kind glyph stands in for the picture, so the box says a file is
+    // there whose bytes could not be drawn.
+    expect(
+      screen.getByTestId("tool-result-image-placeholder").querySelector("svg"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("tool-result-image")).toBeNull();
+  });
+
+  test("keeps a surviving image mounted when an earlier one leaves the strip", async () => {
+    const calls: ChatMessageToolCall[] = [
+      {
+        id: "tc-leaves",
+        name: "media_generate_image",
+        input: {},
+        result: "Generated 1 image",
+        imageAttachmentIds: ["att-leaves"],
+        completedAt: 1,
+      },
+      {
+        id: "tc-stays",
+        name: "file_read",
+        input: {},
+        result: "Read 1 image",
+        imageAttachmentIds: ["att-stays"],
+        completedAt: 2,
+      },
+    ];
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const strip = (messageAttachments?: DisplayAttachment[]): ReactElement =>
+      stripUi(calls, { messageAttachments, client });
+
+    const { rerender } = render(strip());
+    const survivor = await screen.findByAltText("file-read.png");
+    createObjectUrl.mockClear();
+
+    // The end-of-turn chips take the first image over, so the strip drops it
+    // from the middle of the list the second one is keyed in.
+    rerender(strip([attachment("att-leaves")]));
+
+    expect(screen.queryByAltText("media-generate-image.png")).toBeNull();
+    expect(screen.getByAltText("file-read.png")).toBe(survivor);
+    // A remount would have revoked the survivor's object URL and minted a new
+    // one, painting the placeholder box for a frame.
+    expect(createObjectUrl).not.toHaveBeenCalled();
   });
 
   test("keeps a referenced image an unrelated attachment does not cover", () => {

--- a/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/tool-result-images.tsx
@@ -3,6 +3,7 @@ import type { FC, MouseEvent } from "react";
 import { useCallback, useMemo } from "react";
 
 import { AttachmentDownloadOverlay } from "@/domains/chat/components/chat-attachments/attachment-download-overlay";
+import { AttachmentPreviewBox } from "@/domains/chat/components/chat-attachments/attachment-preview-box";
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { estimateBase64Bytes } from "@/domains/chat/components/chat-attachments/utils";
 import { useAttachmentObjectUrl } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
@@ -168,6 +169,20 @@ function toolResultImageInputs(toolCall: ChatMessageToolCall): {
 }
 
 /**
+ * One tool-result image, plus the identity the strip lists it under.
+ *
+ * `id` cannot serve: a referenced image carries the workspace attachment id it
+ * fetches by, and two tool calls in one turn can name the same one. The strip
+ * also drops entries from the middle as a turn settles, so a positional key
+ * would shift under a surviving image and remount it, throwing away the object
+ * URL it had already fetched.
+ */
+export interface ToolResultImage extends DisplayAttachment {
+  /** Stable across a mid-turn removal and unique within the strip. */
+  stripKey: string;
+}
+
+/**
  * Project a message's tool-result images into {@link DisplayAttachment}
  * objects.
  *
@@ -190,8 +205,8 @@ function toolResultImageInputs(toolCall: ChatMessageToolCall): {
 function buildToolResultAttachments(
   toolCalls: ChatMessageToolCall[],
   embeddedImageNames: ReadonlySet<string>,
-): DisplayAttachment[] {
-  const attachments: DisplayAttachment[] = [];
+): ToolResultImage[] {
+  const attachments: ToolResultImage[] = [];
   let globalIndex = 0;
   for (const tc of toolCalls) {
     const { refIds, base64Images } = toolResultImageInputs(tc);
@@ -223,6 +238,7 @@ function buildToolResultAttachments(
       }
       attachments.push({
         id: attachmentId,
+        stripKey: `tool-ref:${tc.id}:${localIndex}`,
         filename: nameFor("png"),
         mimeType: "image/png",
         sizeBytes: 0,
@@ -238,8 +254,10 @@ function buildToolResultAttachments(
       }
       const { mimeType, base64, src } = normalizeToolResultImage(imageData);
       const ext = mimeType.split("/")[1] ?? "png";
+      const syntheticId = `tool-image:${tc.id}:${localIndex}`;
       attachments.push({
-        id: `tool-image:${tc.id}:${localIndex}`,
+        id: syntheticId,
+        stripKey: syntheticId,
         filename: nameFor(ext),
         mimeType,
         sizeBytes: estimateBase64Bytes(base64),
@@ -277,7 +295,7 @@ export function resolveToolResultImages(
   toolCalls: ChatMessageToolCall[],
   messageAttachments: readonly DisplayAttachment[] | undefined,
   embeddedImageNames: ReadonlySet<string> = EMPTY_NAMES,
-): DisplayAttachment[] {
+): ToolResultImage[] {
   const shown = buildToolResultAttachments(toolCalls, embeddedImageNames);
   if (!messageAttachments?.length) {
     return shown;
@@ -330,10 +348,10 @@ const ToolResultImageThumb: FC<{
 /**
  * Renders a workspace-referenced tool-result image from the object URL
  * {@link useAttachmentObjectUrl} fetches for it, which shares its cache entry
- * with the preview modal. A spinner placeholder holds the slot while that
- * resolves; with nothing to fetch with (no assistant id, or an id that can
- * never resolve) the placeholder box stays empty, because there is nothing
- * left to wait for.
+ * with the preview modal. A spinner holds the slot while that resolves; bytes
+ * that failed, or can never be fetched at all (no assistant id, an id that can
+ * never resolve), fall back to the image glyph, so the box names a file whose
+ * picture is missing rather than sitting empty.
  */
 const ReferencedToolResultImage: FC<{
   attachment: DisplayAttachment;
@@ -349,11 +367,18 @@ const ReferencedToolResultImage: FC<{
     return (
       <div
         data-testid="tool-result-image-placeholder"
-        className={`flex h-40 w-40 items-center justify-center ${IMAGE_CLASS}`}
+        className={`h-40 w-40 ${IMAGE_CLASS}`}
       >
-        {!isError && (
-          <Loader2 className="h-6 w-6 animate-spin text-[var(--content-tertiary)]" />
-        )}
+        <AttachmentPreviewBox
+          className="h-full w-full"
+          kind="image"
+          glyphClassName="h-6 w-6"
+          placeholder={
+            isError ? null : (
+              <Loader2 className="h-6 w-6 animate-spin text-[var(--content-tertiary)]" />
+            )
+          }
+        />
       </div>
     );
   }
@@ -419,8 +444,11 @@ export const ToolResultImages: FC<ToolResultImagesProps> = ({
     [assistantId],
   );
 
+  // The modal outlives the strip: an image the end-of-turn attachments take
+  // over mid-preview empties this list, and unmounting the modal with it would
+  // close a preview the user still has open.
   if (attachments.length === 0) {
-    return null;
+    return previewModal;
   }
 
   return (
@@ -428,7 +456,7 @@ export const ToolResultImages: FC<ToolResultImagesProps> = ({
       <div className="flex w-full flex-wrap gap-2">
         {attachments.map((att, index) => (
           <div
-            key={`${index}:${att.id}`}
+            key={att.stripKey}
             role="button"
             aria-label={att.filename}
             title={att.filename}

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.test.tsx
@@ -67,6 +67,24 @@ describe("useAttachmentSquares", () => {
     expect(modal.getAttribute("data-current-index")).toBe("1");
   });
 
+  test("nulls only the failed position's preview when two squares share an id", () => {
+    const withPreview = SHARED_ID.map((att, index) => ({
+      ...att,
+      mimeType: "image/png",
+      filename: `${index}.png`,
+      previewUrl: `https://example.com/${index}.png`,
+    }));
+    const { container } = render(<Squares attachments={withPreview} />);
+
+    const [first] = Array.from(container.querySelectorAll("img"));
+    fireEvent.error(first!);
+
+    const remaining = Array.from(container.querySelectorAll("img"));
+    expect(remaining.map((img) => img.getAttribute("src"))).toEqual([
+      "https://example.com/1.png",
+    ]);
+  });
+
   test("keys each square on its position, so a shared id is still unique", () => {
     const logged: unknown[] = [];
     const realError = console.error;

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
@@ -8,9 +8,9 @@
  *
  *  - the failed-decode fallback - image previews the browser cannot decode
  *    (e.g. a HEIC blob on a Chromium renderer) get their `previewUrl` nulled
- *    by id, so the square falls back to its file-kind icon instead of a dead
- *    image, and the preview modal refetches stored bytes instead of the
- *    broken blob;
+ *    at their own position, so the square falls back to its file-kind icon
+ *    instead of a dead image, and the preview modal refetches stored bytes
+ *    instead of the broken blob;
  *  - the preview modal plus its gallery siblings;
  *  - the download forwarder.
  *
@@ -26,7 +26,10 @@ import type { DisplayAttachment } from "@/domains/chat/types/types";
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
-import { useFailedPreviewIds } from "@/domains/chat/components/chat-attachments/use-failed-preview-ids";
+import {
+  previewEntryKey,
+  useFailedPreviewIds,
+} from "@/domains/chat/components/chat-attachments/use-failed-preview-ids";
 
 interface UseAttachmentSquaresOptions {
   attachments: DisplayAttachment[];
@@ -49,8 +52,10 @@ interface UseAttachmentSquaresResult {
    *  attachment's position in {@link displayAttachments}, which resolves a list
    *  holding two attachments with the same id. */
   openPreview: (attachment: DisplayAttachment, index?: number) => void;
-  /** Records an attachment id whose preview the browser could not decode. */
-  markImageFailed: (id: string) => void;
+  /** Records an attachment whose preview the browser could not decode. Takes
+   *  the position too, so a list holding two attachments with the same id
+   *  keeps the good twin's preview. */
+  markImageFailed: (id: string, index: number) => void;
   /** The rendered preview modal, or `null`. Render it somewhere stable. */
   previewModal: ReactNode;
 }
@@ -59,14 +64,21 @@ export function useAttachmentSquares({
   attachments,
   assistantId,
 }: UseAttachmentSquaresOptions): UseAttachmentSquaresResult {
-  const { failedIds, markFailed: markImageFailed } = useFailedPreviewIds();
+  const { failedIds, markFailed } = useFailedPreviewIds();
+
+  const markImageFailed = useCallback(
+    (id: string, index: number) => markFailed(previewEntryKey(id, index)),
+    [markFailed],
+  );
 
   const displayAttachments = useMemo(
     () =>
       failedIds.size === 0
         ? attachments
-        : attachments.map((att) =>
-            failedIds.has(att.id) ? { ...att, previewUrl: null } : att,
+        : attachments.map((att, index) =>
+            failedIds.has(previewEntryKey(att.id, index))
+              ? { ...att, previewUrl: null }
+              : att,
           ),
     [attachments, failedIds],
   );
@@ -79,7 +91,7 @@ export function useAttachmentSquares({
   const renderSquare = useCallback(
     (attachment: DisplayAttachment, index: number) => (
       <MessageAttachmentSquare
-        key={`${index}:${attachment.id}`}
+        key={previewEntryKey(attachment.id, index)}
         attachment={attachment}
         onPreview={() => openPreview(attachment, index)}
         // Download falls back to previewUrl when the daemon content fetch is
@@ -88,7 +100,7 @@ export function useAttachmentSquares({
         onDownload={() =>
           void downloadAttachment(attachments[index] ?? attachment, assistantId)
         }
-        onPreviewError={() => markImageFailed(attachment.id)}
+        onPreviewError={() => markImageFailed(attachment.id, index)}
       />
     ),
     [attachments, assistantId, openPreview, markImageFailed],

--- a/clients/web/src/domains/chat/components/chat-attachments/use-failed-preview-ids.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-failed-preview-ids.ts
@@ -1,24 +1,35 @@
 import { useCallback, useState } from "react";
 
 interface UseFailedPreviewIdsResult {
-  /** Ids whose preview the browser could not decode. */
+  /** Keys whose preview the browser could not decode. */
   failedIds: ReadonlySet<string>;
-  /** Records an id whose preview failed to decode. */
-  markFailed: (id: string) => void;
+  /** Records a key whose preview failed to decode. */
+  markFailed: (key: string) => void;
 }
 
 /**
- * The set of attachment ids whose image preview the browser could not decode (a
- * TIFF, or a HEIF whose conversion fell back), for the surfaces that swap a
+ * The identity one attachment entry is listed and remembered under.
+ *
+ * A message can hold two entries under one id (the history fallback rehydrates
+ * every row it recovers as `rehydrated:0`), so position joins it. The list
+ * renders under the same key, so the two cannot disagree.
+ */
+export function previewEntryKey(id: string, index: number): string {
+  return `${index}:${id}`;
+}
+
+/**
+ * The set of attachment keys whose image preview the browser could not decode
+ * (a TIFF, or a HEIF whose conversion fell back), for the surfaces that swap a
  * dead picture for something that still names the file.
  *
- * Ids are never reused, and the set is bounded by the attachments one surface
+ * Keys are never reused, and the set is bounded by the attachments one surface
  * shows, so nothing prunes it.
  */
 export function useFailedPreviewIds(): UseFailedPreviewIdsResult {
   const [failedIds, setFailedIds] = useState<ReadonlySet<string>>(new Set());
-  const markFailed = useCallback((id: string) => {
-    setFailedIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+  const markFailed = useCallback((key: string) => {
+    setFailedIds((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
   }, []);
 
   return { failedIds, markFailed };

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -43,6 +43,7 @@ import { useIsNativeMobile } from "@/runtime/platform-detection";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { contrastForeground } from "@/utils/avatar-tone";
+import { formatCompactLocalDate } from "@/utils/format-date";
 
 import { applyRename } from "../identity-actions/apply-rename";
 import {
@@ -155,15 +156,13 @@ const SCHEDULE_GHOSTS = [
 
 /** "14 Jul, 9:00 am" — compact next-fire time for the schedules preview. */
 function formatNextRun(nextRunAt: number): string {
-  if (!Number.isFinite(nextRunAt) || nextRunAt <= 0) {
+  const date = new Date(nextRunAt);
+  // A non-positive timestamp means no next run, and one outside Date's range
+  // would make `toISOString()` throw mid-render.
+  if (nextRunAt <= 0 || Number.isNaN(date.getTime())) {
     return "—";
   }
-  return new Date(nextRunAt).toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+  return formatCompactLocalDate(date.toISOString());
 }
 
 const AVATAR_MAX_SIZE = 280;

--- a/clients/web/src/i18n/host-language.test-helper.ts
+++ b/clients/web/src/i18n/host-language.test-helper.ts
@@ -1,22 +1,35 @@
 /**
- * Swap the host's reported language for the span of one test.
+ * Swap the host's reported languages for the span of one test.
  *
- * A property descriptor rather than a module mock: bun applies `mock.module`
+ * Both `navigator.languages` (the ordered preference list `systemLocales()`
+ * reads) and `navigator.language` (its single-entry fallback) are replaced, so
+ * a test sees the given tag whichever one the code under test reaches for.
+ *
+ * Property descriptors rather than a module mock: bun applies `mock.module`
  * process-wide, so a stub of `navigator` would follow every other test file
  * sharing the process. Returns the restore, which puts back whatever
- * descriptor was there (including none at all).
+ * descriptors were there (including none at all).
  */
 export function stubHostLanguage(tag: string): () => void {
-  const original = Object.getOwnPropertyDescriptor(navigator, "language");
-  Object.defineProperty(navigator, "language", {
-    value: tag,
-    configurable: true,
-  });
+  const restores = [
+    stubNavigatorProperty("language", tag),
+    stubNavigatorProperty("languages", [tag]),
+  ];
+  return () => {
+    for (const restore of restores) {
+      restore();
+    }
+  };
+}
+
+function stubNavigatorProperty(name: string, value: unknown): () => void {
+  const original = Object.getOwnPropertyDescriptor(navigator, name);
+  Object.defineProperty(navigator, name, { value, configurable: true });
   return () => {
     if (original) {
-      Object.defineProperty(navigator, "language", original);
+      Object.defineProperty(navigator, name, original);
     } else {
-      delete (navigator as unknown as { language?: string }).language;
+      delete (navigator as unknown as Record<string, unknown>)[name];
     }
   };
 }

--- a/clients/web/src/i18n/i18n.test.ts
+++ b/clients/web/src/i18n/i18n.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { stubHostLanguage } from "@/i18n/host-language.test-helper";
 import type { SupportedLocale } from "@/i18n/supported-locales";
 
 let preferred: string[] = [];
@@ -139,31 +138,46 @@ describe("ICU message formatting", () => {
 });
 
 describe("formatLocale", () => {
-  async function hostLanguageUnder(
-    host: string,
+  async function hostLanguagesUnder(
+    hosts: string[],
     app: SupportedLocale,
   ): Promise<string> {
     await initI18n();
     await changeLocale(app);
-    const restore = stubHostLanguage(host);
+    preferred = hosts;
     try {
       return formatLocale();
     } finally {
-      restore();
+      preferred = [];
       await changeLocale("en");
     }
   }
 
   test("keeps the host's region when it speaks the app's language", async () => {
-    expect(await hostLanguageUnder("en-GB", "en")).toBe("en-GB");
-    expect(await hostLanguageUnder("es-MX", "es")).toBe("es-MX");
+    expect(await hostLanguagesUnder(["en-GB"], "en")).toBe("en-GB");
+    expect(await hostLanguagesUnder(["es-MX"], "es")).toBe("es-MX");
   });
 
   test("keeps a Chinese host tag under either Chinese catalog", async () => {
-    expect(await hostLanguageUnder("zh-TW", "zh")).toBe("zh-TW");
+    expect(await hostLanguagesUnder(["zh-TW"], "zh")).toBe("zh-TW");
   });
 
   test("falls back to the app locale when the host speaks another language", async () => {
-    expect(await hostLanguageUnder("de-DE", "en")).toBe("en");
+    expect(await hostLanguagesUnder(["de-DE"], "en")).toBe("en");
+  });
+
+  test("reads past the host's first language to the app's own", async () => {
+    // A device that leads with English while the app runs in Spanish still
+    // states a Spanish region, and that is the one to format in.
+    expect(await hostLanguagesUnder(["en-US", "es-MX"], "es")).toBe("es-MX");
+  });
+
+  test("falls back to the app locale for a tag Intl cannot parse", async () => {
+    // A POSIX environment reports `C`, some shells report an underscored
+    // `en_US`, and a truncated tag reaches the region check intact. Handing
+    // any of them to Intl throws RangeError inside a formatter.
+    expect(await hostLanguagesUnder(["C"], "en")).toBe("en");
+    expect(await hostLanguagesUnder(["en_US"], "en")).toBe("en");
+    expect(await hostLanguagesUnder(["en-1"], "en")).toBe("en");
   });
 });

--- a/clients/web/src/i18n/i18n.ts
+++ b/clients/web/src/i18n/i18n.ts
@@ -230,23 +230,43 @@ function primaryLanguage(tag: string): string {
  * locale otherwise, so `en-GB` under app locale `en` keeps its region while
  * `de-DE` under `en` does not format German dates beside English copy.
  *
- * Comparison is by primary subtag, so a `zh-TW` host keeps `zh-TW` under
- * either Chinese catalog.
+ * The host's whole preference list is searched, not just its first entry, so a
+ * user whose device leads with English while the app runs in Spanish still
+ * formats in the Spanish region they also listed. Comparison is by primary
+ * subtag, so a `zh-TW` host keeps `zh-TW` under either Chinese catalog.
  *
  * References:
- * - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
+ * - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages
  * - https://www.rfc-editor.org/rfc/rfc5646 (BCP 47 tag structure)
+ * - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/getCanonicalLocales
  */
 export function formatLocale(): string {
   const app = currentLocale();
-  if (typeof navigator === "undefined") {
+  const host = systemLocales().find(
+    (tag) => primaryLanguage(tag) === primaryLanguage(app),
+  );
+  if (host === undefined || !isFormattableLocale(host)) {
     return app;
   }
-  const host = navigator.language;
-  if (!host) {
-    return app;
+  return host;
+}
+
+/**
+ * Whether `Intl` will accept `tag`, which is not a given for a host-reported
+ * one: a POSIX environment reports `C`, and an underscored `en_US` reaches us
+ * from more than one shell. Every `Intl` constructor throws `RangeError` on
+ * those, and this is read by every date, time, and number formatter in the
+ * app, so the tag is checked once here instead of failing a render later.
+ */
+function isFormattableLocale(tag: string): boolean {
+  try {
+    Intl.getCanonicalLocales(tag);
+    return true;
+  } catch {
+    // A tag Intl cannot parse is host data the caller falls back from, not a
+    // fault to report.
+    return false;
   }
-  return primaryLanguage(host) === primaryLanguage(app) ? host : app;
 }
 
 export { i18next };


### PR DESCRIPTION
## Summary
- the tool-result strip keys on a synthesised id so a mid-turn removal does not remount its neighbours, keeps its preview open when the list empties, and names a failed image
- the failed-decode set is keyed by position and id, so one bad legacy twin does not blank the other
- formatLocale reads the host's full language list and validates the tag before Intl sees it; downloadAttachment reports an interrupted download when no bytes are available; the schedules preview formats through format-date; three lint globs cover their tests and stories

Part of plan: chat-info-assets-panel.md (remediation round 7)