### PR TITLE
fix(oauth): handle 205 responses, keep the ambiguity error from throwing, drop a dead guard

### DIFF
--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
@@ -30,9 +30,18 @@ const bodyText = async (body: BodyInit | null): Promise<string> =>
   await new Response(body).text();
 
 describe("route constants", () => {
-  test("the endpoint pattern and the prefix agree", () => {
-    expect(PROXY_ROUTE_ENDPOINT).toBe("oauth/proxy/:provider/:path*");
-    expect(PROXY_PATH_PREFIX).toBe("/v1/oauth/proxy/");
+  test("the prefix is the v1 mount of the route pattern", () => {
+    // Route endpoints are registered without the `/v1/` the server mounts
+    // them under, and the prefix is that same pattern up to the provider.
+    const [beforeProvider] = PROXY_ROUTE_ENDPOINT.split(":provider");
+    expect(PROXY_PATH_PREFIX).toBe(`/v1/${beforeProvider}`);
+  });
+
+  test("the remainder starts after the prefix and the provider segment", () => {
+    const url = proxyUrl("stripe_link/v1/items");
+
+    expect(url.pathname).toBe(`${PROXY_PATH_PREFIX}stripe_link/v1/items`);
+    expect(extractProxyRemainder(url)).toBe("v1/items");
   });
 });
 
@@ -119,6 +128,18 @@ describe("provider segment", () => {
     expect(
       parseProxyProviderSegment(decodeURIComponent("stripe_link@a%3Ab")),
     ).toEqual({ provider: "stripe_link", account: "a:b" });
+  });
+
+  test("an empty account pins nothing and stays well formed", () => {
+    const segment = encodeProxyProviderSegment("stripe_link", "");
+
+    expect(segment).toBe("stripe_link");
+    expect(parseProxyProviderSegment(segment)).toEqual({
+      provider: "stripe_link",
+    });
+    expect(proxyGrantSubject("stripe_link", "")).toBe(
+      "local:self:oauth-proxy.stripe_link",
+    );
   });
 
   test("refuses an account that cannot be percent-encoded", () => {
@@ -407,12 +428,27 @@ describe("materializeProxyResponse", () => {
     ).toBe(null);
   });
 
-  test("HEAD, 204, and 304 carry no body but keep their headers", () => {
+  test("a 205 carrying the BYO empty-byte body still has no body", () => {
+    // `new Response(new Uint8Array(0), { status: 205 })` is a TypeError under
+    // a spec-strict Response, and a 205 may not carry content on the wire.
+    const response = materializeProxyResponse(
+      upstream({ status: 205, body: new Uint8Array(0) }),
+      "POST",
+    );
+
+    expect(response.body).toBeNull();
+    expect(response.status).toBe(205);
+  });
+
+  test("HEAD and every null-body status keep their headers and no body", () => {
     const headers = { "content-type": "application/json", etag: 'W/"1"' };
 
     for (const [status, method] of [
       [200, "HEAD"],
+      [101, "GET"],
+      [103, "GET"],
       [204, "DELETE"],
+      [205, "POST"],
       [304, "GET"],
     ] as const) {
       const response = materializeProxyResponse(
@@ -578,6 +614,39 @@ describe("ambiguousConnectionError", () => {
         "stripe_link@a%40example.com",
         "stripe_link@b%40example.com",
       ],
+    });
+  });
+
+  test("names every account even when a label pins no segment", () => {
+    // Account labels are nullable free text: one may be empty, and one may
+    // hold a lone surrogate that `encodeURIComponent` refuses.
+    const accounts = ["", "\uD800", "b@example.com"];
+
+    const err = ambiguousConnectionError("stripe_link", accounts);
+
+    expect(err.statusCode).toBe(409);
+    expect(err.code).toBe("CONFLICT");
+    for (const account of accounts) {
+      expect(err.message).toContain(account);
+    }
+    expect(err.message).toContain('"stripe_link@b%40example.com"');
+    expect(err.details).toEqual({
+      provider: "stripe_link",
+      accounts,
+      providerSegments: ["stripe_link@b%40example.com"],
+    });
+  });
+
+  test("drops the example when no account can pin a segment", () => {
+    const err = ambiguousConnectionError("stripe_link", ["", "\uD800"]);
+
+    expect(err.statusCode).toBe(409);
+    expect(err.message).toContain("Multiple stripe_link connections");
+    expect(err.message).not.toContain("for example");
+    expect(err.details).toEqual({
+      provider: "stripe_link",
+      accounts: ["", "\uD800"],
+      providerSegments: [],
     });
   });
 });

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
@@ -34,11 +34,11 @@ export const PROXY_ROUTE_ENDPOINT = "oauth/proxy/:provider/:path*";
 export const PROXY_PATH_PREFIX = "/v1/oauth/proxy/";
 
 /**
- * Number of leading `/`-separated pieces before the upstream path: the empty
- * piece before the leading slash, then `v1`, `oauth`, `proxy`, and the
- * provider segment.
+ * Leading `/`-separated pieces before the upstream path. Splitting the prefix
+ * yields the empty piece before its leading slash, `v1`, `oauth`, `proxy`, and
+ * a trailing empty piece: the slot the provider segment fills.
  */
-const PROXY_PATH_SEGMENT_COUNT = 5;
+const PROXY_PATH_SEGMENT_COUNT = PROXY_PATH_PREFIX.split("/").length;
 
 /** Request headers that must never reach the provider. */
 const STRIPPED_REQUEST_HEADERS = new Set([
@@ -63,6 +63,14 @@ const STRIPPED_REQUEST_HEADERS = new Set([
 
 const TEXT_ENCODER = new TextEncoder();
 
+/**
+ * Statuses the `Response` constructor refuses a body on. A provider reaches
+ * here with 204, 205, or 304; 101 and 103 are interim statuses no HTTP client
+ * surfaces as a final response, and are listed so the set is the spec's rather
+ * than a subset to re-derive.
+ */
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 /** Response headers describing a framing this daemon re-does itself. */
 const STRIPPED_RESPONSE_HEADERS = new Set([
   "content-length",
@@ -75,14 +83,9 @@ const STRIPPED_RESPONSE_HEADERS = new Set([
 ]);
 
 /**
- * Characters `encodeURIComponent` leaves unescaped. None of them is `:`, which
- * is what lets an encoded account sit inside a subject component.
- */
-const ENCODED_ACCOUNT_PATTERN = /^[A-Za-z0-9\-_.!~*'()%]+$/;
-
-/**
  * Provider segment for a base URL. An account pins one connection when the
- * provider has several.
+ * provider has several; an empty label pins nothing, leaving the bare provider
+ * key as the segment and an unpinned subject to match.
  *
  * A provider key carrying `@` or `/` would parse back as a different provider,
  * and one carrying `:` would split {@link proxyGrantSubject} into a fourth
@@ -111,24 +114,18 @@ export function encodeProxyProviderSegment(
  * Percent-encode an account for the segment, and with it for the subject the
  * segment is embedded in: encoding is what keeps a `:` in an account from
  * ending the subject component early, and a control character out of the
- * `x-vellum-subject` header. Text that cannot be encoded is refused here
- * rather than surfacing as an unhandled `URIError`.
+ * `x-vellum-subject` header. Its output alphabet holds none of those, so the
+ * only text refused here is text `encodeURIComponent` itself rejects, such as
+ * a lone surrogate.
  */
 function encodeAccount(account: string): string {
-  let encoded: string;
   try {
-    encoded = encodeURIComponent(account);
+    return encodeURIComponent(account);
   } catch {
     throw new BadRequestError(
       `An OAuth proxy account must be encodable text: "${account}"`,
     );
   }
-  if (!ENCODED_ACCOUNT_PATTERN.test(encoded)) {
-    throw new BadRequestError(
-      `An OAuth proxy account may not carry characters that a subject cannot hold: "${account}"`,
-    );
-  }
-  return encoded;
 }
 
 /**
@@ -291,9 +288,7 @@ export function materializeProxyResponse(
   }
 
   const bodyless =
-    method.toUpperCase() === "HEAD" ||
-    upstream.status === 204 ||
-    upstream.status === 304;
+    method.toUpperCase() === "HEAD" || NULL_BODY_STATUSES.has(upstream.status);
   if (bodyless) {
     return new RouteResponse(null, headers, upstream.status);
   }
@@ -361,20 +356,42 @@ export function mapProxyRequestError(
 /**
  * Several connections match the provider and the caller pinned none. The CLI
  * prints only the message, so it names the accounts and how to pick one.
+ *
+ * Account labels are free text a provider chose, so some of them pin nothing
+ * (an empty label) or cannot be encoded at all. Every account is still named:
+ * building this error may not throw, or the caller would see an encoding
+ * failure in place of the 409.
  */
 export function ambiguousConnectionError(
   provider: string,
   accounts: string[],
 ): ConflictError {
-  const providerSegments = accounts.map((account) =>
-    encodeProxyProviderSegment(provider, account),
-  );
-  const example = providerSegments[0] ?? provider;
+  const providerSegments = accounts
+    .map((account) => pinningProviderSegment(provider, account))
+    .filter((segment): segment is string => segment !== null);
+  const example = providerSegments[0];
+  const pin =
+    "Pin one by putting its account in the provider segment of the base URL";
   return new ConflictError(
     `Multiple ${provider} connections are available (${accounts.join(", ")}). ` +
-      `Pin one by putting its account in the provider segment of the base URL, for example "${example}".`,
+      (example ? `${pin}, for example "${example}".` : `${pin}.`),
     { provider, accounts, providerSegments },
   );
+}
+
+/** Segment pinning one account, or null when the label cannot pin one. */
+function pinningProviderSegment(
+  provider: string,
+  account: string,
+): string | null {
+  if (!account) {
+    return null;
+  }
+  try {
+    return encodeProxyProviderSegment(provider, account);
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- `materializeProxyResponse` treats the Fetch spec's whole null-body status set (101, 103, 204, 205, 304) as bodyless, not just 204 and 304. A provider 205 previously reached the caller as a 205 carrying content, which RFC 9110 forbids, and would be a `TypeError` in place of the response under a spec-strict `Response` constructor.
- `ambiguousConnectionError` no longer throws while building itself. Account labels are nullable free text, so one can be empty or unencodable; such a label is skipped for the example segment while every account still appears in the message and in `details.accounts`. When no label can pin a segment, the message drops the "for example" clause instead of suggesting the unpinned segment the caller already used.
- Removed the `ENCODED_ACCOUNT_PATTERN` check in `encodeAccount`: the character class is exactly the `encodeURIComponent` output alphabet, so no input can fail it (swept every code point up to U+10FFFF). The `try/catch` around `encodeURIComponent` stays, since a lone surrogate genuinely throws `URIError`.
- `PROXY_PATH_SEGMENT_COUNT` is derived from `PROXY_PATH_PREFIX` rather than hardcoded as 5, and the constants test now pins the prefix against the route pattern instead of asserting two literals.

Fixes gaps found in self-review of plan oauth-proxy-passthrough.md.