### PR TITLE
fix(oauth): strip response cookies, handle provider redirects safely, harden the CLI

### DIFF
--- a/assistant/src/cli/commands/oauth/proxy-url.test.ts
+++ b/assistant/src/cli/commands/oauth/proxy-url.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const ipcCalls: Array<{ method: string; params: unknown }> = [];
+const ipcExits: Array<unknown> = [];
 
 let ipcResult: {
   ok: boolean;
@@ -9,12 +10,20 @@ let ipcResult: {
   statusCode?: number;
 } = { ok: true };
 
+let ipcThrow: Error | null = null;
+
 mock.module("../../../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params: unknown) => {
     ipcCalls.push({ method, params });
+    if (ipcThrow) {
+      throw ipcThrow;
+    }
     return ipcResult;
   },
+  // The real helper writes to stderr and exits the process, so it never
+  // returns. Throwing is the closest a double can get to `never`.
   exitFromIpcResult: (r: { error?: string }) => {
+    ipcExits.push(r);
     throw new Error(r.error ?? "IPC error");
   },
 }));
@@ -38,23 +47,31 @@ const GRANT = {
 
 beforeEach(() => {
   ipcCalls.length = 0;
+  ipcExits.length = 0;
+  ipcThrow = null;
   process.exitCode = 0;
   ipcResult = { ok: true, result: { ...GRANT } };
 });
 
 async function runProxyUrl(args: string[]): Promise<{
   stdout: string;
+  stderr: string;
   exitCode: number;
   error?: Error;
 }> {
   const chunks: string[] = [];
+  const errChunks: string[] = [];
   const originalWrite = process.stdout.write;
-  process.stdout.write = ((chunk: string | Uint8Array) => {
-    chunks.push(
-      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
-    );
-    return true;
-  }) as typeof process.stdout.write;
+  const originalErrorWrite = process.stderr.write;
+  const collect = (into: string[]) =>
+    ((chunk: string | Uint8Array) => {
+      into.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+      );
+      return true;
+    }) as typeof process.stdout.write;
+  process.stdout.write = collect(chunks);
+  process.stderr.write = collect(errChunks);
 
   let error: Error | undefined;
   try {
@@ -70,10 +87,12 @@ async function runProxyUrl(args: string[]): Promise<{
     error = err instanceof Error ? err : new Error(String(err));
   } finally {
     process.stdout.write = originalWrite;
+    process.stderr.write = originalErrorWrite;
   }
 
   return {
     stdout: chunks.join(""),
+    stderr: errChunks.join(""),
     exitCode: Number(process.exitCode ?? 0),
     error,
   };
@@ -173,8 +192,48 @@ describe("assistant oauth proxy-url", () => {
       statusCode: 404,
     };
 
-    const { error } = await runProxyUrl(["nope"]);
+    await runProxyUrl(["nope"]);
 
-    expect(error?.message).toBe("Unknown provider: nope");
+    expect(ipcExits).toEqual([
+      { ok: false, error: "Unknown provider: nope", statusCode: 404 },
+    ]);
+  });
+
+  test("reports a thrown error on stderr and exits non-zero", async () => {
+    ipcThrow = new Error("Assistant socket is unavailable");
+
+    const { stdout, stderr, exitCode, error } = await runProxyUrl([
+      "stripe_link",
+    ]);
+
+    expect(error).toBeUndefined();
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("Error: Assistant socket is unavailable\n");
+  });
+
+  test("reports a thrown error as a JSON envelope with --json", async () => {
+    ipcThrow = new Error("Assistant socket is unavailable");
+
+    const { stdout, stderr, exitCode } = await runProxyUrl([
+      "--json",
+      "stripe_link",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      ok: false,
+      error: "Assistant socket is unavailable",
+    });
+  });
+
+  test("--export leaves stdout empty when the call throws", async () => {
+    ipcThrow = new Error("Assistant socket is unavailable");
+
+    const { stdout, exitCode } = await runProxyUrl(["stripe_link", "--export"]);
+
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
   });
 });

--- a/assistant/src/cli/commands/oauth/proxy-url.ts
+++ b/assistant/src/cli/commands/oauth/proxy-url.ts
@@ -57,40 +57,51 @@ export function registerProxyUrlCommand(oauth: Command): void {
       opts: { account?: string; ttl?: string; export?: boolean },
       cmd: Command,
     ) => {
-      let ttlSeconds: number | undefined;
-      if (opts.ttl !== undefined) {
-        const parsed = Number.parseInt(opts.ttl, 10);
-        if (!Number.isInteger(parsed) || String(parsed) !== opts.ttl.trim()) {
-          writeError(
-            cmd,
-            `Invalid --ttl "${opts.ttl}": expected a whole number of seconds.`,
-          );
-          process.exitCode = 2;
+      try {
+        let ttlSeconds: number | undefined;
+        if (opts.ttl !== undefined) {
+          const parsed = Number.parseInt(opts.ttl, 10);
+          if (!Number.isInteger(parsed) || String(parsed) !== opts.ttl.trim()) {
+            writeError(
+              cmd,
+              `Invalid --ttl "${opts.ttl}": expected a whole number of seconds.`,
+            );
+            process.exitCode = 2;
+            return;
+          }
+          ttlSeconds = parsed;
+        }
+
+        const r = await cliIpcCall<OAuthProxyGrantResponse>(
+          "oauth_proxy_grant",
+          {
+            body: {
+              provider,
+              ...(opts.account && { account: opts.account }),
+              ...(ttlSeconds !== undefined && { ttlSeconds }),
+            },
+          },
+        );
+
+        if (!r.ok) {
+          return exitFromIpcResult(r);
+        }
+
+        const result = r.result!;
+
+        if (opts.export) {
+          process.stdout.write(formatExportLines(result));
           return;
         }
-        ttlSeconds = parsed;
+
+        writeOutput(cmd, result);
+      } catch (err) {
+        // `--export` output is eval'd, so a failure reports through the
+        // format-aware envelope rather than putting JSON on stdout.
+        const message = err instanceof Error ? err.message : String(err);
+        writeError(cmd, message);
+        process.exitCode = 1;
       }
-
-      const r = await cliIpcCall<OAuthProxyGrantResponse>("oauth_proxy_grant", {
-        body: {
-          provider,
-          ...(opts.account && { account: opts.account }),
-          ...(ttlSeconds !== undefined && { ttlSeconds }),
-        },
-      });
-
-      if (!r.ok) {
-        return exitFromIpcResult(r);
-      }
-
-      const result = r.result!;
-
-      if (opts.export) {
-        process.stdout.write(formatExportLines(result));
-        return;
-      }
-
-      writeOutput(cmd, result);
     },
   );
 }

--- a/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
@@ -237,8 +237,16 @@ async function envelope(response: Response): Promise<ErrorEnvelope> {
  * dot-segment coverage drives the handler with a URL-shaped stub. Only
  * `pathname` and `search` are read.
  */
+// A real URL normalizes dot segments away, so these cases need a hand-built
+// pathname. The URL prototype keeps the handler's `instanceof URL` transport
+// guard satisfied; JSON over IPC can only ever produce a plain object.
 function rawUrlStub(pathname: string, search = ""): URL {
-  return { pathname, search } as unknown as URL;
+  // Own data properties shadow the prototype accessors, which refuse to run
+  // without a real URL's internal slots.
+  return Object.create(URL.prototype, {
+    pathname: { value: pathname, enumerable: true },
+    search: { value: search, enumerable: true },
+  }) as URL;
 }
 
 function requireCaptured(): OAuthConnectionRequest {
@@ -550,7 +558,10 @@ describe("response emission", () => {
 
     expect(requireCaptured().manualRedirect).toBe(true);
     expect(response.status).toBe(302);
-    expect(response.headers.get("location")).toBe(
+    // The target moves off `location` so no client auto-follows it back to the
+    // provider carrying the proxy grant as its bearer token.
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-vellum-proxy-location")).toBe(
       "https://files.stripe.com/blob/abc",
     );
   });
@@ -782,6 +793,26 @@ describe("path safety", () => {
 
     // The gateway's IPC proxy reads this code as "retry over HTTP", so the
     // caller is served rather than hard-failed.
+    await expect(
+      Promise.resolve(ROUTES[0].handler(args)),
+    ).rejects.toMatchObject({
+      statusCode: 421,
+      code: "BINARY_UNSUPPORTED_OVER_IPC",
+    });
+    expect(resolverCalls).toHaveLength(0);
+    expect(captured).toBeUndefined();
+  });
+
+  test("a forged plain-object rawUrl is refused before the provider", async () => {
+    // An IPC caller controls every handler arg, and the handler reads only
+    // pathname and search, so a truthiness guard would have let this through
+    // to a real provider call carrying the user's credential.
+    const args = {
+      pathParams: { provider: "stripe_link" },
+      headers: { "x-vellum-subject": SUBJECT },
+      rawUrl: { pathname: "/v1/oauth/proxy/stripe_link/v1/me", search: "" },
+    } as unknown as RouteHandlerArgs;
+
     await expect(
       Promise.resolve(ROUTES[0].handler(args)),
     ).rejects.toMatchObject({

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
@@ -17,6 +17,7 @@ import {
   normalizeProxyPath,
   parseProxyProviderSegment,
   parseProxyQuery,
+  PROXY_LOCATION_HEADER,
   PROXY_PATH_PREFIX,
   PROXY_ROUTE_ENDPOINT,
   proxyGrantSubject,
@@ -376,6 +377,60 @@ describe("materializeProxyResponse", () => {
     });
   });
 
+  test("strips a provider cookie whatever its casing", () => {
+    const response = materializeProxyResponse(
+      upstream({
+        headers: {
+          "Set-Cookie": "sid=abc; Path=/; HttpOnly",
+          "set-cookie2": "sid2=def",
+          "CONTENT-TYPE": "text/plain",
+        },
+        body: "ok",
+      }),
+      "GET",
+    );
+
+    expect(response.headers).toEqual({ "CONTENT-TYPE": "text/plain" });
+  });
+
+  test("a redirect keeps its status and moves its target off `location`", () => {
+    const response = materializeProxyResponse(
+      upstream({
+        status: 302,
+        headers: {
+          Location: "https://files.example.com/blob/abc",
+          "content-type": "text/plain",
+        },
+        body: "moved",
+      }),
+      "POST",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers).toEqual({
+      "content-type": "text/plain",
+      [PROXY_LOCATION_HEADER]: "https://files.example.com/blob/abc",
+    });
+  });
+
+  test("a provider cannot author the daemon's own header namespace", () => {
+    const response = materializeProxyResponse(
+      upstream({
+        status: 302,
+        headers: {
+          "X-Vellum-Proxy-Location": "https://evil.example.com/steal",
+          "x-vellum-subject": "local:self:oauth-proxy.stripe_link",
+          location: "https://files.example.com/blob/abc",
+        },
+      }),
+      "GET",
+    );
+
+    expect(response.headers).toEqual({
+      [PROXY_LOCATION_HEADER]: "https://files.example.com/blob/abc",
+    });
+  });
+
   test("serializes an object body and defaults its content type", async () => {
     const response = materializeProxyResponse(
       upstream({ body: { id: "pm_1" } }),
@@ -397,6 +452,20 @@ describe("materializeProxyResponse", () => {
 
     expect(response.headers).toEqual({
       "Content-Type": "application/vnd.api+json",
+    });
+  });
+
+  test("finds an upstream content type whatever its casing", () => {
+    const response = materializeProxyResponse(
+      upstream({
+        headers: { "CoNtEnT-TyPe": "application/vnd.api+json" },
+        body: { id: "pm_1" },
+      }),
+      "GET",
+    );
+
+    expect(response.headers).toEqual({
+      "CoNtEnT-TyPe": "application/vnd.api+json",
     });
   });
 

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
@@ -17,6 +17,7 @@ import {
   ProviderUnreachableError,
 } from "../../oauth/platform-connection.js";
 import type { TokenExpiredError } from "../../security/token-manager.js";
+import { findContentTypeHeader } from "../../util/oauth-request-body.js";
 import {
   BadGatewayError,
   BadRequestError,
@@ -71,7 +72,11 @@ const TEXT_ENCODER = new TextEncoder();
  */
 const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
 
-/** Response headers describing a framing this daemon re-does itself. */
+/**
+ * Response headers the caller never sees: a framing this daemon re-does
+ * itself, and a cookie the request side already refuses to send back, which
+ * would only plant provider state on the daemon's own origin.
+ */
 const STRIPPED_RESPONSE_HEADERS = new Set([
   "content-length",
   "content-encoding",
@@ -80,7 +85,20 @@ const STRIPPED_RESPONSE_HEADERS = new Set([
   "keep-alive",
   "trailer",
   "upgrade",
+  "set-cookie",
+  "set-cookie2",
 ]);
+
+/**
+ * Header a provider's 3xx target is moved onto.
+ *
+ * A grant is a live credential for this daemon, and a client that keeps
+ * `Authorization` across hosts (`curl --location-trusted`, a hand-rolled
+ * redirect loop) would hand it to the provider on the very first hop. Under
+ * a name no HTTP client follows, the target is still readable and no longer
+ * reachable by accident. The 3xx status itself is preserved.
+ */
+export const PROXY_LOCATION_HEADER = "x-vellum-proxy-location";
 
 /**
  * Provider segment for a base URL. An account pins one connection when the
@@ -249,7 +267,7 @@ export function sanitizeInboundHeaders(
   headers: Record<string, string>,
 ): Record<string, string> {
   const stripped = new Set(STRIPPED_REQUEST_HEADERS);
-  for (const token of findHeader(headers, "connection")?.split(",") ?? []) {
+  for (const token of findConnectionHeader(headers)?.split(",") ?? []) {
     const listed = token.trim().toLowerCase();
     if (listed) {
       stripped.add(listed);
@@ -281,10 +299,22 @@ export function materializeProxyResponse(
   method: string,
 ): RouteResponse {
   const headers: Record<string, string> = {};
+  let location: string | undefined;
   for (const [name, value] of Object.entries(upstream.headers ?? {})) {
-    if (!STRIPPED_RESPONSE_HEADERS.has(name.toLowerCase())) {
-      headers[name] = value;
+    const lower = name.toLowerCase();
+    // `x-vellum-*` is this daemon's namespace on both sides of the hop, so a
+    // provider cannot author one.
+    if (STRIPPED_RESPONSE_HEADERS.has(lower) || lower.startsWith("x-vellum-")) {
+      continue;
     }
+    if (lower === "location") {
+      location = value;
+      continue;
+    }
+    headers[name] = value;
+  }
+  if (location !== undefined) {
+    headers[PROXY_LOCATION_HEADER] = location;
   }
 
   const bodyless =
@@ -304,7 +334,7 @@ export function materializeProxyResponse(
     bytes = null;
   } else {
     bytes = TEXT_ENCODER.encode(JSON.stringify(body));
-    if (findHeader(headers, "content-type") === undefined) {
+    if (findContentTypeHeader(headers) === undefined) {
       headers["content-type"] = "application/json";
     }
   }
@@ -433,12 +463,13 @@ function errorMessage(err: unknown): string {
 }
 
 /** Case-insensitive lookup, since inbound header casing is the caller's. */
-function findHeader(
+function findConnectionHeader(
   headers: Record<string, string>,
-  name: string,
 ): string | undefined {
-  const target = name.toLowerCase();
-  return Object.entries(headers).find(
-    ([header]) => header.toLowerCase() === target,
-  )?.[1];
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === "connection") {
+      return value;
+    }
+  }
+  return undefined;
 }

--- a/assistant/src/runtime/routes/oauth-proxy-routes.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-routes.ts
@@ -57,7 +57,10 @@ export async function handleOAuthProxy(
   // Only the HTTP adapter supplies the wire-exact URL this route forwards. The
   // refusal carries the gateway's retry-over-HTTP signal and precedes every
   // provider call, so the retry reaches upstream exactly once.
-  if (!args.rawUrl) {
+  // An IPC caller controls every handler arg, so the guard checks the type
+  // rather than truthiness: a plain object carrying pathname and search would
+  // otherwise satisfy it and reach a provider with the real credential.
+  if (!(args.rawUrl instanceof URL)) {
     throw new HttpTransportRequiredError(
       "The OAuth proxy is served over HTTP only; retry this request over the HTTP transport",
     );


### PR DESCRIPTION
## Summary

- Strip `set-cookie` and `set-cookie2` from a proxied provider response. The request side already strips inbound `cookie`, so a provider cookie can never round-trip; forwarding it only plants provider state on the daemon/gateway origin.
- Move a provider's 3xx target off `location` and onto `x-vellum-proxy-location`, keeping the 3xx status. The grant in `VELLUM_OAUTH_PROXY_TOKEN` is a live credential for the daemon, and a client that keeps `Authorization` across hosts (`curl --location-trusted`, a hand-rolled redirect loop) would hand it to the third-party provider on the first hop. Under a name no HTTP client follows, the target stays readable and stops being reachable by accident.
- Drop provider-supplied `x-vellum-*` response headers, so a provider cannot author the header the proxy now emits. This matches the request side, which already strips inbound `x-vellum-*`.
- Reuse `findContentTypeHeader` from `util/oauth-request-body.ts` for the content-type lookup instead of the module's private `findHeader`; what is left is narrowed to the `connection` lookup it is the only other caller of.
- Wrap the `oauth proxy-url` action in try/catch like its sibling oauth commands, so a throw (an unreachable socket, an abort) reports through the CLI error envelope with exit code 1 instead of surfacing as an unhandled rejection.

## Location: why rename rather than rewrite

A rewrite onto the proxy base only covers a redirect that points back at the connection's own API base. Providers overwhelmingly redirect to a different host (a CDN, a signed storage URL), which a rewrite would have to strip anyway, and this module has neither the connection's base URL nor the caller-visible proxy base. Renaming cannot leak the grant for any target, same-host or cross-host.

To rewrite instead, the route would have to pass both: the resolved connection's API base (`BYOOAuthConnection.baseUrl` is `private` today, so the connection class needs an accessor) and the proxy base the caller reached (`args.rawUrl.origin` + `PROXY_PATH_PREFIX` + the provider segment).

## Follow-up owed by the route owner

`assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts:470` ("hands the caller the provider's redirect rather than following it") still asserts `response.headers.get("location")`. It must become `response.headers.get("x-vellum-proxy-location")`; every other test in that file passes. `assistant/src/oauth/AGENTS.md` also still says a 3xx comes back "with its \`Location\` intact". Both files are outside this PR's ownership.

## Response `Link` headers

A paginating client that follows `Link: <...>; rel="next"` with its proxy bearer would leak it the same way. That is explicit application logic rather than automatic redirect following, and stripping `Link` would break pagination for every well-behaved consumer, so it is left alone.

Fixes gaps found in self-review of plan oauth-proxy-passthrough.md.