### PR TITLE
fix(assistant): keep process alive when gateway IPC socket is missing

### DIFF
--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -344,4 +344,34 @@ describe("gateway-flag-listener", () => {
 
     expect(testServer.clients.size).toBeLessThanOrEqual(initialClientCount);
   });
+
+  test("missing gateway socket does not throw and reconnects when the socket appears", async () => {
+    const uncaught: unknown[] = [];
+    const onUncaught = (err: unknown) => {
+      uncaught.push(err);
+    };
+    process.on("uncaughtException", onUncaught);
+    process.on("unhandledRejection", onUncaught);
+
+    try {
+      startGatewayFlagListener();
+      await new Promise((r) => setTimeout(r, 50));
+      expect(uncaught).toHaveLength(0);
+
+      await new Promise<void>((resolve) => {
+        testServer.server.listen(socketPath, resolve);
+      });
+
+      const client = await Promise.race([
+        testServer.waitForClient(),
+        new Promise<null>((r) => setTimeout(() => r(null), 3000)),
+      ]);
+
+      expect(client).not.toBeNull();
+      expect(uncaught).toHaveLength(0);
+    } finally {
+      process.off("uncaughtException", onUncaught);
+      process.off("unhandledRejection", onUncaught);
+    }
+  });
 });

--- a/assistant/src/__tests__/helpers/gateway-classify-mock.ts
+++ b/assistant/src/__tests__/helpers/gateway-classify-mock.ts
@@ -77,6 +77,30 @@ export function installIpcMock(): void {
       params?: Record<string, unknown>,
     ) => handleCall(method, params),
 
+    IpcCallError: class MockIpcCallError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "IpcCallError";
+      }
+    },
+    IpcConnectError: class MockIpcConnectError extends Error {
+      readonly code?: string;
+      constructor(message: string, code?: string) {
+        super(message);
+        this.name = "IpcConnectError";
+        if (code !== undefined) {
+          this.code = code;
+        }
+      }
+    },
+    isRetryableIpcConnectError: (err: unknown) => {
+      if (typeof err === "object" && err !== null && "code" in err) {
+        const code = (err as { code?: unknown }).code;
+        return code === "ENOENT" || code === "ECONNREFUSED";
+      }
+      return false;
+    },
+
     PersistentIpcClient: class MockPersistentIpcClient {
       async call(
         method: string,

--- a/assistant/src/__tests__/mock-gateway-ipc.ts
+++ b/assistant/src/__tests__/mock-gateway-ipc.ts
@@ -44,6 +44,9 @@ let ipcResults: Record<string, unknown> = {};
 /** Whether the fake ipcCall should simulate a connection error. */
 let simulateError = false;
 
+/** `IpcConnectError.code` used when `simulateError` is set. */
+let simulateErrorCode: string | undefined;
+
 /** Throw a transient (retryable) error for the first N persistent calls, then succeed. */
 let failFirstN = 0;
 
@@ -69,10 +72,10 @@ class FakePersistentIpcClient extends EventEmitter {
       if (failWithIpcCallError) {
         throw new FakeIpcCallError("Mock deterministic gateway error");
       }
-      throw new Error("Mock IPC socket error");
+      throw mockConnectError();
     }
     if (simulateError) {
-      throw new Error("Mock IPC socket error");
+      throw mockConnectError();
     }
     if (method in ipcResults) {
       return ipcResults[method];
@@ -131,7 +134,39 @@ class FakeIpcCallError extends Error {
   }
 }
 
+class FakeIpcConnectError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "IpcConnectError";
+    if (code !== undefined) {
+      this.code = code;
+    }
+  }
+}
+
+const RETRYABLE_CONNECT_CODES = new Set(["ENOENT", "ECONNREFUSED"]);
+
+function isRetryableIpcConnectError(err: unknown): boolean {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "string" && RETRYABLE_CONNECT_CODES.has(code);
+  }
+  return false;
+}
+
+function mockConnectError(): FakeIpcConnectError {
+  return new FakeIpcConnectError(
+    "Mock IPC socket error",
+    simulateErrorCode ?? "ENOENT",
+  );
+}
+
 export function installGatewayIpcMock(): void {
+  // Named exports here must cover every ipc-client symbol the package barrel
+  // re-exports. Bun's mock replaces that module for relative and package
+  // imports, so a missing name fails assistant tests at load time.
   mock.module("@vellumai/gateway-client/ipc-client", () => ({
     ipcCall: async (
       _socketPath: string,
@@ -151,6 +186,8 @@ export function installGatewayIpcMock(): void {
       return undefined;
     },
     IpcCallError: FakeIpcCallError,
+    IpcConnectError: FakeIpcConnectError,
+    isRetryableIpcConnectError,
     PersistentIpcClient: FakePersistentIpcClient,
   }));
 }
@@ -165,7 +202,7 @@ export function installGatewayIpcMock(): void {
  * @param flags — feature flag map returned by `get_feature_flags`. Pass
  *   `null` to skip setting a result (useful when only simulating errors).
  * @param opts.error — simulate a socket connection error
- * @param opts.code — error code (kept for API compat, unused by package mock)
+ * @param opts.code - `IpcConnectError.code` when simulating a connect failure
  * @param opts.results — raw method->result map for arbitrary IPC methods
  */
 export function mockGatewayIpc(
@@ -189,6 +226,9 @@ export function mockGatewayIpc(
   if (opts?.error) {
     simulateError = true;
   }
+  if (opts?.code !== undefined) {
+    simulateErrorCode = opts.code;
+  }
   if (opts?.failFirstN !== undefined) {
     failFirstN = opts.failFirstN;
   }
@@ -211,6 +251,7 @@ export function getMockPersistentCallCount(method: string): number {
 export function resetMockGatewayIpc(): void {
   ipcResults = {};
   simulateError = false;
+  simulateErrorCode = undefined;
   failFirstN = 0;
   failWithIpcCallError = false;
   for (const key of Object.keys(persistentCallCounts)) {

--- a/assistant/src/ipc/__tests__/gateway-validated-call.test.ts
+++ b/assistant/src/ipc/__tests__/gateway-validated-call.test.ts
@@ -3,12 +3,12 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { z } from "zod";
 
 import {
   IpcCallError,
   IpcConnectError,
 } from "@vellumai/gateway-client/ipc-client";
+import { z } from "zod";
 
 import { ServiceUnavailableError } from "../../runtime/routes/errors.js";
 

--- a/assistant/src/ipc/__tests__/gateway-validated-call.test.ts
+++ b/assistant/src/ipc/__tests__/gateway-validated-call.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for ipcCallPersistentValidated connect-failure mapping.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { z } from "zod";
+
+import {
+  IpcCallError,
+  IpcConnectError,
+} from "@vellumai/gateway-client/ipc-client";
+
+import { ServiceUnavailableError } from "../../runtime/routes/errors.js";
+
+let ipcError: Error | undefined;
+let ipcResult: unknown = { ok: true };
+
+const ipcCallPersistentMock = mock(async () => {
+  if (ipcError) {
+    throw ipcError;
+  }
+  return ipcResult;
+});
+
+mock.module("../gateway-client.js", () => ({
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+const { ipcCallPersistentValidated } = await import(
+  "../gateway-validated-call.js"
+);
+
+const OkSchema = z.object({ ok: z.literal(true) });
+
+describe("ipcCallPersistentValidated", () => {
+  beforeEach(() => {
+    ipcError = undefined;
+    ipcResult = { ok: true };
+    ipcCallPersistentMock.mockClear();
+  });
+
+  test("returns a schema-valid response", async () => {
+    const result = await ipcCallPersistentValidated("ping", {}, OkSchema);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("maps IpcConnectError to ServiceUnavailableError", async () => {
+    ipcError = new IpcConnectError("connect ENOENT", "ENOENT");
+
+    await expect(
+      ipcCallPersistentValidated("ping", {}, OkSchema),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+  });
+
+  test("propagates IpcCallError unchanged", async () => {
+    ipcError = new IpcCallError("Invite not found", {
+      statusCode: 404,
+      errorCode: "NOT_FOUND",
+    });
+
+    try {
+      await ipcCallPersistentValidated("ping", {}, OkSchema);
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(IpcCallError);
+      expect((err as IpcCallError).statusCode).toBe(404);
+    }
+  });
+});

--- a/assistant/src/ipc/__tests__/route-error-envelope.test.ts
+++ b/assistant/src/ipc/__tests__/route-error-envelope.test.ts
@@ -9,6 +9,8 @@
 
 import { describe, expect, test } from "bun:test";
 
+import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
+
 import {
   RouteError,
   UnprocessableEntityError,
@@ -76,5 +78,15 @@ describe("AssistantIpcServer error envelope", () => {
     expect(response.error).toBe("Error: raw");
     expect(response.errorCode).toBeUndefined();
     expect(response.errorDetails).toBeUndefined();
+  });
+
+  test("IpcConnectError surfaces as 503 SERVICE_UNAVAILABLE", () => {
+    const response = buildErrorResponse(
+      new IpcConnectError("connect ENOENT", "ENOENT"),
+    );
+
+    expect(response.statusCode).toBe(503);
+    expect(response.errorCode).toBe("SERVICE_UNAVAILABLE");
+    expect(response.error).toContain("Gateway is not reachable over IPC");
   });
 });

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -30,6 +30,7 @@
 
 import { createServer, type Server, type Socket } from "node:net";
 
+import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
 import {
   ensureSocketDir,
   type IpcEnvelope,
@@ -490,6 +491,14 @@ export class AssistantIpcServer {
         response.errorDetails = err.details;
       }
       return response;
+    }
+    if (err instanceof IpcConnectError) {
+      return {
+        id,
+        error: `Gateway is not reachable over IPC: ${err.message}`,
+        statusCode: 503,
+        errorCode: "SERVICE_UNAVAILABLE",
+      };
     }
     return { id, error: String(err) };
   }

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -65,7 +65,9 @@ let persistentClient: PackagePersistentIpcClient | null = null;
  * Unlike `ipcCall()`, this maintains a single connection across calls,
  * making it suitable for hot-path operations like risk classification.
  *
- * Throws on failure (timeout, socket error) — callers must handle errors.
+ * Throws `IpcConnectError` when the gateway socket is missing or refused,
+ * and `IpcCallError` when the gateway returns a structured error. Callers
+ * must handle errors.
  */
 export async function ipcCallPersistent(
   method: string,

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -1,4 +1,4 @@
-import { connect, type Socket } from "node:net";
+import { Socket } from "node:net";
 
 import { refreshOverridesFromGateway } from "../config/assistant-feature-flags.js";
 import { getBalancedModelExperimentArm } from "../config/balanced-model-experiment.js";
@@ -109,7 +109,9 @@ function connectToGateway(): void {
   }
 
   const socketPath = getSocketPath();
-  const conn = connect(socketPath);
+  // Attach error listeners before connect() so a missing gateway.sock cannot
+  // surface as an uncaught exception.
+  const conn = new Socket();
 
   conn.on("connect", () => {
     if (stopped) {
@@ -149,6 +151,8 @@ function connectToGateway(): void {
     log.debug({ err }, "Gateway IPC connection error");
     conn.destroy();
   });
+
+  conn.connect(socketPath);
 }
 
 export function startGatewayFlagListener(): void {

--- a/assistant/src/ipc/gateway-ipc-errors.ts
+++ b/assistant/src/ipc/gateway-ipc-errors.ts
@@ -1,0 +1,49 @@
+/**
+ * Map gateway IPC transport failures to route-layer errors.
+ *
+ * Connect failures (missing or refused `gateway.sock`) are a normal boot-order
+ * race, not a process-fatal exception. Surface them as 503 so the assistant
+ * stays up and the request degrades.
+ */
+
+import {
+  IpcCallError,
+  IpcConnectError,
+} from "@vellumai/gateway-client/ipc-client";
+
+import {
+  RouteError,
+  ServiceUnavailableError,
+} from "../runtime/routes/errors.js";
+
+/**
+ * If `err` is an {@link IpcConnectError}, throw 503. Otherwise return so the
+ * caller can rethrow or map a more specific failure.
+ */
+export function throwIfGatewayIpcConnectFailed(err: unknown): void {
+  if (err instanceof IpcConnectError) {
+    throw new ServiceUnavailableError(
+      `Gateway is not reachable over IPC: ${err.message}`,
+    );
+  }
+}
+
+/**
+ * Re-throw a gateway IPC failure as a route error.
+ *
+ * `IpcConnectError` becomes 503. Structured `IpcCallError` keeps the
+ * gateway's statusCode/errorCode so 4xx engine reasons stay 4xx. Any other
+ * throw propagates unchanged.
+ */
+export function rethrowGatewayIpcFailure(err: unknown): never {
+  throwIfGatewayIpcConnectFailed(err);
+  if (err instanceof IpcCallError) {
+    throw new RouteError(
+      err.message,
+      err.errorCode ?? "INTERNAL_ERROR",
+      err.statusCode ?? 500,
+      err.errorDetails,
+    );
+  }
+  throw err;
+}

--- a/assistant/src/ipc/gateway-validated-call.ts
+++ b/assistant/src/ipc/gateway-validated-call.ts
@@ -7,6 +7,8 @@
  * and the persistent socket avoids per-call connect overhead. Transport
  * failures (`IpcCallError`, carrying the gateway's statusCode/errorCode)
  * propagate unchanged so relay routes surface 4xx engine reasons as 4xx; a
+ * connect failure (`IpcConnectError`, missing or refused gateway socket)
+ * becomes `ServiceUnavailableError` (503) so the assistant stays up; a
  * schema-invalid response throws a generic malformed-response error.
  *
  * The hot voice call-setup path (`calls/gateway-invite-reader.ts`)
@@ -17,13 +19,20 @@
 import type { ZodType } from "zod";
 
 import { ipcCallPersistent } from "./gateway-client.js";
+import { throwIfGatewayIpcConnectFailed } from "./gateway-ipc-errors.js";
 
 export async function ipcCallPersistentValidated<T>(
   method: string,
   params: Record<string, unknown> | undefined,
   responseSchema: ZodType<T>,
 ): Promise<T> {
-  const result = await ipcCallPersistent(method, params);
+  let result: unknown;
+  try {
+    result = await ipcCallPersistent(method, params);
+  } catch (err) {
+    throwIfGatewayIpcConnectFailed(err);
+    throw err;
+  }
   const parsed = responseSchema.safeParse(result);
   if (!parsed.success) {
     throw new Error(`Gateway returned a malformed ${method} response`);

--- a/assistant/src/runtime/middleware/error-handler.ts
+++ b/assistant/src/runtime/middleware/error-handler.ts
@@ -2,6 +2,8 @@
  * Centralized error handling for runtime HTTP request dispatch.
  */
 
+import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
+
 import { ConfigError, ProviderNotConfiguredError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { httpError } from "../http-errors.js";
@@ -30,6 +32,14 @@ export async function withErrorHandling(
     if (err instanceof ConfigError) {
       log.warn({ err, endpoint }, "Runtime HTTP config error");
       return httpError("UNPROCESSABLE_ENTITY", err.message, 422);
+    }
+    if (err instanceof IpcConnectError) {
+      log.warn({ err, endpoint }, "Gateway IPC is unreachable");
+      return httpError(
+        "SERVICE_UNAVAILABLE",
+        `Gateway is not reachable over IPC: ${err.message}`,
+        503,
+      );
     }
     log.error({ err, endpoint }, "Runtime HTTP handler error");
     const message =

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -15,7 +15,10 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+import {
+  IpcCallError,
+  IpcConnectError,
+} from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 let ipcCalls: { method: string; params?: Record<string, unknown> }[] = [];
@@ -240,6 +243,16 @@ describe("contacts read API relays from the gateway", () => {
       statusCode: 503,
     });
     // No assistant-DB fallback read.
+    expect(contactStoreReadGuard).not.toHaveBeenCalled();
+  });
+
+  test("list surfaces a missing gateway socket as 503", async () => {
+    ipcError = new IpcConnectError("connect ENOENT", "ENOENT");
+
+    await expect(handleListContacts({ limit: "50" })).rejects.toMatchObject({
+      statusCode: 503,
+      code: "SERVICE_UNAVAILABLE",
+    });
     expect(contactStoreReadGuard).not.toHaveBeenCalled();
   });
 

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -21,7 +21,6 @@ import {
   MergeContactsIpcResponseSchema,
   UpdateContactChannelIpcResponseSchema,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
-import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import {
@@ -41,6 +40,7 @@ import type {
   ContactWithChannels,
 } from "../../contacts/types.js";
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
+import { rethrowGatewayIpcFailure } from "../../ipc/gateway-ipc-errors.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS, GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
@@ -49,27 +49,10 @@ import {
   resolveInviteGuardianName,
   triggerInviteCall,
 } from "../invite-service.js";
-import { BadRequestError, NotFoundError, RouteError } from "./errors.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("contact-routes");
-
-/**
- * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
- * adapters honor its statusCode/errorCode (4xx surfaces as 4xx, not a generic
- * 500). Non-IpcCallError throws propagate unchanged.
- */
-function rethrowGatewayError(err: unknown): never {
-  if (err instanceof IpcCallError) {
-    throw new RouteError(
-      err.message,
-      err.errorCode ?? "INTERNAL_ERROR",
-      err.statusCode ?? 500,
-      err.errorDetails,
-    );
-  }
-  throw err;
-}
 
 function withGuardianNameOverride<
   T extends { role: string; displayName: string },
@@ -240,7 +223,7 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
       contacts: contacts.map((c) => prepareContactResponse(c)),
     };
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }
 
@@ -428,7 +411,7 @@ export async function handleGetContact(contactId: string) {
     if (err instanceof NotFoundError) {
       throw err;
     }
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }
 
@@ -452,7 +435,7 @@ export async function handleListInvites({
     });
     return { ok: true, invites };
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }
 
@@ -478,7 +461,7 @@ export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
         : {}),
     });
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
   const invite = await composeInvitePresentation({
     contactId,
@@ -499,7 +482,7 @@ export async function handleRevokeInvite({
     const invite = await revokeInvite(pathParams.id);
     return { ok: true, invite };
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }
 
@@ -527,7 +510,7 @@ async function handleRedeemVoiceInvite({ body = {} }: RouteHandlerArgs) {
         : {}),
     });
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }
 
@@ -563,7 +546,7 @@ async function handleRedeemTokenInvite({ body = {} }: RouteHandlerArgs) {
     // `already_member` no-op (which consumes no invite use).
     return await redeemInviteByToken(parsed.data);
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }
 
@@ -1030,7 +1013,7 @@ export async function handleMergeContactsRoute(args: RouteHandlerArgs) {
         : undefined,
     };
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }
 
@@ -1061,6 +1044,6 @@ export async function handleUpdateContactChannelRoute(args: RouteHandlerArgs) {
     });
     return UpdateContactChannelIpcResponseSchema.parse(result);
   } catch (err) {
-    rethrowGatewayError(err);
+    rethrowGatewayIpcFailure(err);
   }
 }

--- a/assistant/src/runtime/routes/gateway-log-routes.ts
+++ b/assistant/src/runtime/routes/gateway-log-routes.ts
@@ -11,6 +11,7 @@ import {
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
+import { throwIfGatewayIpcConnectFailed } from "../../ipc/gateway-ipc-errors.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -23,7 +24,13 @@ async function handleGatewayLogsTail({
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
   const p = GatewayLogsTailRouteParamsSchema.parse(source);
-  const result = await ipcCallPersistent("gateway_logs_tail", p);
+  let result: unknown;
+  try {
+    result = await ipcCallPersistent("gateway_logs_tail", p);
+  } catch (err) {
+    throwIfGatewayIpcConnectFailed(err);
+    throw err;
+  }
   return GatewayLogsTailIpcResponseSchema.parse(result);
 }
 

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -3,6 +3,8 @@
  * for the HTTP server's route table.
  */
 
+import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
+
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { HttpErrorCode } from "../http-errors.js";
 import { httpError } from "../http-errors.js";
@@ -190,6 +192,13 @@ export function routeDefinitionsToHTTPRoutes(
             err.message,
             err.statusCode,
             err.details,
+          );
+        }
+        if (err instanceof IpcConnectError) {
+          return httpError(
+            "SERVICE_UNAVAILABLE",
+            `Gateway is not reachable over IPC: ${err.message}`,
+            503,
           );
         }
         throw err;

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -11,6 +11,7 @@ import {
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
+import { throwIfGatewayIpcConnectFailed } from "../../ipc/gateway-ipc-errors.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -23,7 +24,13 @@ async function handleList({
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
   const p = TrustRulesListIpcParamsSchema.parse(source);
-  const result = await ipcCallPersistent("trust_rules_list", p);
+  let result: unknown;
+  try {
+    result = await ipcCallPersistent("trust_rules_list", p);
+  } catch (err) {
+    throwIfGatewayIpcConnectFailed(err);
+    throw err;
+  }
   return TrustRulesListIpcResponseSchema.parse(result);
 }
 

--- a/packages/gateway-client/src/__tests__/gateway-client.test.ts
+++ b/packages/gateway-client/src/__tests__/gateway-client.test.ts
@@ -15,7 +15,7 @@ import { unlinkSync } from "node:fs";
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { ipcCall, PersistentIpcClient } from "../ipc-client.js";
+import { ipcCall, IpcConnectError, PersistentIpcClient } from "../ipc-client.js";
 import { ChannelDeliveryError, deliverChannelReply } from "../http-delivery.js";
 import type { Logger } from "../types.js";
 
@@ -159,14 +159,26 @@ describe("ipc-client", () => {
     });
 
     test("returns undefined when socket does not exist", async () => {
-      const log = createTestLogger();
-      const result = await ipcCall(
-        "/tmp/nonexistent-socket.sock",
-        "test_method",
-        undefined,
-        log,
-      );
-      expect(result).toBeUndefined();
+      const uncaught: unknown[] = [];
+      const onUncaught = (err: unknown) => {
+        uncaught.push(err);
+      };
+      process.on("uncaughtException", onUncaught);
+      process.on("unhandledRejection", onUncaught);
+      try {
+        const log = createTestLogger();
+        const result = await ipcCall(
+          "/tmp/nonexistent-socket.sock",
+          "test_method",
+          undefined,
+          log,
+        );
+        expect(result).toBeUndefined();
+        expect(uncaught).toHaveLength(0);
+      } finally {
+        process.off("uncaughtException", onUncaught);
+        process.off("unhandledRejection", onUncaught);
+      }
     });
 
     test("forwards params in the request", async () => {
@@ -333,6 +345,68 @@ describe("ipc-client", () => {
       const client = new PersistentIpcClient(socketPath, 100);
       try {
         await expect(client.call("slow_method")).rejects.toThrow("timed out");
+      } finally {
+        client.destroy();
+      }
+    });
+
+    test("throws IpcConnectError without an uncaught exception when the socket is missing", async () => {
+      const uncaught: unknown[] = [];
+      const onUncaught = (err: unknown) => {
+        uncaught.push(err);
+      };
+      process.on("uncaughtException", onUncaught);
+      process.on("unhandledRejection", onUncaught);
+
+      const client = new PersistentIpcClient(
+        socketPath,
+        1_000,
+        createTestLogger(),
+        { connectRetryBackoffsMs: [] },
+      );
+      try {
+        await expect(client.call("any_method")).rejects.toBeInstanceOf(
+          IpcConnectError,
+        );
+        expect(uncaught).toHaveLength(0);
+      } finally {
+        client.destroy();
+        process.off("uncaughtException", onUncaught);
+        process.off("unhandledRejection", onUncaught);
+      }
+    });
+
+    test("retries a missing socket until the gateway binds", async () => {
+      const log = createTestLogger();
+      server = createServer((conn) => {
+        let buf = "";
+        conn.on("data", (chunk) => {
+          buf += chunk.toString();
+          const idx = buf.indexOf("\n");
+          if (idx !== -1) {
+            const req = JSON.parse(buf.slice(0, idx));
+            conn.write(
+              JSON.stringify({ id: req.id, result: "ready" }) + "\n",
+            );
+          }
+        });
+      });
+
+      const client = new PersistentIpcClient(socketPath, 5_000, log, {
+        connectRetryBackoffsMs: [50, 100, 200],
+      });
+      try {
+        const callPromise = client.call("ping");
+        await new Promise((r) => setTimeout(r, 80));
+        await new Promise<void>((resolve) => {
+          server.listen(socketPath, () => resolve());
+        });
+        await expect(callPromise).resolves.toBe("ready");
+        expect(
+          log.messages.some(
+            (m) => m.msg === "Persistent IPC connect failed, retrying",
+          ),
+        ).toBe(true);
       } finally {
         client.destroy();
       }

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -21,7 +21,6 @@ export {
   ipcCall,
   IpcCallError,
   IpcConnectError,
-  isRetryableIpcConnectError,
   PersistentIpcClient,
 } from "./ipc-client.js";
 

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -17,7 +17,13 @@ export {
 
 export * from "./gateway-ipc-contracts.js";
 
-export { ipcCall, IpcCallError, PersistentIpcClient } from "./ipc-client.js";
+export {
+  ipcCall,
+  IpcCallError,
+  IpcConnectError,
+  isRetryableIpcConnectError,
+  PersistentIpcClient,
+} from "./ipc-client.js";
 
 // Outbound delivery contract (daemon → gateway) — Zod schemas + derived types
 export {

--- a/packages/gateway-client/src/ipc-client.ts
+++ b/packages/gateway-client/src/ipc-client.ts
@@ -136,8 +136,8 @@ function connectUnixSocket(
       settled = true;
       clearTimeout(timer);
       sock.off("connect", onConnect);
-      sock.off("error", onError);
       sock.off("close", onClose);
+      // Keep the error listener so sock.destroy() cannot become uncaught.
       if (err) {
         sock.destroy();
         reject(err);

--- a/packages/gateway-client/src/ipc-client.ts
+++ b/packages/gateway-client/src/ipc-client.ts
@@ -8,7 +8,7 @@
  * followed by a newline character.
  */
 
-import { connect, type Socket } from "node:net";
+import { Socket } from "node:net";
 
 import type { IpcRequest, IpcResponse, Logger } from "./types.js";
 import { noopLogger } from "./types.js";
@@ -38,11 +38,145 @@ export class IpcCallError extends Error {
   ) {
     super(message);
     this.name = "IpcCallError";
-    if (fields.statusCode !== undefined) this.statusCode = fields.statusCode;
-    if (fields.errorCode !== undefined) this.errorCode = fields.errorCode;
-    if (fields.errorDetails !== undefined)
+    if (fields.statusCode !== undefined) {
+      this.statusCode = fields.statusCode;
+    }
+    if (fields.errorCode !== undefined) {
+      this.errorCode = fields.errorCode;
+    }
+    if (fields.errorDetails !== undefined) {
       this.errorDetails = fields.errorDetails;
+    }
   }
+}
+
+/**
+ * Transport-level failure to open the gateway Unix socket.
+ *
+ * Distinct from {@link IpcCallError}: the gateway was not reachable, so there
+ * is no structured engine response. Callers should treat this as a transient
+ * availability failure (retry, or surface 503), never as an uncaught
+ * exception that exits the process.
+ */
+export class IpcConnectError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "IpcConnectError";
+    if (code !== undefined) {
+      this.code = code;
+    }
+  }
+}
+
+/** Socket-not-yet-bound codes that are safe to retry during sibling boot. */
+const RETRYABLE_CONNECT_CODES = new Set(["ENOENT", "ECONNREFUSED"]);
+
+export function isRetryableIpcConnectError(err: unknown): boolean {
+  const code = errnoCode(err);
+  return code !== undefined && RETRYABLE_CONNECT_CODES.has(code);
+}
+
+function errnoCode(err: unknown): string | undefined {
+  if (err instanceof IpcConnectError) {
+    return err.code;
+  }
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === "string" ? code : undefined;
+  }
+  return undefined;
+}
+
+function toIpcConnectError(err: unknown, socketPath: string): IpcConnectError {
+  if (err instanceof IpcConnectError) {
+    return err;
+  }
+  const code = errnoCode(err);
+  const message = err instanceof Error ? err.message : String(err);
+  return new IpcConnectError(
+    `Gateway IPC connect failed (${code ?? "unknown"}): ${message} (${socketPath})`,
+    code,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+  });
+}
+
+/**
+ * Open a Unix-domain socket with error listeners registered before connect().
+ *
+ * Bun can emit socket errors synchronously inside `connect()`. Attaching
+ * listeners first keeps a missing `gateway.sock` on the promise rejection
+ * path instead of as an uncaught exception.
+ *
+ * `onConnected` runs synchronously in the connect handler, before this
+ * promise resolves, so the caller can attach post-connect listeners without
+ * a gap where a follow-on error would be uncaught.
+ */
+function connectUnixSocket(
+  socketPath: string,
+  timeoutMs: number,
+  onConnected?: (sock: Socket) => void,
+): Promise<Socket> {
+  return new Promise<Socket>((resolve, reject) => {
+    let settled = false;
+    const sock = new Socket();
+    sock.unref();
+
+    const finish = (err: Error | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      sock.off("connect", onConnect);
+      sock.off("error", onError);
+      sock.off("close", onClose);
+      if (err) {
+        sock.destroy();
+        reject(err);
+        return;
+      }
+      onConnected?.(sock);
+      resolve(sock);
+    };
+
+    const timer = setTimeout(() => {
+      finish(
+        new IpcConnectError(
+          `IPC connect timed out after ${timeoutMs}ms (${socketPath})`,
+          "ETIMEDOUT",
+        ),
+      );
+    }, timeoutMs);
+    timer.unref();
+
+    const onConnect = () => {
+      finish(null);
+    };
+    const onError = (err: Error) => {
+      finish(toIpcConnectError(err, socketPath));
+    };
+    const onClose = () => {
+      finish(
+        new IpcConnectError(
+          `Socket closed before connect (${socketPath})`,
+          "ECONNRESET",
+        ),
+      );
+    };
+
+    sock.on("connect", onConnect);
+    sock.on("error", onError);
+    sock.on("close", onClose);
+    sock.connect(socketPath);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -51,6 +185,16 @@ export class IpcCallError extends Error {
 
 const DEFAULT_CALL_TIMEOUT_MS = 5_000;
 const CONNECT_TIMEOUT_MS = 3_000;
+
+/**
+ * Additional wait before each reconnect attempt when the gateway socket is
+ * missing (`ENOENT`) or refused (`ECONNREFUSED`). The assistant and gateway
+ * start as siblings, so the assistant can race ahead of `gateway.sock`.
+ * Sum of delays: 250 + 500 + 1000 + 2000 = 3.75s.
+ */
+const DEFAULT_CONNECT_RETRY_BACKOFFS_MS: readonly number[] = [
+  250, 500, 1000, 2000,
+];
 
 // ---------------------------------------------------------------------------
 // One-shot IPC call
@@ -81,50 +225,57 @@ export async function ipcCall(
   return new Promise<unknown>((resolve) => {
     let settled = false;
     let callTimer: ReturnType<typeof setTimeout> | undefined;
+    let socket: Socket | undefined;
 
     const finish = (value: unknown) => {
-      if (settled) return;
+      if (settled) {
+        return;
+      }
       settled = true;
-      clearTimeout(connectTimer);
-      if (callTimer) clearTimeout(callTimer);
-      socket.destroy();
+      if (callTimer) {
+        clearTimeout(callTimer);
+      }
+      socket?.destroy();
       resolve(value);
     };
 
-    const connectTimer = setTimeout(() => {
-      log.warn(
-        { method, socketPath, timeoutMs: connectTimeoutMs },
-        "IPC connect timed out",
-      );
-      finish(undefined);
-    }, connectTimeoutMs);
+    void connectUnixSocket(socketPath, connectTimeoutMs, (sock) => {
+      socket = sock;
+      let buffer = "";
+      const reqId = "1";
 
-    const socket: Socket = connect(socketPath);
-    socket.unref();
-
-    let buffer = "";
-    const reqId = "1";
-
-    socket.on("connect", () => {
-      clearTimeout(connectTimer);
-      const req: IpcRequest = { id: reqId, method, params };
-      socket.write(JSON.stringify(req) + "\n");
-
-      callTimer = setTimeout(() => {
+      sock.on("error", (err) => {
         log.warn(
-          { method, socketPath, timeoutMs: callTimeoutMs },
-          "IPC call timed out waiting for response",
+          {
+            err: err instanceof Error ? err.message : String(err),
+            code: errnoCode(err) ?? "unknown",
+            method,
+            socketPath,
+          },
+          "Gateway IPC socket error",
         );
         finish(undefined);
-      }, callTimeoutMs);
+      });
 
-      socket.on("data", (chunk) => {
+      sock.on("close", () => {
+        if (!settled) {
+          log.warn(
+            { method, socketPath },
+            "Gateway IPC socket closed before response",
+          );
+        }
+        finish(undefined);
+      });
+
+      sock.on("data", (chunk) => {
         buffer += chunk.toString();
         let newlineIdx: number;
         while ((newlineIdx = buffer.indexOf("\n")) !== -1) {
           const line = buffer.slice(0, newlineIdx).trim();
           buffer = buffer.slice(newlineIdx + 1);
-          if (!line) continue;
+          if (!line) {
+            continue;
+          }
 
           try {
             const msg = JSON.parse(line) as IpcResponse;
@@ -145,30 +296,34 @@ export async function ipcCall(
           }
         }
       });
-    });
 
-    socket.on("error", (err) => {
-      log.warn(
-        {
-          err: err instanceof Error ? err.message : String(err),
-          code: (err as NodeJS.ErrnoException).code ?? "unknown",
-          method,
-          socketPath,
-        },
-        "Gateway IPC socket error",
-      );
-      finish(undefined);
-    });
+      const req: IpcRequest = { id: reqId, method, params };
+      sock.write(JSON.stringify(req) + "\n");
 
-    socket.on("close", () => {
-      if (!settled) {
+      callTimer = setTimeout(() => {
         log.warn(
-          { method, socketPath },
-          "Gateway IPC socket closed before response",
+          { method, socketPath, timeoutMs: callTimeoutMs },
+          "IPC call timed out waiting for response",
         );
-      }
-      finish(undefined);
-    });
+        finish(undefined);
+      }, callTimeoutMs);
+    }).then(
+      () => {
+        // Handlers are attached in onConnected.
+      },
+      (err: unknown) => {
+        log.warn(
+          {
+            err: err instanceof Error ? err.message : String(err),
+            code: errnoCode(err) ?? "unknown",
+            method,
+            socketPath,
+          },
+          "Gateway IPC socket error",
+        );
+        finish(undefined);
+      },
+    );
   });
 }
 
@@ -180,6 +335,14 @@ type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (reason: Error) => void;
   timer: ReturnType<typeof setTimeout>;
+};
+
+export type PersistentIpcClientOptions = {
+  /**
+   * Additional delays (ms) before each reconnect attempt after a retryable
+   * connect failure. Pass `[]` to fail on the first miss (tests).
+   */
+  connectRetryBackoffsMs?: readonly number[];
 };
 
 /**
@@ -196,18 +359,23 @@ export class PersistentIpcClient {
   private nextId = 1;
   private buffer = "";
   private connecting: Promise<void> | null = null;
+  private destroyed = false;
   private readonly socketPath: string;
   private readonly callTimeoutMs: number;
   private readonly log: Logger;
+  private readonly connectRetryBackoffsMs: readonly number[];
 
   constructor(
     socketPath: string,
     callTimeoutMs = DEFAULT_CALL_TIMEOUT_MS,
     log: Logger = noopLogger,
+    options?: PersistentIpcClientOptions,
   ) {
     this.socketPath = socketPath;
     this.callTimeoutMs = callTimeoutMs;
     this.log = log;
+    this.connectRetryBackoffsMs =
+      options?.connectRetryBackoffsMs ?? DEFAULT_CONNECT_RETRY_BACKOFFS_MS;
   }
 
   /**
@@ -255,6 +423,7 @@ export class PersistentIpcClient {
 
   /** Explicitly close the connection and reject all pending requests. */
   destroy(): void {
+    this.destroyed = true;
     this.rejectAllPending(new Error("PersistentIpcClient destroyed"));
     if (this.socket) {
       this.socket.destroy();
@@ -269,56 +438,80 @@ export class PersistentIpcClient {
   // -------------------------------------------------------------------------
 
   private async ensureConnected(): Promise<void> {
-    if (this.socket) return;
-    if (this.connecting) return this.connecting;
+    if (this.socket) {
+      return;
+    }
+    if (this.connecting) {
+      return this.connecting;
+    }
 
-    this.connecting = new Promise<void>((resolve, reject) => {
-      const sock: Socket = connect(this.socketPath);
-      sock.unref();
+    this.connecting = this.connectWithRetry().finally(() => {
+      this.connecting = null;
+    });
+    return this.connecting;
+  }
 
-      const connectTimer = setTimeout(() => {
-        sock.destroy();
-        reject(
-          new Error(
-            `IPC persistent connect timed out after ${CONNECT_TIMEOUT_MS}ms`,
-          ),
-        );
-      }, CONNECT_TIMEOUT_MS);
-      connectTimer.unref();
+  private async connectWithRetry(): Promise<void> {
+    const backoffs = this.connectRetryBackoffsMs;
+    let lastError: IpcConnectError | undefined;
 
-      sock.on("connect", () => {
-        clearTimeout(connectTimer);
-        this.socket = sock;
-        this.buffer = "";
-        this.connecting = null;
-        this.wireDataHandler(sock);
-        resolve();
-      });
+    for (let attempt = 0; attempt <= backoffs.length; attempt++) {
+      if (this.destroyed) {
+        throw new IpcConnectError("PersistentIpcClient destroyed", "DESTROYED");
+      }
+      if (attempt > 0) {
+        await sleep(backoffs[attempt - 1]!);
+        if (this.destroyed) {
+          throw new IpcConnectError(
+            "PersistentIpcClient destroyed",
+            "DESTROYED",
+          );
+        }
+      }
 
-      sock.on("error", (err) => {
-        clearTimeout(connectTimer);
+      try {
+        await this.connectOnce();
+        return;
+      } catch (err) {
+        lastError = toIpcConnectError(err, this.socketPath);
+        const retryable =
+          isRetryableIpcConnectError(lastError) && attempt < backoffs.length;
+        if (!retryable) {
+          throw lastError;
+        }
         this.log.warn(
           {
-            err: err instanceof Error ? err.message : String(err),
-            code: (err as NodeJS.ErrnoException).code ?? "unknown",
+            err: lastError.message,
+            code: lastError.code ?? "unknown",
+            attempt,
             socketPath: this.socketPath,
           },
-          "Persistent IPC socket error",
+          "Persistent IPC connect failed, retrying",
         );
-        this.handleDisconnect();
-        reject(err);
-      });
+      }
+    }
 
-      sock.on("close", () => {
-        clearTimeout(connectTimer);
-        if (!this.socket) {
-          this.connecting = null;
-          reject(new Error("Socket closed before connect"));
-        }
-      });
-    });
+    throw (
+      lastError ??
+      new IpcConnectError("IPC persistent connect failed", "UNKNOWN")
+    );
+  }
 
-    return this.connecting;
+  private async connectOnce(): Promise<void> {
+    const sock = await connectUnixSocket(
+      this.socketPath,
+      CONNECT_TIMEOUT_MS,
+      (connected) => {
+        this.socket = connected;
+        this.buffer = "";
+        this.wireDataHandler(connected);
+      },
+    );
+    if (this.destroyed) {
+      sock.destroy();
+      this.socket = null;
+      throw new IpcConnectError("PersistentIpcClient destroyed", "DESTROYED");
+    }
   }
 
   private wireDataHandler(sock: Socket): void {
@@ -328,7 +521,9 @@ export class PersistentIpcClient {
       while ((newlineIdx = this.buffer.indexOf("\n")) !== -1) {
         const line = this.buffer.slice(0, newlineIdx).trim();
         this.buffer = this.buffer.slice(newlineIdx + 1);
-        if (!line) continue;
+        if (!line) {
+          continue;
+        }
 
         try {
           const msg = JSON.parse(line) as IpcResponse;
@@ -355,18 +550,20 @@ export class PersistentIpcClient {
     });
 
     sock.on("error", () => {
-      this.handleDisconnect();
+      this.handleDisconnect(sock);
     });
 
     sock.on("close", () => {
-      this.handleDisconnect();
+      this.handleDisconnect(sock);
     });
   }
 
-  private handleDisconnect(): void {
+  private handleDisconnect(sock: Socket): void {
+    if (this.socket !== sock) {
+      return;
+    }
     this.rejectAllPending(new Error("IPC socket disconnected"));
     this.socket = null;
-    this.connecting = null;
     this.buffer = "";
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

The assistant container crash-looped because a gateway-IPC connect failure (ENOENT while `gateway.sock` was not bound yet) was treated as an uncaught exception and hard-exited the process. The same ENOENT is already benign during normal boot ordering on the flag-listener path. The process must stay up when the gateway socket is missing. Gateway IPC reads should raise typed errors instead.

Approach:
- Attach Unix-socket error listeners before `connect()` so Bun cannot emit a synchronous ENOENT as an uncaught exception (same pattern as `cli-client.ts`).
- Retry persistent connects on `ENOENT` / `ECONNREFUSED` with bounded backoff for sibling boot races.
- Throw `IpcConnectError` (not a raw system error) and map it to 503 `SERVICE_UNAVAILABLE` on HTTP, IPC, and contact/log/trust-rule read relays.
- One-shot `ipcCall` still returns `undefined` on miss (feature-flag path).

## Test plan

- `packages/gateway-client`: missing-socket one-shot returns undefined with no uncaught exception. Persistent client throws `IpcConnectError` with no uncaught exception, then retries until the gateway binds.
- Flag listener: missing socket at start does not throw and reconnects when the socket appears.
- Contact list relay and `ipcCallPersistentValidated` map `IpcConnectError` to 503.
- Assistant IPC error envelope maps `IpcConnectError` to `SERVICE_UNAVAILABLE`.
- Assistant test preload mock exports `IpcConnectError` so bun test can import the class (Bun replaces the ipc-client module globally).

## Risk

Medium. Changes process-lifetime behavior on a missing gateway socket and the HTTP/IPC error surface for gateway reads. `IpcConnectError` is intentionally not a subclass of `IpcCallError`, so `ipcClassifyRisk` still retries transport failures. Persistent connect retry adds up to 3.75s on the first persistent call while the gateway is down.

No migrations, feature flags, or companion platform PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4386baad-5718-456c-8ae4-2cf602363830?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4386baad-5718-456c-8ae4-2cf602363830&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

