### PR TITLE
feat(oauth): mint scoped grants for the passthrough proxy

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24383,7 +24383,7 @@ paths:
                   - ttlSeconds
                 additionalProperties: false
         "400":
-          description: Malformed request or provider key
+          description: Malformed request, provider key, or account
         "404":
           description: Unknown provider
         "409":
@@ -24396,7 +24396,8 @@ paths:
       summary: Proxy a DELETE request through an OAuth connection
       description:
         Forwards the remainder path, query, headers, and body to the provider's API base through the connection
-        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted.
+        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and
+        it is honored only for the provider and account its subject names.
       tags:
         - oauth
       parameters:
@@ -24428,7 +24429,7 @@ paths:
         "402":
           description: The managed account is out of balance
         "403":
-          description: The grant was minted for a different provider
+          description: The grant was minted for a different provider or account
         "404":
           description: Unknown provider
         "405":
@@ -24444,7 +24445,8 @@ paths:
       summary: Proxy a GET request through an OAuth connection
       description:
         Forwards the remainder path, query, headers, and body to the provider's API base through the connection
-        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted.
+        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and
+        it is honored only for the provider and account its subject names.
       tags:
         - oauth
       parameters:
@@ -24469,7 +24471,7 @@ paths:
         "402":
           description: The managed account is out of balance
         "403":
-          description: The grant was minted for a different provider
+          description: The grant was minted for a different provider or account
         "404":
           description: Unknown provider
         "405":
@@ -24485,7 +24487,8 @@ paths:
       summary: Proxy a HEAD request through an OAuth connection
       description:
         Forwards the remainder path, query, headers, and body to the provider's API base through the connection
-        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted.
+        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and
+        it is honored only for the provider and account its subject names.
       tags:
         - oauth
       parameters:
@@ -24510,7 +24513,7 @@ paths:
         "402":
           description: The managed account is out of balance
         "403":
-          description: The grant was minted for a different provider
+          description: The grant was minted for a different provider or account
         "404":
           description: Unknown provider
         "405":
@@ -24526,7 +24529,8 @@ paths:
       summary: Proxy a PATCH request through an OAuth connection
       description:
         Forwards the remainder path, query, headers, and body to the provider's API base through the connection
-        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted.
+        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and
+        it is honored only for the provider and account its subject names.
       tags:
         - oauth
       parameters:
@@ -24556,7 +24560,7 @@ paths:
         "402":
           description: The managed account is out of balance
         "403":
-          description: The grant was minted for a different provider
+          description: The grant was minted for a different provider or account
         "404":
           description: Unknown provider
         "405":
@@ -24572,7 +24576,8 @@ paths:
       summary: Proxy a POST request through an OAuth connection
       description:
         Forwards the remainder path, query, headers, and body to the provider's API base through the connection
-        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted.
+        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and
+        it is honored only for the provider and account its subject names.
       tags:
         - oauth
       parameters:
@@ -24602,7 +24607,7 @@ paths:
         "402":
           description: The managed account is out of balance
         "403":
-          description: The grant was minted for a different provider
+          description: The grant was minted for a different provider or account
         "404":
           description: Unknown provider
         "405":
@@ -24618,7 +24623,8 @@ paths:
       summary: Proxy a PUT request through an OAuth connection
       description:
         Forwards the remainder path, query, headers, and body to the provider's API base through the connection
-        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted.
+        resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and
+        it is honored only for the provider and account its subject names.
       tags:
         - oauth
       parameters:
@@ -24648,7 +24654,7 @@ paths:
         "402":
           description: The managed account is out of balance
         "403":
-          description: The grant was minted for a different provider
+          description: The grant was minted for a different provider or account
         "404":
           description: Unknown provider
         "405":

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24317,6 +24317,79 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/oauth/proxy-grant:
+    post:
+      operationId: oauth_proxygrant_post
+      summary: Mint an OAuth proxy grant
+      description:
+        Returns a short-lived token and base URL a third-party CLI uses to call the provider's API through the
+        passthrough proxy.
+      tags:
+        - oauth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider:
+                  type: string
+                  minLength: 1
+                account:
+                  type: string
+                  minLength: 1
+                ttlSeconds:
+                  type: integer
+                  minimum: 60
+                  maximum: 3600
+              required:
+                - provider
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    const: true
+                  provider:
+                    type: string
+                  account:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  baseUrl:
+                    type: string
+                  path:
+                    type: string
+                  token:
+                    type: string
+                  expiresAt:
+                    type: string
+                  ttlSeconds:
+                    type: number
+                required:
+                  - ok
+                  - provider
+                  - account
+                  - baseUrl
+                  - path
+                  - token
+                  - expiresAt
+                  - ttlSeconds
+                additionalProperties: false
+        "400":
+          description: Malformed request or provider key
+        "404":
+          description: Unknown provider
+        "409":
+          description: Several accounts are connected and none was pinned
+        "424":
+          description: No usable connection; reconnect the provider
   /v1/oauth/proxy/{provider}/{path}:
     delete:
       operationId: oauth_proxy_by_provider_by_path_delete

--- a/assistant/src/cli/commands/oauth/index.help.ts
+++ b/assistant/src/cli/commands/oauth/index.help.ts
@@ -897,7 +897,7 @@ Arguments:
 
 Stock third-party CLIs expect to be handed an API base URL and an access
 token. This command produces both without ever revealing the provider
-credential: the grant it mints can reach only /v1/oauth/proxy/<provider>,
+credential: the grant it mints can reach only the one connection it named,
 and it expires. The third-party CLI attaches the grant as its own bearer
 token, and the proxy strips it and substitutes the real credential before
 forwarding the request to the provider. The printed base URL is

--- a/assistant/src/runtime/routes/__tests__/oauth-proxy-grant-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/oauth-proxy-grant-routes.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Tests for the OAuth proxy grant route (`oauth_proxy_grant`).
+ *
+ * The grant is a credential, so the guarantees under test are the ones a
+ * leaked or misdirected grant would break: it verifies only under the subject
+ * of the provider it names, it opens the passthrough route and nothing wider,
+ * its base URL points at the connection the CLI will actually reach, and the
+ * token never appears in a log line.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OAuthConnection } from "../../../oauth/connection.js";
+import type { RouteError } from "../errors.js";
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+const providerLookups: string[] = [];
+mock.module("../../../oauth/oauth-store.js", () => ({
+  getProvider: (provider: string) => {
+    providerLookups.push(provider);
+    return provider === "stripe_link"
+      ? { provider, baseUrl: "https://api.link.com" }
+      : undefined;
+  },
+}));
+
+interface ResolverCall {
+  provider: string;
+  options: { account?: string } | undefined;
+}
+const resolverCalls: ResolverCall[] = [];
+let resolverError: unknown;
+let resolution: {
+  connection: OAuthConnection;
+  ambiguous: boolean;
+  allAccounts: string[];
+};
+
+mock.module("../../../oauth/connection-resolver.js", () => ({
+  resolveOAuthConnectionWithMeta: async (
+    provider: string,
+    options?: { account?: string },
+  ) => {
+    resolverCalls.push({ provider, options });
+    if (resolverError) {
+      throw resolverError;
+    }
+    return resolution;
+  },
+}));
+
+// Spread the real module so the rest of the import graph keeps its env
+// readers; only the gateway base and the auth bypass are pinned.
+const env = await import("../../../config/env.js");
+mock.module("../../../config/env.js", () => ({
+  ...env,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  isHttpAuthDisabled: () => false,
+}));
+
+const logCalls: unknown[][] = [];
+const realLogger = await import("../../../util/logger.js");
+mock.module("../../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get:
+        () =>
+        (...args: unknown[]) => {
+          logCalls.push(args);
+        },
+    }),
+}));
+
+const { authenticateRequest } = await import("../../auth/middleware.js");
+const { enforcePolicy, LOCAL_PRINCIPALS } =
+  await import("../../auth/route-policy.js");
+const { initAuthSigningKey, verifyToken } =
+  await import("../../auth/token-service.js");
+const { handleOAuthProxyGrant, ROUTES } =
+  await import("../oauth-proxy-grant-routes.js");
+const { ROUTES: PROXY_ROUTES } = await import("../oauth-proxy-routes.js");
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+const TEST_KEY = Buffer.from("test-signing-key-32-bytes-long!!");
+
+function connection(accountInfo: string | null): OAuthConnection {
+  return {
+    id: "conn-byo",
+    provider: "stripe_link",
+    accountInfo,
+    request: async () => {
+      throw new Error("the grant route never calls the provider");
+    },
+    async withToken() {
+      throw new Error("the grant route never unwraps the raw token");
+    },
+  };
+}
+
+type Grant = Awaited<ReturnType<typeof handleOAuthProxyGrant>>;
+
+async function grant(body: Record<string, unknown>): Promise<Grant> {
+  return await handleOAuthProxyGrant({ body });
+}
+
+async function grantError(body: Record<string, unknown>): Promise<RouteError> {
+  try {
+    await grant(body);
+  } catch (err) {
+    return err as RouteError;
+  }
+  throw new Error("Expected the grant to be refused");
+}
+
+function claimsOf(token: string): {
+  sub: string;
+  scope_profile: string;
+  exp: number;
+} {
+  const result = verifyToken(token, "vellum-gateway");
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw new Error(result.reason);
+  }
+  return result.claims;
+}
+
+beforeEach(() => {
+  initAuthSigningKey(TEST_KEY);
+  providerLookups.length = 0;
+  resolverCalls.length = 0;
+  logCalls.length = 0;
+  resolverError = undefined;
+  resolution = {
+    connection: connection("user@example.com"),
+    ambiguous: false,
+    allAccounts: ["user@example.com"],
+  };
+});
+
+// ── Minted grant ────────────────────────────────────────────────────────────
+
+describe("the minted grant", () => {
+  test("verifies under the provider's own subject with the proxy profile", async () => {
+    const result = await grant({ provider: "stripe_link" });
+
+    const claims = claimsOf(result.token);
+    expect(claims.sub).toBe("local:self:oauth-proxy.stripe_link");
+    expect(claims.scope_profile).toBe("oauth_proxy_v1");
+
+    const expectedExp = Math.floor(Date.now() / 1000) + 900;
+    expect(Math.abs(claims.exp - expectedExp)).toBeLessThanOrEqual(2);
+  });
+
+  test("points the base URL at the resolved account's provider segment", async () => {
+    const result = await grant({ provider: "stripe_link" });
+
+    expect(result).toMatchObject({
+      ok: true,
+      provider: "stripe_link",
+      account: "user@example.com",
+      path: "/v1/oauth/proxy/stripe_link@user%40example.com",
+      baseUrl:
+        "http://127.0.0.1:7830/v1/oauth/proxy/stripe_link@user%40example.com",
+      ttlSeconds: 900,
+    });
+    expect(result.expiresAt).toBe(
+      new Date(Date.parse(result.expiresAt)).toISOString(),
+    );
+  });
+
+  test("an explicit account wins over the resolved label and is encoded", async () => {
+    const result = await grant({
+      provider: "stripe_link",
+      account: "other user@example.com",
+    });
+
+    expect(resolverCalls).toEqual([
+      {
+        provider: "stripe_link",
+        options: { account: "other user@example.com" },
+      },
+    ]);
+    expect(result.account).toBe("other user@example.com");
+    expect(result.path).toBe(
+      "/v1/oauth/proxy/stripe_link@other%20user%40example.com",
+    );
+  });
+
+  test("leaves the segment unpinned when nothing names an account", async () => {
+    resolution = { ...resolution, connection: connection(null) };
+
+    const result = await grant({ provider: "stripe_link" });
+
+    expect(resolverCalls).toEqual([
+      { provider: "stripe_link", options: undefined },
+    ]);
+    expect(result.account).toBeNull();
+    expect(result.path).toBe("/v1/oauth/proxy/stripe_link");
+    expect(result.baseUrl).toBe(
+      "http://127.0.0.1:7830/v1/oauth/proxy/stripe_link",
+    );
+  });
+
+  test("never writes the token to a log line", async () => {
+    const result = await grant({ provider: "stripe_link" });
+
+    expect(logCalls.length).toBeGreaterThan(0);
+    expect(JSON.stringify(logCalls)).not.toContain(result.token);
+    expect(logCalls.at(-1)?.[0]).toEqual({
+      provider: "stripe_link",
+      account: "user@example.com",
+      ttlSeconds: 900,
+    });
+  });
+});
+
+// ── Request validation ──────────────────────────────────────────────────────
+
+describe("request validation", () => {
+  test.each([60, 3600])("accepts a ttlSeconds of %s", async (ttlSeconds) => {
+    const result = await grant({ provider: "stripe_link", ttlSeconds });
+
+    expect(result.ttlSeconds).toBe(ttlSeconds);
+    const expectedExp = Math.floor(Date.now() / 1000) + ttlSeconds;
+    expect(
+      Math.abs(claimsOf(result.token).exp - expectedExp),
+    ).toBeLessThanOrEqual(2);
+  });
+
+  test.each([59, 3601, 90.5])(
+    "refuses a ttlSeconds of %s with 400",
+    async (ttlSeconds) => {
+      const err = await grantError({ provider: "stripe_link", ttlSeconds });
+
+      expect(err.statusCode).toBe(400);
+      expect(resolverCalls).toEqual([]);
+    },
+  );
+
+  test("refuses a missing provider with 400", async () => {
+    expect((await grantError({})).statusCode).toBe(400);
+    expect((await grantError({ provider: "" })).statusCode).toBe(400);
+    expect(providerLookups).toEqual([]);
+  });
+});
+
+// ── Connection failures ─────────────────────────────────────────────────────
+
+describe("connection failures", () => {
+  test("an unknown provider is a 404 before the resolver runs", async () => {
+    const err = await grantError({ provider: "nope" });
+
+    expect(err.statusCode).toBe(404);
+    expect(resolverCalls).toEqual([]);
+  });
+
+  test("several connected accounts are a 409 naming each one", async () => {
+    resolution = {
+      connection: connection("a@example.com"),
+      ambiguous: true,
+      allAccounts: ["a@example.com", "b@example.com"],
+    };
+
+    const err = await grantError({ provider: "stripe_link" });
+
+    expect(err.statusCode).toBe(409);
+    expect(err.details).toMatchObject({
+      provider: "stripe_link",
+      accounts: ["a@example.com", "b@example.com"],
+    });
+  });
+
+  test("a resolver failure is a 424 telling the caller to reconnect", async () => {
+    resolverError = new Error("No active connection for stripe_link");
+
+    const err = await grantError({ provider: "stripe_link" });
+
+    expect(err.statusCode).toBe(424);
+    expect(err.details).toMatchObject({
+      reconnect: "assistant oauth connect stripe_link",
+    });
+  });
+});
+
+// ── Reach of the grant ──────────────────────────────────────────────────────
+
+describe("what the grant opens", () => {
+  function authContextFor(token: string) {
+    const result = authenticateRequest(
+      new Request(
+        "http://daemon.local/v1/oauth/proxy/stripe_link/v1/accounts",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("The grant did not authenticate");
+    }
+    return result.context;
+  }
+
+  test("passes the passthrough route's policy and no wider one", async () => {
+    const { token } = await grant({ provider: "stripe_link" });
+    const ctx = authContextFor(token);
+
+    for (const route of PROXY_ROUTES) {
+      expect(enforcePolicy(route.endpoint, route.policy, ctx)).toBeNull();
+    }
+
+    const denied = enforcePolicy(
+      "oauth/proxy-grant",
+      {
+        requiredScopes: ["settings.write"],
+        allowedPrincipalTypes: LOCAL_PRINCIPALS,
+      },
+      ctx,
+    );
+    expect(denied?.status).toBe(403);
+  });
+
+  test("the grant route itself is IPC-local and settings-scoped", () => {
+    expect(ROUTES).toHaveLength(1);
+    expect(ROUTES[0]).toMatchObject({
+      operationId: "oauth_proxy_grant",
+      endpoint: "oauth/proxy-grant",
+      method: "POST",
+      policy: {
+        requiredScopes: ["settings.write"],
+        allowedPrincipalTypes: LOCAL_PRINCIPALS,
+      },
+    });
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/oauth-proxy-grant-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/oauth-proxy-grant-routes.test.ts
@@ -19,7 +19,9 @@ const providerLookups: string[] = [];
 mock.module("../../../oauth/oauth-store.js", () => ({
   getProvider: (provider: string) => {
     providerLookups.push(provider);
-    return provider === "stripe_link"
+    // "vendor:eu" stands in for a custom provider key, which is caller-chosen
+    // and unconstrained.
+    return provider === "stripe_link" || provider === "vendor:eu"
       ? { provider, baseUrl: "https://api.link.com" }
       : undefined;
   },
@@ -144,15 +146,61 @@ beforeEach(() => {
 // ── Minted grant ────────────────────────────────────────────────────────────
 
 describe("the minted grant", () => {
-  test("verifies under the provider's own subject with the proxy profile", async () => {
+  test("verifies under the resolved connection's subject with the proxy profile", async () => {
     const result = await grant({ provider: "stripe_link" });
 
     const claims = claimsOf(result.token);
-    expect(claims.sub).toBe("local:self:oauth-proxy.stripe_link");
+    expect(claims.sub).toBe(
+      "local:self:oauth-proxy.stripe_link@user%40example.com",
+    );
     expect(claims.scope_profile).toBe("oauth_proxy_v1");
 
     const expectedExp = Math.floor(Date.now() / 1000) + 900;
     expect(Math.abs(claims.exp - expectedExp)).toBeLessThanOrEqual(2);
+  });
+
+  test("the subject names the same segment the base URL points at", async () => {
+    const result = await grant({
+      provider: "stripe_link",
+      account: "other user@example.com",
+    });
+
+    expect(claimsOf(result.token).sub).toBe(
+      "local:self:oauth-proxy.stripe_link@other%20user%40example.com",
+    );
+    expect(result.path).toBe(
+      "/v1/oauth/proxy/stripe_link@other%20user%40example.com",
+    );
+  });
+
+  test("a grant for a second account gets a subject of its own", async () => {
+    const first = await grant({ provider: "stripe_link", account: "a@x.test" });
+    const second = await grant({
+      provider: "stripe_link",
+      account: "b@x.test",
+    });
+
+    expect(claimsOf(first.token).sub).not.toBe(claimsOf(second.token).sub);
+  });
+
+  test("an unpinned grant keeps the bare provider subject", async () => {
+    resolution = { ...resolution, connection: connection(null) };
+
+    const result = await grant({ provider: "stripe_link" });
+
+    expect(claimsOf(result.token).sub).toBe(
+      "local:self:oauth-proxy.stripe_link",
+    );
+  });
+
+  test("every minted subject stays a three-component local sub", async () => {
+    for (const account of [undefined, "a:b@example.com", "a/b", "a b"]) {
+      const result = await grant({
+        provider: "stripe_link",
+        ...(account && { account }),
+      });
+      expect(claimsOf(result.token).sub.split(":")).toHaveLength(3);
+    }
   });
 
   test("points the base URL at the resolved account's provider segment", async () => {
@@ -245,6 +293,25 @@ describe("request validation", () => {
     expect((await grantError({})).statusCode).toBe(400);
     expect((await grantError({ provider: "" })).statusCode).toBe(400);
     expect(providerLookups).toEqual([]);
+  });
+
+  test("refuses a registered provider key the subject cannot hold", async () => {
+    // "vendor:eu" would mint a four-component local subject, which every
+    // subject parser rejects, so the grant could never be used.
+    const err = await grantError({ provider: "vendor:eu" });
+
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toContain("vendor:eu");
+  });
+
+  test("an account with a colon is encoded rather than refused", async () => {
+    const result = await grant({
+      provider: "stripe_link",
+      account: "a:b@example.com",
+    });
+
+    expect(result.account).toBe("a:b@example.com");
+    expect(result.path).toBe("/v1/oauth/proxy/stripe_link@a%3Ab%40example.com");
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
@@ -132,13 +132,17 @@ const HTTP_ROUTES = routeDefinitionsToHTTPRoutes(ROUTES);
 // ── Harness ─────────────────────────────────────────────────────────────────
 
 const SUBJECT = "local:self:oauth-proxy.stripe_link";
+/** Subject of a grant minted with `--account user@example.com`. */
+const PINNED_SUBJECT = "local:self:oauth-proxy.stripe_link@user%40example.com";
+/** Wire segment the pinned grant's base URL carries. */
+const PINNED_SEGMENT = "stripe_link@user%40example.com";
 
 function buildAuthContext(subject: string): AuthContext {
   return {
     subject,
     principalType: "local",
     assistantId: "self",
-    conversationId: "oauth-proxy.stripe_link",
+    conversationId: subject.slice("local:self:".length),
     scopeProfile: "oauth_proxy_v1",
     scopes: resolveScopeProfile("oauth_proxy_v1"),
     policyEpoch: 0,
@@ -499,7 +503,7 @@ describe("response emission", () => {
 
 describe("connection selection", () => {
   test("pins the account from the provider segment", async () => {
-    await callProxy({ segment: "stripe_link@user%40example.com" });
+    await callProxy({ segment: PINNED_SEGMENT, subject: PINNED_SUBJECT });
 
     expect(resolverCalls).toEqual([
       { provider: "stripe_link", options: { account: "user@example.com" } },
@@ -524,10 +528,7 @@ describe("connection selection", () => {
 
     expect(response.status).toBe(409);
     const { error } = await envelope(response);
-    expect(error.details?.accounts).toEqual([
-      "a@example.com",
-      "b@example.com",
-    ]);
+    expect(error.details?.accounts).toEqual(["a@example.com", "b@example.com"]);
     expect(error.message).toContain("a@example.com");
     expect(error.message).toContain("b@example.com");
     expect(captured).toBeUndefined();
@@ -587,15 +588,82 @@ describe("failure mapping", () => {
 // ── Grant binding and path safety ───────────────────────────────────────────
 
 describe("grant binding", () => {
+  /** Nothing downstream of the subject check ran. */
+  async function expectRefusedBeforeResolution(
+    response: Response,
+  ): Promise<void> {
+    expect(response.status).toBe(403);
+    expect((await envelope(response)).error.code).toBe("FORBIDDEN");
+    expect(resolverCalls).toHaveLength(0);
+    expect(providerLookups).toHaveLength(0);
+    expect(captured).toBeUndefined();
+  }
+
   test("a grant for another provider is rejected before resolution", async () => {
     const response = await callProxy({
       subject: "local:self:oauth-proxy.google",
     });
 
-    expect(response.status).toBe(403);
-    expect((await envelope(response)).error.code).toBe("FORBIDDEN");
+    await expectRefusedBeforeResolution(response);
+  });
+
+  test("a grant pinned to an account reaches that account", async () => {
+    const response = await callProxy({
+      segment: PINNED_SEGMENT,
+      subject: PINNED_SUBJECT,
+    });
+
+    expect(response.status).toBe(200);
+    expect(resolverCalls).toEqual([
+      { provider: "stripe_link", options: { account: "user@example.com" } },
+    ]);
+  });
+
+  test("a pinned grant cannot be rewritten onto another account", async () => {
+    const response = await callProxy({
+      segment: "stripe_link@other%40example.com",
+      subject: PINNED_SUBJECT,
+    });
+
+    await expectRefusedBeforeResolution(response);
+  });
+
+  test("a pinned grant cannot fall back to the default connection", async () => {
+    // The bare segment resolves to whichever connection the resolver prefers,
+    // which is not necessarily the one the grant was minted for.
+    const response = await callProxy({ subject: PINNED_SUBJECT });
+
+    await expectRefusedBeforeResolution(response);
+  });
+
+  test("an unpinned grant works against the bare provider segment", async () => {
+    const response = await callProxy({ subject: SUBJECT });
+
+    expect(response.status).toBe(200);
+    expect(resolverCalls).toEqual([
+      { provider: "stripe_link", options: undefined },
+    ]);
+  });
+
+  test("an unpinned grant cannot name an account of its own", async () => {
+    // Unpinned means the mint identified no account, so any account the caller
+    // supplies here is one the grant never stood for.
+    const response = await callProxy({
+      segment: PINNED_SEGMENT,
+      subject: SUBJECT,
+    });
+
+    await expectRefusedBeforeResolution(response);
+  });
+
+  test("a provider segment the subject cannot hold is a 400", async () => {
+    const response = await callProxy({
+      segment: "vendor%3Aregion",
+      subject: "local:self:oauth-proxy.vendor:region",
+    });
+
+    expect(response.status).toBe(400);
     expect(resolverCalls).toHaveLength(0);
-    expect(providerLookups).toHaveLength(0);
   });
 });
 

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -120,6 +120,7 @@ import { ROUTES as OAUTH_COMMANDS_ROUTES } from "./oauth-commands-routes.js";
 import { ROUTES as OAUTH_CONNECT_ROUTES } from "./oauth-connect-routes.js";
 import { ROUTES as OAUTH_LIFECYCLE_ROUTES } from "./oauth-lifecycle-routes.js";
 import { ROUTES as OAUTH_PROVIDERS_ROUTES } from "./oauth-providers.js";
+import { ROUTES as OAUTH_PROXY_GRANT_ROUTES } from "./oauth-proxy-grant-routes.js";
 import { ROUTES as OAUTH_PROXY_ROUTES } from "./oauth-proxy-routes.js";
 import { ROUTES as ONBOARDING_CHECKIN_ROUTES } from "./onboarding-checkin-routes.js";
 import { ROUTES as PLATFORM_ROUTES } from "./platform-routes.js";
@@ -271,6 +272,7 @@ export const ROUTES: RouteDefinition[] = [
   ...OAUTH_LIFECYCLE_ROUTES,
   ...OAUTH_COMMANDS_ROUTES,
   ...OAUTH_PROXY_ROUTES,
+  ...OAUTH_PROXY_GRANT_ROUTES,
   ...OAUTH_PROVIDERS_ROUTES,
   ...ONBOARDING_CHECKIN_ROUTES,
   ...PLATFORM_ROUTES,

--- a/assistant/src/runtime/routes/oauth-proxy-grant-routes.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-grant-routes.ts
@@ -2,9 +2,10 @@
  * Mints the short-lived grant a third-party CLI presents to the OAuth
  * passthrough proxy (`oauth_proxy_*`).
  *
- * The grant names one provider in its subject and carries the
- * `oauth_proxy_v1` profile, so it opens the proxy route for that provider and
- * nothing else. The provider credential never leaves the daemon.
+ * The grant names one provider, and the account it resolved to, in its subject
+ * and carries the `oauth_proxy_v1` profile, so it opens the proxy route for
+ * that one connection and nothing else. The provider credential never leaves
+ * the daemon.
  */
 
 import { z } from "zod";
@@ -80,25 +81,28 @@ export async function handleOAuthProxyGrant({
     throw ambiguousConnectionError(provider, resolution.allAccounts);
   }
 
-  // Pinning the resolved label keeps the grant pointed at this connection if a
-  // second account connects before the grant expires.
+  // The pinned account is named by the subject as well as by the segment, so
+  // the proxy refuses this grant against any other account of the provider.
   const pinnedAccount = account ?? resolution.connection.accountInfo ?? null;
+
+  // Built before the token so a provider key or account the subject cannot
+  // hold fails with a 400 rather than yielding a grant that never verifies.
+  const segment = encodeProxyProviderSegment(
+    provider,
+    pinnedAccount ?? undefined,
+  );
 
   // The gateway validates the edge token and re-mints a daemon token with the
   // same subject and profile; the daemon middleware also accepts this audience
   // directly.
   const token = mintToken({
     aud: "vellum-gateway",
-    sub: proxyGrantSubject(provider),
+    sub: proxyGrantSubject(provider, pinnedAccount ?? undefined),
     scope_profile: "oauth_proxy_v1",
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds,
   });
 
-  const segment = encodeProxyProviderSegment(
-    provider,
-    pinnedAccount ?? undefined,
-  );
   const path = `/v1/oauth/proxy/${segment}`;
   const baseUrl = `${getGatewayInternalBaseUrl().replace(/\/+$/, "")}${path}`;
 
@@ -135,7 +139,7 @@ export const ROUTES: RouteDefinition[] = [
     requestBody: GrantRequestSchema,
     responseBody: GrantResponseSchema,
     additionalResponses: {
-      "400": { description: "Malformed request or provider key" },
+      "400": { description: "Malformed request, provider key, or account" },
       "404": { description: "Unknown provider" },
       "409": {
         description: "Several accounts are connected and none was pinned",

--- a/assistant/src/runtime/routes/oauth-proxy-grant-routes.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-grant-routes.ts
@@ -1,0 +1,147 @@
+/**
+ * Mints the short-lived grant a third-party CLI presents to the OAuth
+ * passthrough proxy (`oauth_proxy_*`).
+ *
+ * The grant names one provider in its subject and carries the
+ * `oauth_proxy_v1` profile, so it opens the proxy route for that provider and
+ * nothing else. The provider credential never leaves the daemon.
+ */
+
+import { z } from "zod";
+
+import { getGatewayInternalBaseUrl } from "../../config/env.js";
+import type { OAuthConnectionResolution } from "../../oauth/connection-resolver.js";
+import { resolveOAuthConnectionWithMeta } from "../../oauth/connection-resolver.js";
+import { getProvider } from "../../oauth/oauth-store.js";
+import { getLogger } from "../../util/logger.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
+import { mintToken } from "../auth/token-service.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
+import {
+  ambiguousConnectionError,
+  encodeProxyProviderSegment,
+  mapProxyResolveError,
+  proxyGrantSubject,
+} from "./oauth-proxy-passthrough.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const log = getLogger("oauth-proxy-grant-routes");
+
+/** Long enough for a CLI run, short enough that a leaked grant expires fast. */
+const DEFAULT_TTL_SECONDS = 900;
+
+const GrantRequestSchema = z.object({
+  provider: z.string().min(1),
+  account: z.string().min(1).optional(),
+  ttlSeconds: z.number().int().min(60).max(3600).optional(),
+});
+
+const GrantResponseSchema = z.object({
+  ok: z.literal(true),
+  provider: z.string(),
+  account: z.string().nullable(),
+  baseUrl: z.string(),
+  path: z.string(),
+  token: z.string(),
+  expiresAt: z.string(),
+  ttlSeconds: z.number(),
+});
+
+export type OAuthProxyGrantResponse = z.infer<typeof GrantResponseSchema>;
+
+export async function handleOAuthProxyGrant({
+  body = {},
+}: RouteHandlerArgs): Promise<OAuthProxyGrantResponse> {
+  const parsed = GrantRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(parsed.error.issues[0].message);
+  }
+  const { provider, account, ttlSeconds = DEFAULT_TTL_SECONDS } = parsed.data;
+
+  if (!getProvider(provider)) {
+    throw new NotFoundError(
+      `Unknown provider "${provider}". Run 'assistant oauth providers list' to see available providers.`,
+    );
+  }
+
+  // Resolving here means the caller is told to pick an account before any
+  // provider call is made with the grant.
+  let resolution: OAuthConnectionResolution;
+  try {
+    resolution = await resolveOAuthConnectionWithMeta(
+      provider,
+      account ? { account } : undefined,
+    );
+  } catch (err) {
+    throw mapProxyResolveError(err, provider);
+  }
+  if (resolution.ambiguous) {
+    throw ambiguousConnectionError(provider, resolution.allAccounts);
+  }
+
+  // Pinning the resolved label keeps the grant pointed at this connection if a
+  // second account connects before the grant expires.
+  const pinnedAccount = account ?? resolution.connection.accountInfo ?? null;
+
+  // The gateway validates the edge token and re-mints a daemon token with the
+  // same subject and profile; the daemon middleware also accepts this audience
+  // directly.
+  const token = mintToken({
+    aud: "vellum-gateway",
+    sub: proxyGrantSubject(provider),
+    scope_profile: "oauth_proxy_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds,
+  });
+
+  const segment = encodeProxyProviderSegment(
+    provider,
+    pinnedAccount ?? undefined,
+  );
+  const path = `/v1/oauth/proxy/${segment}`;
+  const baseUrl = `${getGatewayInternalBaseUrl().replace(/\/+$/, "")}${path}`;
+
+  log.info(
+    { provider, account: pinnedAccount, ttlSeconds },
+    "OAuth proxy grant minted",
+  );
+
+  return {
+    ok: true,
+    provider,
+    account: pinnedAccount,
+    baseUrl,
+    path,
+    token,
+    expiresAt: new Date(Date.now() + ttlSeconds * 1000).toISOString(),
+    ttlSeconds,
+  };
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "oauth_proxy_grant",
+    endpoint: "oauth/proxy-grant",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: LOCAL_PRINCIPALS,
+    },
+    summary: "Mint an OAuth proxy grant",
+    description:
+      "Returns a short-lived token and base URL a third-party CLI uses to call the provider's API through the passthrough proxy.",
+    tags: ["oauth"],
+    requestBody: GrantRequestSchema,
+    responseBody: GrantResponseSchema,
+    additionalResponses: {
+      "400": { description: "Malformed request or provider key" },
+      "404": { description: "Unknown provider" },
+      "409": {
+        description: "Several accounts are connected and none was pinned",
+      },
+      "424": { description: "No usable connection; reconnect the provider" },
+    },
+    handler: handleOAuthProxyGrant,
+  },
+];

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
@@ -89,6 +89,45 @@ describe("provider segment", () => {
     );
     expect(() => encodeProxyProviderSegment("")).toThrow(BadRequestError);
   });
+
+  test("refuses a provider key that the subject cannot hold", () => {
+    // "vendor:region" mints a four-component local subject, which every
+    // subject parser rejects, so the grant could never be used.
+    expect(() => encodeProxyProviderSegment("vendor:region")).toThrow(
+      BadRequestError,
+    );
+    expect(() =>
+      encodeProxyProviderSegment("vendor:region", "a@example.com"),
+    ).toThrow(BadRequestError);
+    expect(() => parseProxyProviderSegment("vendor:region")).toThrow(
+      BadRequestError,
+    );
+    expect(() =>
+      parseProxyProviderSegment("vendor:region@a@example.com"),
+    ).toThrow(BadRequestError);
+  });
+
+  test("percent-encoding keeps a subject-hostile account safe", () => {
+    // A colon or a newline in an account never reaches the subject or the
+    // header verbatim, so the account needs no rejection of its own.
+    expect(encodeProxyProviderSegment("stripe_link", "a:b")).toBe(
+      "stripe_link@a%3Ab",
+    );
+    expect(encodeProxyProviderSegment("stripe_link", "a\nb")).toBe(
+      "stripe_link@a%0Ab",
+    );
+    expect(
+      parseProxyProviderSegment(decodeURIComponent("stripe_link@a%3Ab")),
+    ).toEqual({ provider: "stripe_link", account: "a:b" });
+  });
+
+  test("refuses an account that cannot be percent-encoded", () => {
+    // A lone surrogate makes `encodeURIComponent` throw; the caller gets a 400
+    // rather than an unhandled URIError.
+    expect(() => encodeProxyProviderSegment("stripe_link", "\uD800")).toThrow(
+      BadRequestError,
+    );
+  });
 });
 
 describe("proxyGrantSubject", () => {
@@ -96,6 +135,34 @@ describe("proxyGrantSubject", () => {
     expect(proxyGrantSubject("stripe_link")).toBe(
       "local:self:oauth-proxy.stripe_link",
     );
+  });
+
+  test("an unpinned grant keeps the shape already in circulation", () => {
+    expect(proxyGrantSubject("stripe_link", undefined)).toBe(
+      "local:self:oauth-proxy.stripe_link",
+    );
+  });
+
+  test("a pinned account gets its own subject, matching the URL segment", () => {
+    const subject = proxyGrantSubject("stripe_link", "a@example.com");
+
+    expect(subject).toBe("local:self:oauth-proxy.stripe_link@a%40example.com");
+    expect(subject).toBe(
+      `local:self:oauth-proxy.${encodeProxyProviderSegment(
+        "stripe_link",
+        "a@example.com",
+      )}`,
+    );
+    expect(subject).not.toBe(proxyGrantSubject("stripe_link"));
+    expect(subject).not.toBe(proxyGrantSubject("stripe_link", "b@example.com"));
+  });
+
+  test("stays a three-component local subject whatever the account holds", () => {
+    for (const account of ["a@example.com", "a:b", "a b", "a/b", "a%3Ab"]) {
+      expect(proxyGrantSubject("stripe_link", account).split(":")).toHaveLength(
+        3,
+      );
+    }
   });
 });
 

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
@@ -75,23 +75,60 @@ const STRIPPED_RESPONSE_HEADERS = new Set([
 ]);
 
 /**
+ * Characters `encodeURIComponent` leaves unescaped. None of them is `:`, which
+ * is what lets an encoded account sit inside a subject component.
+ */
+const ENCODED_ACCOUNT_PATTERN = /^[A-Za-z0-9\-_.!~*'()%]+$/;
+
+/**
  * Provider segment for a base URL. An account pins one connection when the
  * provider has several.
  *
  * A provider key carrying `@` or `/` would parse back as a different provider,
- * so it is rejected here, where a grant is minted, rather than silently
- * misrouting a request later.
+ * and one carrying `:` would split {@link proxyGrantSubject} into a fourth
+ * component that both subject parsers reject, so a grant minted with it could
+ * never be used. Both are refused at mint time rather than misrouting or
+ * failing opaquely later.
  */
 export function encodeProxyProviderSegment(
   provider: string,
   account?: string,
 ): string {
-  if (!provider || provider.includes("@") || provider.includes("/")) {
+  if (
+    !provider ||
+    provider.includes("@") ||
+    provider.includes("/") ||
+    provider.includes(":")
+  ) {
     throw new BadRequestError(
-      `An OAuth proxy provider key may not be empty or contain "@" or "/": "${provider}"`,
+      `An OAuth proxy provider key may not be empty or contain "@", "/", or ":": "${provider}"`,
     );
   }
-  return account ? `${provider}@${encodeURIComponent(account)}` : provider;
+  return account ? `${provider}@${encodeAccount(account)}` : provider;
+}
+
+/**
+ * Percent-encode an account for the segment, and with it for the subject the
+ * segment is embedded in: encoding is what keeps a `:` in an account from
+ * ending the subject component early, and a control character out of the
+ * `x-vellum-subject` header. Text that cannot be encoded is refused here
+ * rather than surfacing as an unhandled `URIError`.
+ */
+function encodeAccount(account: string): string {
+  let encoded: string;
+  try {
+    encoded = encodeURIComponent(account);
+  } catch {
+    throw new BadRequestError(
+      `An OAuth proxy account must be encodable text: "${account}"`,
+    );
+  }
+  if (!ENCODED_ACCOUNT_PATTERN.test(encoded)) {
+    throw new BadRequestError(
+      `An OAuth proxy account may not carry characters that a subject cannot hold: "${account}"`,
+    );
+  }
+  return encoded;
 }
 
 /**
@@ -107,7 +144,7 @@ export function parseProxyProviderSegment(segment: string): {
   const provider = at === -1 ? segment : segment.slice(0, at);
   const account = at === -1 ? "" : segment.slice(at + 1);
 
-  if (!provider || provider.includes("/")) {
+  if (!provider || provider.includes("/") || provider.includes(":")) {
     throw new BadRequestError(
       `Invalid OAuth proxy provider segment: "${segment}"`,
     );
@@ -118,10 +155,16 @@ export function parseProxyProviderSegment(segment: string): {
 
 /**
  * Subject a proxy grant is minted with, and the value the route requires in
- * `x-vellum-subject`, so a grant for one provider cannot reach another.
+ * `x-vellum-subject`, so a grant for one provider cannot reach another, nor a
+ * grant pinned to one account reach a second account of the same provider.
+ *
+ * The segment builder is reused so the subject and the URL segment cannot
+ * drift: the route re-derives this from the account in the request path, and a
+ * rewritten `@account` therefore stops matching. An unpinned grant keeps the
+ * bare `local:self:oauth-proxy.<provider>` shape.
  */
-export function proxyGrantSubject(provider: string): string {
-  return `local:self:oauth-proxy.${provider}`;
+export function proxyGrantSubject(provider: string, account?: string): string {
+  return `local:self:oauth-proxy.${encodeProxyProviderSegment(provider, account)}`;
 }
 
 /**

--- a/assistant/src/runtime/routes/oauth-proxy-routes.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-routes.ts
@@ -4,7 +4,8 @@
  * A stock third-party CLI points its API base here and presents a grant minted
  * by `oauth_proxy_grant`. The route trades that grant for the credential the
  * resolved connection holds, so the CLI never sees a provider token and can
- * reach nothing but that connection's own API base.
+ * reach nothing but that connection's own API base, for the one provider and
+ * account the grant's subject names.
  *
  * Wire semantics (path fidelity, header stripping, error mapping) live in
  * `oauth-proxy-passthrough.ts`; this module is the wiring around them.
@@ -63,14 +64,18 @@ export async function handleOAuthProxy(
     args.pathParams?.provider ?? "",
   );
 
-  // A grant names one provider in its subject. The bypass is the one
+  // A grant names one provider and, when it pinned one, one account. The
+  // subject is re-derived from this request's own segment, so rewriting or
+  // dropping `@account` no longer matches the grant. The bypass is the one
   // `enforcePolicy` honors: platform pods discard the token and build a
   // synthetic context rather than one derived from the grant.
   if (
     !isHttpAuthDisabled() &&
-    args.headers?.["x-vellum-subject"] !== proxyGrantSubject(provider)
+    args.headers?.["x-vellum-subject"] !== proxyGrantSubject(provider, account)
   ) {
-    throw new ForbiddenError("This grant was minted for a different provider");
+    throw new ForbiddenError(
+      "This grant was minted for a different provider or account",
+    );
   }
 
   if (!getProvider(provider)) {
@@ -164,7 +169,9 @@ const BINARY_BODY = {
 const ERROR_RESPONSES: Record<string, { description: string }> = {
   "400": { description: "Malformed provider segment or proxied path" },
   "402": { description: "The managed account is out of balance" },
-  "403": { description: "The grant was minted for a different provider" },
+  "403": {
+    description: "The grant was minted for a different provider or account",
+  },
   "404": { description: "Unknown provider" },
   "405": { description: "The resolved connection rejects this method" },
   "409": { description: "Several accounts are connected and none was pinned" },
@@ -183,7 +190,7 @@ export const ROUTES: RouteDefinition[] = METHODS.map((method) => ({
   rawRequestBody: true,
   summary: `Proxy a ${method} request through an OAuth connection`,
   description:
-    "Forwards the remainder path, query, headers, and body to the provider's API base through the connection resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted.",
+    "Forwards the remainder path, query, headers, and body to the provider's API base through the connection resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and it is honored only for the provider and account its subject names.",
   tags: ["oauth"],
   ...(carriesBody(method) ? { requestBody: BINARY_BODY } : {}),
   responseBody: BINARY_BODY,


### PR DESCRIPTION
## Summary

- Adds `oauth_proxy_grant` (`POST oauth/proxy-grant`), the IPC route behind `assistant oauth proxy-url`. It resolves the connection first, pins the account into the provider segment, and mints a short-lived `oauth_proxy_v1` token subjected to that one provider, so a stock third-party CLI can call the provider API through the passthrough proxy without ever seeing the provider token.
- Resolution failures surface before any provider call: unknown provider is 404, several connected accounts is 409 naming each one, and a dead connection is 424 with the reconnect command.
- The handler logs the provider, account, and TTL only; the token never reaches a log line. Response shape matches the contract `src/cli/commands/oauth/proxy-url.ts` already declares, field for field.

Part of plan: oauth-proxy-passthrough.md (PR 6 of 8)