### PR TITLE
fix(oauth): stop replaying non-idempotent proxied writes on the managed path

### DIFF
--- a/assistant/src/oauth/connection.test.ts
+++ b/assistant/src/oauth/connection.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   decodeJsonSafeOAuthBody,
   decodeOAuthResponseBytes,
+  isIdempotentHttpMethod,
   jsonSafeOAuthBody,
   materializeOAuthRequestOutput,
 } from "./connection.js";
@@ -37,10 +38,7 @@ describe("decodeOAuthResponseBytes", () => {
   });
 
   test("treats Google Drive media downloads as raw bytes", () => {
-    const body = decodeOAuthResponseBytes(
-      PNG_MAGIC,
-      "application/pdf",
-    );
+    const body = decodeOAuthResponseBytes(PNG_MAGIC, "application/pdf");
     expect(Buffer.from(body as Uint8Array).equals(PNG_MAGIC)).toBe(true);
   });
 
@@ -62,9 +60,9 @@ describe("jsonSafeOAuthBody", () => {
       body: PNG_MAGIC.toString("base64"),
       bodyEncoding: "base64",
     });
-    expect(Buffer.from(PNG_MAGIC.toString("base64"), "base64").equals(PNG_MAGIC)).toBe(
-      true,
-    );
+    expect(
+      Buffer.from(PNG_MAGIC.toString("base64"), "base64").equals(PNG_MAGIC),
+    ).toBe(true);
   });
 });
 
@@ -107,5 +105,23 @@ describe("materializeOAuthRequestOutput", () => {
 
   test("returns null for a missing body", () => {
     expect(materializeOAuthRequestOutput({ body: null })).toBeNull();
+  });
+});
+
+describe("isIdempotentHttpMethod", () => {
+  test("accepts the methods HTTP defines as idempotent", () => {
+    for (const method of ["GET", "HEAD", "PUT", "DELETE", "OPTIONS", "TRACE"]) {
+      expect(isIdempotentHttpMethod(method)).toBe(true);
+    }
+  });
+
+  test("rejects POST and PATCH", () => {
+    expect(isIdempotentHttpMethod("POST")).toBe(false);
+    expect(isIdempotentHttpMethod("PATCH")).toBe(false);
+  });
+
+  test("is case-insensitive", () => {
+    expect(isIdempotentHttpMethod("get")).toBe(true);
+    expect(isIdempotentHttpMethod("post")).toBe(false);
   });
 });

--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -31,6 +31,33 @@ export interface OAuthConnectionRequest {
    * provider's own redirect instead of an upstream hop the caller never made.
    */
   manualRedirect?: boolean;
+  /**
+   * When true the connection makes exactly one upstream attempt and surfaces a
+   * retryable status to the caller instead of replaying the request. For
+   * callers forwarding writes they cannot safely repeat. Governs status-driven
+   * retries only: a BYO connection's refresh-and-retry follows a provider 401,
+   * which rejected the request before it took effect.
+   */
+  singleAttempt?: boolean;
+}
+
+/** Methods HTTP defines as idempotent, so replaying one is safe. */
+const IDEMPOTENT_METHODS = new Set([
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "PUT",
+  "DELETE",
+  "TRACE",
+]);
+
+/**
+ * Whether repeating this method is safe by HTTP semantics. Callers forwarding
+ * arbitrary traffic pair this with `singleAttempt` so POST and PATCH are never
+ * replayed on their behalf.
+ */
+export function isIdempotentHttpMethod(method: string): boolean {
+  return IDEMPOTENT_METHODS.has(method.toUpperCase());
 }
 
 export interface OAuthConnectionResponse {

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -15,6 +15,7 @@ import {
   InsufficientBalanceError,
   PlatformOAuthConnection,
   ProviderUnreachableError,
+  unhonoredManagedOptions,
 } from "./platform-connection.js";
 
 function makeMockClient(
@@ -478,6 +479,142 @@ describe("PlatformOAuthConnection", () => {
       conn.request({ method: "GET", path: "/test" }),
     ).rejects.toThrow("Platform proxy returned unexpected status 403");
     expect(callCount).toBe(1);
+  });
+
+  test("singleAttempt makes one attempt on a retryable status", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        return new Response("", { status: 429 });
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({
+        method: "POST",
+        path: "/v1/payment_intents",
+        singleAttempt: true,
+      }),
+    ).rejects.toThrow("Platform proxy returned unexpected status 429");
+    expect(callCount).toBe(1);
+  });
+
+  test("singleAttempt does not replay a write after a 502", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        return new Response("", { status: 502 });
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(
+      conn.request({
+        method: "POST",
+        path: "/v1/payment_intents",
+        singleAttempt: true,
+      }),
+    ).rejects.toThrow(ProviderUnreachableError);
+    expect(callCount).toBe(1);
+  });
+
+  test("a POST without singleAttempt keeps retrying", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return new Response("", { status: 503 });
+        }
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: { ok: true } }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    const result = await conn.request({
+      method: "POST",
+      path: "/messages/send",
+      body: { text: "hi" },
+    });
+
+    expect(result.body).toEqual({ ok: true });
+    expect(callCount).toBe(3);
+  });
+
+  test("singleAttempt leaves a successful response untouched", async () => {
+    let callCount = 0;
+    const client = makeMockClient(
+      mock(async () => {
+        callCount++;
+        return new Response(
+          JSON.stringify({ status: 201, headers: {}, body: { id: "pi_1" } }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    const result = await conn.request({
+      method: "POST",
+      path: "/v1/payment_intents",
+      singleAttempt: true,
+    });
+
+    expect(result.status).toBe(201);
+    expect(result.body).toEqual({ id: "pi_1" });
+    expect(callCount).toBe(1);
+  });
+
+  // The platform proxy parses the response and follows redirects server-side,
+  // so managed mode diverges from BYO on both flags by design.
+  test("names rawResponseBody and manualRedirect as unhonored", () => {
+    expect(unhonoredManagedOptions({ method: "GET", path: "/x" })).toEqual([]);
+    expect(
+      unhonoredManagedOptions({
+        method: "GET",
+        path: "/x",
+        rawResponseBody: true,
+        manualRedirect: true,
+      }),
+    ).toEqual(["rawResponseBody", "manualRedirect"]);
+  });
+
+  test("manualRedirect neither errors nor reaches the proxy envelope", async () => {
+    const client = makeMockClient(
+      mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        const parsed = JSON.parse(init?.body as string);
+        expect("manual_redirect" in parsed.request).toBe(false);
+        expect("redirect" in parsed.request).toBe(false);
+
+        return new Response(
+          JSON.stringify({
+            status: 200,
+            headers: { "content-type": "application/json" },
+            body: { followed: true },
+          }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    const result = await conn.request({
+      method: "GET",
+      path: "/v1/redirecting",
+      manualRedirect: true,
+      rawResponseBody: true,
+    });
+
+    // The platform already followed the redirect and parsed the body, so the
+    // caller sees the destination's JSON rather than a 3xx or raw bytes.
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ followed: true });
   });
 
   test("uses connectionId in proxy URL regardless of provider format", async () => {

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -40,6 +40,22 @@ export class InsufficientBalanceError extends BackendError {
   }
 }
 
+/**
+ * Request options the platform proxy cannot honor. It parses the response body
+ * and follows provider redirects server-side, so a managed connection answers
+ * with re-serialized JSON and the redirect target's response. A caller that
+ * needs the provider's exact bytes or a verbatim 3xx needs a BYO connection.
+ */
+const UNHONORED_MANAGED_OPTIONS = [
+  "rawResponseBody",
+  "manualRedirect",
+] as const;
+
+/** Which of {@link UNHONORED_MANAGED_OPTIONS} this request asks for. */
+export function unhonoredManagedOptions(req: OAuthConnectionRequest): string[] {
+  return UNHONORED_MANAGED_OPTIONS.filter((option) => req[option] === true);
+}
+
 export interface PlatformOAuthConnectionOptions {
   id: string;
   provider: string;
@@ -104,7 +120,20 @@ export class PlatformOAuthConnection implements OAuthConnection {
     }
     const body: Record<string, unknown> = { request };
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const unhonored = unhonoredManagedOptions(req);
+    if (unhonored.length > 0) {
+      log.debug(
+        { provider: this.provider, options: unhonored },
+        "Platform proxy handles the response server-side; these request options do not apply",
+      );
+    }
+
+    // A retry replays the whole request upstream, and a 502 arrives only after
+    // the platform already called the provider, so a caller forwarding a write
+    // it cannot repeat gets a single attempt.
+    const retriesAllowed = req.singleAttempt === true ? 0 : MAX_RETRIES;
+
+    for (let attempt = 0; attempt <= retriesAllowed; attempt++) {
       const response = await this.client.fetch(proxyPath, {
         method: "POST",
         headers: {
@@ -125,11 +154,11 @@ export class PlatformOAuthConnection implements OAuthConnection {
       if (
         !response.ok &&
         isRetryableStatus(response.status) &&
-        attempt < MAX_RETRIES
+        attempt < retriesAllowed
       ) {
         log.warn(
           { status: response.status, attempt, provider: "platform-proxy" },
-          `Retryable status ${response.status} from platform proxy (attempt ${attempt + 1}/${MAX_RETRIES + 1})`,
+          `Retryable status ${response.status} from platform proxy (attempt ${attempt + 1}/${retriesAllowed + 1})`,
         );
         await sleep(getHttpRetryDelay(response, attempt));
         continue;


### PR DESCRIPTION
## Summary

- `OAuthConnectionRequest` grows an opt-in `singleAttempt`. When set, `PlatformOAuthConnection.request` makes exactly one upstream attempt and surfaces a retryable status to the caller instead of replaying the request. The passthrough proxy forwards arbitrary caller POST, PATCH and DELETE traffic, so a platform 429, 503 or 502 could otherwise replay a third-party CLI's write up to four times.
- A 502 arrives only after the platform already called the provider, so even that status was replaying a write that may have landed.
- Existing callers are untouched. Without the flag the managed path still retries up to `MAX_RETRIES`, so no pre-existing behavior changes.
- `isIdempotentHttpMethod` in `connection.ts` names the methods HTTP defines as safe to repeat, so a caller forwarding arbitrary traffic sets `singleAttempt` for POST and PATCH alone rather than restating the rule.
- `unhonoredManagedOptions` makes the managed divergence explicit: the platform proxy parses the response body and follows provider redirects server-side, so `rawResponseBody` and `manualRedirect` do not apply there. A managed request that asks for one logs it at debug rather than dropping it silently.
- Tests pin the attempt counts on both sides of the flag, that a successful `singleAttempt` request is unaffected, and that a managed `manualRedirect` request returns the destination's parsed body with nothing redirect-related in the proxy envelope.

The proxy route still needs to pass `singleAttempt`. That call site is wired in a follow-up.

Fixes gaps found in self-review of plan oauth-proxy-passthrough.md.