### PR TITLE
fix(web): run the usage panel's route classifier beside the subscription

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Tests for `usePreferencesUsage`, and specifically for when it arms the BYOK
+ * route classifier behind the extra-credits claim.
+ *
+ * The claim needs the subscription; the classifier's reads do not. Arming them
+ * off `spent` queued them behind that request, so the panel spent a whole
+ * round trip showing a bar it was about to replace with the amber line. What
+ * these tests hold is the arming contract that fixed it: armed off the summary
+ * for anyone whose grants it can already see are spent, still idle for
+ * everyone else.
+ *
+ * The subscription is driven from the SDK boundary the way the panel tests
+ * drive it. The wallet status and the classifier are mocked: the real hooks
+ * need the platform gate, the org store, and five daemon queries that these
+ * tests do not stand up.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type { SubscriptionResponse } from "@/generated/api/types.gen";
+
+let subscription: SubscriptionResponse | null = null;
+/** Holds the subscription read open so the renders before it can be read. */
+let holdSubscription = false;
+/** Releases a held read, or null when none is waiting. */
+let releaseSubscription: (() => void) | null = null;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionRetrieve: () => {
+    const payload = { data: subscription, response: { ok: true } };
+    if (!holdSubscription) {
+      return Promise.resolve(payload);
+    }
+    return new Promise((resolve) => {
+      releaseSubscription = () => resolve(payload);
+    });
+  },
+}));
+
+let billingEnabled = true;
+let effectiveBalance: string | null = null;
+let availableUsageBalance: string | null = null;
+let totalUsageBalance: string | null = null;
+
+mock.module("@/hooks/use-billing-balance-status", () => ({
+  useBillingBalanceStatus: () => ({
+    isExhausted: false,
+    isLowBalance: false,
+    dailyLimitReached: false,
+    dailyLimitSnoozed: false,
+    dailyLimit: null,
+    dailySpend: null,
+    balance: effectiveBalance,
+    availableUsageBalance,
+    totalUsageBalance,
+    enabled: billingEnabled,
+    settled: true,
+  }),
+}));
+
+/**
+ * Every `candidate` the hook has asked the classifier with, in render order.
+ * The arming contract is about when the reads start, which only this records:
+ * a verdict read after the fact cannot say whether it was asked in time.
+ */
+let candidates: boolean[] = [];
+
+/** Whether the classifier has been asked to run, and whether it has answered. */
+let classifierArmed = false;
+let classifierAnswered = false;
+
+mock.module("@/hooks/use-byok-credit-banner-gate", () => ({
+  useByokCreditRouteVerdict: (candidate: boolean) => {
+    candidates.push(candidate);
+    if (candidate && !classifierArmed) {
+      classifierArmed = true;
+      // The classifier reads five daemon queries, so its verdict lands a tick
+      // after it is asked and never on the render that asks. A double that
+      // answers instantly cannot tell arming early from arming late, which is
+      // the whole of what these tests are about.
+      setTimeout(() => {
+        classifierAnswered = true;
+      }, 0);
+    }
+    return {
+      suppress: false,
+      settled: !candidate || classifierAnswered,
+      routeBurnsManaged: classifierAnswered,
+    };
+  },
+}));
+
+const { usePreferencesUsage } = await import("./use-preferences-usage");
+
+function proSubscription(): SubscriptionResponse {
+  return {
+    plan_id: "pro",
+    status: "active",
+    renewal_date: null,
+    current_period_start: "2026-07-10T00:00:00Z",
+    current_period_end: "2026-08-10T00:00:00Z",
+    cancel_at_period_end: false,
+    cancel_at: null,
+    package: { key: "mighty", name: "Mighty", version: 1, customized: false },
+    entitlements: { managed_email: false, phone_number: false },
+  };
+}
+
+function renderUsage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return renderHook(() => usePreferencesUsage({ conversationId: null }), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+/** Lets the subscription read settle inside `act`, so nothing lands mid-assert. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+beforeEach(() => {
+  subscription = proSubscription();
+  holdSubscription = false;
+  releaseSubscription = null;
+  billingEnabled = true;
+  // A wallet with credit behind fully spent grants: the state the panel
+  // describes as running on extra usage credits.
+  effectiveBalance = "12.00";
+  totalUsageBalance = "5.00";
+  availableUsageBalance = "0.00";
+  candidates = [];
+  classifierArmed = false;
+  classifierAnswered = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("usePreferencesUsage", () => {
+  test("arms the route classifier before the subscription answers", async () => {
+    holdSubscription = true;
+    const { result } = renderUsage();
+
+    await settle();
+    // Still no reading, because the plan has not landed. The classifier is
+    // already running against it rather than after it.
+    expect(result.current.usage).toBeNull();
+    expect(candidates).toContain(true);
+  });
+
+  test("the first reading it produces is already the settled one", async () => {
+    holdSubscription = true;
+    const { result } = renderUsage();
+    await settle();
+
+    await act(async () => {
+      releaseSubscription?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // The render that first carries a reading carries the claim with it, so
+    // the panel never paints the bar on its way to the amber line.
+    expect(result.current.settled).toBe(true);
+    expect(result.current.usage?.usingExtraCredits).toBe(true);
+  });
+
+  test("stays idle while the grants still have room", async () => {
+    availableUsageBalance = "3.00";
+    renderUsage();
+
+    await settle();
+    expect(candidates).not.toContain(true);
+  });
+
+  test("stays idle with nothing in the wallet to spend", async () => {
+    effectiveBalance = "0.00";
+    renderUsage();
+
+    await settle();
+    expect(candidates).not.toContain(true);
+  });
+
+  test("stays idle without managed billing to read", async () => {
+    billingEnabled = false;
+    renderUsage();
+
+    await settle();
+    expect(candidates).not.toContain(true);
+  });
+
+  test("arms on the plan's fallback for a Pro sub with no live grants", async () => {
+    // Every grant expired, so the summary alone has no ratio to read and the
+    // full bar comes from the plan. That reading still arms the classifier,
+    // just at the subscription rather than ahead of it.
+    totalUsageBalance = "0.00";
+    availableUsageBalance = "0.00";
+    const { result } = renderUsage();
+
+    await settle();
+    expect(result.current.usage?.spent).toBe(true);
+    expect(candidates.at(-1)).toBe(true);
+  });
+
+  test("a free plan that was never granted credit arms nothing", async () => {
+    subscription = { ...proSubscription(), plan_id: "base", package: null };
+    totalUsageBalance = null;
+    availableUsageBalance = null;
+    const { result } = renderUsage();
+
+    await settle();
+    expect(result.current.usage).toBeNull();
+    expect(candidates).not.toContain(true);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.test.tsx
@@ -2,12 +2,11 @@
  * Tests for `usePreferencesUsage`, and specifically for when it arms the BYOK
  * route classifier behind the extra-credits claim.
  *
- * The claim needs the subscription; the classifier's reads do not. Arming them
- * off `spent` queued them behind that request, so the panel spent a whole
- * round trip showing a bar it was about to replace with the amber line. What
- * these tests hold is the arming contract that fixed it: armed off the summary
- * for anyone whose grants it can already see are spent, still idle for
- * everyone else.
+ * The claim needs the subscription; the classifier's reads do not, so the two
+ * run alongside each other and the first reading the hook produces already
+ * carries the claim rather than a bar standing in for it. The contract these
+ * tests hold is the arming one: armed off the summary for anyone whose grants
+ * it can already see are spent, idle for everyone else.
  *
  * The subscription is driven from the SDK boundary the way the panel tests
  * drive it. The wallet status and the classifier are mocked: the real hooks
@@ -155,7 +154,7 @@ describe("usePreferencesUsage", () => {
 
     await settle();
     // Still no reading, because the plan has not landed. The classifier is
-    // already running against it rather than after it.
+    // already running alongside that request.
     expect(result.current.usage).toBeNull();
     expect(candidates).toContain(true);
   });

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
@@ -103,12 +103,11 @@ export function usePreferencesUsage(
   // stay idle until the claim is otherwise live, so the common healthy path
   // costs nothing.
   //
-  // Live is the summary's own ratio rather than `spent`, which waits on the
-  // subscription: the same population either way, but the classifier's reads
-  // now run beside that request instead of queueing behind it, so the panel's
-  // first painted frame is the settled one rather than a bar it is about to
-  // replace. `spent` stays in the disjunction for the Pro sub whose grants
-  // total nothing, whose full bar is the plan's fallback rather than a ratio.
+  // What makes it live is the summary's own ratio, which the subscription does
+  // not gate, so the classifier's reads run alongside that request and the
+  // first reading the hook produces already carries the claim. `spent` widens
+  // the same condition to the Pro sub whose grants total nothing, whose full
+  // bar is the plan's fallback rather than a ratio the summary can derive.
   const { settled: claimSettled, routeBurnsManaged } =
     useByokCreditRouteVerdict(
       enabled &&

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
@@ -15,7 +15,11 @@ import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { awaitsAnswer } from "@/lib/query-awaits-answer";
 import { useByokCreditRouteVerdict } from "@/hooks/use-byok-credit-banner-gate";
-import { usePlanUsageBalance } from "@/hooks/use-plan-usage-balance";
+import {
+  usageGrantRatio,
+  usePlanUsageBalance,
+} from "@/hooks/use-plan-usage-balance";
+import { parseUsd } from "@/lib/billing/parse-usd";
 
 export interface PreferencesUsage {
   /** Used share of the granted usage credit, clamped to 0..1. */
@@ -87,13 +91,29 @@ export function usePreferencesUsage(
   // next turn spends extra credits. A null balance is unknown, not credit,
   // so the claim also waits for a summary proving the wallet holds something.
   const hasWalletCredit = balance != null && Number(balance) > 0;
+  // The same ratio the reading quotes, off the summary alone: the plan decides
+  // whether a reading is shown and which fallback covers a missing one, never
+  // what a derivable one says.
+  const grantRatio = usageGrantRatio(
+    parseUsd(totalUsageBalance),
+    parseUsd(availableUsageBalance),
+  );
   // A wallet with credit is still not proof it gets spent: a BYOK route
   // dispatches the next turn on the user's own key. The classifier's queries
   // stay idle until the claim is otherwise live, so the common healthy path
   // costs nothing.
+  //
+  // Live is the summary's own ratio rather than `spent`, which waits on the
+  // subscription: the same population either way, but the classifier's reads
+  // now run beside that request instead of queueing behind it, so the panel's
+  // first painted frame is the settled one rather than a bar it is about to
+  // replace. `spent` stays in the disjunction for the Pro sub whose grants
+  // total nothing, whose full bar is the plan's fallback rather than a ratio.
   const { settled: claimSettled, routeBurnsManaged } =
     useByokCreditRouteVerdict(
-      enabled && spent && hasWalletCredit,
+      enabled &&
+        (spent || (grantRatio != null && grantRatio >= 1)) &&
+        hasWalletCredit,
       opts.conversationId ?? null,
     );
 


### PR DESCRIPTION
Opening the preferences menu at 100% used shows a neutral full bar for a beat before it settles to the amber "Now using extra usage credits" line. This is the residual left after #42099, which stopped the red flash and the credits row but not this one.

## Why the bar appears

The panel's final state needs three answers, and they arrive in a chain rather than in parallel:

| stage | query | warm on a chat page? | gives |
| --- | --- | --- | --- |
| 1 | billing **summary** | yes, the composer's balance banners read it | wallet balance, grant figures |
| 2 | billing **subscription** | no, only settings pages fetch it | `plan_id`, which makes `usage` non-null |
| 3 | BYOK **route classifier** (4 daemon reads) | no, `connections` / `profiles` / `defaultprovider` have no other chat-page consumer | `routeBurnsManaged`, which is what turns the bar into the amber line |

Stage 3 could not start until stage 2 returned, because the classifier was armed off `spent`, and `spent` is derived from `usage`, which needs `plan_id`:

```ts
const spent = usage != null && usage.ratio >= 1;   // waits on the subscription
useByokCreditRouteVerdict(enabled && spent && hasWalletCredit, ...)
```

So the subscription lands, the panel mounts showing the bar, and only then do the classifier's reads begin. The bar is on screen for exactly that round trip. `ProgressBar` carries a `transition: width 400ms`, so it also animates 0 to 100% during the window it is about to be discarded, which is why a short gap reads as a distinct state rather than a blink.

## The change

The ratio is a summary-only reading. `usageGrantRatio(total, available)` needs no subscription at all; the plan only decides whether a reading is *shown* and which fallback covers a missing one, never what a derivable one says. So the classifier is armed from the summary's own ratio:

```ts
const grantRatio = usageGrantRatio(
  parseUsd(totalUsageBalance),
  parseUsd(availableUsageBalance),
);

useByokCreditRouteVerdict(
  enabled && (spent || (grantRatio != null && grantRatio >= 1)) && hasWalletCredit,
  opts.conversationId ?? null,
);
```

- **Same population, same requests.** Only spent-with-credit users arm it, exactly as before, so the gate's "the common healthy path costs nothing" promise is intact. Only the start time moves.
- The classifier's daemon reads now run **beside** the subscription's platform request instead of behind it, so by the time `usage` goes non-null the verdict is normally already settled and the panel's first painted frame is the amber line.
- `usingExtraCredits` keeps its exact contract (`settled && routeBurnsManaged && spent && hasWalletCredit`). No display semantics change: firing a query is not a claim.
- `spent` stays in the disjunction for the Pro sub whose grants total nothing, whose full bar comes from the plan's fallback rather than a ratio the summary can derive.

## Why the panel is not simply held until `settled`

That was the obvious alternative and it is a trap. When no assistant is resolved, `useByokCreditRouteVerdict` reports `settled: false` **permanently** (`cannotAskYet`), so holding would make the panel disappear for those users instead of showing them the honest 100% bar. The fail-safe render stays.

## Tests

New `use-preferences-usage.test.tsx`, 7 tests. The classifier double models the round trip rather than answering instantly, so it can tell arming early from arming late; a double that always reports settled cannot see this bug at all.

Negative control on the previous condition (`enabled && spent && hasWalletCredit`): the two headline tests fail, the other five pass.

```
(fail) arms the route classifier before the subscription answers
(fail) the first reading it produces is already the settled one
```

## Verification

```
bun test src/domains/chat/hooks/use-preferences-usage.test.tsx     7 pass
bun test src/domains/chat/components/preferences-usage-panel.test.tsx    21 pass
bun test src/domains/chat/components/preferences-menu.test.tsx     24 pass
bun test src/hooks/use-billing-balance-status.test.ts              21 pass
bun test src/hooks/use-plan-usage-balance.test.tsx                 21 pass
bun run typecheck    clean
bun run lint         0 errors (15 pre-existing warnings, none in these files)
```

Suites run one file at a time: `mock.module` is process-global in bun and these files mock overlapping modules.

## Manual QA owed

Throttle devtools, open the preferences menu cold on a chat page at 100% used with wallet credit. Expect the panel to appear already showing the amber line, with no white bar in between. The remaining gap before the panel appears at all is the subscription round trip and is unchanged by this PR.

## Honest limit

This makes the bar very unlikely, not impossible. If the daemon happens to answer slower than the platform, a short bar can still appear. Closing it completely would need the verdict to distinguish "in flight" from "can never settle" so the slot could blank only in the first case, which is worth doing only if the bar is still observed after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Zo49F2wiQrwaMR6rRpJg
