### PR TITLE
feat(companion): pencil cursor while annotating (JARVIS-1774)

### DIFF
--- a/clients/web/src/components/companion-share-annotation.test.tsx
+++ b/clients/web/src/components/companion-share-annotation.test.tsx
@@ -20,6 +20,7 @@ const {
   CompanionShareAnnotation,
   COMPANION_INK_FADE_MS,
   COMPANION_INK_HOLD_MS,
+  pencilCursor,
 } = await import("./companion-share-annotation");
 
 /**
@@ -276,5 +277,27 @@ describe("drawing on what the call is shown", () => {
       clientY: 500,
     });
     expect(sent.filter((one) => one.phase === "released")).toHaveLength(1);
+  });
+});
+
+/**
+ * The pointer is the one thing on screen that can say the mode took: the
+ * surface under it is someone else's app, and nothing on that app changes.
+ */
+describe("the pointer while drawing is on", () => {
+  test("is a pencil, drawn in the ink the mark will be", () => {
+    const cursor = pencilCursor(INK);
+    expect(cursor.startsWith('url("data:image/svg+xml,')).toBe(true);
+    expect(cursor).toContain(encodeURIComponent(`stroke="${INK}"`));
+  });
+
+  test("points from the pencil's tip and falls back to a crosshair", () => {
+    expect(pencilCursor(INK).endsWith(") 2 22, crosshair")).toBe(true);
+  });
+
+  test("hangs on the drawing layer", () => {
+    const { container } = render(<CompanionShareAnnotation ink={INK} />);
+    const layer = layerOf(container);
+    expect(layer.getAttribute("style")).toContain("data:image/svg+xml");
   });
 });

--- a/clients/web/src/components/companion-share-annotation.tsx
+++ b/clients/web/src/components/companion-share-annotation.tsx
@@ -27,7 +27,7 @@
  * circle they have to clear up.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useWindowBox } from "@/components/companion-window-box";
 import { annotateCompanionShare } from "@/runtime/companion-surface";
@@ -77,6 +77,33 @@ export function movedEnough(
   const dx = (next.x - last.x) * aspect;
   const dy = next.y - last.y;
   return dx * dx + dy * dy >= COMPANION_ANNOTATION_MIN_STEP ** 2;
+}
+
+/** Lucide's `pencil`, as path data: a cursor is an image, not an element. */
+const PENCIL_MARKS =
+  '<path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z"/>' +
+  '<path d="m15 5 4 4"/>';
+
+/**
+ * The pointer while drawing is on: a pencil, in the ink the mark will be.
+ *
+ * This is how the user learns the mode took: the pill's control is behind
+ * them and the surface under the pointer is someone else's app, so the
+ * pointer is the only thing on screen that can say a press here is now a
+ * mark. Its colour is the mark's, for the same reason the frame's edge is.
+ *
+ * The ink is laid over a white halo so the pencil holds over a dark editor
+ * and a white page alike. The hotspot is the pencil's tip, so a mark starts
+ * where the pencil points. A crosshair stands behind it for a browser that
+ * refuses the image.
+ */
+export function pencilCursor(ink: string): string {
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round">' +
+    `<g stroke="#ffffff" stroke-width="4">${PENCIL_MARKS}</g>` +
+    `<g stroke="${ink}" stroke-width="2">${PENCIL_MARKS}</g>` +
+    "</svg>";
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 2 22, crosshair`;
 }
 
 export function CompanionShareAnnotation({ ink }: { ink: string }) {
@@ -239,12 +266,16 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
   // so this line and the one drawn onto the captured frame carry the same
   // weight relative to the surface they are on.
   const width = COMPANION_ANNOTATION_STROKE * Math.min(box.width, box.height);
+  // Built once per colour rather than on every move: the layer re-renders as
+  // the hand travels, and the cursor does not change under it.
+  const cursor = useMemo(() => pencilCursor(ink), [ink]);
 
   return (
     <svg
       className="companion-share-annotation fixed inset-0 h-full w-full"
       data-testid="companion-share-annotation"
       role="presentation"
+      style={{ cursor }}
       onPointerDown={handleDown}
       onPointerMove={handleMove}
       onPointerUp={handleUp}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -463,12 +463,11 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* The layer the user draws on inside that frame, while a call is being shown
  * the surface and drawing is on. The only thing on either of the companion's
- * click-through windows that deliberately takes the mouse, so the cursor says
- * so: for as long as this is up, a press on the shared surface is a mark
- * rather than a click on the app underneath. */
+ * click-through windows that deliberately takes the mouse, and the pencil it
+ * hangs on the pointer says so: for as long as this is up, a press on the
+ * shared surface is a mark rather than a click on the app underneath. */
 .companion-share-annotation {
   pointer-events: auto;
-  cursor: crosshair;
   touch-action: none;
 }
 


### PR DESCRIPTION
## Why

Anita's QA of the macOS companion: after clicking the annotate tool nothing changes at the pointer, so the user has no way to tell the shared screen will now take a mark rather than a click.

## What

The drawing layer that mounts inside the watch-frame window while `annotating` is on (`companion-share-annotation.tsx`) now hangs a pencil on the pointer:

- `pencilCursor(ink)` builds a CSS cursor from lucide's `pencil` as an inline SVG data URI, stroked in the same accent the marks are drawn in over a white halo (holds on dark editors and white pages alike), hotspot at the pencil's tip, `crosshair` fallback.
- Applied as an inline `style` on the overlay SVG, memoized per ink. The layer unmounts when main lowers `annotating` (or the share ends), so the default cursor comes back with it. No new state, no changes to the annotation input path or to main.
- The stylesheet's `cursor: crosshair` is dropped since the inline cursor replaces it.

How the renderer learns the mode: main's `setAnnotating` flips `setIgnoreMouseEvents(!annotating)` on the frame window and `pushState()`s; the page reads `state.annotating` off the push and mounts the layer. The window takes the mouse in exactly that state, so a CSS cursor on the layer is honored whenever the pencil should show.

Deliberately small so it merges cleanly beside the JARVIS-1773 scroll-event fix in the same file.

## Tests

- `clients/web`: `bun test src/components/companion-share-annotation.test.tsx` (17 pass, 3 new: ink in the cursor, hotspot + fallback, cursor on the layer), `companion-watch-frame-page.test.tsx` (34 pass), `bunx tsc --noEmit` clean, eslint + prettier clean.
- Not verified in the running app; the decoded SVG was rendered standalone and reads as a pencil with the halo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZTyGdrVc4zr5tsyDr262w
