### PR TITLE
fix(companion): draw point-at marks on the surface the model measured (JARVIS-1776)

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ScreenCapture.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ScreenCapture.swift
@@ -87,6 +87,7 @@ final class ScreenCapture: ScreenCaptureProviding, @unchecked Sendable {
         let filter: SCContentFilter
         let sourceSize: CGSize
         let captureDisplayId: CGDirectDisplayID
+        let config = SCStreamConfiguration()
 
         switch target {
         case .window(let windowID):
@@ -98,6 +99,13 @@ final class ScreenCapture: ScreenCaptureProviding, @unchecked Sendable {
             }
             filter = SCContentFilter(desktopIndependentWindow: window)
             sourceSize = window.frame.size
+            // Without this the picture is the window plus its shadow, scaled
+            // together into the window's own size, so the content comes out
+            // smaller than the window and inset from its edges. Whoever
+            // measures against that picture (the assistant, drawing marks in
+            // fractions of the shared surface) then lands inward of what they
+            // meant. The window's frame is the surface; the shadow is not.
+            config.ignoreShadowsSingleWindow = true
             captureDisplayId = Self.displayHolding(window.frame)
 
         case .display(let displayID):
@@ -120,8 +128,6 @@ final class ScreenCapture: ScreenCaptureProviding, @unchecked Sendable {
             sourceSize = CGSize(width: display.width, height: display.height)
             captureDisplayId = display.displayID
         }
-
-        let config = SCStreamConfiguration()
 
         let sourceWidth = max(sourceSize.width, 1)
         let sourceHeight = max(sourceSize.height, 1)

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -382,12 +382,16 @@ type GlowWindow = {
 };
 let glow: GlowWindow | null = null;
 const glowPushes: CompanionSurfaceState[] = [];
+/** The BrowserWindow options the frame was last opened with. */
+let glowOptions: Record<string, unknown> | undefined;
 
 const openGlow = (options: {
   position?: { x: number; y: number } | (() => { x: number; y: number });
   width: number;
   height: number;
+  browserWindow?: Record<string, unknown>;
 }): GlowWindow => {
+  glowOptions = options.browserWindow;
   const at =
     typeof options.position === "function"
       ? options.position()
@@ -1530,6 +1534,20 @@ describe("the light a watch session puts on the display", () => {
       }),
     );
     expect(glow?.bounds).toEqual({ x: 1440, y: 0, width: 1920, height: 1080 });
+  });
+
+  test("is allowed to cover the menu bar, so it is the whole display", () => {
+    // macOS holds a window to the work area unless told otherwise, and a
+    // frame a menu bar short of the display draws every fraction measured
+    // against the display's picture low by that much.
+    send(
+      "vellum:companion:setContext",
+      context({
+        watching: true,
+        captureTarget: { kind: "display", displayId: 2 },
+      }),
+    );
+    expect(glowOptions?.enableLargerThanScreen).toBe(true);
   });
 
   test("is placed again when the picked display changes shape", () => {

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1444,12 +1444,11 @@ const surfaceBounds = async (
   share: WatchCaptureTarget,
 ): Promise<Rectangle | null> => {
   // The frame's own rectangle, because that is the one the marks are drawn
-  // on, and it is not always the one the share names. A frame asked for a
-  // display's whole bounds is held to that display's work area, which begins
-  // a menu bar lower and ends a menu bar shorter, so a fraction measured
-  // against the display and drawn into the frame lands low by exactly that
-  // much. Deriving the surface twice is what let the two disagree; asking the
-  // frame is what keeps them the same rectangle by construction.
+  // on. It is placed on the share's bounds, and `placeWatchFrame` asks for
+  // the whole display rather than its work area, so the two should agree;
+  // asking the frame rather than deriving the surface a second time is what
+  // keeps them the same rectangle by construction, whatever the window
+  // system did with the request.
   const frame = getFloatingWindow(WATCH_FRAME_KIND);
   if (frame !== null) {
     return frame.getBounds();
@@ -1508,6 +1507,15 @@ const placeWatchFrame = (bounds: Rectangle): void => {
       minimizable: false,
       maximizable: false,
       backgroundColor: "#00000000",
+      // **The frame must be the surface, to the pixel.** Without this macOS
+      // holds a window to the display's work area: asked for the whole
+      // display it comes back a menu bar lower and a menu bar shorter, and
+      // says nothing. The assistant measures its marks against a picture of
+      // the whole display, and a fraction of that drawn into the shorter
+      // window lands low by the menu bar's height at the top, shrinking to
+      // nothing at the foot. The menu bar draws over the top of the window
+      // either way; `frameInsetTop` is what keeps the rim clear of it.
+      enableLargerThanScreen: true,
     },
   });
   win.setAlwaysOnTop(true, "floating", -1);


### PR DESCRIPTION
## What

`screen_point_at` rings (coordinate marks) landed below and inward of what they described, while named-target arrows were exact. Two geometric mismatches between the picture the model measures against and the window the ring is drawn on, both verified on a 16-inch display:

1. **Display share: the watch frame was clamped to the work area.** `placeWatchFrame` created the frame without `enableLargerThanScreen`, so macOS returned `(0, 33, 1728, 1084)` for a request of `(0, 0, 1728, 1117)`. The sight frame is the whole display, so a fraction `y` drew `33 * (1 - y)` pt low. Fixed by passing the option; `frameInsetTop` already keeps the rim clear of the menu bar that now draws over the window's top.
2. **Window share: the capture included the window shadow.** `SCContentFilter(desktopIndependentWindow:)` without `ignoreShadowsSingleWindow` returns the window plus its shadow scaled into the window's size. A 1431x1084 capture had opaque content only at x 33-1377, y 40-1058. Fixed by setting the flag (deployment target is macOS 15, no availability guard needed).

The `surfaceBounds` comment that described the clamp as expected is retired, and a test pins the frame's option.

## Not in this PR

The model's own estimate in the frame Alex shared was also biased (thumbnail at y 0.143, model said 0.175 twice). That is estimation error on top of the geometry and is why the skill already prefers named targets; nothing here changes it.

## Verification

- `bun test src/main/companion-window.test.ts` in `clients/macos`: 233 pass
- `bun run typecheck` in `clients/macos`: clean
- `swift build` in `clients/macos/native/mac-helper`: builds
- Scratch Electron and ScreenCaptureKit scripts for the two measurements above

Not yet verified in the running app: the helper needs a rebuild and the app a restart, and a rebuild resets the helper's TCC grants.

Closes JARVIS-1776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kHpUf7T5hxUppEV7ar21U
