### PR TITLE
fix(oauth): wire single-attempt writes, declare the 421, preserve the raw query

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24436,6 +24436,8 @@ paths:
           description: The resolved connection rejects this method
         "409":
           description: Several accounts are connected and none was pinned
+        "421":
+          description: Dispatched over IPC; retry over HTTP
         "424":
           description: No usable connection; reconnect the provider
         "502":
@@ -24478,6 +24480,8 @@ paths:
           description: The resolved connection rejects this method
         "409":
           description: Several accounts are connected and none was pinned
+        "421":
+          description: Dispatched over IPC; retry over HTTP
         "424":
           description: No usable connection; reconnect the provider
         "502":
@@ -24520,6 +24524,8 @@ paths:
           description: The resolved connection rejects this method
         "409":
           description: Several accounts are connected and none was pinned
+        "421":
+          description: Dispatched over IPC; retry over HTTP
         "424":
           description: No usable connection; reconnect the provider
         "502":
@@ -24567,6 +24573,8 @@ paths:
           description: The resolved connection rejects this method
         "409":
           description: Several accounts are connected and none was pinned
+        "421":
+          description: Dispatched over IPC; retry over HTTP
         "424":
           description: No usable connection; reconnect the provider
         "502":
@@ -24614,6 +24622,8 @@ paths:
           description: The resolved connection rejects this method
         "409":
           description: Several accounts are connected and none was pinned
+        "421":
+          description: Dispatched over IPC; retry over HTTP
         "424":
           description: No usable connection; reconnect the provider
         "502":
@@ -24661,6 +24671,8 @@ paths:
           description: The resolved connection rejects this method
         "409":
           description: Several accounts are connected and none was pinned
+        "421":
+          description: Dispatched over IPC; retry over HTTP
         "424":
           description: No usable connection; reconnect the provider
         "502":

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -324,6 +324,70 @@ describe("BYOOAuthConnection", () => {
       expect(parsed.searchParams.get("labelIds")).toBe("INBOX");
     });
 
+    test("appends rawQuery verbatim, keeping interleaved repeated keys", async () => {
+      await setupCredential("google");
+      const conn = createConnection();
+
+      await conn.request({
+        method: "GET",
+        path: "/messages",
+        rawQuery: "?a=1&b=2&a=3",
+      });
+
+      // Rebuilding through URLSearchParams would group the two `a` values.
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages?a=1&b=2&a=3",
+      );
+    });
+
+    test("leaves %20 and a valueless flag as the caller wrote them", async () => {
+      await setupCredential("google");
+      const conn = createConnection();
+
+      await conn.request({
+        method: "GET",
+        path: "/messages",
+        rawQuery: "q=a%20b&flag",
+      });
+
+      // URLSearchParams would emit `q=a+b&flag=`, which a signed query rejects.
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages?q=a%20b&flag",
+      );
+    });
+
+    test("falls back to the parsed query when rawQuery is empty", async () => {
+      await setupCredential("google");
+      const conn = createConnection();
+
+      await conn.request({
+        method: "GET",
+        path: "/messages",
+        rawQuery: "",
+        query: { maxResults: "10" },
+      });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=10",
+      );
+    });
+
+    test("prefers rawQuery over the parsed query", async () => {
+      await setupCredential("google");
+      const conn = createConnection();
+
+      await conn.request({
+        method: "GET",
+        path: "/messages",
+        rawQuery: "?signed=1",
+        query: { maxResults: "10" },
+      });
+
+      expect(mockFetch.mock.calls[0][0]).toBe(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages?signed=1",
+      );
+    });
+
     test("uses per-request baseUrl override", async () => {
       await setupCredential("google");
       const conn = createConnection();

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -58,18 +58,9 @@ export class BYOOAuthConnection implements OAuthConnection {
           : req.path;
         let fullUrl = `${effectiveBaseUrl}${requestPath}`;
 
-        if (req.query && Object.keys(req.query).length > 0) {
-          const params = new URLSearchParams();
-          for (const [key, value] of Object.entries(req.query)) {
-            if (Array.isArray(value)) {
-              for (const v of value) {
-                params.append(key, v);
-              }
-            } else {
-              params.append(key, value);
-            }
-          }
-          fullUrl += `?${params.toString()}`;
+        const search = resolveQueryString(req);
+        if (search) {
+          fullUrl += `?${search}`;
         }
 
         const logUrl = isTelegram
@@ -143,6 +134,34 @@ export class BYOOAuthConnection implements OAuthConnection {
       connectionId: this.id,
     });
   }
+}
+
+/**
+ * Query string to append, without its `?`.
+ *
+ * `rawQuery` is the caller's own bytes and is returned untouched, so a query a
+ * provider signs keeps its key order, its `%20`, and its valueless flags. An
+ * empty one falls through to `query`, which `URLSearchParams` rebuilds.
+ */
+function resolveQueryString(req: OAuthConnectionRequest): string {
+  const raw = req.rawQuery?.replace(/^\?/, "") ?? "";
+  if (raw) {
+    return raw;
+  }
+  if (!req.query) {
+    return "";
+  }
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(req.query)) {
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        params.append(key, v);
+      }
+    } else {
+      params.append(key, value);
+    }
+  }
+  return params.toString();
 }
 
 function buildTelegramBotApiPath(path: string, token: string): string {

--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -2,6 +2,16 @@ export interface OAuthConnectionRequest {
   method: string;
   path: string; // relative, e.g. "/2/tweets"
   query?: Record<string, string | string[]>;
+  /**
+   * Query string appended to the URL verbatim, leading `?` optional and the
+   * text already wire-encoded. For callers forwarding a query a provider signs,
+   * where rebuilding {@link OAuthConnectionRequest.query} would reorder
+   * interleaved repeated keys, rewrite `%20` as `+`, and give a valueless flag
+   * an `=`. An empty one falls through to `query`. Honored by BYO connections;
+   * a managed connection sends `query` to the platform proxy, which rebuilds
+   * it.
+   */
+  rawQuery?: string;
   headers?: Record<string, string>;
   /**
    * A string is forwarded to the provider verbatim under the caller's own

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -571,6 +571,65 @@ describe("PlatformOAuthConnection", () => {
     expect(callCount).toBe(1);
   });
 
+  test("an out-of-range envelope status fails instead of being clamped", async () => {
+    const client = makeMockClient(
+      mock(async () => {
+        return new Response(
+          JSON.stringify({ status: 700, headers: {}, body: { ok: true } }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    // 700 reaches `new Response(body, { status })` as a RangeError, which is
+    // not a mapped error, so the caller would see an opaque 500.
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(conn.request({ method: "GET", path: "/x" })).rejects.toThrow(
+      "Platform proxy returned an unusable response status: 700",
+    );
+  });
+
+  test("a missing envelope status fails", async () => {
+    const client = makeMockClient(
+      mock(async () => {
+        return new Response(JSON.stringify({ headers: {}, body: null }), {
+          status: 200,
+        });
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await expect(conn.request({ method: "GET", path: "/x" })).rejects.toThrow(
+      BackendError,
+    );
+  });
+
+  // The platform proxy rebuilds the query from the parsed record, so managed
+  // mode cannot carry a signed query string.
+  test("sends the parsed query and never rawQuery", async () => {
+    const client = makeMockClient(
+      mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        const parsed = JSON.parse(init?.body as string);
+        expect(parsed.request.query).toEqual({ a: "1" });
+        expect("rawQuery" in parsed.request).toBe(false);
+        expect("raw_query" in parsed.request).toBe(false);
+
+        return new Response(
+          JSON.stringify({ status: 200, headers: {}, body: null }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({ ...DEFAULT_OPTIONS, client });
+    await conn.request({
+      method: "GET",
+      path: "/x",
+      query: { a: "1" },
+      rawQuery: "?a=1&flag",
+    });
+  });
+
   // The platform proxy parses the response and follows redirects server-side,
   // so managed mode diverges from BYO on both flags by design.
   test("names rawResponseBody and manualRedirect as unhonored", () => {

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -12,6 +12,10 @@ import { isBinaryOAuthBody } from "./connection.js";
 const log = getLogger("platform-oauth-connection");
 const MAX_RETRIES = 3;
 
+/** Status range the `Response` constructor accepts for a final response. */
+const MIN_RESPONSE_STATUS = 200;
+const MAX_RESPONSE_STATUS = 599;
+
 export class CredentialRequiredError extends BackendError {
   constructor(
     message = "OAuth credential for this provider has expired or been revoked. The service needs to be reconnected.",
@@ -203,6 +207,20 @@ function decodePlatformProxyEnvelope(json: {
   body: unknown;
   body_encoding?: string | null;
 }): OAuthConnectionResponse {
+  // A status outside the range `Response` accepts cannot be emitted, and
+  // clamping it would attribute a status to the provider that it never sent,
+  // so an unusable envelope fails as a platform fault instead.
+  const { status } = json;
+  if (
+    !Number.isInteger(status) ||
+    status < MIN_RESPONSE_STATUS ||
+    status > MAX_RESPONSE_STATUS
+  ) {
+    throw new BackendError(
+      `Platform proxy returned an unusable response status: ${JSON.stringify(status)}`,
+    );
+  }
+
   let body = json.body;
   if (json.body_encoding === "base64") {
     if (typeof body !== "string") {
@@ -213,7 +231,7 @@ function decodePlatformProxyEnvelope(json: {
     body = Buffer.from(body, "base64");
   }
   return {
-    status: json.status,
+    status,
     headers: json.headers ?? {},
     body,
   };

--- a/assistant/src/runtime/http-errors.ts
+++ b/assistant/src/runtime/http-errors.ts
@@ -11,9 +11,13 @@
 /**
  * Well-known HTTP error codes for the runtime API.
  *
- * These are wire-protocol identifiers (stable, client-facing strings) — not
- * to be confused with `ErrorCode` from `util/errors.ts`, which is for
- * internal assistant-layer errors.
+ * These are wire-protocol identifiers (stable, client-facing strings), not to
+ * be confused with `ErrorCode` from `util/errors.ts`, which is for internal
+ * assistant-layer errors.
+ *
+ * The union covers every `code` a `RouteError` subclass in
+ * `routes/errors.ts` carries, because both adapters emit one through
+ * `err.code as HttpErrorCode`.
  */
 export type HttpErrorCode =
   | "BAD_REQUEST"
@@ -21,17 +25,24 @@ export type HttpErrorCode =
   | "UNAUTHORIZED"
   | "PAYMENT_REQUIRED"
   | "FORBIDDEN"
+  | "LLM_REQUEST_LOGS_DISABLED"
   | "NOT_FOUND"
   | "METHOD_NOT_ALLOWED"
   | "CONFLICT"
   | "GONE"
+  | "PAYLOAD_TOO_LARGE"
+  | "UNSUPPORTED_MEDIA_TYPE"
+  | "RANGE_NOT_SATISFIABLE"
+  | "BINARY_UNSUPPORTED_OVER_IPC"
   | "RATE_LIMITED"
   | "UNPROCESSABLE_ENTITY"
   | "FAILED_DEPENDENCY"
   | "INTERNAL_ERROR"
   | "NOT_IMPLEMENTED"
   | "BAD_GATEWAY"
-  | "SERVICE_UNAVAILABLE";
+  | "UPSTREAM_PROVIDER_ERROR"
+  | "SERVICE_UNAVAILABLE"
+  | "GATEWAY_TIMEOUT";
 
 // ── Response type ────────────────────────────────────────────────────────────
 

--- a/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
@@ -23,6 +23,7 @@ import {
   PlatformOAuthConnection,
   ProviderUnreachableError,
 } from "../../../oauth/platform-connection.js";
+import type { VellumPlatformClient } from "../../../platform/client.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import type { AuthContext } from "../../auth/types.js";
 import { routeDefinitionsToHTTPRoutes } from "../http-adapter.js";
@@ -67,6 +68,26 @@ const byoConnection: OAuthConnection = {
     throw new Error("the proxy never unwraps the raw token");
   },
 };
+
+/**
+ * A real managed connection over a stub platform, for the paths whose behavior
+ * lives inside `PlatformOAuthConnection` rather than in the route.
+ */
+function realManagedConnection(
+  fetchImpl: () => Promise<Response>,
+): PlatformOAuthConnection {
+  return new PlatformOAuthConnection({
+    id: "conn-managed",
+    provider: "stripe_link",
+    externalId: "ext-1",
+    accountInfo: null,
+    connectionId: "platform-conn-1",
+    client: {
+      platformAssistantId: "asst-1",
+      fetch: fetchImpl,
+    } as unknown as VellumPlatformClient,
+  });
+}
 
 /** Satisfies the route's `instanceof PlatformOAuthConnection` check. */
 function managedConnection(): OAuthConnection {
@@ -267,7 +288,19 @@ describe("path and query fidelity", () => {
 
   test("omits query entirely when the caller sent none", async () => {
     await callProxy({});
-    expect(requireCaptured().query).toBeUndefined();
+    const req = requireCaptured();
+    expect(req.query).toBeUndefined();
+    expect(req.rawQuery).toBe("");
+  });
+
+  test("hands the connection the query bytes alongside the parsed form", async () => {
+    await callProxy({ search: "?a=1&b=2&a=3&q=x%20y&flag" });
+
+    const req = requireCaptured();
+    // Byte-exact for a provider that signs the query it receives.
+    expect(req.rawQuery).toBe("?a=1&b=2&a=3&q=x%20y&flag");
+    // The parsed form is all a managed connection can send.
+    expect(req.query).toEqual({ a: ["1", "3"], b: "2", q: "x y", flag: "" });
   });
 
   test("normalizes an inner dot segment", async () => {
@@ -315,6 +348,42 @@ describe("method passthrough", () => {
 
     expect(response.status).toBe(405);
     expect(captured).toBeUndefined();
+  });
+});
+
+// ── Write safety ────────────────────────────────────────────────────────────
+
+describe("write safety", () => {
+  for (const method of ["POST", "PATCH"]) {
+    test(`a proxied ${method} asks for a single attempt`, async () => {
+      await callProxy({ method, body: "{}" });
+      expect(requireCaptured().singleAttempt).toBe(true);
+    });
+  }
+
+  for (const method of ["GET", "PUT", "DELETE"]) {
+    test(`a proxied ${method} keeps its retries`, async () => {
+      await callProxy({ method });
+      expect(requireCaptured().singleAttempt).toBe(false);
+    });
+  }
+
+  test("a managed write is not replayed after a 502", async () => {
+    let attempts = 0;
+    resolution = {
+      ...resolution,
+      connection: realManagedConnection(async () => {
+        attempts++;
+        return new Response("", { status: 502 });
+      }),
+    };
+
+    const response = await callProxy({ method: "POST", body: "{}" });
+
+    // The platform answers 502 only after calling the provider, so a replay
+    // could land the write twice.
+    expect(attempts).toBe(1);
+    expect(response.status).toBe(502);
   });
 });
 
@@ -583,6 +652,25 @@ describe("failure mapping", () => {
     requestError = new ProviderUnreachableError();
     expect((await callProxy({})).status).toBe(502);
   });
+
+  test("an unusable managed status is a mapped 502, not an opaque 500", async () => {
+    resolution = {
+      ...resolution,
+      connection: realManagedConnection(async () => {
+        return new Response(
+          JSON.stringify({ status: 700, headers: {}, body: null }),
+          { status: 200 },
+        );
+      }),
+    };
+
+    // Handing 700 to `new Response` would throw a RangeError, which is not a
+    // RouteError and reaches the caller as a bare 500.
+    const response = await callProxy({});
+
+    expect(response.status).toBe(502);
+    expect((await envelope(response)).error.code).toBe("BAD_GATEWAY");
+  });
 });
 
 // ── Grant binding and path safety ───────────────────────────────────────────
@@ -702,6 +790,12 @@ describe("path safety", () => {
     });
     expect(resolverCalls).toHaveLength(0);
     expect(captured).toBeUndefined();
+  });
+
+  test("every proxy route declares the 421 it can throw", () => {
+    for (const route of ROUTES) {
+      expect(route.additionalResponses?.["421"]).toBeDefined();
+    }
   });
 });
 

--- a/assistant/src/runtime/routes/oauth-proxy-routes.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-routes.ts
@@ -12,7 +12,10 @@
  */
 
 import { isHttpAuthDisabled } from "../../config/env.js";
-import type { OAuthConnectionResponse } from "../../oauth/connection.js";
+import {
+  isIdempotentHttpMethod,
+  type OAuthConnectionResponse,
+} from "../../oauth/connection.js";
 import type { OAuthConnectionResolution } from "../../oauth/connection-resolver.js";
 import { resolveOAuthConnectionWithMeta } from "../../oauth/connection-resolver.js";
 import { getProvider } from "../../oauth/oauth-store.js";
@@ -136,6 +139,14 @@ export async function handleOAuthProxy(
       // The caller's own HTTP client decides what to do with a 3xx; the
       // proxy never makes an upstream hop on its behalf.
       manualRedirect: true,
+      // A retryable status can arrive after the provider has already been
+      // called, so a write the caller cannot repeat is never replayed. GET and
+      // the other idempotent methods keep their retries.
+      singleAttempt: !isIdempotentHttpMethod(method),
+      // The provider signing this query sees the bytes the caller wrote: key
+      // order, `%20`, and valueless flags all survive. Managed connections
+      // have no raw mode and send `query` instead.
+      rawQuery: args.rawUrl.search,
     });
   } catch (err) {
     throw mapProxyRequestError(err, provider);
@@ -175,6 +186,7 @@ const ERROR_RESPONSES: Record<string, { description: string }> = {
   "404": { description: "Unknown provider" },
   "405": { description: "The resolved connection rejects this method" },
   "409": { description: "Several accounts are connected and none was pinned" },
+  "421": { description: "Dispatched over IPC; retry over HTTP" },
   "424": { description: "No usable connection; reconnect the provider" },
   "502": { description: "The provider API could not be reached" },
 };


### PR DESCRIPTION
## Summary

- The proxy route now sets `singleAttempt: !isIdempotentHttpMethod(method)` on every forwarded request, so a proxied POST or PATCH is never replayed by `PlatformOAuthConnection`'s retry loop. The flag and the helper already existed but nothing set them, so the earlier fix was inert. Proxied GET, PUT, and DELETE keep their retries.
- `ERROR_RESPONSES` declares the 421 the handler throws first thing when `rawUrl` is absent, so the generated spec matches the prose. `HttpErrorCode` gains `BINARY_UNSUPPORTED_OVER_IPC` plus the other codes `routes/errors.ts` can carry, so the adapters' `err.code as HttpErrorCode` cast no longer lies.
- `decodePlatformProxyEnvelope` validates the platform's `status` against the range `Response` accepts. An unusable status now fails as a platform fault (a mapped 502) instead of throwing `RangeError` inside the HTTP adapter and reaching the caller as an opaque 500. Clamping was rejected: it would attribute a status to the provider that it never sent.
- `OAuthConnectionRequest` gains an opt-in `rawQuery`, which `BYOOAuthConnection` appends verbatim, and the route passes `args.rawUrl.search`. A query a provider signs keeps its interleaved repeated keys in order, its `%20`, and its valueless flags, matching the byte fidelity the path already had. Managed connections have no raw mode and still send the parsed `query`, which the platform proxy rebuilds.

Fixes gaps found in self-review of plan oauth-proxy-passthrough.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHYWQLdQvdW2dcnsMfZxyz