### PR TITLE
fix(runtime): derive the verified subject on IPC and keep it out of user handlers

### DIFF
--- a/assistant/src/ipc/__tests__/inject-local-actor-header.test.ts
+++ b/assistant/src/ipc/__tests__/inject-local-actor-header.test.ts
@@ -1,15 +1,25 @@
 /**
- * `injectLocalActorHeader` resolves the IPC caller's principal type. Routes
- * that elevate trust gate on `"local"`, so a gateway-proxied remote request
- * must never resolve to `local` — even when it arrives with no verified
- * principal header (e.g. `runtimeProxyRequireAuth` disabled). The
+ * `injectLocalActorHeader` resolves the IPC caller's identity. Routes that
+ * elevate trust gate on `"local"`, so a gateway-proxied remote request must
+ * never resolve to `local`, even when it arrives with no verified principal
+ * header (e.g. `runtimeProxyRequireAuth` disabled). The
  * `x-vellum-proxy-server: ipc` marker (forwarded by the gateway, never sent by
  * a direct CLI) distinguishes the two.
+ *
+ * The transport verifies no subject and serves no wire-exact URL, so the two
+ * fields that carry those (`x-vellum-subject`, `rawUrl`) are dropped rather
+ * than passed through from a caller that can reach the socket.
  */
 
 import { describe, expect, test } from "bun:test";
 
-import { injectLocalActorHeader } from "../assistant-server.js";
+import type { RouteHandlerArgs } from "../../runtime/routes/types.js";
+import {
+  AssistantIpcServer,
+  injectLocalActorHeader,
+} from "../assistant-server.js";
+
+const SPOOFED_SUBJECT = "local:self:oauth-proxy.stripe_link";
 
 describe("injectLocalActorHeader principal resolution", () => {
   test("a forwarded verified principal wins", () => {
@@ -29,5 +39,91 @@ describe("injectLocalActorHeader principal resolution", () => {
   test("a direct IPC caller (no proxy marker, no principal) defaults to local", () => {
     const out = injectLocalActorHeader({ headers: {} });
     expect(out.headers?.["x-vellum-principal-type"]).toBe("local");
+  });
+});
+
+describe("injectLocalActorHeader identity sanitation", () => {
+  test("drops a caller-supplied x-vellum-subject", () => {
+    const out = injectLocalActorHeader({
+      headers: { "x-vellum-subject": SPOOFED_SUBJECT },
+    });
+    expect(out.headers?.["x-vellum-subject"]).toBeUndefined();
+  });
+
+  test("drops the subject a gateway-proxied caller forwards", () => {
+    const out = injectLocalActorHeader({
+      headers: {
+        "x-vellum-proxy-server": "ipc",
+        "x-vellum-subject": SPOOFED_SUBJECT,
+      },
+    });
+    expect(out.headers?.["x-vellum-subject"]).toBeUndefined();
+  });
+
+  test("drops a caller-supplied rawUrl", () => {
+    const out = injectLocalActorHeader({
+      rawUrl: { pathname: "/v1/oauth/proxy/stripe_link/v1/charges" },
+    });
+    expect(out.rawUrl).toBeUndefined();
+  });
+
+  test("leaves the caller's other params alone", () => {
+    const out = injectLocalActorHeader({
+      pathParams: { provider: "stripe_link" },
+      queryParams: { limit: "1" },
+    });
+    expect(out.pathParams).toEqual({ provider: "stripe_link" });
+    expect(out.queryParams).toEqual({ limit: "1" });
+  });
+});
+
+/**
+ * Every dispatched method funnels through `injectLocalActorHeader`, so the
+ * spoofed values must be gone by the time a handler runs. `handleEnvelope` is
+ * private; reach it through an interface cast (same pattern as
+ * route-error-envelope.test.ts) and hand it a destroyed socket, which makes
+ * the response write a no-op.
+ */
+type PrivateApi = {
+  methods: Map<string, (args: RouteHandlerArgs) => unknown>;
+  handleEnvelope(
+    socket: unknown,
+    reader: unknown,
+    envelope: unknown,
+    binary: Uint8Array | undefined,
+  ): void;
+};
+
+describe("IPC dispatch", () => {
+  test("a spoofed subject and rawUrl never reach the handler", () => {
+    const server = new AssistantIpcServer() as unknown as PrivateApi;
+    let received: RouteHandlerArgs | undefined;
+    server.methods.set("identity_probe", (args) => {
+      received = args;
+      return null;
+    });
+
+    server.handleEnvelope(
+      { destroyed: true },
+      { isLegacy: false },
+      {
+        id: "req-1",
+        method: "identity_probe",
+        params: {
+          headers: {
+            "x-vellum-subject": SPOOFED_SUBJECT,
+            "x-vellum-principal-type": "local",
+          },
+          pathParams: { provider: "stripe_link" },
+          rawUrl: { pathname: "/v1/oauth/proxy/stripe_link/v1/charges" },
+        },
+      },
+      undefined,
+    );
+
+    expect(received).toBeDefined();
+    expect(received?.headers?.["x-vellum-subject"]).toBeUndefined();
+    expect(received?.rawUrl).toBeUndefined();
+    expect(received?.pathParams).toEqual({ provider: "stripe_link" });
   });
 });

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -681,17 +681,23 @@ export class AssistantIpcServer {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve an IPC caller's identity headers, mirroring what the HTTP adapter
- * derives from the verified `AuthContext`: `x-vellum-principal-type` and a
- * synthetic `x-vellum-actor-principal-id` for the local guardian. Handlers read
- * the resolved identity from `headers` (the single source of truth across both
- * transports); they never trust the request body.
+ * Resolve an IPC caller's identity headers, the IPC counterpart to what the
+ * HTTP adapter derives from the verified `AuthContext`:
+ * `x-vellum-principal-type` and a synthetic `x-vellum-actor-principal-id` for
+ * the local guardian. Handlers read the resolved identity from `headers` (the
+ * single source of truth across both transports); they never trust the request
+ * body.
  *
  * Principal type comes from the gateway-forwarded `x-vellum-principal-type`,
  * else `svc_gateway` for a gateway-proxied request (marked by
  * `x-vellum-proxy-server: ipc`, which a direct CLI never sends), else `local`.
  * Routes that elevate trust gate on `local`, so a remote caller arriving with
  * no verified principal must resolve to `svc_gateway`, never `local`.
+ *
+ * `x-vellum-subject` and `rawUrl` are dropped: this transport verifies no
+ * subject, and the wire-exact URL is the HTTP adapter's to set. Both are
+ * spoofable by anything that reaches the socket, and a handler that reads
+ * either treats absence as the fail-closed case.
  */
 export function injectLocalActorHeader(
   params: Record<string, unknown> | undefined,
@@ -707,6 +713,7 @@ export function injectLocalActorHeader(
     "x-vellum-principal-type":
       forwardedPrincipal ?? (isGatewayProxied ? "svc_gateway" : "local"),
   };
+  delete headers["x-vellum-subject"];
 
   // Fill the local guardian's actor id for direct callers that lack one.
   // Defensive: the lookup queries the contacts table, which may not exist on a
@@ -726,7 +733,9 @@ export function injectLocalActorHeader(
     }
   }
 
-  return { ...args, headers };
+  const sanitized: RouteHandlerArgs = { ...args, headers };
+  delete sanitized.rawUrl;
+  return sanitized;
 }
 
 // ── Process-level singleton ───────────────────────────────────────────────

--- a/assistant/src/runtime/routes/__tests__/user-routes-request.test.ts
+++ b/assistant/src/runtime/routes/__tests__/user-routes-request.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the `Request` the `/x/*` routes synthesize for user-authored
+ * handler files.
+ *
+ * Two properties matter here. Fidelity: served over HTTP the handler sees the
+ * URL the client sent, so repeated query keys and percent-encoded path
+ * segments survive; served over IPC there is no wire URL, so it is rebuilt
+ * from the matched path and the flattened query. And audience: the verified
+ * `x-vellum-subject` is daemon-side authorization material and stays out of
+ * workspace code, while the identity the handler has always seen, and every
+ * other header, still reaches it.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { getWorkspaceRoutesDir } from "../../../util/platform.js";
+import type { RouteHandlerArgs, RouteResponse } from "../types.js";
+import { ROUTES } from "../user-routes.js";
+
+/** A path whose single segment is percent-encoded on the wire. */
+const ROUTE_PATH = "hello world";
+
+const ECHO_HANDLER = `export function GET(request) {
+  const url = new URL(request.url);
+  return Response.json({
+    pathname: url.pathname,
+    tags: url.searchParams.getAll("tag"),
+    subject: request.headers.get("x-vellum-subject"),
+    principalType: request.headers.get("x-vellum-principal-type"),
+    actorPrincipalId: request.headers.get("x-vellum-actor-principal-id"),
+    clientId: request.headers.get("x-vellum-client-id"),
+  });
+}
+`;
+
+interface EchoBody {
+  pathname: string;
+  tags: string[];
+  subject: string | null;
+  principalType: string | null;
+  actorPrincipalId: string | null;
+  clientId: string | null;
+}
+
+const getHandler = ROUTES.find((r) => r.operationId === "user_route_get")!
+  .handler as (args: RouteHandlerArgs) => Promise<RouteResponse>;
+
+const IDENTITY_HEADERS_IN: Record<string, string> = {
+  "x-vellum-principal-type": "actor",
+  "x-vellum-actor-principal-id": "user-123",
+  "x-vellum-subject": "actor:self:user-123",
+  "x-vellum-client-id": "client-abc",
+};
+
+async function echo(args: RouteHandlerArgs): Promise<EchoBody> {
+  const response = await getHandler(args);
+  expect(response.status).toBe(200);
+  return (await new Response(response.body).json()) as EchoBody;
+}
+
+beforeEach(() => {
+  mkdirSync(getWorkspaceRoutesDir(), { recursive: true });
+  writeFileSync(
+    join(getWorkspaceRoutesDir(), `${ROUTE_PATH}.ts`),
+    ECHO_HANDLER,
+  );
+});
+
+afterEach(() => {
+  rmSync(getWorkspaceRoutesDir(), { recursive: true, force: true });
+});
+
+describe("user route request URL", () => {
+  test("served over HTTP, the wire URL reaches the handler intact", async () => {
+    const body = await echo({
+      pathParams: { path: ROUTE_PATH },
+      // The flattened record the adapter also passes: last value wins, so it
+      // cannot be the source of the repeated keys.
+      queryParams: { tag: "b" },
+      rawUrl: new URL("http://127.0.0.1:4747/v1/x/hello%20world?tag=a&tag=b"),
+      headers: IDENTITY_HEADERS_IN,
+    });
+
+    expect(body.pathname).toBe("/v1/x/hello%20world");
+    expect(body.tags).toEqual(["a", "b"]);
+  });
+
+  test("served over IPC, the URL is rebuilt from the matched path and query", async () => {
+    const body = await echo({
+      pathParams: { path: ROUTE_PATH },
+      queryParams: { tag: "b" },
+      headers: IDENTITY_HEADERS_IN,
+    });
+
+    expect(body.pathname).toBe("/v1/x/hello%20world");
+    expect(body.tags).toEqual(["b"]);
+  });
+});
+
+describe("user route identity headers", () => {
+  test("the verified subject does not reach a user-authored handler", async () => {
+    const body = await echo({
+      pathParams: { path: ROUTE_PATH },
+      rawUrl: new URL("http://127.0.0.1:4747/v1/x/hello%20world"),
+      headers: IDENTITY_HEADERS_IN,
+    });
+
+    expect(body.subject).toBeNull();
+  });
+
+  test("the caller's principal type, actor id, and other headers still do", async () => {
+    const body = await echo({
+      pathParams: { path: ROUTE_PATH },
+      headers: IDENTITY_HEADERS_IN,
+    });
+
+    expect(body.principalType).toBe("actor");
+    expect(body.actorPrincipalId).toBe("user-123");
+    expect(body.clientId).toBe("client-abc");
+  });
+});

--- a/assistant/src/runtime/routes/types.ts
+++ b/assistant/src/runtime/routes/types.ts
@@ -96,6 +96,22 @@ export type RouteResponseBody =
       schema: z.ZodType | Record<string, unknown>;
     };
 
+/**
+ * Identity headers the adapters own. The HTTP adapter deletes all three off
+ * the inbound request and rewrites them from the verified `AuthContext`; the
+ * IPC adapter resolves the first two and deletes the third (see
+ * {@link RouteHandlerArgs.headers}).
+ *
+ * A consumer that forwards `RouteHandlerArgs.headers` anywhere less trusted
+ * (a user-authored `/x/*` handler) filters against this list, so adding a
+ * fourth header does not widen that audience by default.
+ */
+export const IDENTITY_HEADERS = [
+  "x-vellum-principal-type",
+  "x-vellum-actor-principal-id",
+  "x-vellum-subject",
+] as const;
+
 export interface RouteHandlerArgs {
   pathParams?: Record<string, string>;
   queryParams?: Record<string, string>;
@@ -103,18 +119,26 @@ export interface RouteHandlerArgs {
   rawBody?: Uint8Array;
   /**
    * The request URL exactly as received: percent-encoding intact in
-   * `pathname`, repeated keys intact in `search`. Set only by the HTTP
-   * adapter, so a handler that needs wire-exact input treats `undefined` as
-   * "not served over HTTP".
+   * `pathname`, repeated keys intact in `search`. Set by the HTTP adapter
+   * alone (the IPC adapter drops any inbound value), so a handler that needs
+   * wire-exact input treats `undefined` as "not served over HTTP".
    */
   rawUrl?: URL;
   /**
-   * Caller identity headers, including `x-vellum-principal-type` (the verified
-   * principal type), `x-vellum-actor-principal-id`, and `x-vellum-subject`
-   * (the verified `AuthContext.subject`). Both adapters derive these from a
-   * trusted source (HTTP from the verified `AuthContext`, IPC from
-   * `injectLocalActorHeader`), never from caller-supplied values, so handlers
-   * that elevate trust can gate on the header (e.g. `"local"`).
+   * Caller identity ({@link IDENTITY_HEADERS}) alongside the transport's own
+   * headers.
+   *
+   * The HTTP adapter derives all three from the verified `AuthContext`, so a
+   * handler that elevates trust can gate on `x-vellum-principal-type` (e.g.
+   * `"local"`) and on the `x-vellum-subject` a capability grant names.
+   *
+   * The IPC adapter (`injectLocalActorHeader`) has no verified context to
+   * derive from: it resolves the principal type from the gateway-forwarded
+   * header, else the gateway proxy marker, else `local`; fills the local
+   * guardian's `x-vellum-actor-principal-id` when the caller sent none; and
+   * drops `x-vellum-subject` outright, since nothing on that transport
+   * verifies a subject. A subject therefore reaches a handler over HTTP only,
+   * and a subject check fails closed over IPC.
    */
   headers?: Record<string, string>;
   /**

--- a/assistant/src/runtime/routes/user-routes.ts
+++ b/assistant/src/runtime/routes/user-routes.ts
@@ -17,26 +17,56 @@
 
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
-import { RouteResponse } from "./types.js";
+import { IDENTITY_HEADERS, RouteResponse } from "./types.js";
 import { UserRouteDispatcher } from "./user-route-dispatcher.js";
 
 const dispatcher = new UserRouteDispatcher();
 
 /**
- * Reconstruct a Web API `Request` from transport-agnostic handler args.
- *
- * The synthesized Request carries all information the dispatcher needs:
- * path, method, headers, and body. The host/port/scheme are synthetic —
- * user handlers should not depend on them.
+ * The identity a user-authored handler is allowed to see. The verified
+ * subject is withheld: it is the daemon's own authorization material (an
+ * OAuth proxy grant is honored for the subject it names), and handler files
+ * in the workspace are a wider audience than the routes that gate on it.
+ * Every other {@link IDENTITY_HEADERS} entry is withheld too, so a new one
+ * reaches user code only when someone adds it here.
  */
-function synthesizeRequest(method: string, args: RouteHandlerArgs): Request {
+const USER_HANDLER_IDENTITY_HEADERS = new Set<string>([
+  "x-vellum-principal-type",
+  "x-vellum-actor-principal-id",
+]);
+
+/**
+ * URL for a request that did not arrive over HTTP, rebuilt from the matched
+ * path and the flattened query. Repeated query keys collapsed on the way in,
+ * so only `rawUrl` carries them.
+ */
+function reconstructUrl(args: RouteHandlerArgs): URL {
   const path = args.pathParams?.path ?? "";
   const url = new URL(`http://localhost/v1/x/${path}`);
   for (const [k, v] of Object.entries(args.queryParams ?? {})) {
     url.searchParams.set(k, v);
   }
+  return url;
+}
+
+/**
+ * Reconstruct a Web API `Request` from transport-agnostic handler args.
+ *
+ * The synthesized Request carries all information the dispatcher needs:
+ * path, method, headers, and body. Over HTTP the URL is the one the client
+ * sent, percent-encoding and repeated query keys intact; over IPC it is
+ * rebuilt around a synthetic origin, so user handlers should not depend on
+ * host, port, or scheme.
+ */
+function synthesizeRequest(method: string, args: RouteHandlerArgs): Request {
+  const url = args.rawUrl ?? reconstructUrl(args);
 
   const headers = new Headers(args.headers ?? {});
+  for (const name of IDENTITY_HEADERS) {
+    if (!USER_HANDLER_IDENTITY_HEADERS.has(name)) {
+      headers.delete(name);
+    }
+  }
 
   let body: BodyInit | undefined;
   if (args.rawBody) {


### PR DESCRIPTION
## Summary

- The IPC adapter now deletes `x-vellum-subject` instead of passing a caller's through. Nothing on that transport verifies a subject: the unix socket is the whole credential, and a synthetic one would sit in the same `local:self:*` namespace the OAuth proxy grants use, so absence is the honest signal and a subject check fails closed over IPC.
- The IPC adapter also drops a caller-supplied `rawUrl`. The shared type says the HTTP adapter alone sets it, and `handleOAuthProxy` guards on `!args.rawUrl` before it checks the subject, so an IPC caller could otherwise clear that guard with a JSON object shaped like a URL.
- `assistant/src/runtime/routes/types.ts` states what is actually true of both adapters, and exports `IDENTITY_HEADERS` as the list of adapter-owned identity headers.
- User-authored `/x/*` handlers get an allowlist rather than every identity header: principal type and actor id (what they have always seen) pass, the verified subject does not, and a fourth identity header stays out until someone adds it to the allowlist.
- `synthesizeRequest` uses `args.rawUrl` when the request arrived over HTTP, so repeated query keys and percent-encoded path segments survive; the flattened reconstruction remains the IPC fallback.
- Tests: a spoofed subject (and rawUrl) is gone by the time an IPC-dispatched handler runs, the subject does not reach a user-authored handler while the other headers still do, and a user route served over HTTP sees repeated query keys and its encoded path segment intact.

Fixes gaps found in self-review of plan oauth-proxy-passthrough.md.