### PR TITLE
fix(auth): contain oauth proxy grants to the passthrough route

### DIFF
--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -7,7 +7,8 @@
  * side-registry to look up against.
  *
  * Covers:
- * - `policy: null` is treated as unprotected (always allowed)
+ * - `policy: null` is unprotected for a broad profile, closed to a grant
+ *   minted for a single route
  * - Principal type check denies disallowed types
  * - Scope check denies missing scopes
  * - Allowed requests return null
@@ -35,13 +36,14 @@ import type { AuthContext, Scope } from "../types.js";
 function buildTestContext(overrides?: {
   principalType?: AuthContext["principalType"];
   scopes?: Scope[];
+  scopeProfile?: AuthContext["scopeProfile"];
 }): AuthContext {
   return {
     subject: "actor:self:test-principal",
     principalType: overrides?.principalType ?? "actor",
     assistantId: "self",
     actorPrincipalId: "test-principal",
-    scopeProfile: "actor_client_v1",
+    scopeProfile: overrides?.scopeProfile ?? "actor_client_v1",
     scopes: new Set(
       overrides?.scopes ?? [
         "chat.read",
@@ -196,6 +198,118 @@ describe("enforcePolicy", () => {
     const ctx = buildTestContext({ scopes: [] });
     const result = enforcePolicy("open", openPolicy, ctx);
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single-route grants
+//
+// An oauth_proxy_v1 grant is printed for a user to export into a stock
+// third-party CLI's environment, so it sits outside this install's trust
+// boundary. `policy: null` admits any valid token, which for this grant means
+// mutating routes it was never minted for (integrations/a2a/invite/accept).
+// ---------------------------------------------------------------------------
+
+/** The context an exported OAuth proxy grant produces. */
+function buildProxyGrantContext(): AuthContext {
+  return {
+    ...buildTestContext({
+      principalType: "local",
+      scopes: [...resolveScopeProfile("oauth_proxy_v1")],
+      scopeProfile: "oauth_proxy_v1",
+    }),
+    subject: "local:self:oauth-proxy.stripe_link",
+    actorPrincipalId: undefined,
+    conversationId: "oauth-proxy.stripe_link",
+  };
+}
+
+describe("enforcePolicy with an oauth_proxy_v1 grant", () => {
+  test("denies an unprotected route", () => {
+    authDisabled = false;
+    const result = enforcePolicy(
+      "integrations/a2a/invite/accept",
+      null,
+      buildProxyGrantContext(),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("denies a policy that names no scope", () => {
+    authDisabled = false;
+    const result = enforcePolicy(
+      "open",
+      { requiredScopes: [], allowedPrincipalTypes: ["local"] },
+      buildProxyGrantContext(),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("allows the passthrough policy", () => {
+    authDisabled = false;
+    expect(
+      enforcePolicy(
+        "oauth/proxy",
+        OAUTH_PROXY_POLICY,
+        buildProxyGrantContext(),
+      ),
+    ).toBeNull();
+  });
+
+  test("denies a settings.write policy", () => {
+    authDisabled = false;
+    const result = enforcePolicy(
+      "settings",
+      { requiredScopes: ["settings.write"], allowedPrincipalTypes: ["local"] },
+      buildProxyGrantContext(),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(403);
+  });
+
+  test("the dev bypass still admits it", () => {
+    authDisabled = true;
+    expect(
+      enforcePolicy(
+        "integrations/a2a/invite/accept",
+        null,
+        buildProxyGrantContext(),
+      ),
+    ).toBeNull();
+    authDisabled = false;
+  });
+
+  test("a local CLI token still reaches an unprotected route", () => {
+    authDisabled = false;
+    const ctx = buildTestContext({
+      principalType: "local",
+      scopes: [...resolveScopeProfile("local_v1")],
+      scopeProfile: "local_v1",
+    });
+    expect(
+      enforcePolicy("integrations/a2a/invite/accept", null, ctx),
+    ).toBeNull();
+  });
+
+  test("the passthrough ROUTES entries admit the grant", async () => {
+    authDisabled = false;
+    const { ROUTES } = await import("../../routes/index.js");
+    const proxyRoutes = ROUTES.filter((r) =>
+      r.operationId.startsWith("oauth_proxy_"),
+    );
+    expect(proxyRoutes.length).toBeGreaterThan(1);
+    const ctx = buildProxyGrantContext();
+    for (const route of proxyRoutes) {
+      const result = enforcePolicy(route.endpoint, route.policy, ctx);
+      if (route.operationId === "oauth_proxy_grant") {
+        // Minting takes settings.write, so a grant cannot mint another.
+        expect(result!.status).toBe(403);
+      } else {
+        expect(result).toBeNull();
+      }
+    }
   });
 });
 

--- a/assistant/src/runtime/auth/route-policy.ts
+++ b/assistant/src/runtime/auth/route-policy.ts
@@ -13,7 +13,12 @@
 
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getLogger } from "../../util/logger.js";
-import type { AuthContext, PrincipalType, Scope } from "./types.js";
+import type {
+  AuthContext,
+  PrincipalType,
+  Scope,
+  ScopeProfile,
+} from "./types.js";
 
 const log = getLogger("route-policy");
 
@@ -63,6 +68,26 @@ export const GATEWAY_PRINCIPALS: PrincipalType[] = ["svc_gateway"];
 export const LOCAL_PRINCIPALS: PrincipalType[] = ["local"];
 
 // ---------------------------------------------------------------------------
+// Scope profiles a route may admit on identity alone
+// ---------------------------------------------------------------------------
+
+/**
+ * Profiles broad enough to reach a route that names no scope of its own.
+ * A profile outside this set is minted for a single route and handed to code
+ * outside this install's trust boundary, so it reaches only a route whose
+ * policy names the scope it carries. New profiles land outside the set and
+ * therefore fail closed.
+ */
+const UNSCOPED_ROUTE_PROFILES: ReadonlySet<ScopeProfile> =
+  new Set<ScopeProfile>([
+    "actor_client_v1",
+    "gateway_ingress_v1",
+    "gateway_service_v1",
+    "local_v1",
+    "ui_page_v1",
+  ]);
+
+// ---------------------------------------------------------------------------
 // Enforcement
 // ---------------------------------------------------------------------------
 
@@ -72,8 +97,9 @@ export const LOCAL_PRINCIPALS: PrincipalType[] = ["local"];
  * Returns an error Response if the request should be denied, or null
  * if the request is allowed to proceed.
  *
- * When `policy` is null the route is explicitly unprotected (e.g.
- * health, debug) — always allowed.
+ * A route naming no scope (`policy` null, or empty `requiredScopes`) is
+ * unprotected (e.g. health, debug) for the broad profiles in
+ * {@link UNSCOPED_ROUTE_PROFILES}, and closed to every other profile.
  *
  * When auth is bypassed (dev mode), the policy is still checked
  * against the synthetic context for type safety but always returns
@@ -84,13 +110,34 @@ export function enforcePolicy(
   policy: RoutePolicy | null,
   authCtx: AuthContext,
 ): Response | null {
-  if (!policy) {
-    // No policy declared — unprotected endpoint (e.g. health, debug)
+  // Dev bypass: log but allow everything through
+  if (isHttpAuthDisabled()) {
     return null;
   }
 
-  // Dev bypass: log but allow everything through
-  if (isHttpAuthDisabled()) {
+  // A single-route grant reaches only a route that names its scope, so an
+  // unprotected one refuses it rather than admitting any valid token.
+  if (
+    (policy?.requiredScopes.length ?? 0) === 0 &&
+    !UNSCOPED_ROUTE_PROFILES.has(authCtx.scopeProfile)
+  ) {
+    log.warn(
+      { endpoint, scopeProfile: authCtx.scopeProfile },
+      "Route policy denied: grant is scoped to a single route",
+    );
+    return Response.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "This grant is not permitted for this endpoint",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  if (!policy) {
+    // No policy declared — unprotected endpoint (e.g. health, debug)
     return null;
   }
 

--- a/assistant/src/runtime/auth/scopes.ts
+++ b/assistant/src/runtime/auth/scopes.ts
@@ -39,7 +39,8 @@ const PROFILE_SCOPES: Record<ScopeProfile, ReadonlySet<Scope>> = {
   ]),
   local_v1: new Set<Scope>(["local.all"]),
   // A grant minted for a third-party CLI to reach the OAuth passthrough
-  // route; it opens no other route.
+  // route. `enforcePolicy` admits it only where the route's policy names
+  // oauth.proxy, so a route naming no scope refuses it too.
   oauth_proxy_v1: new Set<Scope>(["oauth.proxy"]),
   // Managed speech relay only (ATL-1033): the daemon's relay-dial token must
   // not open any other edge-scoped route.

--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -452,6 +452,142 @@ describe("requireEdgeAuthWithScope — JWT mode", () => {
 });
 
 // =========================================================================
+// Single-route grants — the OAuth passthrough grant a third-party CLI holds
+//
+// The grant is a valid edge token: signature, audience, expiry and policy
+// epoch all check out. Every gateway edge route would otherwise accept it,
+// including mutating ones (Telegram config, contacts control plane). Its own
+// route is the runtime-proxy catch-all, which validates the token itself and
+// never reaches this middleware.
+// =========================================================================
+
+const PROXY_GRANT_CLAIMS = {
+  sub: "local:asst:oauth-proxy.stripe_link",
+  scope_profile: "oauth_proxy_v1",
+};
+
+describe("edge auth refuses a single-route grant", () => {
+  test("requireEdgeAuth 401s an oauth_proxy_v1 grant", async () => {
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: PROXY_GRANT_CLAIMS,
+    }));
+    const { requireEdgeAuth } = makeMiddleware();
+    const res = await requireEdgeAuth(
+      makeReq({ authorization: "Bearer proxy.grant" }),
+    );
+    expect(res?.status).toBe(401);
+  });
+
+  test("the refusal is not softened by the loopback fallback", async () => {
+    // A third-party CLI holding the grant runs on the loopback host itself,
+    // so a fallback here would return exactly what the refusal withholds.
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: PROXY_GRANT_CLAIMS,
+    }));
+    const { requireEdgeAuth } = makeMiddleware();
+    const res = await requireEdgeAuth(
+      makeReq({ authorization: "Bearer proxy.grant" }),
+      makeLoopbackServer(),
+    );
+    expect(res?.status).toBe(401);
+    expect(loopbackFallbackCountTracker.snapshot()).toEqual([]);
+  });
+
+  test("requireEdgeAuthWithScope 401s the grant before the scope check", async () => {
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: PROXY_GRANT_CLAIMS,
+    }));
+    const { requireEdgeAuthWithScope } = makeMiddleware();
+    const res = await requireEdgeAuthWithScope(
+      makeReq({ authorization: "Bearer proxy.grant" }),
+      "settings.write",
+    );
+    // 401 (not the under-scoped 403): the credential is refused outright.
+    expect(res?.status).toBe(401);
+  });
+
+  test("requireEdgeGuardianAuth 401s the grant", async () => {
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: PROXY_GRANT_CLAIMS,
+    }));
+    const { requireEdgeGuardianAuth } = makeMiddleware();
+    const res = await requireEdgeGuardianAuth(
+      makeReq({ authorization: "Bearer proxy.grant" }),
+      makeLoopbackServer(),
+    );
+    expect(res?.status).toBe(401);
+  });
+
+  test("a proxy subject is refused even under a broad profile", async () => {
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: {
+        sub: "local:asst:oauth-proxy.stripe_link",
+        scope_profile: "local_v1",
+      },
+    }));
+    const { requireEdgeAuth } = makeMiddleware();
+    const res = await requireEdgeAuth(
+      makeReq({ authorization: "Bearer proxy.grant" }),
+    );
+    expect(res?.status).toBe(401);
+  });
+
+  test("an unrecognized profile is refused", async () => {
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: {
+        sub: "actor:asst:123",
+        scope_profile: "minted_by_a_newer_peer",
+      },
+    }));
+    const { requireEdgeAuth } = makeMiddleware();
+    const res = await requireEdgeAuth(
+      makeReq({ authorization: "Bearer future.jwt" }),
+    );
+    expect(res?.status).toBe(401);
+  });
+
+  test("an actor client token still satisfies both guards", async () => {
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: { sub: "actor:asst:123", scope_profile: "actor_client_v1" },
+    }));
+    const { requireEdgeAuth, requireEdgeAuthWithScope } = makeMiddleware();
+    expect(
+      await requireEdgeAuth(makeReq({ authorization: "Bearer good.jwt" })),
+    ).toBeNull();
+    expect(
+      await requireEdgeAuthWithScope(
+        makeReq({ authorization: "Bearer good.jwt" }),
+        "settings.write",
+      ),
+    ).toBeNull();
+  });
+
+  test("a local CLI token still satisfies both guards", async () => {
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: { sub: "local:asst:conv-123", scope_profile: "local_v1" },
+    }));
+    const { requireEdgeAuth, requireEdgeAuthWithScope } = makeMiddleware();
+    expect(
+      await requireEdgeAuth(makeReq({ authorization: "Bearer local.jwt" })),
+    ).toBeNull();
+    expect(
+      await requireEdgeAuthWithScope(
+        makeReq({ authorization: "Bearer local.jwt" }),
+        "local.all",
+      ),
+    ).toBeNull();
+  });
+});
+
+// =========================================================================
 // Loopback fallback + trustProxy — proxied-remote vs direct-local
 //
 // A same-host reverse proxy / tunnel always connects over 127.0.0.1, so the
@@ -619,8 +755,7 @@ describe("requireEdgeAuth: device last-used stamping", () => {
 // =========================================================================
 
 const { handleCreateToken } = await import("../http/routes/auth-token.js");
-const { initSigningKey, mintToken } =
-  await import("../auth/token-service.js");
+const { initSigningKey, mintToken } = await import("../auth/token-service.js");
 const { CURRENT_POLICY_EPOCH } = await import("../auth/policy.js");
 const { contacts } = await import("../db/schema.js");
 const { bustGuardianIntegrityCache } =

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -5,7 +5,7 @@ import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
-import type { Scope, TokenClaims } from "../../auth/types.js";
+import type { Scope, ScopeProfile, TokenClaims } from "../../auth/types.js";
 import { AuthFallbackCountTracker } from "../../auth-fallback-count-tracker.js";
 import { AuthFallbackLogThrottle } from "../../auth-fallback-log-throttle.js";
 import type { AuthRateLimiter } from "../../auth-rate-limiter.js";
@@ -102,6 +102,10 @@ export function logAuthBypassState(): void {
  *     vembda; the gateway only verifies the cross-checked user id.
  *   - `requireEdgeGuardianAuth` — same pattern, additionally requires the
  *     authenticated principal to match the bound guardian.
+ *
+ * All three refuse a single-route grant (see `isSingleRouteGrant`) outright,
+ * with no loopback fallback: such a grant is handed to code outside this
+ * install's trust boundary, which usually runs on the loopback host itself.
  */
 export function createAuthMiddleware(
   authRateLimiter: AuthRateLimiter,
@@ -259,6 +263,8 @@ export function createAuthMiddleware(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
+    const contained = rejectSingleRouteGrant(req, result.claims, "Edge auth");
+    if (contained) return contained;
     return rejectIfActorTokenRevoked(req, token, result.claims);
   }
 
@@ -286,6 +292,13 @@ export function createAuthMiddleware(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
+    const contained = rejectSingleRouteGrant(
+      req,
+      result.claims,
+      "Scoped edge auth",
+      { scope },
+    );
+    if (contained) return contained;
     const revoked = rejectIfActorTokenRevoked(req, token, result.claims);
     if (revoked) return revoked;
     const scopes = resolveScopeProfile(result.claims.scope_profile);
@@ -345,6 +358,30 @@ export function createAuthMiddleware(
     log.warn(
       { path: new URL(req.url).pathname, ...extra },
       `${label} rejected: malformed Authorization header`,
+    );
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  /**
+   * Refuse a grant minted for one route. Edge auth speaks for its caller on
+   * every route it guards, which such a grant may not do, so the refusal is
+   * unconditional: the loopback fallback would hand back what it withholds.
+   */
+  function rejectSingleRouteGrant(
+    req: Request,
+    claims: TokenClaims,
+    label: string,
+    extra?: Record<string, unknown>,
+  ): Response | null {
+    if (!isSingleRouteGrant(claims)) return null;
+    authRateLimiter.recordFailure(getClientIp());
+    log.warn(
+      {
+        path: new URL(req.url).pathname,
+        scopeProfile: claims.scope_profile,
+        ...extra,
+      },
+      `${label} rejected: grant is scoped to a single route`,
     );
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -465,6 +502,12 @@ export function createAuthMiddleware(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
+    const contained = rejectSingleRouteGrant(
+      req,
+      result.claims,
+      "Guardian edge auth",
+    );
+    if (contained) return contained;
     const revoked = rejectIfActorTokenRevoked(req, token, result.claims);
     if (revoked) return revoked;
     const parsed = parseSub(result.claims.sub);
@@ -544,6 +587,38 @@ export function wrapWithAuthFailureTracking(
 // ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
+
+/**
+ * Scope profiles broad enough to stand for their caller on any edge route.
+ * A profile outside this set is minted for a single route, which validates the
+ * grant itself, so edge auth refuses it. New profiles land outside the set and
+ * therefore fail closed.
+ */
+const EDGE_AUTH_PROFILES: ReadonlySet<ScopeProfile> = new Set<ScopeProfile>([
+  "actor_client_v1",
+  "gateway_ingress_v1",
+  "gateway_service_v1",
+  "local_v1",
+  "ui_page_v1",
+]);
+
+/** Conversation component of an OAuth passthrough grant's subject. */
+const OAUTH_PROXY_SUBJECT_PREFIX = "oauth-proxy.";
+
+/**
+ * True when the claims name a grant minted for a single route rather than an
+ * edge credential. The scope profile is the gate; the subject shape is a
+ * second signal, catching a proxy grant that carries some other profile.
+ */
+function isSingleRouteGrant(claims: TokenClaims): boolean {
+  if (!EDGE_AUTH_PROFILES.has(claims.scope_profile)) return true;
+  const parsed = parseSub(claims.sub);
+  return (
+    parsed.ok &&
+    parsed.principalType === "local" &&
+    (parsed.conversationId ?? "").startsWith(OAUTH_PROXY_SUBJECT_PREFIX)
+  );
+}
 
 /** Extract the raw token from a Bearer Authorization header, or null. */
 function extractBearerToken(req: Request): string | null {


### PR DESCRIPTION
## Summary

The `oauth_proxy_v1` grant minted by `assistant oauth proxy-url` is printed for a user to export into a stock third-party CLI's environment, so it lives outside this install's trust boundary. It nonetheless satisfied every gateway `auth: "edge"` route and every daemon `policy: null` route, because neither guard looked past signature, audience, expiry and policy epoch.

**Gateway.** `validateEdgeBearer` performed no scope or principal check, so the grant opened every unscoped edge route, including `POST|DELETE /v1/integrations/telegram/config`, `POST /v1/channel-verification-sessions` and the contacts control plane. Edge auth now admits only the scope profiles broad enough to stand for their caller on any route (`EDGE_AUTH_PROFILES`: actor_client_v1, gateway_ingress_v1, gateway_service_v1, local_v1, ui_page_v1) and refuses anything else with the usual 401, with the OAuth proxy subject shape as a second signal. All three guards apply it, scoped and guardian included, and the refusal is deliberately not eligible for the legacy loopback fallback: a third-party CLI holding the grant runs on the loopback host itself. An unrecognized profile from a newer peer lands outside the set and fails closed.

**Daemon.** `enforcePolicy` returned null immediately for `policy: null`, so any valid token reached those routes, `POST integrations/a2a/invite/accept` among them. A route naming no scope (null policy or empty `requiredScopes`) is now unprotected only for the same broad profiles and returns 403 to every other profile. The dev bypass (`isHttpAuthDisabled`) still short-circuits first, so local development is unaffected.

The passthrough itself is untouched: it is the runtime-proxy catch-all (`auth: "track-failures"`), which validates the edge token in `createRuntimeProxyHandler` directly rather than through this middleware, and its own policy requires `oauth.proxy`, which the grant carries.

Fixes a gap found in self-review of plan oauth-proxy-passthrough.md: the oauth_proxy_v1 grant is handed to untrusted third-party CLIs but satisfied every gateway auth: "edge" route and every daemon policy: null route.