### PR TITLE
fix(companion): annotating no longer swallows scroll for the shared app (JARVIS-1773)

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -563,6 +563,11 @@ final class MacHelper: @unchecked Sendable {
     /// Watch every scroll on the desktop for the moment it stops, or stop
     /// watching. Idempotent: a second enable keeps the monitor it has, and
     /// a disable with none up is nothing to take down.
+    ///
+    /// The watch is asked for by a scroll already under way: the caller saw
+    /// the first wheel event itself, and that one is over before the monitor
+    /// is up. A single tick is a whole scroll, so the end is scheduled on
+    /// enable and only pushed out by whatever the monitor sees after.
     private func setScrollWatch(enable: Bool) throws -> [String: Any] {
         if !enable {
             removeScrollMonitor()
@@ -571,20 +576,21 @@ final class MacHelper: @unchecked Sendable {
         if scrollMonitor == nil {
             guard
                 let monitor = NSEvent.addGlobalMonitorForEvents(matching: .scrollWheel, handler: { [weak self] _ in
-                    self?.handleScroll()
+                    self?.pushScrollEnd()
                 })
             else {
                 throw HelperError.eventMonitor("NSEvent.addGlobalMonitorForEvents(.scrollWheel)")
             }
             scrollMonitor = monitor
         }
+        pushScrollEnd()
         return ["enabled": true]
     }
 
-    /// A scroll-wheel event went by. Where it went, and how far, is never
-    /// read; only that the scroll is not over yet. The report of its end is
-    /// pushed out by the gap again.
-    private func handleScroll() {
+    /// The scroll is not over yet: the watch just went up for one, or a
+    /// wheel event went by. Where it went, and how far, is never read. The
+    /// report of its end is pushed out by the gap again.
+    private func pushScrollEnd() {
         scrollEndReport?.cancel()
         let report = DispatchWorkItem { [weak self] in
             guard let self, self.scrollMonitor != nil else { return }

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -78,6 +78,19 @@ final class MacHelper: @unchecked Sendable {
     /// key.
     private var activityWatch = false
     private var lastActivityReport = Date.distantPast
+    /// The global scroll-wheel monitor, up only while main is waiting to hear
+    /// a scroll end, and the debounce that decides when one has. A scroll is
+    /// many events, from a trackpad's phases through its momentum to a mouse
+    /// wheel's plain ticks, and the one thing they share is that they stop:
+    /// the end is a quiet gap after the last of them.
+    ///
+    /// An `NSEvent` monitor rather than a second event tap because it reads
+    /// mouse and scroll events without Input Monitoring, which only the
+    /// keyboard side of a global monitor needs, so the frame's scroll
+    /// stepping does not depend on the grant the voice key needs.
+    private var scrollMonitor: Any?
+    private var scrollEndReport: DispatchWorkItem?
+    private static let scrollEndGap: TimeInterval = 0.12
     private let outputLock = NSLock()
     private var dictationSession: DictationPartialsSession?
     // Bumped on every dictation.setPartials so a pending speech-authorization
@@ -231,6 +244,23 @@ final class MacHelper: @unchecked Sendable {
                 )
             }
             return try self.setActivityWatch(enable: enable)
+        }
+        // Whether a scroll is still going anywhere on the desktop, reported
+        // as the moment it stops and nothing else, for a window that stepped
+        // aside for one and has to know when to take the mouse back.
+        router.register("input.setScrollWatch") { [weak self] params in
+            guard let self else {
+                throw JsonRpcDispatchError.internalError("Helper is shutting down")
+            }
+            guard
+                let object = params as? [String: Any],
+                let enable = object["enable"] as? Bool
+            else {
+                throw JsonRpcDispatchError.invalidParams(
+                    "input.setScrollWatch requires enable"
+                )
+            }
+            return try self.setScrollWatch(enable: enable)
         }
         // Where a paste would land, asked when there are words to paste rather
         // than when a hold opens. No hold guard: the hold is over by then, and
@@ -528,6 +558,50 @@ final class MacHelper: @unchecked Sendable {
             releaseMonitorIfUnused()
         }
         return ["enabled": enable]
+    }
+
+    /// Watch every scroll on the desktop for the moment it stops, or stop
+    /// watching. Idempotent: a second enable keeps the monitor it has, and
+    /// a disable with none up is nothing to take down.
+    private func setScrollWatch(enable: Bool) throws -> [String: Any] {
+        if !enable {
+            removeScrollMonitor()
+            return ["enabled": false]
+        }
+        if scrollMonitor == nil {
+            guard
+                let monitor = NSEvent.addGlobalMonitorForEvents(matching: .scrollWheel, handler: { [weak self] _ in
+                    self?.handleScroll()
+                })
+            else {
+                throw HelperError.eventMonitor("NSEvent.addGlobalMonitorForEvents(.scrollWheel)")
+            }
+            scrollMonitor = monitor
+        }
+        return ["enabled": true]
+    }
+
+    /// A scroll-wheel event went by. Where it went, and how far, is never
+    /// read; only that the scroll is not over yet. The report of its end is
+    /// pushed out by the gap again.
+    private func handleScroll() {
+        scrollEndReport?.cancel()
+        let report = DispatchWorkItem { [weak self] in
+            guard let self, self.scrollMonitor != nil else { return }
+            self.scrollEndReport = nil
+            self.writeNotification(method: "input.scrollEnded")
+        }
+        scrollEndReport = report
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.scrollEndGap, execute: report)
+    }
+
+    private func removeScrollMonitor() {
+        scrollEndReport?.cancel()
+        scrollEndReport = nil
+        if let scrollMonitor {
+            NSEvent.removeMonitor(scrollMonitor)
+        }
+        scrollMonitor = nil
     }
 
     private func readCommands() {
@@ -1472,6 +1546,7 @@ final class MacHelper: @unchecked Sendable {
         chordKeys = ChordKeySet()
         activityWatch = false
         releaseMonitorIfUnused()
+        removeScrollMonitor()
     }
 
     private func writeNotification(method: String, params: Any? = nil) {
@@ -1499,6 +1574,7 @@ final class MacHelper: @unchecked Sendable {
 private enum HelperError: LocalizedError {
     case carbon(String, OSStatus)
     case eventTap(String)
+    case eventMonitor(String)
 
     var errorDescription: String? {
         switch self {
@@ -1506,6 +1582,8 @@ private enum HelperError: LocalizedError {
             return "\(operation) failed with status \(status)"
         case let .eventTap(operation):
             return "\(operation) failed; Input Monitoring may not be granted"
+        case let .eventMonitor(operation):
+            return "\(operation) returned no monitor"
         }
     }
 }

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -378,7 +378,15 @@ type GlowWindow = {
   isVisible: () => boolean;
   /** Whether presses go through it, which is the whole of drawing mode. */
   clickThrough: boolean;
-  setIgnoreMouseEvents: (ignore: boolean) => void;
+  /**
+   * Whether mouse-move still reaches the page while presses go through,
+   * which is how the frame knows to take the mouse back after a scroll.
+   */
+  forwarded: boolean;
+  setIgnoreMouseEvents: (
+    ignore: boolean,
+    options?: { forward?: boolean },
+  ) => void;
 };
 let glow: GlowWindow | null = null;
 const glowPushes: CompanionSurfaceState[] = [];
@@ -424,8 +432,10 @@ const openGlow = (options: {
     isVisible: () => window.visible,
     // How main opens it, and where it goes back to whenever drawing is off.
     clickThrough: true,
-    setIgnoreMouseEvents: (ignore) => {
+    forwarded: false,
+    setIgnoreMouseEvents: (ignore, options) => {
       window.clickThrough = ignore;
+      window.forwarded = ignore && options?.forward === true;
     },
   };
   glow = window;
@@ -3176,6 +3186,74 @@ describe("companion window: drawing on what is shared", () => {
     send("vellum:companion:toggleAnnotating");
     expect(state().annotating).toBe(false);
     expect(glow?.clickThrough).toBe(true);
+  });
+
+  /**
+   * A frame taking presses takes the wheel with them, and it cannot forward
+   * a wheel event it has taken. So on the first one the renderer sees, the
+   * frame steps aside for the rest of the scroll, with mouse-move forwarded
+   * so the renderer can see the pointer move and ask for the mouse back. The
+   * mode stays on the whole time: the user did not press Draw again.
+   */
+  test("a scroll on the frame lets the rest of it through to the app", () => {
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setFrameScrolling", true);
+    expect(glow?.clickThrough).toBe(true);
+    expect(glow?.forwarded).toBe(true);
+    expect(state().annotating).toBe(true);
+  });
+
+  test("the pointer moving after a scroll takes the mouse back", () => {
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setFrameScrolling", true);
+    send("vellum:companion:setFrameScrolling", false);
+    expect(glow?.clickThrough).toBe(false);
+    expect(state().annotating).toBe(true);
+  });
+
+  /**
+   * Off the mode the frame has no mouse to hand back, and a scroll remembered
+   * against the next press would open the mode click-through.
+   */
+  test("a scroll with the mode off changes nothing, now or later", () => {
+    shareDisplay();
+    send("vellum:companion:setFrameScrolling", true);
+    expect(glow?.clickThrough).toBe(true);
+    expect(glow?.forwarded).toBe(false);
+    send("vellum:companion:setAnnotating", true);
+    expect(glow?.clickThrough).toBe(false);
+  });
+
+  /** The mode going off leaves nothing for the scroll to have stepped aside from. */
+  test("the mode going off forgets the scroll it stepped aside for", () => {
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setFrameScrolling", true);
+    send("vellum:companion:setAnnotating", false);
+    expect(glow?.clickThrough).toBe(true);
+    expect(glow?.forwarded).toBe(false);
+    send("vellum:companion:setAnnotating", true);
+    expect(glow?.clickThrough).toBe(false);
+  });
+
+  /**
+   * The mode outlives the frame's window, which is replaced when the share
+   * ends and starts again. The new window's renderer has seen no scroll, so
+   * one the old window stepped aside for would leave it click-through with
+   * nothing to ask for the mouse back.
+   */
+  test("a frame opened afresh takes the mouse whatever the last one did", () => {
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setFrameScrolling", true);
+    send("vellum:companion:setContext", context());
+    expect(glow).toBeNull();
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    expect(glow?.clickThrough).toBe(false);
+    expect(glow?.forwarded).toBe(false);
   });
 
   /**

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -537,6 +537,12 @@ const {
   installCompanionWindow,
 } = await import("./companion-window");
 
+const {
+  __resetFrameScrollWatchForTesting,
+  frameScrollEnded,
+  provideFrameScrollWatch,
+} = await import("./frame-scroll-watch");
+
 installCompanionWindow();
 
 /**
@@ -544,6 +550,7 @@ installCompanionWindow();
  * size leaves it there. Put both axes back and forget the window's position.
  */
 beforeEach(() => {
+  __resetFrameScrollWatchForTesting();
   sizes.avatar = "small";
   sizes.options = "small";
   setCompanionSurfaceSize("avatar", "small");
@@ -3211,6 +3218,63 @@ describe("companion window: drawing on what is shared", () => {
     send("vellum:companion:setFrameScrolling", false);
     expect(glow?.clickThrough).toBe(false);
     expect(state().annotating).toBe(true);
+  });
+
+  /**
+   * A hand that scrolls and then presses without moving the pointer never
+   * sends the renderer a move to ask with, and the press would land on the
+   * app. The desktop knows when the scroll stopped, so main asks the helper
+   * to watch for that while the frame is stepped aside, and takes the mouse
+   * back the moment it hears it.
+   */
+  test("the scroll ending takes the mouse back without a move", () => {
+    const watches: boolean[] = [];
+    provideFrameScrollWatch((enable) => watches.push(enable));
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setFrameScrolling", true);
+    expect(watches).toEqual([true]);
+    frameScrollEnded();
+    expect(glow?.clickThrough).toBe(false);
+    expect(glow?.forwarded).toBe(false);
+    expect(state().annotating).toBe(true);
+    expect(watches).toEqual([true, false]);
+  });
+
+  /** The watch is up only while the frame is stepped aside, whichever way that ends. */
+  test("every way out of a scroll takes the watch down with it", () => {
+    const watches: boolean[] = [];
+    provideFrameScrollWatch((enable) => watches.push(enable));
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+
+    send("vellum:companion:setFrameScrolling", true);
+    send("vellum:companion:setFrameScrolling", false);
+    expect(watches).toEqual([true, false]);
+
+    send("vellum:companion:setFrameScrolling", true);
+    send("vellum:companion:setAnnotating", false);
+    expect(watches).toEqual([true, false, true, false]);
+
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setFrameScrolling", true);
+    send("vellum:companion:setContext", context());
+    expect(watches).toEqual([true, false, true, false, true, false]);
+
+    // A scroll that ended after the frame stopped waiting changes nothing.
+    frameScrollEnded();
+    expect(watches).toHaveLength(6);
+  });
+
+  /** Off the mode there is no watch to put up, and no scroll end to act on. */
+  test("a scroll ending with the mode off is nothing", () => {
+    const watches: boolean[] = [];
+    provideFrameScrollWatch((enable) => watches.push(enable));
+    shareDisplay();
+    send("vellum:companion:setFrameScrolling", true);
+    frameScrollEnded();
+    expect(watches).toEqual([]);
+    expect(glow?.clickThrough).toBe(true);
   });
 
   /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1094,9 +1094,49 @@ let annotating = false;
 const framesTheShare = (): boolean =>
   context.watching !== true && context.screenShare !== undefined;
 
-/** Give the frame the mouse, or give it back to the desktop. */
+/**
+ * Whether the frame has handed the mouse back to the desktop for a scroll,
+ * while the mode stays on.
+ *
+ * A frame taking presses takes the wheel with them, and a transparent window
+ * the size of the shared surface that eats every wheel event is a shared
+ * app the user cannot scroll or move through. Nothing on the desktop forwards
+ * a wheel event through a window that is taking the mouse, so the frame
+ * steps aside instead: the renderer reports the first wheel event it
+ * receives, the frame goes click-through with mouse-move forwarded so the
+ * rest of that scroll reaches the app underneath, and the renderer takes the
+ * mouse back on the first move it is forwarded. A hand that has moved the
+ * pointer is pointing at something again; a hand that is scrolling does not
+ * move it.
+ *
+ * Main's for the reason {@link annotating} is: it decides what a window main
+ * opened does with the mouse.
+ */
+let frameScrolling = false;
+
+/**
+ * Give the frame the mouse, or give it back to the desktop.
+ *
+ * Forwarded mouse-move only while the frame has stepped aside for a scroll:
+ * that is the one state in which the renderer has to see the pointer without
+ * holding it, so it can ask for the mouse back. Off the mode, nothing is
+ * forwarded, since there is nothing on the frame to point at and a forwarded
+ * move over a display-sized window is a move on every pixel of the screen.
+ */
 const applyFrameMouse = (): void => {
-  getFloatingWindow(WATCH_FRAME_KIND)?.setIgnoreMouseEvents(!annotating);
+  const frame = getFloatingWindow(WATCH_FRAME_KIND);
+  if (frame === null) {
+    return;
+  }
+  if (!annotating) {
+    frame.setIgnoreMouseEvents(true);
+    return;
+  }
+  if (frameScrolling) {
+    frame.setIgnoreMouseEvents(true, { forward: true });
+    return;
+  }
+  frame.setIgnoreMouseEvents(false);
 };
 
 /**
@@ -1106,6 +1146,11 @@ const applyFrameMouse = (): void => {
  * Idempotent, and run after every change to the context as well as on the
  * press: a mode left on over a share that ended is a transparent window
  * eating every click on that display.
+ *
+ * Either edge forgets a scroll the frame stepped aside for. The mode going
+ * on is the user asking for the mouse, whatever the pointer was doing before
+ * the press; the mode going off leaves nothing for the scroll to have stepped
+ * aside from.
  */
 const setAnnotating = (next: boolean): void => {
   const resolved = next && framesTheShare();
@@ -1113,8 +1158,25 @@ const setAnnotating = (next: boolean): void => {
     return;
   }
   annotating = resolved;
+  frameScrolling = false;
   applyFrameMouse();
   pushState();
+};
+
+/**
+ * Step aside for a scroll on the frame, or take the mouse back after one.
+ *
+ * Refused off the mode rather than remembered: a frame that is not taking
+ * presses has no mouse to hand back, and a scroll recorded against the next
+ * time the mode goes on would open it click-through.
+ */
+const setFrameScrolling = (next: boolean): void => {
+  const resolved = next && annotating;
+  if (resolved === frameScrolling) {
+    return;
+  }
+  frameScrolling = resolved;
+  applyFrameMouse();
 };
 
 /**
@@ -1513,7 +1575,10 @@ const placeWatchFrame = (bounds: Rectangle): void => {
   win.setAlwaysOnTop(true, "floating", -1);
   // A frame opened while the mode is already on is one the user is expecting
   // to draw on: the mode outlives the window, which is replaced whenever the
-  // share moves to another target.
+  // share moves to another target. A scroll the old window stepped aside for
+  // does not: this window's renderer has seen no scroll and would never ask
+  // for a mouse it does not know it gave up.
+  frameScrolling = false;
   applyFrameMouse();
 };
 
@@ -2132,6 +2197,20 @@ export const installCompanionWindow = (): void => {
    */
   on("vellum:companion:toggleAnnotating", z.tuple([]), () => {
     setAnnotating(!annotating);
+  });
+
+  /**
+   * A scroll on the frame, or the pointer moving after one, from the frame's
+   * own window.
+   *
+   * The frame is what decides where a wheel event lands, and it cannot
+   * forward one it has taken. What it can do is stop taking them: on the
+   * first the renderer sees, the frame steps aside so the rest of the scroll
+   * reaches the app underneath, and on the first forwarded move it takes the
+   * mouse back. See {@link frameScrolling}.
+   */
+  on("vellum:companion:setFrameScrolling", z.tuple([z.boolean()]), ([next]) => {
+    setFrameScrolling(next);
   });
 
   /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -90,6 +90,7 @@ import {
   windowBoundsFor,
 } from "./companion-capture-sources";
 import { setPointerOnCompanion } from "./companion-pointer";
+import { unwatchFrameScroll, watchFrameScroll } from "./frame-scroll-watch";
 import { handle, on } from "./ipc";
 import log from "./logger";
 import {
@@ -1104,10 +1105,13 @@ const framesTheShare = (): boolean =>
  * a wheel event through a window that is taking the mouse, so the frame
  * steps aside instead: the renderer reports the first wheel event it
  * receives, the frame goes click-through with mouse-move forwarded so the
- * rest of that scroll reaches the app underneath, and the renderer takes the
- * mouse back on the first move it is forwarded. A hand that has moved the
- * pointer is pointing at something again; a hand that is scrolling does not
- * move it.
+ * rest of that scroll reaches the app underneath, and the frame takes the
+ * mouse back when the scroll ends. Two things say it has. The renderer
+ * reports the first move it is forwarded, since a hand that has moved the
+ * pointer is pointing at something again. The mac helper reports the scroll
+ * stopping, since a hand that scrolls and then presses without moving the
+ * pointer is one the renderer would never hear from, and the press would
+ * land on the app.
  *
  * Main's for the reason {@link annotating} is: it decides what a window main
  * opened does with the mouse.
@@ -1159,6 +1163,7 @@ const setAnnotating = (next: boolean): void => {
   }
   annotating = resolved;
   frameScrolling = false;
+  unwatchFrameScroll();
   applyFrameMouse();
   pushState();
 };
@@ -1176,6 +1181,11 @@ const setFrameScrolling = (next: boolean): void => {
     return;
   }
   frameScrolling = resolved;
+  if (resolved) {
+    watchFrameScroll(() => setFrameScrolling(false));
+  } else {
+    unwatchFrameScroll();
+  }
   applyFrameMouse();
 };
 
@@ -1579,6 +1589,7 @@ const placeWatchFrame = (bounds: Rectangle): void => {
   // does not: this window's renderer has seen no scroll and would never ask
   // for a mouse it does not know it gave up.
   frameScrolling = false;
+  unwatchFrameScroll();
   applyFrameMouse();
 };
 

--- a/clients/macos/src/main/frame-scroll-watch.ts
+++ b/clients/macos/src/main/frame-scroll-watch.ts
@@ -1,0 +1,67 @@
+/**
+ * The moment a scroll on the desktop stops, for the watch frame that stepped
+ * aside for it.
+ *
+ * The frame goes click-through for a scroll so the shared app can take it,
+ * and in that state it is told about mouse-move and nothing else: a press
+ * that follows the scroll without a move lands on the app. The desktop has
+ * the signal the frame is missing, and the mac helper reads it: this module
+ * is where the two meet.
+ *
+ * A module of its own for the reason `companion-pointer.ts` is: the companion
+ * window owns the frame, the helper bridge owns the input stream, and neither
+ * imports the other. The window says whether it is waiting and what to do
+ * when the scroll ends; the bridge says how to ask the helper, and reports
+ * the end when the helper does.
+ */
+
+type SendScrollWatch = (enable: boolean) => void;
+
+let send: SendScrollWatch | null = null;
+let onEnded: (() => void) | null = null;
+
+/**
+ * Start waiting for the current scroll to end. One waiter at a time: a
+ * second call replaces the first's listener, and asks the helper again
+ * only if nothing was being watched.
+ */
+export const watchFrameScroll = (listener: () => void): void => {
+  const wasWatching = onEnded !== null;
+  onEnded = listener;
+  if (!wasWatching) {
+    send?.(true);
+  }
+};
+
+/** Stop waiting, and take the helper's watch down with it. */
+export const unwatchFrameScroll = (): void => {
+  if (onEnded === null) {
+    return;
+  }
+  onEnded = null;
+  send?.(false);
+};
+
+/** Whether a waiter is up, so a helper that restarts is put back to watching. */
+export const isFrameScrollWatched = (): boolean => onEnded !== null;
+
+/**
+ * Register the way to ask the helper. A waiter that arrived first gets its
+ * watch sent now.
+ */
+export const provideFrameScrollWatch = (next: SendScrollWatch): void => {
+  send = next;
+  if (onEnded !== null) {
+    next(true);
+  }
+};
+
+/** The helper saw the scroll stop. */
+export const frameScrollEnded = (): void => {
+  onEnded?.();
+};
+
+export const __resetFrameScrollWatchForTesting = (): void => {
+  send = null;
+  onEnded = null;
+};

--- a/clients/macos/src/main/hotkey-helper.test.ts
+++ b/clients/macos/src/main/hotkey-helper.test.ts
@@ -121,6 +121,11 @@ Object.defineProperty(process, "resourcesPath", {
 });
 
 const { setPointerOnCompanion } = await import("./companion-pointer");
+const {
+  __resetFrameScrollWatchForTesting,
+  unwatchFrameScroll,
+  watchFrameScroll,
+} = await import("./frame-scroll-watch");
 
 const {
   __resetForTesting,
@@ -242,6 +247,7 @@ beforeEach(() => {
 
 afterEach(() => {
   __resetForTesting();
+  __resetFrameScrollWatchForTesting();
 });
 
 describe("getMacHelperPath", () => {
@@ -849,6 +855,43 @@ describe("installHotkeyHelper", () => {
     const writes = lastChild?.stdin.writes.join("") ?? "";
     expect(writes).toContain('"method":"input.setActivityWatch"');
     expect(writes).toContain('"enable":true');
+  });
+
+  /**
+   * The watch frame asks for the scroll watch through `frame-scroll-watch.ts`
+   * rather than through the renderer: it is main's own window, and the end
+   * of the scroll is main's to act on.
+   */
+  test("asks the helper to watch for the scroll ending and reports it", async () => {
+    __setSupervisorOptionsForTesting({ initialBackoffMs: 1, maxBackoffMs: 1 });
+    installHotkeyHelper();
+    expect(await registerHold()).toEqual({ ok: true, enabled: true });
+
+    let ended = 0;
+    watchFrameScroll(() => {
+      ended += 1;
+    });
+    await wait(0);
+    let writes = lastChild?.stdin.writes.join("") ?? "";
+    expect(writes).toContain('"method":"input.setScrollWatch"');
+    expect(writes).toContain('"enable":true');
+
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from('{"jsonrpc":"2.0","method":"input.scrollEnded"}\n'),
+    );
+    expect(ended).toBe(1);
+
+    // The watch goes down with the helper and comes back with it.
+    lastChild?.emit("close", 1, null);
+    await wait(10);
+    writes = lastChild?.stdin.writes.join("") ?? "";
+    expect(writes).toContain('"method":"input.setScrollWatch"');
+
+    unwatchFrameScroll();
+    await wait(0);
+    writes = lastChild?.stdin.writes.join("") ?? "";
+    expect(writes).toContain('"enable":false');
   });
 
   test("forwards input activity to the window that holds the key", async () => {

--- a/clients/macos/src/main/hotkey-helper.ts
+++ b/clients/macos/src/main/hotkey-helper.ts
@@ -43,6 +43,11 @@ import type {
 } from "@vellumai/ipc-contract";
 
 import { isPointerOnCompanion } from "./companion-pointer";
+import {
+  frameScrollEnded,
+  isFrameScrollWatched,
+  provideFrameScrollWatch,
+} from "./frame-scroll-watch";
 import { handle } from "./ipc";
 import log from "./logger";
 import {
@@ -428,6 +433,25 @@ const sendInputActivityWatch = async (enable: boolean): Promise<boolean> => {
   } catch (err) {
     log.warn(
       `[mac-helper] input activity watch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+};
+
+/**
+ * Ask the helper to report the end of the scroll the watch frame stepped
+ * aside for. Wanted-or-not lives in `frame-scroll-watch.ts`, where the frame
+ * put it, so a helper that comes back from a crash is put back to watching
+ * the same way the activity watch is.
+ */
+const sendScrollWatch = async (enable: boolean): Promise<boolean> => {
+  try {
+    const result = await client.call("input.setScrollWatch", { enable });
+    const parsed = HOTKEY_RESULT_SCHEMA.safeParse(result);
+    return parsed.success && parsed.data.enabled === enable;
+  } catch (err) {
+    log.warn(
+      `[mac-helper] scroll watch failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return false;
   }
@@ -870,6 +894,9 @@ const handleHelperState = (state: MacHelperState): void => {
     if (desiredInputActivityWatch) {
       void sendInputActivityWatch(true);
     }
+    if (isFrameScrollWatched()) {
+      void sendScrollWatch(true);
+    }
     return;
   }
 
@@ -902,6 +929,7 @@ const restartHelper = (): HelperRestartResult => {
 let installed = false;
 let unsubscribeHotkeyEvents: (() => void) | null = null;
 let unsubscribeInputActivity: (() => void) | null = null;
+let unsubscribeScrollEnded: (() => void) | null = null;
 let unsubscribeHelperState: (() => void) | null = null;
 let unsubscribeDictationPartials: (() => void) | null = null;
 let unsubscribeDictationFinalized: (() => void) | null = null;
@@ -926,6 +954,16 @@ export const installHotkeyHelper = (): void => {
       sendInputActivityToOwner();
     },
   );
+  unsubscribeScrollEnded = client.onNotification(
+    "input.scrollEnded",
+    z.unknown(),
+    () => {
+      frameScrollEnded();
+    },
+  );
+  provideFrameScrollWatch((enable) => {
+    void sendScrollWatch(enable);
+  });
   unsubscribeDictationPartials = client.onNotification(
     "dictation.partial",
     DICTATION_PARTIAL_SCHEMA,
@@ -1085,6 +1123,8 @@ export const __resetForTesting = (): void => {
   unsubscribeHotkeyEvents = null;
   unsubscribeInputActivity?.();
   unsubscribeInputActivity = null;
+  unsubscribeScrollEnded?.();
+  unsubscribeScrollEnded = null;
   unsubscribeHelperState?.();
   unsubscribeHelperState = null;
   unsubscribeDictationPartials?.();

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -586,6 +586,9 @@ const bridge: VellumBridge = {
     ): void => {
       ipcRenderer.send("vellum:companion:annotateShare", phase, strokes, ink);
     },
+    setFrameScrolling: (scrolling: boolean): void => {
+      ipcRenderer.send("vellum:companion:setFrameScrolling", scrolling);
+    },
     sharedFrame: (target: WatchCaptureTarget): void => {
       ipcRenderer.send("vellum:companion:sharedFrame", target);
     },

--- a/clients/web/src/components/companion-share-annotation.test.tsx
+++ b/clients/web/src/components/companion-share-annotation.test.tsx
@@ -15,12 +15,18 @@ const sent: {
   strokes: readonly CompanionAnnotationStroke[];
 }[] = [];
 
+/** What the layer told main about the frame stepping aside for a scroll. */
+const scrolled: boolean[] = [];
+
 mock.module("@/runtime/companion-surface", () => ({
   annotateCompanionShare: (
     phase: string,
     strokes: readonly CompanionAnnotationStroke[],
   ) => {
     sent.push({ phase, strokes });
+  },
+  setCompanionFrameScrolling: (scrolling: boolean) => {
+    scrolled.push(scrolling);
   },
 }));
 
@@ -42,6 +48,7 @@ const INK = "#a78bfa";
 
 beforeEach(() => {
   sent.length = 0;
+  scrolled.length = 0;
   // The window is what the shell sizes to the shared surface, and what the
   // marks are measured against.
   Object.defineProperty(window, "innerWidth", { value: SIDE, writable: true });
@@ -79,6 +86,73 @@ const move = (layer: Element, x: number, y: number): void => {
 const up = (layer: Element, x: number, y: number): void => {
   fireEvent.pointerUp(layer, { pointerId: 1, clientX: x, clientY: y });
 };
+const wheel = (layer: Element): void => {
+  fireEvent.wheel(layer, { deltaY: 40 });
+};
+
+/**
+ * Scrolling the app under the frame. The layer takes the wheel along with the
+ * presses and cannot hand it on, so what it does is tell main to step aside
+ * for the rest of the scroll, and to take the mouse back once the pointer
+ * moves. Each edge is said once, however many events make it up.
+ */
+describe("scrolling the app under the frame", () => {
+  test("the first wheel event asks main to step aside", () => {
+    const { container } = render(<CompanionShareAnnotation ink={INK} />);
+    const layer = layerOf(container);
+    wheel(layer);
+    wheel(layer);
+    wheel(layer);
+    expect(scrolled).toEqual([true]);
+  });
+
+  test("the pointer moving afterwards takes the mouse back", () => {
+    const { container } = render(<CompanionShareAnnotation ink={INK} />);
+    const layer = layerOf(container);
+    wheel(layer);
+    move(layer, 200, 200);
+    move(layer, 300, 300);
+    expect(scrolled).toEqual([true, false]);
+    // A move with no stroke in flight draws nothing.
+    expect(sent).toHaveLength(0);
+  });
+
+  test("a press arriving first takes the mouse back as well", () => {
+    const { container } = render(<CompanionShareAnnotation ink={INK} />);
+    const layer = layerOf(container);
+    wheel(layer);
+    down(layer, 200, 200);
+    up(layer, 200, 200);
+    expect(scrolled).toEqual([true, false]);
+    expect(sent.filter((one) => one.phase === "released")).toHaveLength(1);
+  });
+
+  /**
+   * The hand is down and captured. A frame that let go of the mouse now would
+   * lose the release that sends the mark and lifts the hold on the session's
+   * frames.
+   */
+  test("a wheel event mid-stroke keeps the hand", () => {
+    const { container } = render(<CompanionShareAnnotation ink={INK} />);
+    const layer = layerOf(container);
+    down(layer, 100, 100);
+    wheel(layer);
+    move(layer, 500, 500);
+    up(layer, 500, 500);
+    expect(scrolled).toHaveLength(0);
+    expect(sent.at(-1)?.phase).toBe("released");
+    expect(sent.at(-1)?.strokes[0]?.points).toHaveLength(2);
+  });
+
+  test("says nothing about the mouse when nothing was scrolled", () => {
+    const { container } = render(<CompanionShareAnnotation ink={INK} />);
+    const layer = layerOf(container);
+    move(layer, 200, 200);
+    down(layer, 200, 200);
+    up(layer, 200, 200);
+    expect(scrolled).toHaveLength(0);
+  });
+});
 
 /**
  * Drawing on the surface a call is being shown. What these pin is the bargain

--- a/clients/web/src/components/companion-share-annotation.test.tsx
+++ b/clients/web/src/components/companion-share-annotation.test.tsx
@@ -97,13 +97,23 @@ const wheel = (layer: Element): void => {
  * moves. Each edge is said once, however many events make it up.
  */
 describe("scrolling the app under the frame", () => {
-  test("the first wheel event asks main to step aside", () => {
+  /**
+   * In the window itself, only the first wheel event of a scroll ever
+   * reaches the layer: the frame steps aside on it and the rest go to the
+   * app. A second one arriving is therefore the next scroll, after main took
+   * the mouse back on its own when the desktop said the first had ended,
+   * which this layer is never told about. Each has to ask again, or a scroll
+   * that follows a scroll, with no move between, is swallowed whole.
+   */
+  test("every wheel event that reaches the layer asks main to step aside", () => {
     const { container } = render(<CompanionShareAnnotation ink={INK} />);
     const layer = layerOf(container);
     wheel(layer);
     wheel(layer);
-    wheel(layer);
-    expect(scrolled).toEqual([true]);
+    expect(scrolled).toEqual([true, true]);
+    move(layer, 200, 200);
+    move(layer, 300, 300);
+    expect(scrolled).toEqual([true, true, false]);
   });
 
   test("the pointer moving afterwards takes the mouse back", () => {

--- a/clients/web/src/components/companion-share-annotation.tsx
+++ b/clients/web/src/components/companion-share-annotation.tsx
@@ -29,9 +29,11 @@
  * **The app underneath stays scrollable.** This layer takes the wheel along
  * with the presses, and a window cannot hand on a wheel event it has taken,
  * so on the first one it asks main to make the frame click-through for the
- * rest of the scroll, and takes the mouse back on the first pointer move
- * main forwards afterwards (`setCompanionFrameScrolling`). Drawing is a mode
- * the user is in, not a lock on the surface they are sharing.
+ * rest of the scroll (`setCompanionFrameScrolling`). Main takes the mouse
+ * back when the scroll ends, which it hears from the desktop, and this layer
+ * asks for it back on the first pointer move main forwards afterwards, in
+ * case that comes first. Drawing is a mode the user is in, not a lock on the
+ * surface they are sharing.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -232,7 +234,10 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
   /**
    * Take the mouse back after a scroll. Main forwards mouse-move while the
    * frame is stepped aside, so the first move to arrive is a hand that has
-   * stopped scrolling and is pointing at something again.
+   * stopped scrolling and is pointing at something again. Main also takes it
+   * back on its own when the desktop says the scroll has ended, so a press
+   * with no move before it still lands here; that path never reaches this
+   * layer, and the flag here is cleared by the next move either way.
    */
   const reclaim = (): void => {
     if (!scrolling.current) {
@@ -335,13 +340,13 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
       className="companion-share-annotation fixed inset-0 h-full w-full"
       style={
         {
+          cursor,
           "--companion-ink-hold": `${COMPANION_INK_HOLD_MS}ms`,
           "--companion-ink-fade": `${COMPANION_INK_FADE_MS}ms`,
         } as React.CSSProperties
       }
       data-testid="companion-share-annotation"
       role="presentation"
-      style={{ cursor }}
       onPointerDown={handleDown}
       onPointerMove={handleMove}
       onPointerUp={handleUp}

--- a/clients/web/src/components/companion-share-annotation.tsx
+++ b/clients/web/src/components/companion-share-annotation.tsx
@@ -25,12 +25,22 @@
  * annotation layer: the user pointed at something and the call has the
  * picture, and a circle still sitting on the screen a minute later is a
  * circle they have to clear up.
+ *
+ * **The app underneath stays scrollable.** This layer takes the wheel along
+ * with the presses, and a window cannot hand on a wheel event it has taken,
+ * so on the first one it asks main to make the frame click-through for the
+ * rest of the scroll, and takes the mouse back on the first pointer move
+ * main forwards afterwards (`setCompanionFrameScrolling`). Drawing is a mode
+ * the user is in, not a lock on the surface they are sharing.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useWindowBox } from "@/components/companion-window-box";
-import { annotateCompanionShare } from "@/runtime/companion-surface";
+import {
+  annotateCompanionShare,
+  setCompanionFrameScrolling,
+} from "@/runtime/companion-surface";
 import {
   COMPANION_ANNOTATION_MAX_POINTS,
   COMPANION_ANNOTATION_MAX_STROKES,
@@ -127,6 +137,14 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
    */
   const live = useRef<readonly LiveStroke[]>([]);
   const drawing = useRef<number | null>(null);
+  /**
+   * Whether the frame has stepped aside for a scroll, as the last report to
+   * main left it.
+   *
+   * Kept so each edge is reported once: a scroll is many wheel events, and
+   * the pointer resting after one is many moves.
+   */
+  const scrolling = useRef(false);
   const nextId = useRef(0);
   // The timers dropping spent marks once they have finished fading, cleared on
   // unmount so nothing is left to write to a component that has gone.
@@ -192,7 +210,40 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
     y: box.height === 0 ? 0 : clamp(event.clientY / box.height),
   });
 
+  /**
+   * A wheel event on the layer is a scroll meant for the app under it, and
+   * this window cannot hand it on: a window taking presses takes the wheel
+   * with them. What it can do is ask main to stop taking them, so the rest of
+   * the scroll reaches the app underneath. The one event that got here is
+   * the price of finding out.
+   *
+   * Not mid-stroke. The hand is down and captured, and a frame that let go
+   * of the mouse now would lose the release that sends the mark and lifts
+   * the hold on the session's frames.
+   */
+  const handleWheel = (): void => {
+    if (drawing.current !== null || scrolling.current) {
+      return;
+    }
+    scrolling.current = true;
+    setCompanionFrameScrolling(true);
+  };
+
+  /**
+   * Take the mouse back after a scroll. Main forwards mouse-move while the
+   * frame is stepped aside, so the first move to arrive is a hand that has
+   * stopped scrolling and is pointing at something again.
+   */
+  const reclaim = (): void => {
+    if (!scrolling.current) {
+      return;
+    }
+    scrolling.current = false;
+    setCompanionFrameScrolling(false);
+  };
+
   const handleDown = (event: React.PointerEvent<SVGSVGElement>): void => {
+    reclaim();
     if (drawing.current !== null) {
       return;
     }
@@ -211,6 +262,7 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
   };
 
   const handleMove = (event: React.PointerEvent<SVGSVGElement>): void => {
+    reclaim();
     const id = drawing.current;
     if (id === null) {
       return;
@@ -294,6 +346,7 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
       onPointerMove={handleMove}
       onPointerUp={handleUp}
       onPointerCancel={handleUp}
+      onWheel={handleWheel}
     >
       {strokes.map((stroke) => (
         <Ink

--- a/clients/web/src/components/companion-share-annotation.tsx
+++ b/clients/web/src/components/companion-share-annotation.tsx
@@ -140,11 +140,14 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
   const live = useRef<readonly LiveStroke[]>([]);
   const drawing = useRef<number | null>(null);
   /**
-   * Whether the frame has stepped aside for a scroll, as the last report to
-   * main left it.
+   * Whether this layer last asked main to step aside for a scroll.
    *
-   * Kept so each edge is reported once: a scroll is many wheel events, and
-   * the pointer resting after one is many moves.
+   * Kept for the way back only, so a pointer resting after a scroll, which
+   * is many moves, asks for the mouse once. It is not the truth about the
+   * frame: main takes the mouse back on its own when the desktop says the
+   * scroll has ended, and this layer is not told. So a wheel event never
+   * reads it. One reaching this layer at all means the frame is holding the
+   * mouse right now, whatever was asked for last.
    */
   const scrolling = useRef(false);
   const nextId = useRef(0);
@@ -219,12 +222,18 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
    * the scroll reaches the app underneath. The one event that got here is
    * the price of finding out.
    *
+   * Every one, not the first: while the frame is stepped aside the wheel
+   * goes to the app and none arrive here, so one that does arrive is the
+   * start of a scroll the frame is taking, either the first or the next
+   * after main took the mouse back on its own. Main ignores an ask that
+   * changes nothing.
+   *
    * Not mid-stroke. The hand is down and captured, and a frame that let go
    * of the mouse now would lose the release that sends the mark and lifts
    * the hold on the session's frames.
    */
   const handleWheel = (): void => {
-    if (drawing.current !== null || scrolling.current) {
+    if (drawing.current !== null) {
       return;
     }
     scrolling.current = true;

--- a/clients/web/src/components/companion-watch-frame-page.test.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.test.tsx
@@ -28,6 +28,7 @@ mock.module("@/runtime/companion-surface", () => ({
   // sends is `companion-share-annotation.test.tsx`'s subject, and this file
   // only cares whether the layer is on the page at all.
   annotateCompanionShare: () => undefined,
+  setCompanionFrameScrolling: () => undefined,
   getCompanionState: async () => STATE,
   subscribeCompanionState: (
     listener: (state: CompanionSurfaceState) => void,

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -177,6 +177,20 @@ export function annotateCompanionShare(
 }
 
 /**
+ * Tell main the user is scrolling the app under the frame, or has moved the
+ * pointer since, from the frame's own window while drawing is on.
+ *
+ * The frame takes the wheel along with the presses and cannot forward it, so
+ * main answers a scroll by making the frame click-through until the pointer
+ * moves: the rest of the scroll reaches the app underneath, and the first
+ * forwarded move is the frame's cue to take the mouse back. Main holds the
+ * state; this only reports the two events it cannot see.
+ */
+export function setCompanionFrameScrolling(scrolling: boolean): void {
+  bridge()?.setFrameScrolling?.(scrolling);
+}
+
+/**
  * One frame of what the user is sharing, as the helper takes it.
  *
  * The one call in this module made from the app's own window on a cadence

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -415,6 +415,7 @@ declare global {
           strokes: readonly CompanionAnnotationStroke[],
           ink: string,
         ): void;
+        setFrameScrolling?(scrolling: boolean): void;
         sharedFrame?(target: WatchCaptureTarget): void;
         captureScreen?(
           target: WatchCaptureTarget,

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -686,6 +686,19 @@ export interface VellumBridge {
       ink: string,
     ): void;
     /**
+     * The user is scrolling the app under the frame, or has moved the
+     * pointer since, from the frame's own window while it is taking presses.
+     *
+     * A window taking presses takes the wheel with them and cannot forward
+     * it, so on `true` main makes the frame click-through with mouse-move
+     * forwarded, which lets the rest of the scroll reach the app underneath
+     * and still shows the renderer where the pointer is; on `false` it takes
+     * the mouse back. Refused while drawing is off, since there is no mouse
+     * to hand back. Absent on a shell that predates it, which the frame
+     * reads as having no scroll to let through.
+     */
+    setFrameScrolling?(scrolling: boolean): void;
+    /**
      * One frame of `target`, as the helper takes it, for the window holding a
      * shared call to hand to the session. Resolves to null when no frame
      * could be taken: the window has gone, the display was unplugged, or

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -203,6 +203,8 @@ export const COMPANION_SET_SCREEN_SHARE = "vellum:companion:setScreenShare";
 export const COMPANION_SET_ANNOTATING = "vellum:companion:setAnnotating";
 export const COMPANION_TOGGLE_ANNOTATING = "vellum:companion:toggleAnnotating";
 export const COMPANION_ANNOTATE_SHARE = "vellum:companion:annotateShare";
+export const COMPANION_SET_FRAME_SCROLLING =
+  "vellum:companion:setFrameScrolling";
 export const COMPANION_CAPTURE_SCREEN = "vellum:companion:captureScreen";
 export const COMPANION_SHARED_FRAME = "vellum:companion:sharedFrame";
 export const COMPANION_ANSWER_WATCH_RETRO = "vellum:companion:answerWatchRetro";


### PR DESCRIPTION
Fixes JARVIS-1773

## Problem

Selecting the annotation tool on the macOS companion locks up the shared screen. The watch frame is a transparent floating window sized to the shared surface, and `setAnnotating` makes it take the mouse (`setIgnoreMouseEvents(false)`) so the user can draw. A window taking presses takes the wheel with them, so every scroll and every click that is not a stroke lands in the frame and never reaches the app underneath.

## Fix

Electron has no way to forward a wheel event through a window that is taking the mouse, so the frame steps aside instead:

- The drawing layer (`companion-share-annotation.tsx`) reports the first wheel event it receives over a new `vellum:companion:setFrameScrolling` channel.
- Main flips the frame to `setIgnoreMouseEvents(true, { forward: true })`. The rest of the scroll reaches the shared app, and forwarded mouse-move still reaches the renderer (the same mechanism the pill's hover uses).
- On the first forwarded pointer move (or press) the renderer asks for the mouse back and main makes the frame interactive again. A scrolling hand does not move the pointer; a pointing hand does.
- The mode stays on the whole time. A wheel event mid-stroke is ignored so the captured drag and its `released` are never lost. Either edge of the mode, and a freshly opened frame window, forget any scroll the frame stepped aside for, so the mode can never come on click-through.

Cost: the single wheel event that reached the frame is spent finding out the user is scrolling. On a trackpad that is the gesture's first tick.

## Tests

- `clients/macos/src/main/companion-window.test.ts`: 5 new cases (step aside on scroll, take back on move, refused off the mode, forgotten on either edge, fresh frame takes the mouse). 237 pass.
- `clients/web/src/components/companion-share-annotation.test.tsx`: 5 new cases (first wheel reports once, move reclaims, press reclaims, mid-stroke wheel ignored, nothing said when nothing scrolled). 19 pass.
- `companion-watch-frame-page.test.tsx`: 34 pass.
- `tsc --noEmit` clean for `clients/macos`, `clients/web`, `packages/ipc-contract`.

Not verified in a running app: whether macOS re-routes the remainder of an in-progress scroll gesture to the window below once the frame goes click-through, or latches it to the frame until the gesture ends. In the latter case the first scroll gesture after moving the pointer is lost and the next one works; either way the shared app is no longer locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZTyGdrVc4zr5tsyDr262w
