### PR TITLE
feat(companion): greet the user first on companion entry (JARVIS-1772)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -74,6 +74,8 @@ const {
 } = await import("@/domains/chat/voice/live-voice/start-voice-request");
 const { isLiveVoiceSessionOwnedBy, useLiveVoiceStore } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
+const { voiceEntryGreetingSeed } =
+  await import("@/domains/chat/voice/live-voice/voice-entry-greeting");
 const { useAssistantIdentityStore } =
   await import("@/stores/assistant-identity-store");
 const { useConversationStore } = await import("@/stores/conversation-store");
@@ -164,13 +166,18 @@ function mintedConversationId(): string {
  * The whole binding in one assertion: the session was started on a conversation
  * minted for it rather than the one the app was left on, and the composer for
  * that conversation was navigated onto the screen so it can own the session.
+ * A minted draft is empty, so the session opens with the assistant speaking
+ * first, exactly as the composer's voice button opens one on a blank thread.
  */
 function expectStartedOnFreshDraft(
   entry: "deep_link" | "companion" = "deep_link",
 ): void {
   const draftId = mintedConversationId();
   expect(draftId).not.toBe(PRIOR_CONVERSATION_ID);
-  expect(starter).toHaveBeenCalledWith("assistant-1", draftId, { entry });
+  expect(starter).toHaveBeenCalledWith("assistant-1", draftId, {
+    entry,
+    seedText: voiceEntryGreetingSeed(true),
+  });
   expect(navigate).toHaveBeenCalledWith(routes.conversation(draftId), {
     replace: true,
   });
@@ -388,6 +395,7 @@ describe("a request that cannot be served yet stays parked", () => {
     expect(draftId).not.toBe(PRIOR_CONVERSATION_ID);
     expect(starter).toHaveBeenCalledWith("assistant-2", draftId, {
       entry: "deep_link",
+      seedText: voiceEntryGreetingSeed(true),
     });
     expect(isParked()).toBe(false);
   });
@@ -594,6 +602,27 @@ describe("startVoiceFromSurface", () => {
     expectStartedOnFreshDraft("companion");
   });
 
+  test("the companion's press opens with the assistant speaking first", async () => {
+    // The call lands on a draft minted for it, which has nothing in it, and a
+    // blank thread is where in-app voice mode has the assistant greet. The
+    // seed is the composer's own, hidden rather than rendered as the user's
+    // words, and it is not an ask, so the call stays open after the reply.
+    identityHydrated();
+    registerStarter();
+
+    startVoiceFromSurface(navigate, { entry: "companion" });
+    await flushDrain();
+
+    const seed = voiceEntryGreetingSeed(true);
+    const draftId = mintedConversationId();
+    expect(seed).toBeString();
+    expect(starter).toHaveBeenCalledTimes(1);
+    expect(starter).toHaveBeenCalledWith("assistant-1", draftId, {
+      entry: "companion",
+      seedText: seed,
+    });
+  });
+
   test("a running session spends the press", () => {
     identityHydrated();
     registerStarter();
@@ -601,8 +630,10 @@ describe("startVoiceFromSurface", () => {
 
     startVoiceFromSurface(navigate, { entry: "companion" });
 
-    // That session is the one the user is in. Navigating would only walk the
-    // app away from the composer that owns it.
+    // That session is the one the user is in, on a thread already underway:
+    // nothing starts, so nothing greets into it. Navigating would only walk
+    // the app away from the composer that owns it.
+    expect(starter).not.toHaveBeenCalled();
     expect(navigate).not.toHaveBeenCalled();
     expect(isParked()).toBe(false);
   });

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -31,6 +31,7 @@ import {
   publishConfigNotice,
   voiceReadiness,
 } from "@/domains/chat/voice/live-voice/voice-entry-guards";
+import { voiceEntryGreetingSeed } from "@/domains/chat/voice/live-voice/voice-entry-greeting";
 import { mintVoiceDraftConversation } from "@/domains/chat/voice/voice-draft-conversation";
 import { formatVoiceError } from "@/domains/chat/utils/chat";
 import { supportsLiveVoice } from "@/lib/backwards-compat/use-supports-live-voice";
@@ -427,7 +428,16 @@ export async function drainPendingVoiceStart(
   // Absent only from a park written by code that predates the field.
   const entry = consumed.entry ? { entry: consumed.entry } : {};
   if (consumed.ask === null) {
-    readyStarter.start(assistantId, conversationId, entry);
+    // The draft was minted a moment ago, so the conversation is empty by
+    // construction, and an empty conversation is where the assistant speaks
+    // first (see `voiceEntryGreetingSeed`): the same seed the composer's voice
+    // button sends on a blank thread, so a call opened from the companion or
+    // the voice key does not open silent while one opened in the app greets.
+    // `start()` spends the seed once per start and never on a reconnect.
+    readyStarter.start(assistantId, conversationId, {
+      ...entry,
+      seedText: voiceEntryGreetingSeed(true),
+    });
     return;
   }
   // The question is the user's own words, so it renders as theirs, and the

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -118,6 +118,8 @@ const renderConsumer = () =>
   renderHook(() => useGlobalDeepLinkConsumer(), { wrapper: Wrapper });
 const { drainPendingVoiceStart } =
   await import("@/domains/chat/voice/live-voice/start-voice-request");
+const { voiceEntryGreetingSeed } =
+  await import("@/domains/chat/voice/live-voice/voice-entry-greeting");
 const { useIsVoiceRoomVisible } =
   await import("@/domains/chat/voice/voice-room/use-is-voice-room-visible");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
@@ -536,9 +538,10 @@ describe("deeplink.startVoice", () => {
     expect(conversationId).not.toBeNull();
     expect(conversationId).not.toBe(PRIOR_CONVERSATION_ID);
     // A link is one of several ways in, and the daemon's telemetry is told
-    // which.
+    // which. The minted draft is empty, so the assistant speaks first on it.
     expect(starterMock).toHaveBeenCalledWith("assistant-1", conversationId, {
       entry: "deep_link",
+      seedText: voiceEntryGreetingSeed(true),
     });
     expect(mockPathname).toBe(routes.conversation(conversationId ?? ""));
   };


### PR DESCRIPTION
## Summary

Anita's QA: entering a call from the macOS companion surface was silent, while in-app voice mode has the assistant greet first.

**Root cause.** The composer's voice button starts the session with `seedText: voiceEntryGreetingSeed(conversationIsEmpty)` (`chat-composer.tsx`). The companion's Talk goes through `startVoiceFromSurface` -> `drainPendingVoiceStart` in `clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts`, which mints a fresh draft and then called `readyStarter.start(assistantId, conversationId, entry)` with only the `entry`, never a seed. Same drain serves the voice key and the deep link, so all three opened silent.

**Fix.** The drain now passes `seedText: voiceEntryGreetingSeed(true)` on the plain (non-ask) start. The draft it just minted is empty by construction, so this is the same rule and the same copy the composer applies. Nothing new for the guard: `useLiveVoice.start()` already holds the seed in `pendingSeedRef`, spends it once when the microphone comes up, and never re-sends it on the reconnect path, so a socket blip cannot greet twice. The ask path (`seedVisible` / `endAfterSeedReply`) is unchanged.

One line of behaviour in the shared seam rather than a companion-only branch, since the module's whole point is that the three outside-the-chat entries cannot drift into different ideas of what a press means.

## Tests

- `start-voice-request.test.ts`: new case `the companion's press opens with the assistant speaking first` (seed equals the composer's greeting, hidden, not an ask); `a running session spends the press` now also asserts nothing starts, so nothing greets into a thread already underway; the fresh-draft assertions include the seed.
- `use-global-deep-link-consumer.test.tsx`: the fresh-draft assertion includes the seed.
- The empty vs non-empty rule itself stays covered by `voice-entry-greeting.test.ts`, and the once-per-connect / no-double-greet-on-reconnect behaviour by `use-live-voice.test.ts`.

Ran (specific files, per the repo's macOS `bun test <dir>` gotcha):
- `start-voice-request.test.ts`: 43 pass, 0 fail
- `use-global-deep-link-consumer.test.tsx`: 56 pass, 0 fail
- `use-live-voice-session-controller.test.tsx`: 31 pass, 0 fail
- `use-live-voice.test.ts`: 131 pass, 0 fail
- `use-is-voice-room-visible.test.tsx`, `voice-entry-greeting.test.ts`, `global-push-to-talk-bridge.test.tsx`: pass individually (the 3-file combined run fails identically on untouched main, the known mock.module bleed)
- `bunx tsc --noEmit` in `clients/web`: clean
- eslint on the changed files: clean

Not verified in the running Electron app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZTyGdrVc4zr5tsyDr262w
