### PR TITLE
fix(gateway): refuse single-route grants on the IPC fast path

### DIFF
--- a/gateway/src/__tests__/twilio-media-websocket.test.ts
+++ b/gateway/src/__tests__/twilio-media-websocket.test.ts
@@ -15,12 +15,29 @@ import {
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
 
-/** Mint a valid edge JWT (aud=vellum-gateway) for test requests. */
+/**
+ * Mint the relay token the gateway injects into `<Stream>` TwiML, which is
+ * what Twilio presents on the upgrade. Mirrors `mintRelayToken`.
+ */
 function mintEdgeToken(): string {
   return mintToken({
     aud: "vellum-gateway",
     sub: "svc:gateway:self",
     scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+/** Mint some other valid edge JWT (aud=vellum-gateway) for test requests. */
+function mintNonRelayToken(
+  sub: string,
+  scopeProfile: "oauth_proxy_v1" | "actor_client_v1" | "ui_page_v1",
+): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub,
+    scope_profile: scopeProfile,
     policy_epoch: CURRENT_POLICY_EPOCH,
     ttlSeconds: 300,
   });
@@ -316,6 +333,67 @@ describe("createTwilioMediaWebsocketHandler", () => {
     const handler = createTwilioMediaWebsocketHandler(config);
     const req = new Request(
       "http://localhost:7830/webhooks/twilio/media-stream?callSessionId=sess-1",
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  // The siblings on runtime-audio-stream.ts and live-voice-websocket.ts
+  // require an actor principal. Twilio never presents one: the credential it
+  // dials back with is the gateway's own relay token, so the equivalent
+  // containment here is the relay identity, not an actor one. Every other
+  // valid edge token is refused, an OAuth passthrough grant included.
+
+  test("returns 401 for an oauth proxy grant that knows a callSessionId", () => {
+    const grant = mintNonRelayToken(
+      "local:self:oauth-proxy.stripe_link",
+      "oauth_proxy_v1",
+    );
+    const handler = createTwilioMediaWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/webhooks/twilio/media-stream/sess-1/${grant}`,
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 for an actor token", () => {
+    const actorToken = mintNonRelayToken(
+      "actor:asst_1:user_1",
+      "actor_client_v1",
+    );
+    const handler = createTwilioMediaWebsocketHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/webhooks/twilio/media-stream/sess-1",
+      { headers: { authorization: `Bearer ${actorToken}` } },
+    );
+    const fakeServer = {
+      upgrade: mock(() => true),
+    } as unknown as import("bun").Server<any>;
+    const res = handler(req, fakeServer);
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(401);
+    expect(fakeServer.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 for a gateway-minted token on another profile", () => {
+    const uiPageToken = mintNonRelayToken("svc:gateway:self", "ui_page_v1");
+    const handler = createTwilioMediaWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/webhooks/twilio/media-stream/sess-1/${uiPageToken}`,
     );
     const fakeServer = {
       upgrade: mock(() => true),

--- a/gateway/src/http/routes/ipc-runtime-proxy.test.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.test.ts
@@ -9,6 +9,8 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import "../../__tests__/test-preload.js";
 
+import type { ScopeProfile } from "../../auth/types.js";
+
 // ---------------------------------------------------------------------------
 // Mock implementations
 // ---------------------------------------------------------------------------
@@ -69,6 +71,27 @@ const ROUTE_SCHEMA = [
       allowedPrincipalTypes: ["actor"],
     },
   },
+  // A policy that names principals but no scope. `enforcePolicy` treats it
+  // exactly like `policy: null`, so the IPC fast path must too.
+  {
+    operationId: "debug_ping",
+    endpoint: "debug/ping",
+    method: "GET",
+    policy: {
+      requiredScopes: [],
+      allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
+    },
+  },
+  // The OAuth passthrough proxy: the one route an oauth_proxy_v1 grant opens.
+  {
+    operationId: "oauth_proxy_get",
+    endpoint: "oauth/proxy/:provider/:path*",
+    method: "GET",
+    policy: {
+      requiredScopes: ["oauth.proxy"],
+      allowedPrincipalTypes: ["local"],
+    },
+  },
 ];
 
 const defaultIpcImpl = (
@@ -99,7 +122,7 @@ const validateEdgeTokenMock = mock(
     | { ok: true; claims: Record<string, string | number> }
     | { ok: false; reason: string } => ({
     ok: true,
-    claims: { sub: "test", scope_profile: "test" },
+    claims: { sub: "actor:asst_1:user_1", scope_profile: "actor_client_v1" },
   }),
 );
 
@@ -230,7 +253,7 @@ describe("tryIpcProxy", () => {
     validateEdgeTokenMock.mockReset();
     validateEdgeTokenMock.mockImplementation(() => ({
       ok: true,
-      claims: { sub: "test", scope_profile: "test" },
+      claims: { sub: "actor:asst_1:user_1", scope_profile: "actor_client_v1" },
     }));
   });
 
@@ -438,7 +461,7 @@ describe("tryIpcProxy", () => {
     }));
 
     const config = makeConfig({ runtimeProxyRequireAuth: true });
-    const req = makeRequest("/v1/health", {
+    const req = makeRequest("/v1/oauth/proxy/stripe_link/v1/accounts", {
       headers: {
         authorization: "Bearer valid",
         "x-vellum-subject": "local:self:oauth-proxy.attacker",
@@ -651,6 +674,143 @@ describe("policy enforcement", () => {
 
     const body = (await result!.json()) as { error: { message: string } };
     expect(body.error.message).toContain("Unable to determine principal type");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: single-route grants on the IPC fast path
+//
+// An oauth_proxy_v1 grant is printed for a user to export into a stock
+// third-party CLI's environment. Setting one request header engages this fast
+// path, and the daemon's IPC server runs no policy check behind it, so the
+// containment has to hold here.
+// ---------------------------------------------------------------------------
+
+/** Subject shapes that parse for each profile under test. */
+const SUB_BY_PROFILE: Record<ScopeProfile, string> = {
+  actor_client_v1: "actor:asst_1:user_1",
+  gateway_ingress_v1: "svc:gateway:self",
+  gateway_service_v1: "svc:gateway:self",
+  local_v1: "local:asst_1:conv_1",
+  oauth_proxy_v1: "local:asst_1:oauth-proxy.stripe_link",
+  speech_relay_v1: "svc:daemon:self",
+  ui_page_v1: "svc:gateway:self",
+};
+
+/**
+ * Which profiles may reach a route that names no scope. Exhaustive over
+ * ScopeProfile so a new profile has to be classified here rather than
+ * inheriting whichever answer the compiler happens to allow.
+ */
+const REACHES_UNSCOPED_ROUTES: Record<ScopeProfile, boolean> = {
+  actor_client_v1: true,
+  gateway_ingress_v1: true,
+  gateway_service_v1: true,
+  local_v1: true,
+  oauth_proxy_v1: false,
+  speech_relay_v1: false,
+  ui_page_v1: true,
+};
+
+function mockClaims(profile: ScopeProfile) {
+  validateEdgeTokenMock.mockImplementation(() => ({
+    ok: true,
+    claims: {
+      iss: "vellum-auth",
+      aud: "vellum-gateway",
+      sub: SUB_BY_PROFILE[profile],
+      scope_profile: profile,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      policy_epoch: 1,
+    },
+  }));
+}
+
+const AUTHED_CONFIG = () => makeConfig({ runtimeProxyRequireAuth: true });
+
+describe("single-route grants on the IPC fast path", () => {
+  beforeEach(() => {
+    ipcCallAssistantMock.mockReset();
+    ipcCallAssistantMock.mockImplementation(defaultIpcImpl);
+    validateEdgeTokenMock.mockReset();
+  });
+
+  test.each(Object.entries(REACHES_UNSCOPED_ROUTES))(
+    "%s on a null-policy route",
+    async (profile, allowed) => {
+      mockClaims(profile as ScopeProfile);
+      const req = makeRequest("/v1/health", {
+        headers: { authorization: "Bearer valid" },
+      });
+      const result = await tryIpcProxy(req, AUTHED_CONFIG());
+      expect(result!.status).toBe(allowed ? 200 : 403);
+    },
+  );
+
+  test.each(Object.entries(REACHES_UNSCOPED_ROUTES))(
+    "%s on a route whose policy names no scope",
+    async (profile, allowed) => {
+      mockClaims(profile as ScopeProfile);
+      const req = makeRequest("/v1/debug/ping", {
+        headers: { authorization: "Bearer valid" },
+      });
+      const result = await tryIpcProxy(req, AUTHED_CONFIG());
+      expect(result!.status).toBe(allowed ? 200 : 403);
+    },
+  );
+
+  test("a proxy grant reaches no route over IPC beyond the passthrough", async () => {
+    mockClaims("oauth_proxy_v1");
+    const req = makeRequest("/v1/health", {
+      headers: { authorization: "Bearer valid" },
+    });
+    const result = await tryIpcProxy(req, AUTHED_CONFIG());
+
+    expect(result!.status).toBe(403);
+    const body = (await result!.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("FORBIDDEN");
+    // Refused before the daemon is called: nothing downstream re-checks.
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("the passthrough proxy route still serves a proxy grant over IPC", async () => {
+    mockClaims("oauth_proxy_v1");
+    const req = makeRequest("/v1/oauth/proxy/stripe_link/v1/accounts", {
+      headers: { authorization: "Bearer valid" },
+    });
+    const result = await tryIpcProxy(req, AUTHED_CONFIG());
+
+    expect(result!.status).toBe(200);
+    const [opId] = ipcCallAssistantMock.mock.calls[0] as [string];
+    expect(opId).toBe("oauth_proxy_get");
+  });
+
+  test("the passthrough proxy route still falls back to HTTP for a binary reply", async () => {
+    mockClaims("oauth_proxy_v1");
+    ipcCallAssistantMock.mockImplementation((method: string) => {
+      if (method === "get_route_schema") return Promise.resolve(ROUTE_SCHEMA);
+      return Promise.reject(
+        new IpcHandlerError(
+          "Binary/streaming responses are not supported over the IPC transport; use HTTP",
+          421,
+          "BINARY_UNSUPPORTED_OVER_IPC",
+        ),
+      );
+    });
+
+    const req = makeRequest("/v1/oauth/proxy/stripe_link/v1/accounts", {
+      headers: { authorization: "Bearer valid" },
+    });
+    expect(await tryIpcProxy(req, AUTHED_CONFIG())).toBeNull();
+  });
+
+  test("a speech-relay token is refused on an unprotected route", async () => {
+    mockClaims("speech_relay_v1");
+    const req = makeRequest("/v1/health", {
+      headers: { authorization: "Bearer valid" },
+    });
+    const result = await tryIpcProxy(req, AUTHED_CONFIG());
+    expect(result!.status).toBe(403);
   });
 });
 

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -19,7 +19,7 @@ import {
   toDaemonSubject,
   validateEdgeToken,
 } from "../../auth/token-exchange.js";
-import type { TokenClaims } from "../../auth/types.js";
+import type { ScopeProfile, TokenClaims } from "../../auth/types.js";
 import type { GatewayConfig } from "../../config.js";
 import {
   IpcHandlerError,
@@ -298,18 +298,64 @@ export async function tryIpcProxy(
 // ---------------------------------------------------------------------------
 
 /**
+ * Profiles broad enough to reach a route that names no scope of its own.
+ * A profile outside this set is minted for a single route and handed to code
+ * outside this install's trust boundary, so it reaches only a route whose
+ * policy names the scope it carries. New profiles land outside the set and
+ * therefore fail closed.
+ *
+ * Mirrors `UNSCOPED_ROUTE_PROFILES` in
+ * `assistant/src/runtime/auth/route-policy.ts`. The daemon's IPC server runs
+ * no policy check of its own, so this fast path is the only place the rule
+ * applies to IPC-served requests.
+ */
+const UNSCOPED_ROUTE_PROFILES: ReadonlySet<ScopeProfile> =
+  new Set<ScopeProfile>([
+    "actor_client_v1",
+    "gateway_ingress_v1",
+    "gateway_service_v1",
+    "local_v1",
+    "ui_page_v1",
+  ]);
+
+/**
  * Enforce the route's scope/principal policy against the caller's token.
  * Returns a 403 Response when denied, null when allowed.
+ *
+ * A route naming no scope (`policy` null, or empty `requiredScopes`) is
+ * unprotected (e.g. health, debug) for the broad profiles in
+ * {@link UNSCOPED_ROUTE_PROFILES}, and closed to every other profile.
  */
 function enforceRoutePolicy(
   policy: RouteSchemaPolicy | null,
   claims: TokenClaims | undefined,
   path: string,
 ): Response | null {
-  if (!policy) return null;
-
   // When auth is disabled (dev mode), no claims → skip enforcement.
   if (!claims) return null;
+
+  // A single-route grant reaches only a route that names its scope, so an
+  // unprotected one refuses it rather than admitting any valid token.
+  if (
+    (policy?.requiredScopes.length ?? 0) === 0 &&
+    !UNSCOPED_ROUTE_PROFILES.has(claims.scope_profile)
+  ) {
+    log.warn(
+      { path, scopeProfile: claims.scope_profile },
+      "IPC proxy policy denied: grant is scoped to a single route",
+    );
+    return Response.json(
+      {
+        error: {
+          code: "FORBIDDEN",
+          message: "This grant is not permitted for this endpoint",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  if (!policy) return null;
 
   // Check principal type.
   if (policy.allowedPrincipalTypes.length > 0) {

--- a/gateway/src/http/routes/twilio-media-websocket.ts
+++ b/gateway/src/http/routes/twilio-media-websocket.ts
@@ -5,11 +5,22 @@ import {
   validateEdgeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
+import type { ScopeProfile } from "../../auth/types.js";
 import type { GatewayConfig } from "../../config.js";
 import type { ConfigFileCache } from "../../config-file-cache.js";
 import { getLogger } from "../../logger.js";
 
 const log = getLogger("twilio-media-ws");
+
+/**
+ * Identity of the relay token `mintRelayToken` embeds in the `<Stream>` TwiML
+ * Twilio dials back with, and the only credential this upgrade accepts. The
+ * sibling upgrades on `runtime-audio-stream.ts` and `live-voice-websocket.ts`
+ * require an actor principal; Twilio presents the gateway service principal
+ * instead, so that is the equivalent gate here.
+ */
+const RELAY_TOKEN_SUB = "svc:gateway:self";
+const RELAY_TOKEN_PROFILE: ScopeProfile = "gateway_service_v1";
 
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
@@ -124,7 +135,9 @@ export function createTwilioMediaWebsocketHandler(
  *   3. `token` query parameter (legacy Twilio media streams fallback)
  *
  * Fail-closed: rejects all unauthenticated requests unless the deliver auth
- * bypass flag is set (local-dev only escape hatch).
+ * bypass flag is set (local-dev only escape hatch). A valid edge token is not
+ * enough on its own; it must carry the relay-token identity (see
+ * {@link RELAY_TOKEN_SUB}).
  */
 function checkMediaStreamAuth(
   req: Request,
@@ -156,6 +169,17 @@ function checkMediaStreamAuth(
     log.warn(
       { reason: result.reason },
       "Media stream WS: authentication failed",
+    );
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  if (
+    result.claims.sub !== RELAY_TOKEN_SUB ||
+    result.claims.scope_profile !== RELAY_TOKEN_PROFILE
+  ) {
+    log.warn(
+      { sub: result.claims.sub, scopeProfile: result.claims.scope_profile },
+      "Media stream WS: token is not a relay token",
     );
     return new Response("Unauthorized", { status: 401 });
   }


### PR DESCRIPTION
## Summary

`enforceRoutePolicy` in the gateway's IPC fast path opened with `if (!policy) return null`, the exact short-circuit the daemon fix in #42432 removed. The daemon's IPC server calls no policy check of its own (only the HTTP router calls `enforcePolicy`), and the catch-all runtime-proxy path never reaches the edge-auth middleware that #42432 hardened, so an OAuth passthrough grant plus one `X-Vellum-Proxy-Server: ipc` request header reached every unprotected route, mutating ones included.

`enforceRoutePolicy` now mirrors `enforcePolicy`: a route naming no scope (null policy, or empty `requiredScopes`) is unprotected only for the broad profiles in a gateway-local `UNSCOPED_ROUTE_PROFILES`, and refuses every other profile with a 403 before the daemon is called. The dev-mode bypass (`!claims`) moves ahead of the new gate so an auth-disabled install is unaffected. The passthrough route's own policy names `oauth.proxy`, so a proxy grant still reaches it over IPC, and its binary retry-over-HTTP fallback still returns null.

The Twilio media-stream WebSocket upgrade validated an edge token and checked nothing else, so any valid edge token, a proxy grant included, satisfied it given a `callSessionId`. Its siblings `runtime-audio-stream.ts` and `live-voice-websocket.ts` require an actor principal, which Twilio never presents: the credential Twilio dials back with is the gateway's own relay token (`mintRelayToken`, `sub=svc:gateway:self`, `scope_profile=gateway_service_v1`), the only minter for that URL. The upgrade now requires exactly that identity, mirroring how `speech-relay-websocket.ts` pins the daemon service sub.

Closes the gateway IPC mirror of the containment added in #42432: enforceRoutePolicy short-circuited on a null policy, and the daemon IPC server never calls enforcePolicy, so a proxy grant plus one request header reached every unprotected route.