### PR TITLE
fix(image-fallback): time-box vision captioning without failing the turn

### DIFF
--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -108,7 +108,9 @@ const postToolUse = (await import("../hooks/post-tool-use.js")).default;
 const postCompact = (await import("../hooks/post-compact.js")).default;
 const conversationDeleted = (await import("../hooks/conversation-deleted.js"))
   .default;
-const { findVisionProfile } = await import("../src/vision-caption.js");
+const { CAPTION_TIMEOUT_MS, findVisionProfile } = await import(
+  "../src/vision-caption.js"
+);
 const { flattenTextOnlyBlocks } = await import("../src/caption-blocks.js");
 const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
   await import("../src/caption-cache.js");
@@ -370,6 +372,177 @@ describe("image-fallback user-prompt-submit hook", () => {
     expect(
       (ctx.latestMessages[0].content[0] as { text: string }).text,
     ).toContain("auto-description failed");
+  });
+
+  test("the vision request time-box finishes inside the hook time-box", () => {
+    // Plugin hooks are time-boxed at 30s (HOOK_TIMEOUT_MS). The vision
+    // request must settle sooner so a timeout can still substitute prompt text.
+    expect(CAPTION_TIMEOUT_MS).toBe(25_000);
+    expect(CAPTION_TIMEOUT_MS).toBeLessThan(30_000);
+  });
+
+  test("substitutes timeout prompt text when the vision request times out", async () => {
+    /**
+     * Tests that a vision-caption timeout keeps the turn alive: the image
+     * becomes prompt text naming the model that timed out, instead of
+     * remaining a raw image a text-only provider would reject.
+     */
+
+    // GIVEN a vision caption request that times out
+    const timeoutProvider = {
+      name: "mock-vision-provider",
+      async sendMessage() {
+        throw new DOMException("The operation timed out", "TimeoutError");
+      },
+    };
+    installPluginApiMock({
+      getConfiguredProvider: async () => timeoutProvider,
+    });
+
+    // AND a turn that submits an image to a text-only model
+    const messages = [imageMsg()];
+    const ctx = makeCtx({ latestMessages: messages });
+
+    // WHEN the turn starts
+    await userPromptSubmit(ctx);
+
+    // THEN the image is replaced with timeout prompt text naming the vision model
+    const text = (ctx.latestMessages[0].content[0] as { text: string }).text;
+    expect(ctx.latestMessages[0].content[0].type).toBe("text");
+    expect(text).toBe(
+      '[Image: the vision model "Vision" timed out reading it. Consider using a different vision-capable model.]',
+    );
+  });
+
+  test("treats an aborted vision request as a timeout", async () => {
+    const abortProvider = {
+      name: "mock-vision-provider",
+      async sendMessage() {
+        throw new DOMException("This operation was aborted", "AbortError");
+      },
+    };
+    installPluginApiMock({
+      getConfiguredProvider: async () => abortProvider,
+    });
+
+    const ctx = makeCtx({ latestMessages: [imageMsg()] });
+    await userPromptSubmit(ctx);
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("timed out reading it");
+  });
+
+  test("uses fail-open placeholder when the vision request fails for a non-timeout reason", async () => {
+    const failingProvider = {
+      name: "mock-vision-provider",
+      async sendMessage() {
+        throw new Error("upstream 500");
+      },
+    };
+    installPluginApiMock({
+      getConfiguredProvider: async () => failingProvider,
+    });
+
+    const ctx = makeCtx({ latestMessages: [imageMsg()] });
+    await userPromptSubmit(ctx);
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("auto-description failed");
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).not.toContain("timed out");
+  });
+
+  test("does not cache a timed-out caption; a later turn retries the vision call", async () => {
+    let callCount = 0;
+    const timeoutThenOk = {
+      name: "mock-vision-provider",
+      async sendMessage() {
+        callCount++;
+        if (callCount === 1) {
+          throw new DOMException("The operation timed out", "TimeoutError");
+        }
+        return sendMessageResponse;
+      },
+    };
+    installPluginApiMock({
+      getConfiguredProvider: async () => timeoutThenOk,
+    });
+
+    const ctx1 = makeCtx({ latestMessages: [imageMsg("timeout-then-ok")] });
+    await userPromptSubmit(ctx1);
+    expect(
+      (ctx1.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("timed out reading it");
+    expect(callCount).toBe(1);
+
+    const ctx2 = makeCtx({ latestMessages: [imageMsg("timeout-then-ok")] });
+    await userPromptSubmit(ctx2);
+    expect(callCount).toBe(2);
+    expect(
+      (ctx2.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("[Image auto-described");
+  });
+
+  test("passes an abort signal so the vision request is time-boxed", async () => {
+    let seenSignal: AbortSignal | undefined;
+    const trackingProvider = {
+      name: "mock-vision-provider",
+      async sendMessage(
+        _messages: unknown,
+        options?: { signal?: AbortSignal },
+      ) {
+        seenSignal = options?.signal;
+        return sendMessageResponse;
+      },
+    };
+    installPluginApiMock({
+      getConfiguredProvider: async () => trackingProvider,
+    });
+
+    await userPromptSubmit(makeCtx({ latestMessages: [imageMsg()] }));
+    expect(seenSignal).toBeDefined();
+    expect(seenSignal!.aborted).toBe(false);
+  });
+
+  test("settles a hung vision request at the caption time-box instead of failing the hook", async () => {
+    /**
+     * Tests that the timeout is on the vision request itself: a provider that
+     * never resolves is still settled, and the hook substitutes timeout
+     * prompt text instead of discarding the substitution.
+     */
+
+    // GIVEN a vision request that hangs and ignores abort
+    const hungProvider = {
+      name: "mock-vision-provider",
+      async sendMessage() {
+        return new Promise(() => {});
+      },
+    };
+    installPluginApiMock({
+      getConfiguredProvider: async () => hungProvider,
+    });
+
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    const timeoutSpy = mock((ms: number) => {
+      expect(ms).toBe(CAPTION_TIMEOUT_MS);
+      return originalTimeout(5);
+    });
+    const abortSignal = AbortSignal as unknown as {
+      timeout: (ms: number) => AbortSignal;
+    };
+    abortSignal.timeout = timeoutSpy;
+
+    try {
+      const ctx = makeCtx({ latestMessages: [imageMsg("hung")] });
+      await userPromptSubmit(ctx);
+      expect(
+        (ctx.latestMessages[0].content[0] as { text: string }).text,
+      ).toContain("timed out reading it");
+      expect(timeoutSpy).toHaveBeenCalled();
+    } finally {
+      abortSignal.timeout = originalTimeout;
+    }
   });
 
   test("caches captions — second call with same image does not invoke provider", async () => {
@@ -788,6 +961,25 @@ describe("image-fallback post-tool-use hook", () => {
     expect(block.type).toBe("text");
     expect((block as { text: string }).text).toContain(
       "no vision-capable model",
+    );
+  });
+
+  test("substitutes timeout prompt text when the vision request times out", async () => {
+    const timeoutProvider = {
+      name: "mock-vision-provider",
+      async sendMessage() {
+        throw new DOMException("The operation timed out", "TimeoutError");
+      },
+    };
+    installPluginApiMock({
+      getConfiguredProvider: async () => timeoutProvider,
+    });
+    const ctx = makeToolCtx({
+      toolResponse: toolResult([imageBlock("shot1")]),
+    });
+    await postToolUse(ctx);
+    expect((ctx.toolResponse.contentBlocks![0] as { text: string }).text).toBe(
+      '[Image: the vision model "Vision" timed out reading it. Consider using a different vision-capable model.]',
     );
   });
 

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -27,9 +27,11 @@
  * image was auto-described to text, so the model treats the block as a derived
  * description rather than a verbatim transcript.
  *
- * Fail-open is the dominant error mode: a captioning failure leaves a
- * placeholder text block rather than the raw image (which a text-only provider
- * would reject) or nothing (which would lose information).
+ * Fail-open is the dominant error mode: a captioning failure or timeout
+ * leaves a placeholder text block rather than the raw image (which a
+ * text-only provider would reject) or nothing (which would lose information).
+ * A vision-request timeout uses a distinct placeholder so the model can tell
+ * the user to try a different vision-capable model.
  */
 
 import {
@@ -44,7 +46,30 @@ import {
 } from "@vellumai/plugin-api";
 
 import { persistImage } from "./image-persist.js";
-import { captionImage } from "./vision-caption.js";
+import {
+  captionImage,
+  type CaptionResult,
+  visionProfileLabel,
+} from "./vision-caption.js";
+
+/**
+ * Prompt text substituted for an image block after captioning. A timeout
+ * names the vision model that timed out so the turn can continue and the
+ * model can tell the user to try a different one.
+ */
+function captionPromptText(
+  result: CaptionResult,
+  visionProfileKey: string,
+): string {
+  if (result.status === "caption") {
+    return `[Image auto-described for text-only model: ${result.text}]`;
+  }
+  if (result.status === "timeout") {
+    const label = visionProfileLabel(visionProfileKey);
+    return `[Image: the vision model "${label}" timed out reading it. Consider using a different vision-capable model.]`;
+  }
+  return `[Image: auto-description failed (text-only model)]`;
+}
 
 /**
  * Whether the profile a turn runs needs image→text fallback (i.e. it can't
@@ -102,7 +127,7 @@ export async function captionImageBlocks(
     }
 
     if (visionProfileKey != null) {
-      const caption = await captionImage(
+      const result = await captionImage(
         image,
         conversationId,
         visionProfileKey,
@@ -110,10 +135,7 @@ export async function captionImageBlocks(
       );
       blocks[i] = {
         type: "text",
-        text:
-          caption != null
-            ? `[Image auto-described for text-only model: ${caption}]`
-            : `[Image: auto-description failed (text-only model)]`,
+        text: captionPromptText(result, visionProfileKey),
       };
     } else {
       // No vision profile configured at all: fail-open placeholder.

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -14,6 +14,7 @@ import {
   getModelProfiles,
   type ImageContent,
   type PluginLogger,
+  type Provider,
   resolveMediaSourceData,
 } from "@vellumai/plugin-api";
 
@@ -23,7 +24,17 @@ import {
   setCachedCaption,
 } from "./caption-cache.js";
 
-const CAPTION_TIMEOUT_MS = 30_000;
+/**
+ * Time-box for the vision caption request. Kept below the 30s plugin hook
+ * time-box so a timed-out caption still substitutes prompt text rather than
+ * discarding the whole hook.
+ */
+export const CAPTION_TIMEOUT_MS = 25_000;
+
+export type CaptionResult =
+  | { status: "caption"; text: string }
+  | { status: "timeout" }
+  | { status: "failed" };
 
 const CAPTION_SYSTEM_PROMPT =
   "You are a vision assistant. Describe the image concisely in 1-2 sentences. " +
@@ -61,25 +72,25 @@ export function findVisionProfile(): string | null {
  *          cache row so `conversation-deleted` cleanup stays accurate.
  * @param profileKey  Key of a vision-capable profile (from {@link findVisionProfile}).
  * @param logger    Turn-scoped logger for attribution.
- * @returns The caption text, or `null` when captioning failed (caller should
- *          use a fail-open placeholder).
+ * @returns A caption, a timeout marker, or `failed` when captioning could
+ *          not run (caller substitutes fail-open prompt text).
  */
 export async function captionImage(
   image: ImageContent,
   conversationId: string,
   profileKey: string,
   logger: PluginLogger,
-): Promise<string | null> {
+): Promise<CaptionResult> {
   // Hash the image's content (resolving a reference source to its bytes, a
   // no-op for inline base64) so the caption cache keys on the image itself.
   const resolved = resolveMediaSourceData(image.source);
   if (!resolved) {
-    return null;
+    return { status: "failed" };
   }
   const hash = imageHash(resolved.data);
   const cached = getCachedCaption(hash, conversationId);
   if (cached !== undefined) {
-    return cached;
+    return { status: "caption", text: cached };
   }
 
   try {
@@ -92,28 +103,14 @@ export async function captionImage(
         { plugin: "image-fallback" },
         "No provider resolved for vision captioning profile",
       );
-      return null;
+      return { status: "failed" };
     }
 
-    const response = await provider.sendMessage(
-      [
-        {
-          role: "user",
-          content: [image, { type: "text", text: CAPTION_USER_PROMPT }],
-        },
-      ],
-      {
-        systemPrompt: CAPTION_SYSTEM_PROMPT,
-        config: {
-          callSite: "vision",
-          conversationId,
-          overrideProfile: profileKey,
-          forceOverrideProfile: true,
-          tool_choice: { type: "none" },
-        },
-        signal: AbortSignal.timeout(CAPTION_TIMEOUT_MS),
-      },
-    );
+    const response = await sendCaptionRequest(provider, {
+      image,
+      conversationId,
+      profileKey,
+    });
 
     // Vision captioning returns text content; concatenate any text blocks
     // (effectively always one here, since tool use is disabled).
@@ -123,19 +120,99 @@ export async function captionImage(
       .trim();
     if (caption.length > 0) {
       setCachedCaption(hash, conversationId, caption);
-      return caption;
+      return { status: "caption", text: caption };
     }
 
     logger.warn(
       { plugin: "image-fallback" },
       "Vision captioning returned empty text",
     );
-    return null;
+    return { status: "failed" };
   } catch (err) {
+    if (isCaptionTimeoutError(err)) {
+      logger.warn(
+        { plugin: "image-fallback", err, profileKey },
+        "Vision captioning timed out",
+      );
+      return { status: "timeout" };
+    }
     logger.warn(
       { plugin: "image-fallback", err },
       "Vision captioning call failed",
     );
-    return null;
+    return { status: "failed" };
   }
+}
+
+/**
+ * Label of the vision profile used for captioning, for timeout prompt text.
+ */
+export function visionProfileLabel(profileKey: string): string {
+  const profile = getModelProfiles().find((p) => p.key === profileKey);
+  return profile?.label ?? profileKey;
+}
+
+function isCaptionTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  return (
+    err.name === "TimeoutError" ||
+    err.name === "AbortError" ||
+    err.name === "APIUserAbortError"
+  );
+}
+
+/**
+ * Time-box the vision `sendMessage` call itself: abort the request at
+ * {@link CAPTION_TIMEOUT_MS}, and settle on that deadline even if the provider
+ * ignores the abort signal.
+ */
+async function sendCaptionRequest(
+  provider: Provider,
+  args: {
+    image: ImageContent;
+    conversationId: string;
+    profileKey: string;
+  },
+): Promise<Awaited<ReturnType<Provider["sendMessage"]>>> {
+  const signal = AbortSignal.timeout(CAPTION_TIMEOUT_MS);
+  const timedOut = new Promise<never>((_, reject) => {
+    const rejectTimedOut = () => {
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new DOMException("The operation timed out", "TimeoutError"),
+      );
+    };
+    if (signal.aborted) {
+      rejectTimedOut();
+      return;
+    }
+    signal.addEventListener("abort", rejectTimedOut, { once: true });
+  });
+  // Absorb whichever side loses the race so a late abort or late response
+  // does not become an unhandled rejection.
+  timedOut.catch(() => {});
+  const work = provider.sendMessage(
+    [
+      {
+        role: "user",
+        content: [args.image, { type: "text", text: CAPTION_USER_PROMPT }],
+      },
+    ],
+    {
+      systemPrompt: CAPTION_SYSTEM_PROMPT,
+      config: {
+        callSite: "vision",
+        conversationId: args.conversationId,
+        overrideProfile: args.profileKey,
+        forceOverrideProfile: true,
+        tool_choice: { type: "none" },
+      },
+      signal,
+    },
+  );
+  work.catch(() => {});
+  return await Promise.race([work, timedOut]);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Vision captioning is time-boxed at 25s on the caption API request itself, inside the 30s plugin hook time-box.
- If that request times out (or hangs past the deadline), the image is replaced with prompt text naming the vision model that timed out and suggesting a different one, instead of failing the whole turn.
- Timeouts are not cached, so a later turn retries the vision call.

## Prompt / plan
When the image plugin times out on processing the image, it fails the whole request. We should instead have a 25 second timeout on the API request itself, and if it times out, return prompt text that said the vision model chosen timed out reading it and the user should consider another one.

The previous 30s caption abort raced the 30s hook time-box. When the hook timed out, its substitution was discarded and the raw image reached a text-only provider, which failed the request.

## Test plan
- [x] `cd assistant && bun test src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts` (49 pass)
- [x] Timeout, abort, hang, non-timeout failure, and cache-miss-on-timeout cases
- [x] `cd assistant && bun test src/plugins/defaults/image-fallback/__tests__/vision-recovery.test.ts` and caption-cache persistence tests (22 pass)
- [x] `cd assistant && bun run typecheck:fast`

## Risk
Low. Fail-open substitution already existed; this distinguishes timeout from other failures and settles the vision request before the hook time-box discards it. Multiple uncached images in one turn can still exceed the 30s hook budget if each waits the full 25s.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8f3c0ea-7539-4380-83da-8a5b43b4b971?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8f3c0ea-7539-4380-83da-8a5b43b4b971&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

