### PR TITLE
chore(web): stories for the Coding Agents card and the ACP MODEL tile

### DIFF
--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-model-stat-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-model-stat-card.stories.tsx
@@ -1,0 +1,165 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { screen, userEvent } from "storybook/test";
+
+import { Toaster } from "@vellumai/design-library";
+
+import type { AcpModelOption, AcpRunEntry } from "@/domains/chat/acp-run-store";
+import { ApiError } from "@/utils/api-errors";
+
+import { AcpModelStatCard } from "./acp-model-stat-card";
+
+/**
+ * The option set as an ACP adapter reports it: a leading ungrouped row, then
+ * two named groups. `groupOptions` splits on each change of `group`, so this
+ * is the shape that exercises both a heading and the rows above the first one.
+ */
+const MODEL_OPTIONS: AcpModelOption[] = [
+  {
+    value: "default",
+    label: "Default",
+    description: "Whatever the agent picks",
+  },
+  {
+    value: "sonnet",
+    label: "Sonnet",
+    description: "Fast, for most turns",
+    group: "Claude",
+  },
+  {
+    value: "opus",
+    label: "Opus",
+    description: "Most capable",
+    group: "Claude",
+  },
+  { value: "haiku", label: "Haiku", description: "Fastest", group: "Claude" },
+  { value: "fable", label: "Fable", group: "Claude" },
+  {
+    value: "opusplan",
+    label: "Opus plan mode",
+    description: "Opus to plan, Sonnet to execute",
+    group: "Mixed",
+  },
+];
+
+const RUNNING_ENTRY: AcpRunEntry = {
+  acpSessionId: "acp-story",
+  agent: "claude",
+  parentConversationId: "conv-1",
+  task: "Review IBM's Q2 2026 results.",
+  status: "running",
+  startedAt: 0,
+  usedTokens: 61_500,
+  contextSize: 200_000,
+  events: [],
+  model: "opus",
+  availableModels: MODEL_OPTIONS,
+};
+
+/** The answer the daemon would give, for the stories that never take a choice. */
+const settledSwitch = () =>
+  Promise.resolve({ model: "haiku", availableModels: MODEL_OPTIONS });
+
+/** A switch that never answers, which holds the pending state still. */
+const neverSettles = () => new Promise<never>(() => {});
+
+/** A 409: the adapter dropped its model selector mid-run. */
+const rejectedSwitch = () =>
+  Promise.reject(
+    new ApiError(409, "This session no longer offers a model selector."),
+  );
+
+/** Pick a model from the open surface, which is what starts a switch. */
+async function chooseHaiku(): Promise<void> {
+  await userEvent.click(await screen.findByRole("menuitem", { name: /Haiku/ }));
+}
+
+function TileFrame({ children }: { children: ReactNode }) {
+  return <div style={{ maxWidth: 400, padding: 24 }}>{children}</div>;
+}
+
+const meta: Meta<typeof AcpModelStatCard> = {
+  title: "Chat/AcpModelStatCard",
+  component: AcpModelStatCard,
+  args: {
+    entry: RUNNING_ENTRY,
+    onSwitchModel: settledSwitch,
+  },
+  decorators: [
+    (Story) => (
+      <TileFrame>
+        <Story />
+      </TileFrame>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AcpModelStatCard>;
+
+/**
+ * The menu the tile opens, held open by `defaultOpen`.
+ *
+ * The selected row carries the check and `aria-current`, the group headings
+ * are the adapter's own, and the closing line says a choice lands on the next
+ * turn rather than the one already streaming.
+ */
+export const ModelMenuOpen: Story = {
+  args: { defaultOpen: true },
+};
+
+/**
+ * A switch in flight. The tile names the model being moved to, dims it, and
+ * refuses a second choice through `aria-disabled` rather than the native
+ * attribute, so the focus the closing menu returns still lands somewhere.
+ *
+ * The run store stays on the old value: it is written from the daemon's
+ * answer, so a snapshot fetched mid-switch cannot roll the tile back.
+ */
+export const ModelSwitchPending: Story = {
+  args: { defaultOpen: true, onSwitchModel: neverSettles },
+  play: async () => {
+    await chooseHaiku();
+    await screen.findByRole("button", { name: "Model: Haiku. Change model" });
+  },
+};
+
+/**
+ * A switch the daemon refused. A 400 is the adapter's verdict on the value and
+ * a 409 says it no longer offers a choice at all; both carry a message written
+ * for the user, so it is shown verbatim instead of generic retry copy.
+ *
+ * The rejection reaches the user as a toast rather than as tile state, so the
+ * story mounts a `Toaster` and the toast dismisses itself on its own timer.
+ * The tile drops back to the model the run is still on.
+ */
+export const ModelSwitchRejected: Story = {
+  args: { defaultOpen: true, onSwitchModel: rejectedSwitch },
+  decorators: [
+    (Story) => (
+      <>
+        <Story />
+        <Toaster />
+      </>
+    ),
+  ],
+  // The play stops at the choice. The toast runs on its own dismiss timer, so
+  // waiting for it here would be a race the story could lose.
+  play: chooseHaiku,
+};
+
+/**
+ * A terminal run has nothing left to switch, so the tile is the plain metric
+ * card: the id the run finished on, and no trigger.
+ */
+export const Terminal: Story = {
+  args: {
+    entry: {
+      ...RUNNING_ENTRY,
+      status: "completed",
+      completedAt: 1,
+      model: "claude-opus-4-5-20260301",
+      availableModels: undefined,
+    },
+  },
+};

--- a/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-detail-panel/acp-run-detail-panel.stories.tsx
@@ -1,10 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, useState, type ReactNode } from "react";
+import { screen, userEvent } from "storybook/test";
 
-import type { AcpRunEntry } from "@/domains/chat/acp-run-store";
+import { TOUCH_SURFACE_MEDIA_QUERY } from "@vellumai/design-library/utils/touch-surface";
+
+import type { AcpModelOption, AcpRunEntry } from "@/domains/chat/acp-run-store";
+import { MIN_VERSION } from "@/lib/backwards-compat/acp-model-switching";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 import { DetailPanelStoryFrame } from "@/domains/chat/components/detail-panel-story-frame";
 
 import { AcpRunDetailPanel } from "./acp-run-detail-panel";
+
+const ASSISTANT_ID = "story-assistant";
 
 const meta: Meta<typeof AcpRunDetailPanel> = {
   title: "Chat/AcpRunDetailPanel",
@@ -56,5 +64,182 @@ export const Completed: Story = {
   args: {
     entry: completedEntry,
     onClose: () => {},
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Runs that report a model
+// ---------------------------------------------------------------------------
+
+/**
+ * The options an ACP adapter reports: an ungrouped row followed by two named
+ * groups, which is the shape the menu has to draw headings for.
+ */
+const MODEL_OPTIONS: AcpModelOption[] = [
+  {
+    value: "default",
+    label: "Default",
+    description: "Whatever the agent picks",
+  },
+  {
+    value: "sonnet",
+    label: "Sonnet",
+    description: "Fast, for most turns",
+    group: "Claude",
+  },
+  {
+    value: "opus",
+    label: "Opus",
+    description: "Most capable",
+    group: "Claude",
+  },
+  { value: "haiku", label: "Haiku", description: "Fastest", group: "Claude" },
+  { value: "fable", label: "Fable", group: "Claude" },
+  {
+    value: "opusplan",
+    label: "Opus plan mode",
+    description: "Opus to plan, Sonnet to execute",
+    group: "Mixed",
+  },
+];
+
+const runningWithModelEntry: AcpRunEntry = {
+  ...runningEntry,
+  acpSessionId: "acp-ibm-model",
+  model: "opus",
+  availableModels: MODEL_OPTIONS,
+};
+
+// A terminal run keeps the model it ran on and loses the selector, so the tile
+// shows the adapter's raw value with nothing to look a label up in.
+const completedWithModelEntry: AcpRunEntry = {
+  ...completedEntry,
+  acpSessionId: "acp-ibm-model-done",
+  model: "opus",
+};
+
+/**
+ * Pins the version the ACP model-switching gate reads, then puts it back.
+ *
+ * The identity store is a module singleton, so a story that leaves a version
+ * behind changes how later stories resolve. Seeding in `beforeEach` rather
+ * than during decorator render also keeps the write out of the render pass,
+ * where two mounted variants would race and the last one would win. The gate
+ * is scoped, so the owner has to be stamped alongside the version or the
+ * MODEL tile stays hidden.
+ */
+function seedAssistantVersion() {
+  const { version, assistantId } = useAssistantIdentityStore.getState();
+  useAssistantIdentityStore.setState({
+    version: MIN_VERSION,
+    assistantId: ASSISTANT_ID,
+  });
+  return () => {
+    useAssistantIdentityStore.setState({ version, assistantId });
+  };
+}
+
+/** Swap `window.matchMedia`; `configurable` so the teardown can put it back. */
+function setMatchMedia(impl: typeof window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    value: impl,
+    configurable: true,
+    writable: true,
+  });
+}
+
+/**
+ * Answers the design library's touch-surface query `true` for the duration of
+ * the story, so `ActionMenu` resolves to its bottom sheet.
+ *
+ * The mobile viewport alone cannot do it: the query is a narrow viewport AND a
+ * coarse pointer, and a desktop browser at phone width still reports a fine
+ * one. The tile takes no presentation prop by design, so the signal itself is
+ * what a story has to move.
+ */
+function ForceTouchSurface({ children }: { children: ReactNode }) {
+  // Installed from a `useState` initializer, which runs exactly once and during
+  // this component's render, i.e. before any child samples the query. An
+  // identity check against the saved original would not work here: `bind`
+  // returns a new function object, so it never compares equal to the global.
+  const [original] = useState(() => {
+    const saved = window.matchMedia.bind(window);
+    setMatchMedia(((query: string) => {
+      const result = saved(query);
+      if (query !== TOUCH_SURFACE_MEDIA_QUERY) {
+        return result;
+      }
+      return {
+        ...result,
+        media: query,
+        matches: true,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      } as MediaQueryList;
+    }) as typeof window.matchMedia);
+    return saved;
+  });
+  useEffect(() => {
+    return () => setMatchMedia(original);
+  }, [original]);
+  return <>{children}</>;
+}
+
+/**
+ * A live run whose adapter offers a model list. The MODEL tile takes a row of
+ * its own under the token pair: a model id in half of a 400px panel has
+ * nowhere to render.
+ */
+export const RunningWithModel: Story = {
+  beforeEach: seedAssistantVersion,
+  args: {
+    entry: runningWithModelEntry,
+    onClose: () => {},
+    assistantId: ASSISTANT_ID,
+  },
+};
+
+/**
+ * A finished run. There is nothing left to switch, so the tile is the plain
+ * metric card carrying the value the adapter last reported.
+ */
+export const CompletedWithModel: Story = {
+  beforeEach: seedAssistantVersion,
+  args: {
+    entry: completedWithModelEntry,
+    onClose: () => {},
+    assistantId: ASSISTANT_ID,
+  },
+};
+
+/**
+ * The same picker under a thumb. `ActionMenu` substitutes a bottom sheet for
+ * the anchored menu, so the rows become sheet rows with a visible title and
+ * the surface is a dialog rather than a menu.
+ */
+export const MobileSheet: Story = {
+  beforeEach: seedAssistantVersion,
+  args: {
+    entry: runningWithModelEntry,
+    onClose: () => {},
+    assistantId: ASSISTANT_ID,
+  },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+  decorators: [
+    (Story) => (
+      <ForceTouchSurface>
+        <Story />
+      </ForceTouchSurface>
+    ),
+  ],
+  play: async () => {
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Change model/ }),
+    );
+    await screen.findByRole("dialog");
   },
 };

--- a/clients/web/src/domains/settings/ai/coding-agents-card.stories.tsx
+++ b/clients/web/src/domains/settings/ai/coding-agents-card.stories.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { expect, screen, userEvent, waitFor } from "storybook/test";
+
+import { CodingAgentsCard } from "@/domains/settings/ai/coding-agents-card";
+import { configGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+import { MIN_VERSION } from "@/lib/backwards-compat/acp-model-switching";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+const ASSISTANT_ID = "story-assistant";
+
+/** No `acp` section at all: what a config that never picked a model looks like. */
+const NO_MODEL_CONFIG: ConfigGetResponse = {};
+
+const ALIAS_CONFIG: ConfigGetResponse = { acp: { defaultModel: "opus" } };
+
+// A full model id rather than one of the resolver aliases the picker lists.
+// The adapter accepts both, so the card has to keep a value it cannot offer.
+const CUSTOM_CONFIG: ConfigGetResponse = {
+  acp: { defaultModel: "claude-opus-4-5-20260301" },
+};
+
+// Storybook has no daemon, so the config query is seeded through the generated
+// factory; HeyAPI bakes the path params into the key, so a hand-written key
+// would miss and the card would render against an empty config.
+function seededClient(config: ConfigGetResponse): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnMount: false,
+        refetchOnWindowFocus: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  client.setQueryData(
+    configGetOptions({ path: { assistant_id: ASSISTANT_ID } }).queryKey,
+    config,
+  );
+  return client;
+}
+
+/** Wraps a story in a provider seeded with `config`. */
+function withConfig(config: ConfigGetResponse) {
+  const client = seededClient(config);
+  return function ConfigDecorator(Story: () => ReactNode) {
+    return (
+      <QueryClientProvider client={client}>
+        <div style={{ maxWidth: 640, padding: 24 }}>
+          <Story />
+        </div>
+      </QueryClientProvider>
+    );
+  };
+}
+
+/**
+ * Pins the active assistant and the version the ACP model-switching gate
+ * reads, then puts both stores back.
+ *
+ * Both stores are module singletons, so seeding in `beforeEach` rather than
+ * during a decorator's render keeps the write out of the render pass, where
+ * two mounted variants would race and the last one would win. Without the
+ * version the gate is closed and the card renders nothing at all.
+ */
+function seedAssistant() {
+  const identity = useAssistantIdentityStore.getState();
+  const previousActive =
+    useResolvedAssistantsStore.getState().activeAssistantId;
+  useAssistantIdentityStore.setState({
+    version: MIN_VERSION,
+    assistantId: ASSISTANT_ID,
+  });
+  useResolvedAssistantsStore.setState({ activeAssistantId: ASSISTANT_ID });
+  return () => {
+    useAssistantIdentityStore.setState({
+      version: identity.version,
+      assistantId: identity.assistantId,
+    });
+    useResolvedAssistantsStore.setState({ activeAssistantId: previousActive });
+  };
+}
+
+const meta: Meta<typeof CodingAgentsCard> = {
+  title: "Settings/AI/CodingAgentsCard",
+  component: CodingAgentsCard,
+  beforeEach: seedAssistant,
+};
+
+export default meta;
+type Story = StoryObj<typeof CodingAgentsCard>;
+
+/**
+ * Nothing stored: the picker sits on the agent-default row, which writes
+ * `null` and leaves model selection to the adapter. Save is disabled until
+ * the choice differs from what the daemon holds.
+ */
+export const Default: Story = {
+  decorators: [withConfig(NO_MODEL_CONFIG)],
+};
+
+/** A stored alias from claude-agent-acp's own vocabulary. */
+export const AliasSelected: Story = {
+  decorators: [withConfig(ALIAS_CONFIG)],
+};
+
+/**
+ * A stored value the picker does not list. The card opens on the Custom row
+ * with the text input pre-filled rather than silently dropping a setting it
+ * cannot name, which is what makes a second adapter usable before its models
+ * have entries here.
+ */
+export const CustomModel: Story = {
+  decorators: [withConfig(CUSTOM_CONFIG)],
+};
+
+/**
+ * An unsaved choice. Picking a model the daemon does not hold is what enables
+ * Save, so this is the state a user reaches before the write.
+ *
+ * The play stops at the enabled button: Storybook has no daemon and this repo
+ * has no request mock for stories, so clicking Save would post into the void.
+ */
+export const Dirty: Story = {
+  decorators: [withConfig(NO_MODEL_CONFIG)],
+  play: async () => {
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: "Default model" }),
+    );
+    await userEvent.click(await screen.findByRole("option", { name: "Haiku" }));
+    await waitFor(() => {
+      const save = screen.getByRole("button", {
+        name: "Save",
+      }) as HTMLButtonElement;
+      expect(save.disabled).toBe(false);
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- Stories for the Coding Agents settings card (default, alias, custom model)
- The ACP run panel with a model: picker, open menu, pending and rejected switch, terminal row, mobile sheet

Part of plan: acp-model-control.md (storybook coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D