### PR TITLE
fix(companion): annotations linger on the shared screen before fading (JARVIS-1775)

### DIFF
--- a/clients/web/src/components/companion-share-annotation.test.tsx
+++ b/clients/web/src/components/companion-share-annotation.test.tsx
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  mock,
+  test,
+} from "bun:test";
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import type { CompanionAnnotationStroke } from "@vellumai/ipc-contract";
 
@@ -41,6 +49,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  jest.useRealTimers();
 });
 
 const layerOf = (container: HTMLElement): Element => {
@@ -186,9 +195,12 @@ describe("drawing on what the call is shown", () => {
   /**
    * The mark is a gesture rather than an annotation layer: it has been sent,
    * and a circle still sitting on the user's screen a minute later is one
-   * they have to clear up themselves.
+   * they have to clear up themselves. But it stays for the sentence that goes
+   * with it: a mark gone before the user has finished saying "this one" is a
+   * drawing that looks like it failed.
    */
-  test("the mark fades and is taken away once it has been sent", async () => {
+  test("the mark stays through the hold, then fades and is taken away", () => {
+    jest.useFakeTimers();
     const { container } = render(<CompanionShareAnnotation ink={INK} />);
     const layer = layerOf(container);
     down(layer, 100, 100);
@@ -197,12 +209,34 @@ describe("drawing on what the call is shown", () => {
     expect(
       container.querySelector(".companion-share-ink-spent"),
     ).not.toBeNull();
-    await act(async () => {
-      await new Promise((resolve) =>
-        setTimeout(resolve, COMPANION_INK_HOLD_MS + COMPANION_INK_FADE_MS + 20),
+    // The hold is a few seconds, not a beat: long enough to say what the
+    // mark is about.
+    expect(COMPANION_INK_HOLD_MS).toBeGreaterThanOrEqual(4000);
+    act(() => {
+      jest.advanceTimersByTime(
+        COMPANION_INK_HOLD_MS + COMPANION_INK_FADE_MS - 1,
       );
     });
+    expect(container.querySelector("polyline")).not.toBeNull();
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
     expect(container.querySelector("polyline")).toBeNull();
+  });
+
+  /**
+   * The stylesheet fades the mark on the layer's own numbers, so the element
+   * cannot be dropped mid-fade or sit invisible after it.
+   */
+  test("tells the stylesheet how long the hold and the fade are", () => {
+    const { container } = render(<CompanionShareAnnotation ink={INK} />);
+    const layer = layerOf(container) as HTMLElement;
+    expect(layer.style.getPropertyValue("--companion-ink-hold")).toBe(
+      `${COMPANION_INK_HOLD_MS}ms`,
+    );
+    expect(layer.style.getPropertyValue("--companion-ink-fade")).toBe(
+      `${COMPANION_INK_FADE_MS}ms`,
+    );
   });
 
   /**

--- a/clients/web/src/components/companion-share-annotation.tsx
+++ b/clients/web/src/components/companion-share-annotation.tsx
@@ -42,12 +42,20 @@ import {
  * How long a finished mark stays at full strength before it starts to go, and
  * how long it takes to go.
  *
- * The hold is there so the user sees the mark land: the frame leaves on the
- * same release, and a line that began dissolving as the hand came off would
- * read as a drawing that failed rather than one that was sent. The fade is
- * slow enough to be a departure rather than a blink.
+ * The hold is the time it takes to say what the mark is about. The frame
+ * leaves on the release, but the user is usually mid-sentence when the hand
+ * comes off ("this button, here"), and a circle that has dissolved before the
+ * sentence ends reads as a drawing that failed rather than one that was
+ * sent. Long enough for that sentence and for the assistant to start
+ * answering to it; short enough that the surface is clear again before the
+ * next thing worth pointing at. The fade is slow enough to be a departure
+ * rather than a blink.
+ *
+ * The overlay's stylesheet reads both through custom properties set on the
+ * layer, so the moment the element is dropped and the moment its fade ends
+ * are the same number.
  */
-export const COMPANION_INK_HOLD_MS = 500;
+export const COMPANION_INK_HOLD_MS = 4500;
 export const COMPANION_INK_FADE_MS = 900;
 
 /** A fraction of the shared surface, held inside it. */
@@ -243,6 +251,12 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
   return (
     <svg
       className="companion-share-annotation fixed inset-0 h-full w-full"
+      style={
+        {
+          "--companion-ink-hold": `${COMPANION_INK_HOLD_MS}ms`,
+          "--companion-ink-fade": `${COMPANION_INK_FADE_MS}ms`,
+        } as React.CSSProperties
+      }
       data-testid="companion-share-annotation"
       role="presentation"
       onPointerDown={handleDown}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -473,14 +473,18 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 /* A mark on its way out, once it has been sent. The delay is the hold that
- * lets the user see it land, and `forwards` is what keeps it gone for the
- * moment between the fade ending and the element being dropped. */
+ * lets the user see it land and say what it is about, and `forwards` is what
+ * keeps it gone for the moment between the fade ending and the element being
+ * dropped. Both times come from the layer (`COMPANION_INK_HOLD_MS` and
+ * `COMPANION_INK_FADE_MS` in `companion-share-annotation.tsx`), which drops
+ * the element on the same numbers. */
 @keyframes companion-share-ink-out {
   to { opacity: 0; }
 }
 
 .companion-share-ink-spent {
-  animation: companion-share-ink-out 900ms ease-out 500ms forwards;
+  animation: companion-share-ink-out var(--companion-ink-fade) ease-out
+    var(--companion-ink-hold) forwards;
 }
 
 /* Taken away rather than left standing: the mark is spent, and the reason it
@@ -488,7 +492,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * drawn on with no way to clear it. */
 @media (prefers-reduced-motion: reduce) {
   .companion-share-ink-spent {
-    animation: companion-share-ink-out 1ms linear 1400ms forwards;
+    animation: companion-share-ink-out 1ms linear
+      calc(var(--companion-ink-hold) + var(--companion-ink-fade)) forwards;
   }
 }
 


### PR DESCRIPTION
Fixes JARVIS-1775

## What

Marks drawn on the shared screen with the companion's annotation tool disappeared almost as soon as the hand came off. Anita's QA read that as the drawing failing.

The cause is the hold in `companion-share-annotation.tsx`: a finished mark stayed at full strength for `COMPANION_INK_HOLD_MS = 500` and then faded over `COMPANION_INK_FADE_MS = 900`, with a timer dropping the element at 1.4s. Nothing else was clearing it early (the frame gate and the next captured frame never touch the overlay; the layer lives in its own window and captures exclude it).

- `COMPANION_INK_HOLD_MS` goes from 500 to 4500. The comment on it says why: the user is usually mid-sentence when the hand comes off ("this button, here"), and the mark needs to outlast that sentence and the start of the assistant's answer. The 900ms fade is unchanged.
- The same two numbers were duplicated as literals in `index.css` (`900ms ease-out 500ms`, and `1400ms` for reduced motion). The layer now sets them as `--companion-ink-hold` / `--companion-ink-fade` custom properties from the one pair of constants, and the stylesheet reads those, so the timer that drops the element and the animation that fades it are the same number.
- The fade test drives fake timers synchronously instead of sleeping for the real duration (which would now be 5.4s per run), and pins that the mark is still on the page right up to the end of the hold. A second test pins the custom properties.

## Not changed, on purpose

- No settings knob and no feature flag; one duration.
- `setCoachmarks` in `companion-window.ts` still lowers `annotating` when the assistant points at a control, which unmounts the layer and takes any marks with it. That is a deliberate rule (a press on a ringed control has to reach the app) and a separate mechanism from the fade; if a drawing vanishes the moment the assistant replies with a coachmark, that is the path, not this one.
- Kept to three files in `clients/web` so it merges cleanly beside the JARVIS-1773 (scroll pass-through) and JARVIS-1774 (pencil cursor) work in the same area.

## Verification

- `bun test src/components/companion-share-annotation.test.tsx`: 15 pass, 0 fail.
- `bunx tsc --noEmit` in `clients/web`: clean.
- eslint and prettier (3.8.1) on the touched TS files: clean.
- Not verified in a running app: the real-time feel of 4.5s on the shared screen, and the reduced-motion `calc()` delay in Chromium. The CSS `calc()` on `animation-delay` with `var()` ms values is standard, but worth one look in the built app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZTyGdrVc4zr5tsyDr262w
