### PR TITLE
fix(assistant): centralize gateway IPC connect errors and risk retry budget

### DIFF
--- a/assistant/src/__tests__/error-handler-friendly-messages.test.ts
+++ b/assistant/src/__tests__/error-handler-friendly-messages.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
+
 import { withErrorHandling } from "../runtime/middleware/error-handler.js";
 import { ConfigError, ProviderNotConfiguredError } from "../util/errors.js";
 
@@ -41,5 +43,18 @@ describe("withErrorHandling – friendly error messages", () => {
       error: { code: string; message: string };
     };
     expect(body.error.message).toBe("Twilio phone number not configured.");
+  });
+
+  test("IpcConnectError surfaces as 503 SERVICE_UNAVAILABLE", async () => {
+    const response = await withErrorHandling("test", async () => {
+      throw new IpcConnectError("connect ENOENT", "ENOENT");
+    });
+
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.error.message).toContain("Gateway is not reachable over IPC");
   });
 });

--- a/assistant/src/ipc/__tests__/gateway-ipc-errors.test.ts
+++ b/assistant/src/ipc/__tests__/gateway-ipc-errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  IpcCallError,
+  IpcConnectError,
+} from "@vellumai/gateway-client/ipc-client";
+
+import {
+  RouteError,
+  ServiceUnavailableError,
+} from "../../runtime/routes/errors.js";
+import {
+  mapGatewayIpcConnectError,
+  rethrowGatewayIpcFailure,
+} from "../gateway-ipc-errors.js";
+
+describe("mapGatewayIpcConnectError", () => {
+  test("maps IpcConnectError to ServiceUnavailableError", () => {
+    const mapped = mapGatewayIpcConnectError(
+      new IpcConnectError("connect ENOENT", "ENOENT"),
+    );
+    expect(mapped).toBeInstanceOf(ServiceUnavailableError);
+    expect((mapped as ServiceUnavailableError).statusCode).toBe(503);
+    expect((mapped as ServiceUnavailableError).message).toContain(
+      "Gateway is not reachable over IPC",
+    );
+  });
+
+  test("leaves other errors unchanged", () => {
+    const err = new Error("boom");
+    expect(mapGatewayIpcConnectError(err)).toBe(err);
+  });
+});
+
+describe("rethrowGatewayIpcFailure", () => {
+  test("maps IpcCallError onto RouteError with the gateway status", () => {
+    try {
+      rethrowGatewayIpcFailure(
+        new IpcCallError("Invite not found", {
+          statusCode: 404,
+          errorCode: "NOT_FOUND",
+        }),
+      );
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RouteError);
+      expect((err as RouteError).statusCode).toBe(404);
+      expect((err as RouteError).code).toBe("NOT_FOUND");
+    }
+  });
+});

--- a/assistant/src/ipc/__tests__/gateway-validated-call.test.ts
+++ b/assistant/src/ipc/__tests__/gateway-validated-call.test.ts
@@ -4,10 +4,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import {
-  IpcCallError,
-  IpcConnectError,
-} from "@vellumai/gateway-client/ipc-client";
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import { ServiceUnavailableError } from "../../runtime/routes/errors.js";
@@ -44,8 +41,10 @@ describe("ipcCallPersistentValidated", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  test("maps IpcConnectError to ServiceUnavailableError", async () => {
-    ipcError = new IpcConnectError("connect ENOENT", "ENOENT");
+  test("propagates ServiceUnavailableError from ipcCallPersistent", async () => {
+    ipcError = new ServiceUnavailableError(
+      "Gateway is not reachable over IPC: connect ENOENT",
+    );
 
     await expect(
       ipcCallPersistentValidated("ping", {}, OkSchema),

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -30,7 +30,6 @@
 
 import { createServer, type Server, type Socket } from "node:net";
 
-import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
 import {
   ensureSocketDir,
   type IpcEnvelope,
@@ -58,6 +57,7 @@ import type {
 } from "../runtime/routes/types.js";
 import { RouteResponse } from "../runtime/routes/types.js";
 import { getLogger } from "../util/logger.js";
+import { mapGatewayIpcConnectError } from "./gateway-ipc-errors.js";
 import { CONTACTS_INFO_IPC_METHODS } from "./routes/contacts-info-ipc-routes.js";
 import { CONTACTS_MIRROR_IPC_METHODS } from "./routes/contacts-mirror-ipc-routes.js";
 import { CONVERSATION_SYNC_IPC_METHODS } from "./routes/conversation-sync-ipc-routes.js";
@@ -480,27 +480,20 @@ export class AssistantIpcServer {
   }
 
   private buildErrorResponse(id: string, err: unknown): IpcResponse {
-    if (err instanceof RouteError) {
+    const mapped = mapGatewayIpcConnectError(err);
+    if (mapped instanceof RouteError) {
       const response: IpcResponse = {
         id,
-        error: err.message,
-        statusCode: err.statusCode,
-        errorCode: err.code,
+        error: mapped.message,
+        statusCode: mapped.statusCode,
+        errorCode: mapped.code,
       };
-      if (err.details !== undefined) {
-        response.errorDetails = err.details;
+      if (mapped.details !== undefined) {
+        response.errorDetails = mapped.details;
       }
       return response;
     }
-    if (err instanceof IpcConnectError) {
-      return {
-        id,
-        error: `Gateway is not reachable over IPC: ${err.message}`,
-        statusCode: 503,
-        errorCode: "SERVICE_UNAVAILABLE",
-      };
-    }
-    return { id, error: String(err) };
+    return { id, error: String(mapped) };
   }
 
   /**

--- a/assistant/src/ipc/gateway-client.test.ts
+++ b/assistant/src/ipc/gateway-client.test.ts
@@ -13,6 +13,7 @@ import {
   mockGatewayIpc,
   resetMockGatewayIpc,
 } from "../__tests__/mock-gateway-ipc.js";
+import { ServiceUnavailableError } from "../runtime/routes/errors.js";
 import {
   ipcCall,
   ipcCallPersistent,
@@ -67,11 +68,14 @@ describe("ipcCallPersistent", () => {
     expect(result).toBe("persistent-result");
   });
 
-  test("throws when mock simulates error", async () => {
+  test("maps a missing gateway socket to ServiceUnavailableError", async () => {
     mockGatewayIpc(null, { error: true });
 
+    await expect(ipcCallPersistent("any_method")).rejects.toBeInstanceOf(
+      ServiceUnavailableError,
+    );
     await expect(ipcCallPersistent("any_method")).rejects.toThrow(
-      /Mock IPC socket error/,
+      /Gateway is not reachable over IPC: Mock IPC socket error/,
     );
   });
 

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -28,6 +28,7 @@ import {
 
 import { getLogger } from "../util/logger.js";
 import { abortableSleep, computeRetryDelay } from "../util/retry.js";
+import { throwIfGatewayIpcConnectFailed } from "./gateway-ipc-errors.js";
 import { resolveIpcSocketPath } from "./socket-path.js";
 
 const log = getLogger("gateway-ipc-client");
@@ -57,23 +58,30 @@ export async function ipcCall(
 // ---------------------------------------------------------------------------
 
 let persistentClient: PackagePersistentIpcClient | null = null;
+let failFastPersistentClient: PackagePersistentIpcClient | null = null;
 
-/**
- * Persistent IPC call — singleton wrapper around PersistentIpcClient.
- *
- * Creates the instance on first call using the gateway socket path.
- * Unlike `ipcCall()`, this maintains a single connection across calls,
- * making it suitable for hot-path operations like risk classification.
- *
- * Throws `IpcConnectError` when the gateway socket is missing or refused,
- * and `IpcCallError` when the gateway returns a structured error. Callers
- * must handle errors.
- */
-export async function ipcCallPersistent(
-  method: string,
-  params?: Record<string, unknown>,
-  timeoutMs?: number,
-): Promise<unknown> {
+export type IpcCallPersistentOptions = {
+  /**
+   * When false, skip sibling-boot connect retries so the caller owns the
+   * retry budget. Default true.
+   */
+  retryConnect?: boolean;
+};
+
+function getPersistentClient(
+  retryConnect: boolean,
+): PackagePersistentIpcClient {
+  if (!retryConnect) {
+    if (!failFastPersistentClient) {
+      failFastPersistentClient = new PackagePersistentIpcClient(
+        getGatewaySocketPath(),
+        undefined,
+        log,
+        { connectRetryBackoffsMs: [] },
+      );
+    }
+    return failFastPersistentClient;
+  }
   if (!persistentClient) {
     persistentClient = new PackagePersistentIpcClient(
       getGatewaySocketPath(),
@@ -81,17 +89,47 @@ export async function ipcCallPersistent(
       log,
     );
   }
-  return persistentClient.call(method, params, timeoutMs);
+  return persistentClient;
 }
 
 /**
- * Destroy and nullify the singleton persistent client.
- * Exported for testing — ensures no leaked handles between test runs.
+ * Persistent IPC call — singleton wrapper around PersistentIpcClient.
+ *
+ * Creates the instance on first call using the gateway socket path.
+ * Unlike `ipcCall()`, this maintains a single connection across calls.
+ *
+ * Throws `ServiceUnavailableError` (503) when the gateway socket is missing
+ * or refused, and `IpcCallError` when the gateway returns a structured
+ * error. Callers that already handle `RouteError` do not need a local
+ * connect-failure try/catch.
+ */
+export async function ipcCallPersistent(
+  method: string,
+  params?: Record<string, unknown>,
+  timeoutMs?: number,
+  options?: IpcCallPersistentOptions,
+): Promise<unknown> {
+  const client = getPersistentClient(options?.retryConnect !== false);
+  try {
+    return await client.call(method, params, timeoutMs);
+  } catch (err) {
+    throwIfGatewayIpcConnectFailed(err);
+    throw err;
+  }
+}
+
+/**
+ * Destroy and nullify the singleton persistent clients.
+ * Exported for testing. Ensures no leaked handles between test runs.
  */
 export function resetPersistentClient(): void {
   if (persistentClient) {
     persistentClient.destroy();
     persistentClient = null;
+  }
+  if (failFastPersistentClient) {
+    failFastPersistentClient.destroy();
+    failFastPersistentClient = null;
   }
 }
 
@@ -276,6 +314,7 @@ export async function ipcClassifyRisk(
         "classify_risk",
         params,
         CLASSIFY_RISK_ATTEMPT_TIMEOUT_MS,
+        { retryConnect: false },
       );
 
       // A returned-but-malformed response is deterministic, not transient:

--- a/assistant/src/ipc/gateway-ipc-errors.ts
+++ b/assistant/src/ipc/gateway-ipc-errors.ts
@@ -17,14 +17,26 @@ import {
 } from "../runtime/routes/errors.js";
 
 /**
+ * Convert a gateway socket connect failure into a 503 RouteError. Other
+ * values pass through unchanged so adapters can share one RouteError branch.
+ */
+export function mapGatewayIpcConnectError(err: unknown): unknown {
+  if (err instanceof IpcConnectError) {
+    return new ServiceUnavailableError(
+      `Gateway is not reachable over IPC: ${err.message}`,
+    );
+  }
+  return err;
+}
+
+/**
  * If `err` is an {@link IpcConnectError}, throw 503. Otherwise return so the
  * caller can rethrow or map a more specific failure.
  */
 export function throwIfGatewayIpcConnectFailed(err: unknown): void {
-  if (err instanceof IpcConnectError) {
-    throw new ServiceUnavailableError(
-      `Gateway is not reachable over IPC: ${err.message}`,
-    );
+  const mapped = mapGatewayIpcConnectError(err);
+  if (mapped !== err) {
+    throw mapped;
   }
 }
 

--- a/assistant/src/ipc/gateway-validated-call.ts
+++ b/assistant/src/ipc/gateway-validated-call.ts
@@ -6,10 +6,10 @@
  * Uses the persistent IPC client: these are fail-closed control-plane relays
  * and the persistent socket avoids per-call connect overhead. Transport
  * failures (`IpcCallError`, carrying the gateway's statusCode/errorCode)
- * propagate unchanged so relay routes surface 4xx engine reasons as 4xx; a
- * connect failure (`IpcConnectError`, missing or refused gateway socket)
- * becomes `ServiceUnavailableError` (503) so the assistant stays up; a
- * schema-invalid response throws a generic malformed-response error.
+ * propagate unchanged so relay routes surface 4xx engine reasons as 4xx.
+ * Connect failures are mapped to `ServiceUnavailableError` (503) inside
+ * `ipcCallPersistent`. A schema-invalid response throws a generic
+ * malformed-response error.
  *
  * The hot voice call-setup path (`calls/gateway-invite-reader.ts`)
  * deliberately does NOT use this — it needs one-shot `ipcCall` with explicit
@@ -19,20 +19,13 @@
 import type { ZodType } from "zod";
 
 import { ipcCallPersistent } from "./gateway-client.js";
-import { throwIfGatewayIpcConnectFailed } from "./gateway-ipc-errors.js";
 
 export async function ipcCallPersistentValidated<T>(
   method: string,
   params: Record<string, unknown> | undefined,
   responseSchema: ZodType<T>,
 ): Promise<T> {
-  let result: unknown;
-  try {
-    result = await ipcCallPersistent(method, params);
-  } catch (err) {
-    throwIfGatewayIpcConnectFailed(err);
-    throw err;
-  }
+  const result = await ipcCallPersistent(method, params);
   const parsed = responseSchema.safeParse(result);
   if (!parsed.success) {
     throw new Error(`Gateway returned a malformed ${method} response`);

--- a/assistant/src/runtime/middleware/error-handler.ts
+++ b/assistant/src/runtime/middleware/error-handler.ts
@@ -2,17 +2,19 @@
  * Centralized error handling for runtime HTTP request dispatch.
  */
 
-import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
-
+import { mapGatewayIpcConnectError } from "../../ipc/gateway-ipc-errors.js";
 import { ConfigError, ProviderNotConfiguredError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import type { HttpErrorCode } from "../http-errors.js";
 import { httpError } from "../http-errors.js";
+import { RouteError } from "../routes/errors.js";
 
 const log = getLogger("runtime-http");
 
 /**
  * Wrap an async endpoint handler with standard error handling.
- * Catches ConfigError (422) and generic errors (500).
+ * Catches ConfigError (422), RouteError (including gateway IPC 503), and
+ * generic errors (500).
  */
 export async function withErrorHandling(
   endpoint: string,
@@ -33,17 +35,19 @@ export async function withErrorHandling(
       log.warn({ err, endpoint }, "Runtime HTTP config error");
       return httpError("UNPROCESSABLE_ENTITY", err.message, 422);
     }
-    if (err instanceof IpcConnectError) {
-      log.warn({ err, endpoint }, "Gateway IPC is unreachable");
+    const mapped = mapGatewayIpcConnectError(err);
+    if (mapped instanceof RouteError) {
+      log.warn({ err: mapped, endpoint }, "Runtime HTTP route error");
       return httpError(
-        "SERVICE_UNAVAILABLE",
-        `Gateway is not reachable over IPC: ${err.message}`,
-        503,
+        mapped.code as HttpErrorCode,
+        mapped.message,
+        mapped.statusCode,
+        mapped.details,
       );
     }
-    log.error({ err, endpoint }, "Runtime HTTP handler error");
+    log.error({ err: mapped, endpoint }, "Runtime HTTP handler error");
     const message =
-      err instanceof Error ? err.message : "Internal server error";
+      mapped instanceof Error ? mapped.message : "Internal server error";
     return httpError("INTERNAL_ERROR", message, 500);
   }
 }

--- a/assistant/src/runtime/routes/gateway-log-routes.ts
+++ b/assistant/src/runtime/routes/gateway-log-routes.ts
@@ -11,7 +11,6 @@ import {
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
-import { throwIfGatewayIpcConnectFailed } from "../../ipc/gateway-ipc-errors.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -24,13 +23,7 @@ async function handleGatewayLogsTail({
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
   const p = GatewayLogsTailRouteParamsSchema.parse(source);
-  let result: unknown;
-  try {
-    result = await ipcCallPersistent("gateway_logs_tail", p);
-  } catch (err) {
-    throwIfGatewayIpcConnectFailed(err);
-    throw err;
-  }
+  const result = await ipcCallPersistent("gateway_logs_tail", p);
   return GatewayLogsTailIpcResponseSchema.parse(result);
 }
 

--- a/assistant/src/runtime/routes/http-adapter.ts
+++ b/assistant/src/runtime/routes/http-adapter.ts
@@ -3,8 +3,7 @@
  * for the HTTP server's route table.
  */
 
-import { IpcConnectError } from "@vellumai/gateway-client/ipc-client";
-
+import { mapGatewayIpcConnectError } from "../../ipc/gateway-ipc-errors.js";
 import { requireBoundGuardian } from "../auth/require-bound-guardian.js";
 import type { HttpErrorCode } from "../http-errors.js";
 import { httpError } from "../http-errors.js";
@@ -186,22 +185,16 @@ export function routeDefinitionsToHTTPRoutes(
           headers: responseHeaders,
         });
       } catch (err) {
-        if (err instanceof RouteError) {
+        const mapped = mapGatewayIpcConnectError(err);
+        if (mapped instanceof RouteError) {
           return httpError(
-            err.code as HttpErrorCode,
-            err.message,
-            err.statusCode,
-            err.details,
+            mapped.code as HttpErrorCode,
+            mapped.message,
+            mapped.statusCode,
+            mapped.details,
           );
         }
-        if (err instanceof IpcConnectError) {
-          return httpError(
-            "SERVICE_UNAVAILABLE",
-            `Gateway is not reachable over IPC: ${err.message}`,
-            503,
-          );
-        }
-        throw err;
+        throw mapped;
       }
     },
   }));

--- a/assistant/src/runtime/routes/trust-rules-routes.ts
+++ b/assistant/src/runtime/routes/trust-rules-routes.ts
@@ -11,7 +11,6 @@ import {
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
-import { throwIfGatewayIpcConnectFailed } from "../../ipc/gateway-ipc-errors.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -24,13 +23,7 @@ async function handleList({
   // HTTP GET delivers filters via queryParams; CLI IPC puts them in body.
   const source = Object.keys(queryParams).length > 0 ? queryParams : body;
   const p = TrustRulesListIpcParamsSchema.parse(source);
-  let result: unknown;
-  try {
-    result = await ipcCallPersistent("trust_rules_list", p);
-  } catch (err) {
-    throwIfGatewayIpcConnectFailed(err);
-    throw err;
-  }
+  const result = await ipcCallPersistent("trust_rules_list", p);
   return TrustRulesListIpcResponseSchema.parse(result);
 }
 

--- a/packages/gateway-client/src/ipc-client.ts
+++ b/packages/gateway-client/src/ipc-client.ts
@@ -340,7 +340,8 @@ type PendingRequest = {
 export type PersistentIpcClientOptions = {
   /**
    * Additional delays (ms) before each reconnect attempt after a retryable
-   * connect failure. Pass `[]` to fail on the first miss (tests).
+   * connect failure. Pass `[]` to fail on the first miss (tests and callers
+   * that already own a retry budget, such as classify_risk).
    */
   connectRetryBackoffsMs?: readonly number[];
 };
@@ -350,8 +351,9 @@ export type PersistentIpcClientOptions = {
  * reconnection on failure. Multiplexes requests by ID so many concurrent
  * callers can share one socket.
  *
- * Designed for hot-path calls (e.g. classify_risk) where connecting per call
- * adds unacceptable overhead.
+ * Designed for multiplexed calls over one socket. Control-plane callers
+ * typically keep the default connect retries for sibling boot races.
+ * Callers that already own a retry budget pass `connectRetryBackoffsMs: []`.
  */
 export class PersistentIpcClient {
   private socket: Socket | null = null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Follow-up to #42411 after merge review.

David asked that `ipcCallPersistent` own the connect-failure mapping instead of duplicating `throwIfGatewayIpcConnectFailed` in `trust-rules-routes.ts` and `gateway-log-routes.ts`.

Codex P1s on the same PR:
- Default persistent connect retries (3.75s) stacked with `ipcClassifyRisk`'s three attempts (~11s on a down gateway). Give the risk path a no-retry client.
- HTTP adapter, IPC `buildErrorResponse`, and runtime error-handler each reconstructed the same 503. Normalize `IpcConnectError` once into a `RouteError`, then have adapters consume that.

Approach:
- `ipcCallPersistent` maps `IpcConnectError` to `ServiceUnavailableError` (503). Trust-rules, gateway-log, and `ipcCallPersistentValidated` call it without a local connect try/catch.
- `ipcClassifyRisk` passes `{ retryConnect: false }` so only its existing 3x ~1.5s loop (and abort signal) governs the budget.
- `mapGatewayIpcConnectError` is the single conversion used by HTTP, IPC, and `withErrorHandling`.

## Test plan

- `ipcCallPersistent` maps a missing socket to `ServiceUnavailableError`.
- `ipcClassifyRisk` still retries transient failures three times and does not retry `IpcCallError`.
- Trust-rules and gateway-log routes call `ipcCallPersistent` with no local connect wrapper.
- HTTP error-handler and IPC error envelope map `IpcConnectError` to 503 via the shared helper.

## Risk

Low to medium. Control-plane persistent calls still retry connect for sibling boot. Risk classification no longer pays the inner 3.75s. `IpcCallError` is unchanged so 4xx gateway reasons stay 4xx.

No new routes, migrations, feature flags, or companion platform PR.

Related to #42411

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4386baad-5718-456c-8ae4-2cf602363830?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4386baad-5718-456c-8ae4-2cf602363830&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

