### PR TITLE
fix(web): merge the annotation layer's two style props (JARVIS-1774, JARVIS-1775)

### DIFF
--- a/clients/web/src/components/companion-share-annotation.tsx
+++ b/clients/web/src/components/companion-share-annotation.tsx
@@ -283,13 +283,13 @@ export function CompanionShareAnnotation({ ink }: { ink: string }) {
       className="companion-share-annotation fixed inset-0 h-full w-full"
       style={
         {
+          cursor,
           "--companion-ink-hold": `${COMPANION_INK_HOLD_MS}ms`,
           "--companion-ink-fade": `${COMPANION_INK_FADE_MS}ms`,
         } as React.CSSProperties
       }
       data-testid="companion-share-annotation"
       role="presentation"
-      style={{ cursor }}
       onPointerDown={handleDown}
       onPointerMove={handleMove}
       onPointerUp={handleUp}


### PR DESCRIPTION
## Summary
#42435 (pencil cursor) and #42436 (annotation linger) each added a `style` attribute to the annotation layer's SVG. Merged together they leave main with a duplicate JSX attribute, which fails web typecheck (TS17001). This folds the cursor into the one style object beside the ink timing custom properties.

The same resolution is already on #42439's branch, so it rebases cleanly once this lands.

## Verification
- `bunx tsc --noEmit` in `clients/web`: clean
- `companion-share-annotation.test.tsx`: 18 pass; `companion-watch-frame-page.test.tsx`: 34 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZTyGdrVc4zr5tsyDr262w