### PR TITLE
ci: enable Windows staging and production installers

### DIFF
--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -2,8 +2,7 @@ name: Release Windows
 
 # Reusable Windows desktop release: build, sign, verify, and publish the NSIS
 # installers and electron-updater feed for one environment. Called by
-# dev-release.yaml and release.yml. Dev runs on every dev release; staging and
-# production remain behind their WINDOWS_<ENV>_RELEASE_ENABLED variables.
+# dev-release.yaml and release.yml for dev, staging, and production.
 # Never dispatched on its own.
 #
 # External gates (repository secrets can be shared across environments):

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2651,11 +2651,7 @@ jobs:
     needs: [extract-version, publish-meta-prod, publish-meta-staging, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest]
     if: >-
       ${{
-        (
-          (needs.extract-version.outputs.is_staging == 'true' && vars.WINDOWS_STAGING_RELEASE_ENABLED == 'true')
-          || (needs.extract-version.outputs.is_staging != 'true' && vars.WINDOWS_PRODUCTION_RELEASE_ENABLED == 'true')
-        )
-        && always() && !cancelled()
+        always() && !cancelled()
         && needs.extract-version.result == 'success'
         && needs.push-assistant-manifest.result == 'success'
         && needs.push-gateway-manifest.result == 'success'

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -150,11 +150,12 @@ uninstall-tests the installer.
 
 `.github/workflows/release-windows.yaml` is the reusable release: both
 `dev-release.yaml` and `release.yml` call it with `{ environment, version }`.
-Dev runs on every dev release, while staging and production stay behind the
-`WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED` variables. It stamps the version
-and builds the helper, preview handler, CLI runtime, and renderer on native
-runners (x64 on `windows-2025`, arm64 on `windows-11-vs2026-arm`). Each native
-payload and its stamped app manifest transfer to an x64 `windows-2025` runner
+Windows installers build for dev, staging, and production releases. Staging
+and production wait for the release images and channel metadata to publish.
+The workflow stamps the version and builds the helper, preview handler, CLI
+runtime, and renderer on native runners (x64 on `windows-2025`, arm64 on
+`windows-11-vs2026-arm`). Each native payload and its stamped app manifest
+transfer to an x64 `windows-2025` runner
 for packaging and signing through `electron-builder`, because
 [Azure Artifact Signing does not support Windows ARM runners](https://github.com/Azure/artifact-signing-action#runner-requirements).
 The workflow verifies every manifest binary and the installer with

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -616,7 +616,7 @@ Creating the GitHub Release triggers three workflows in parallel:
 - **Publish velly to npm** (`publish-velly.yml`): Publishes the `velly` CLI package to npm with provenance.
 - **Slack Release Notification** (`slack-release-notification.yml`): Posts a summary message to the releases Slack channel with a threaded changelog.
 
-- **Release Windows** (`release-windows` job, reusable `release-windows.yaml`): Builds, signs, and verifies the NSIS installer per architecture on native Windows runners, then publishes the installer, blockmap, and `{env}.yml` manifest to the GCS feed at `win-electron/{arch}/`. Dev runs on every dev release and also publishes a stable installer alias for the dev download page; staging and production are enabled by `WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED`. Signing credentials are an explicit gate documented in `clients/windows/README.md`.
+- **Release Windows** (`release-windows` job, reusable `release-windows.yaml`): Builds, signs, and verifies the NSIS installer per architecture on native Windows runners, then publishes the installer, blockmap, and `{env}.yml` manifest to the GCS feed at `win-electron/{arch}/`. Dev runs on every dev release and also publishes a stable installer alias for the dev download page; staging and production run after the release images and channel metadata publish. Signing credentials are an explicit gate documented in `clients/windows/README.md`.
 
 #### Auto-updates for macOS clients
 


### PR DESCRIPTION
## Summary

- Enable Windows x64 and ARM64 installer releases for staging and production by removing the opt-in variable gates.
- Preserve release image and channel metadata dependencies, signing verification, and update-feed publication.
- Update the Windows release documentation to reflect all three CD environments.

## Validation

- Reviewed the workflow conditions and ran `git diff --check`.
- No application tests added or run for this workflow-only change.

## Original prompt

Enable Windows installer building for staging and production in the GitHub Actions CD pipeline, extending the existing dev release behavior. Use the `/do` workflow to implement the change in an isolated worktree and open a PR for review.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->