### PR TITLE
feat(workspace-git): run auto-commit heartbeat in the monitoring worker

### DIFF
--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -23,10 +23,15 @@ import type {
 import {
   _getConsecutiveFailures,
   _resetGitServiceRegistry,
+  getWorkspaceGitService,
   WorkspaceGitService,
 } from "../workspace/git-service.js";
 import {
+  _resetHeartbeatServiceForTests,
   _resetHeartbeatState,
+  commitAllPendingWorkspaceChanges,
+  startWorkspaceHeartbeatService,
+  stopWorkspaceHeartbeatService,
   WorkspaceHeartbeatService,
 } from "../workspace/heartbeat-service.js";
 
@@ -568,6 +573,42 @@ describe("WorkspaceHeartbeatService", () => {
       expect(capturedCtx!.trigger).toBe("shutdown");
       expect(capturedCtx!.workspaceDir).toBe(testDir);
       expect(capturedCtx!.changedFiles).toContain("shutdown-file.txt");
+    });
+  });
+
+  describe("process singleton", () => {
+    afterEach(async () => {
+      await _resetHeartbeatServiceForTests();
+    });
+
+    test("stopWorkspaceHeartbeatService is a no-op when never started", async () => {
+      await _resetHeartbeatServiceForTests();
+      await stopWorkspaceHeartbeatService();
+    });
+
+    test("startWorkspaceHeartbeatService is idempotent", async () => {
+      await _resetHeartbeatServiceForTests();
+      startWorkspaceHeartbeatService();
+      startWorkspaceHeartbeatService();
+      await stopWorkspaceHeartbeatService();
+    });
+
+    test("commitAllPendingWorkspaceChanges constructs on demand", async () => {
+      await _resetHeartbeatServiceForTests();
+      _resetGitServiceRegistry();
+      const registered = getWorkspaceGitService(testDir);
+      await registered.ensureInitialized();
+      writeFileSync(join(testDir, "shutdown-on-demand.txt"), "pending");
+
+      await commitAllPendingWorkspaceChanges();
+
+      const commitMsg = execFileSync("git", ["log", "-1", "--pretty=%B"], {
+        cwd: testDir,
+        encoding: "utf-8",
+      });
+      expect(commitMsg).toContain("auto-commit");
+      expect(commitMsg).toContain("shutdown");
+      expect(commitMsg).toContain("safety net");
     });
   });
 });

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -70,7 +70,6 @@ import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-t
 import { ensureByokDefaultProfiles } from "../workspace/byok-default-profile-ensure.js";
 import { ensureCompleteCustomProfiles } from "../workspace/custom-profile-ensure.js";
 import { ensureDefaultProvider } from "../workspace/default-provider-ensure.js";
-import { startWorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import { startAppSourceWatcher } from "./app-source-watcher.js";
@@ -833,8 +832,6 @@ export async function runDaemon(): Promise<void> {
   installAssistantCommand();
 
   void startEmbeddingRuntimeManager();
-
-  startWorkspaceHeartbeatService();
 
   startHeartbeatService();
 

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -98,6 +98,8 @@ async function shutdown(): Promise<void> {
   }, 30_000);
   forceTimer.unref();
 
+  // Workspace git heartbeat timer lives in the monitor process. This
+  // in-process stop is a no-op unless the singleton was started here.
   await stopWorkspaceHeartbeatService();
   await stopHeartbeatService();
 

--- a/assistant/src/monitoring/__tests__/workspace-git-heartbeat.test.ts
+++ b/assistant/src/monitoring/__tests__/workspace-git-heartbeat.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The workspace git auto-commit heartbeat runs in the resource monitor
+ * process, not on the daemon event loop. These tests cover the monitor-side
+ * starter (registry wiring + stop) and a source guard so the timer is not
+ * put back on the daemon.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { getWorkspaceDir } from "../../util/platform.js";
+import {
+  _resetGitServiceRegistry,
+  getAllWorkspaceGitServices,
+} from "../../workspace/git-service.js";
+import { _resetHeartbeatServiceForTests } from "../../workspace/heartbeat-service.js";
+import { startWorkspaceGitHeartbeat } from "../workspace-git-heartbeat.js";
+
+const SRC_ROOT = join(import.meta.dir, "../..");
+
+describe("workspace git heartbeat on the monitoring worker", () => {
+  afterEach(async () => {
+    await _resetHeartbeatServiceForTests();
+    _resetGitServiceRegistry();
+  });
+
+  test("registers the default workspace before starting the timer", async () => {
+    await _resetHeartbeatServiceForTests();
+    _resetGitServiceRegistry();
+    const handle = startWorkspaceGitHeartbeat();
+    try {
+      expect(getAllWorkspaceGitServices().has(getWorkspaceDir())).toBe(true);
+    } finally {
+      await handle.stop();
+    }
+  });
+
+  test("stop is idempotent", async () => {
+    await _resetHeartbeatServiceForTests();
+    _resetGitServiceRegistry();
+    const handle = startWorkspaceGitHeartbeat();
+    await handle.stop();
+    await handle.stop();
+  });
+
+  test("resource monitor starts the heartbeat and daemon lifecycle does not", () => {
+    const worker = readFileSync(join(SRC_ROOT, "monitoring/worker.ts"), "utf8");
+    const lifecycle = readFileSync(
+      join(SRC_ROOT, "daemon/lifecycle.ts"),
+      "utf8",
+    );
+    expect(worker).toContain("startWorkspaceGitHeartbeat(");
+    expect(worker).toContain("await workspaceGitHeartbeat?.stop()");
+    expect(lifecycle).not.toContain("startWorkspaceHeartbeatService");
+  });
+});

--- a/assistant/src/monitoring/worker.ts
+++ b/assistant/src/monitoring/worker.ts
@@ -9,6 +9,8 @@
  * whole point: the sampler keeps recording during a main-thread freeze, its
  * on-disk ring buffer survives the OOM SIGKILL that resets all in-VM state,
  * and telemetry keeps flushing while the daemon is busy or stalled.
+ * Periodic workspace git auto-commits also run here so large `git add` /
+ * `git commit` work cannot stall the daemon event loop.
  */
 
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -60,6 +62,10 @@ import {
   type ResourceSamplerHandle,
   startResourceSampler,
 } from "./resource-sampler.js";
+import {
+  startWorkspaceGitHeartbeat,
+  type WorkspaceGitHeartbeatHandle,
+} from "./workspace-git-heartbeat.js";
 
 const log = getLogger("monitoring-worker");
 
@@ -96,6 +102,7 @@ async function main(): Promise<void> {
   let sourceWatch: PluginSourceWatchHandle | null = null;
   let autoUpdate: PluginAutoUpdateHandle | null = null;
   let recovery: RecoveryHandle | null = null;
+  let workspaceGitHeartbeat: WorkspaceGitHeartbeatHandle | null = null;
 
   let shuttingDown = false;
   let disposePidGuard: (() => void) | null = null;
@@ -105,6 +112,13 @@ async function main(): Promise<void> {
     }
     shuttingDown = true;
     log.info({ signal }, "Resource monitor process shutting down");
+    // Wait for in-flight git add/commit so SIGTERM does not leave index.lock.
+    try {
+      await workspaceGitHeartbeat?.stop();
+    } catch (err) {
+      log.warn({ err }, "Workspace git heartbeat shutdown failed (non-fatal)");
+    }
+    workspaceGitHeartbeat = null;
     recovery?.stop();
     stopConfigSnapshotReporter();
     stopMemoryTierReporter();
@@ -165,6 +179,10 @@ async function main(): Promise<void> {
   autoUpdate = startPluginAutoUpdate();
   // Crash recovery runs here, off the daemon's boot path and event loop.
   recovery = startRecovery();
+  // Workspace git auto-commit safety net. Turn-boundary commits stay on
+  // the daemon; this timer must not run there because large `git add` /
+  // `git commit` work stalls the event loop.
+  workspaceGitHeartbeat = startWorkspaceGitHeartbeat();
 
   // Flush the non-turn telemetry sources from this process, off the daemon's
   // event loop. The reporter's share_analytics gate reads the consent cache,

--- a/assistant/src/monitoring/workspace-git-heartbeat.ts
+++ b/assistant/src/monitoring/workspace-git-heartbeat.ts
@@ -1,0 +1,45 @@
+/**
+ * Workspace git auto-commit heartbeat, driven from the resource monitor
+ * process.
+ *
+ * Turn-boundary commits stay on the daemon (they must finish before the next
+ * turn starts). The periodic safety net is different: a dirty tree of
+ * thousands of files makes `git add` / `git commit` block for seconds, and
+ * running that on the daemon event loop stalls every in-process handler.
+ * The monitor already owns other periodic, non-turn work (plugin auto-update,
+ * crash recovery, the resource sampler), so the heartbeat timer lives here.
+ *
+ * `getAllWorkspaceGitServices()` is process-local. The daemon's registry is
+ * invisible here, so this process registers the default workspace before
+ * starting the timer. Git `index.lock` (plus stale-lock cleanup) serializes
+ * against the daemon's turn-boundary commits.
+ */
+
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { getWorkspaceGitService } from "../workspace/git-service.js";
+import {
+  startWorkspaceHeartbeatService,
+  stopWorkspaceHeartbeatService,
+} from "../workspace/heartbeat-service.js";
+
+const log = getLogger("workspace-git-heartbeat");
+
+export interface WorkspaceGitHeartbeatHandle {
+  stop(): Promise<void>;
+}
+
+/**
+ * Register the default workspace in this process and start the heartbeat
+ * timer. Idempotent: a second call reuses the singleton.
+ */
+export function startWorkspaceGitHeartbeat(): WorkspaceGitHeartbeatHandle {
+  getWorkspaceGitService(getWorkspaceDir());
+  startWorkspaceHeartbeatService();
+  log.info("Workspace git heartbeat started in resource monitor");
+  return {
+    async stop() {
+      await stopWorkspaceHeartbeatService();
+    },
+  };
+}

--- a/assistant/src/workspace/heartbeat-service.ts
+++ b/assistant/src/workspace/heartbeat-service.ts
@@ -65,11 +65,17 @@ const firstSeenDirty = new Map<string, number>();
  * Heartbeat service that periodically checks all tracked workspaces for
  * uncommitted changes and auto-commits them when thresholds are met.
  *
- * This is a SAFETY NET -- turn-boundary commits (M2) handle the primary case.
+ * This is a SAFETY NET. Turn-boundary commits handle the primary case.
  * The heartbeat catches:
  * - Long-running bash scripts that modify files without returning to the agent loop
  * - Background processes that write to the workspace
  * - Forgotten state from crashed or interrupted sessions
+ *
+ * The monitoring worker owns the periodic timer so git add/commit of large
+ * working trees cannot stall the daemon event loop. Turn-boundary commits
+ * still run in the daemon process. Daemon shutdown still flushes pending
+ * changes via commitAllPendingWorkspaceChanges() against the daemon's
+ * GitService registry.
  */
 export class WorkspaceHeartbeatService {
   private readonly ageThresholdMs: number;
@@ -113,6 +119,7 @@ export class WorkspaceHeartbeatService {
         log.error({ err }, "Heartbeat check failed");
       });
     }, this.intervalMs);
+    this.timer.unref?.();
   }
 
   /**
@@ -382,32 +389,50 @@ export class WorkspaceHeartbeatService {
 
 let instance: WorkspaceHeartbeatService | null = null;
 
-/** Construct and start the workspace heartbeat service singleton. */
+/**
+ * Construct (if needed) and start the workspace heartbeat service singleton.
+ * Idempotent: a second call reuses the existing instance and does not start
+ * a second timer.
+ */
 export function startWorkspaceHeartbeatService(): void {
-  instance = new WorkspaceHeartbeatService();
+  if (!instance) {
+    instance = new WorkspaceHeartbeatService();
+  }
   instance.start();
 }
 
 /**
- * Stop the workspace heartbeat service singleton if one is running. The instance
- * is retained so a final commitAllPendingWorkspaceChanges() during shutdown can
- * still flush after the periodic loop has stopped.
+ * Stop the periodic timer and wait for any in-flight check. The instance
+ * is retained so a later commitAllPendingWorkspaceChanges() can still flush.
  */
 export async function stopWorkspaceHeartbeatService(): Promise<void> {
   await instance?.stop();
 }
 
 /**
- * Commit any uncommitted workspace changes via the singleton; no-op when the
- * service was never started.
+ * Commit any uncommitted workspace changes via the singleton. Constructs the
+ * service if it was never started, so daemon shutdown can flush pending
+ * workspace git changes even when the periodic timer runs in another process.
  */
 export async function commitAllPendingWorkspaceChanges(): Promise<void> {
-  await instance?.commitAllPending();
+  if (!instance) {
+    instance = new WorkspaceHeartbeatService();
+  }
+  await instance.commitAllPending();
 }
 
 /**
  * @internal Test-only: clear the dirty tracking state
  */
 export function _resetHeartbeatState(): void {
+  firstSeenDirty.clear();
+}
+
+/**
+ * @internal Test-only: stop the singleton and drop it so later tests start clean.
+ */
+export async function _resetHeartbeatServiceForTests(): Promise<void> {
+  await instance?.stop();
+  instance = null;
   firstSeenDirty.clear();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

When git unstashed changes are large, workspace auto-commits stall the daemon event loop. Move the periodic workspace git heartbeat to the resource monitor process so it no longer competes with the main thread.

This is the second of two PRs. Batching of `git add` / `git commit` for large working trees is https://github.com/vellum-ai/vellum-assistant/pull/42418.

## Summary

- The resource monitor registers the default workspace in its process-local GitService registry and starts the heartbeat timer.
- SIGTERM on the monitor awaits the in-flight check so a kill does not leave `.git/index.lock`.
- The daemon no longer starts the periodic timer. Turn-boundary commits stay on the daemon.
- `commitAllPendingWorkspaceChanges()` constructs the singleton if it was never started, so daemon shutdown can still flush against the daemon's GitService registry.

## Test plan

- `cd assistant && bun test src/monitoring/__tests__/workspace-git-heartbeat.test.ts src/__tests__/workspace-heartbeat-service.test.ts src/__tests__/workspace-lifecycle.test.ts src/__tests__/commit-guarantee.test.ts src/__tests__/worker-entrypoint-guards.test.ts`
- 44 pass, 0 fail, including wiring guard: `monitoring/worker.ts` starts `startWorkspaceGitHeartbeat`; `daemon/lifecycle.ts` does not call `startWorkspaceHeartbeatService`.
- `cd assistant && bun test src/__tests__/background-workers-disk-pressure.test.ts` (2 pass; run separately because that file mocks the disk-pressure gate process-wide).

## Risk

- The heartbeat and turn-boundary commits now run in different processes. Git `index.lock` (plus stale-lock cleanup) serializes them. A daemon shutdown flush can overlap a monitor check that has not yet received SIGTERM (`stopMonitoring()` still happens later in shutdown). That race already existed against external git; the shutdown commit path is already non-fatal.
- Heartbeat enrichment still uses the process-local enrichment queue (currently a no-op placeholder writing git notes).
- No migration, no feature flag, no companion platform PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5dfb4dd-135c-4d18-8297-57bf48b14017?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5dfb4dd-135c-4d18-8297-57bf48b14017&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

