### PR TITLE
fix(gateway): return proxied error bodies byte-exact and keep them out of logs

### DIFF
--- a/gateway/src/__tests__/runtime-proxy-error-body.test.ts
+++ b/gateway/src/__tests__/runtime-proxy-error-body.test.ts
@@ -1,0 +1,219 @@
+/**
+ * The runtime proxy's error path must be transparent.
+ *
+ * Every OAuth passthrough request (`/v1/oauth/proxy/...`) reaches the provider
+ * through this catch-all, so a 4xx/5xx body has to come back byte-for-byte and
+ * must never land in the gateway log: those bytes belong to a third-party API
+ * and routinely name its customers.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+let fetchMock: ReturnType<typeof mock<FetchFn>> = mock(
+  async () => new Response(),
+);
+
+mock.module("../fetch.js", () => ({
+  fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
+}));
+
+type LogCall = {
+  level: string;
+  fields: Record<string, unknown>;
+  msg: string;
+};
+
+let logCalls: LogCall[] = [];
+
+function recorder(level: string) {
+  return (fields: unknown, msg?: string) => {
+    logCalls.push({
+      level,
+      fields: (fields ?? {}) as Record<string, unknown>,
+      msg: msg ?? "",
+    });
+  };
+}
+
+const actualLogger = await import("../logger.js");
+
+mock.module("../logger.js", () => ({
+  ...actualLogger,
+  getLogger: () => ({
+    debug: recorder("debug"),
+    info: recorder("info"),
+    warn: recorder("warn"),
+    error: recorder("error"),
+  }),
+}));
+
+const { createRuntimeProxyHandler } =
+  await import("../http/routes/runtime-proxy.js");
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+const TOKEN = mintToken({
+  aud: "vellum-gateway",
+  sub: "actor:test-assistant:test-user",
+  scope_profile: "actor_client_v1",
+  policy_epoch: CURRENT_POLICY_EPOCH,
+  ttlSeconds: 300,
+});
+
+function makeConfig(): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    port: 7830,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+  };
+}
+
+/** Reply to the next proxied request with these exact bytes. */
+function mockUpstream(
+  body: BodyInit,
+  status: number,
+  headers: Record<string, string> = {},
+) {
+  fetchMock = mock(async () => new Response(body, { status, headers }));
+}
+
+function proxyRequest(path: string): Request {
+  return new Request(`http://localhost:7830${path}`, {
+    headers: { authorization: `Bearer ${TOKEN}` },
+  });
+}
+
+/** The single "Upstream returned error" record, or undefined. */
+function upstreamErrorLog(): LogCall | undefined {
+  return logCalls.find((c) => c.msg === "Upstream returned error");
+}
+
+const PROXY_PATH = "/v1/oauth/proxy/stripe/v1/charges";
+
+beforeEach(() => {
+  logCalls = [];
+  fetchMock = mock(async () => new Response());
+});
+
+describe("runtime proxy error bodies", () => {
+  test("returns a non-UTF-8 provider error body byte-for-byte", async () => {
+    // Raw 0xff/0xfe, a bare continuation byte, and an encoded surrogate:
+    // decoding this as UTF-8 turns all six into U+FFFD.
+    const bytes = new Uint8Array([
+      0x7b, 0xff, 0xfe, 0x80, 0x41, 0xed, 0xa0, 0x80, 0x7d,
+    ]);
+    mockUpstream(bytes, 402, { "content-type": "application/json" });
+
+    const res = await createRuntimeProxyHandler(makeConfig())(
+      proxyRequest(PROXY_PATH),
+    );
+
+    expect(res.status).toBe(402);
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(bytes);
+  });
+
+  test("declares the content-length of the bytes it re-emits", async () => {
+    const bytes = new Uint8Array([0xff, 0xfe, 0x00, 0x41]);
+    // A stale upstream length: text round-tripping these bytes would grow them.
+    mockUpstream(bytes, 409, { "content-length": "99" });
+
+    const res = await createRuntimeProxyHandler(makeConfig())(
+      proxyRequest(PROXY_PATH),
+    );
+
+    expect(res.headers.get("content-length")).toBe("4");
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(bytes);
+  });
+
+  test("returns a long multi-byte error body whole", async () => {
+    const text = `{"error":"${"日本語テキスト🎉".repeat(40)}"}`;
+    mockUpstream(text, 429, { "content-type": "application/json" });
+
+    const res = await createRuntimeProxyHandler(makeConfig())(
+      proxyRequest(PROXY_PATH),
+    );
+
+    expect(await res.text()).toBe(text);
+  });
+
+  test("keeps a proxied provider error body out of the log", async () => {
+    const secret = "cus_9f3 alice@example.com sk_live_notatoken";
+    mockUpstream(`{"error":{"message":"${secret}"}}`, 400);
+
+    await createRuntimeProxyHandler(makeConfig())(proxyRequest(PROXY_PATH));
+
+    const record = upstreamErrorLog();
+    expect(record).toBeDefined();
+    expect(record!.level).toBe("warn");
+    expect(record!.fields).not.toHaveProperty("body");
+    expect(JSON.stringify(logCalls)).not.toContain("cus_9f3");
+    expect(JSON.stringify(logCalls)).not.toContain("alice@example.com");
+  });
+
+  test("logs only the byte count for a non-proxy route error", async () => {
+    // Pins the decision: no route keeps the body snippet. A path allowlist
+    // would leak again the next time a passthrough family is added.
+    mockUpstream("assistant said no", 404);
+
+    await createRuntimeProxyHandler(makeConfig())(
+      proxyRequest("/v1/conversations/abc"),
+    );
+
+    const record = upstreamErrorLog();
+    expect(record).toBeDefined();
+    expect(record!.fields).not.toHaveProperty("body");
+    expect(record!.fields.bodyBytes).toBe(17);
+    expect(record!.fields.status).toBe(404);
+    expect(JSON.stringify(logCalls)).not.toContain("assistant said no");
+  });
+
+  test("logs a 5xx at error level, still without the body", async () => {
+    mockUpstream("upstream stack trace", 502);
+
+    await createRuntimeProxyHandler(makeConfig())(
+      proxyRequest("/v1/conversations/abc"),
+    );
+
+    const record = upstreamErrorLog();
+    expect(record!.level).toBe("error");
+    expect(record!.fields).not.toHaveProperty("body");
+    expect(JSON.stringify(logCalls)).not.toContain("upstream stack trace");
+  });
+
+  test("leaves a successful response streaming and untouched", async () => {
+    mockUpstream('{"ok":true}', 200, { "content-type": "application/json" });
+
+    const res = await createRuntimeProxyHandler(makeConfig())(
+      proxyRequest(PROXY_PATH),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('{"ok":true}');
+    expect(upstreamErrorLog()).toBeUndefined();
+  });
+});

--- a/gateway/src/http/routes/ipc-runtime-proxy.test.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.test.ts
@@ -86,7 +86,7 @@ mock.module("../../ipc/assistant-client.js", () => ({
   ipcCallAssistant: ipcCallAssistantMock,
 }));
 
-// Stub validateEdgeToken — default: auth passes. The rest of the module
+// Stub validateEdgeToken; by default auth passes. The rest of the module
 // (notably toDaemonSubject, which the proxy uses to derive the forwarded
 // subject header) keeps its real implementation.
 const actualTokenExchange = await import("../../auth/token-exchange.js");

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -176,21 +176,28 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
     const duration = Math.round(performance.now() - start);
 
     if (response.status >= 400) {
-      const body = await response.text();
+      // Buffer the bytes rather than decoding to text: an error body that is
+      // not valid UTF-8, such as one the OAuth passthrough carries verbatim
+      // from a provider, has to reach the client unchanged. Only the byte
+      // count is logged: bodies here are written by the daemon or by a third
+      // party, carry other people's data, and the log serializers redact only
+      // `err`/`req`/`res`.
+      const bodyBytes = new Uint8Array(await response.arrayBuffer());
+      // Both headers describe a framing this hop redoes around the buffer.
+      resHeaders.set("content-length", String(bodyBytes.byteLength));
+      resHeaders.delete("content-encoding");
       const level = response.status >= 500 ? "error" : "warn";
-      const bodySnippet =
-        body.length > 256 ? body.slice(0, 256) + "\u2026[truncated]" : body;
       log[level](
         {
           method: req.method,
           path: url.pathname,
           status: response.status,
           duration,
-          body: bodySnippet,
+          bodyBytes: bodyBytes.byteLength,
         },
         "Upstream returned error",
       );
-      return new Response(body, {
+      return new Response(bodyBytes, {
         status: response.status,
         headers: resHeaders,
       });


### PR DESCRIPTION
## Summary

The runtime proxy catch-all is the hop every OAuth passthrough request takes, and its `status >= 400` branch broke both guarantees the passthrough makes.

- It read the upstream body with `response.text()` and re-emitted the decoded string, so any provider error body that is not valid UTF-8 came back with U+FFFD replacement characters. This is the path a third-party CLI parses most carefully (validation errors, 401, 404, 409, 429).
- It logged up to 256 characters of that body at warn/error. For a payments provider those bytes routinely name customer ids, email addresses and request details, and `logSerializers` redacts only `err`/`req`/`res`, so the `body` field reached both the pretty log and the JSONL sidecar unscrubbed. The daemon handler deliberately logs only `{ provider, method, path, status }`; the next hop dumped the payload.
- `stripHopByHop` does not remove `content-length`, so a text round trip that changed the byte count re-emitted a stale length.

The branch now buffers with `arrayBuffer()` and returns those exact bytes, sets `content-length` from the buffer, and drops `content-encoding` (both headers describe a framing this hop redoes). The log line keeps method, path, status and duration, and replaces the snippet with a `bodyBytes` count.

### Why no body snippet anywhere, rather than a path check

Suppressing the snippet only for `/v1/oauth/proxy/` would be a denylist that protects the one path we thought of today. This handler is the catch-all for everything a client sends the daemon, the bodies are authored by the daemon or by a third party rather than by the gateway, and the next passthrough family added would silently start leaking until someone remembered to extend the regex. The daemon logs its own errors with structure at the source, so the snippet was duplicative there and privacy-hostile everywhere else. Dropping it also removes the multi-byte truncation hazard entirely. Status, path and byte count keep the signal that matters at this hop.

## Tests

`gateway/src/__tests__/runtime-proxy-error-body.test.ts`: a non-UTF-8 4xx body returns byte-for-byte, `content-length` matches the re-emitted bytes (a stale upstream length is replaced), a long multi-byte body returns whole, a proxied provider error keeps its body and its customer data out of the log mock, a non-proxy route error logs only `bodyBytes` (pinning the no-allowlist decision), and 5xx still logs at error level. Five of the seven fail against the pre-fix handler.

Also recast one em dash in a comment in `ipc-runtime-proxy.test.ts`.

Fixes a gap found in self-review of plan oauth-proxy-passthrough.md: the runtime proxy's >= 400 branch re-decoded provider error bodies as UTF-8 and logged a snippet of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHYWQLdQvdW2dcnsMfZxyz