### PR TITLE
docs: document Windows desktop setup and support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ DB migration steps registered in `steps.ts` are checkpointed by function name in
 
 ## Multi-Client Assistant State Sync
 
-Persisted assistant state that must converge across macOS, web/Capacitor iOS, and CLI should use the generic `sync_changed` invalidation contract instead of adding a new bespoke server message for each resource. The event payload is `{ type: "sync_changed", tags: [...] }`; tags describe which cached resource is stale, not the new value.
+Persisted assistant state that must converge across macOS, Windows, web/Capacitor iOS, and CLI should use the generic `sync_changed` invalidation contract instead of adding a new bespoke server message for each resource. The event payload is `{ type: "sync_changed", tags: [...] }`; tags describe which cached resource is stale, not the new value.
 
 When adding a synced resource:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you've set up a Personal AI on OpenClaw, Hermes Agent, or Claude Code, you kn
 | **Identity**                  | Behavior lives in SOUL.md. During onboarding the assistant observes how you communicate and writes its own personality files. It keeps a per-user journal of reflections and uses NOW.md as a scratchpad for current focus and active threads. |
 | **Proactivity**               | Every hour the assistant re-reads its notes, looks for anything unfinished or due soon, and messages you if something needs attention. Notifications go to the right channel and won't interrupt an active conversation. |
 | **Security**                  | Actor identity (guardian, trusted, unknown) is resolved once and enforced everywhere; unknown actors can't read memory, trigger tools, or escalate. Credentials live in a separate process and never reach the model. Every tool call runs in a sandbox. The default is to deny. |
-| **Channels**           | macOS, iOS, Web, Voice, Email, Telegram, Slack, Twilio. One assistant, one memory, every channel. |
+| **Channels**           | macOS, Windows, iOS, Web, Voice, Email, Telegram, Slack, Twilio. One assistant, one memory, every channel. |
 | **OAuth**             | Slack, Notion, Google, HubSpot, Linear, Discord, Twitter, Telegram, Twilio. No hand-rolled token refresh. |
 | **Hosting**      | Managed runtime on Vellum Platform, or self-hosted. Same codebase, same data model. |
 
@@ -32,6 +32,8 @@ If you've set up a Personal AI on OpenClaw, Hermes Agent, or Claude Code, you kn
 ## Get Started
 
 **1. [Sign up](https://vellum.ai/signup) or [download the app](https://vellum.ai/download)**
+
+The desktop app is available for macOS and Windows. The Windows download is currently a dev build connected to the development environment, with x64 (Intel/AMD) and ARM64 installers. See the [installation guide](https://www.vellum.ai/docs/getting-started/installation) for setup and permissions.
 
 **2. Pick your mode**
 
@@ -61,7 +63,7 @@ If you've set up a Personal AI on OpenClaw, Hermes Agent, or Claude Code, you kn
 
 <br>
 
-The CLI works but the desktop app is our primary focus. Available for advanced users, contributors, and non-macOS environments.
+The CLI works but the desktop app is our primary focus. Available for advanced users, contributors, and terminal-based workflows. The Windows desktop app installs the bundled CLI for your user account on first launch; open a new terminal afterward to use `vellum`.
 
 **Install**
 
@@ -107,7 +109,7 @@ All commands target the default assistant. If you have multiple, pass the assist
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Computer use**           | The assistant works in its own sandbox, and with your approval reaches your actual machine: reads and edits files, runs commands, drives the browser. Every action is permission-gated, and you can grant once, for ten minutes, or always. |
 | **Skills**                 | Plugins defined by a SKILL.md and a TOOLS.json that add tools and prompt sections at runtime, sandboxed like everything else. Install them from the catalog, bundle them, or drop them in the workspace.                                                                                      |
-| **Channels**               | One assistant with one memory, reachable from the macOS app, Telegram, or Slack. Start a thought in one channel and pick it up in another.                                                                                                                                                              |
+| **Channels**               | One assistant with one memory, reachable from the macOS or Windows app, Telegram, or Slack. Start a thought in one channel and pick it up in another.                                                                                                                                                              |
 | **Multi-provider support** | Works with Anthropic, OpenAI, Google Gemini, Fireworks, OpenRouter, MiniMax, [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=vellum-assistant), and any OpenAI-compatible endpoint. Local models run through Ollama. Embeddings run on local ONNX by default and fall back to cloud providers automatically.                                                                                    |
 
 ---

--- a/clients/docs/src/app/docs/(documentation)/getting-started/installation/page.tsx
+++ b/clients/docs/src/app/docs/(documentation)/getting-started/installation/page.tsx
@@ -4,7 +4,7 @@ import { createMetadata } from "@/lib/metadata";
 export const metadata = createMetadata({
   title: "Installation - Vellum Docs",
   description:
-    "Get started with Vellum: sign up for Vellum Cloud, install the desktop app on macOS, or self-host. System requirements, setup, and permissions.",
+    "Get started with Vellum: sign up for Vellum Cloud, install the desktop app on macOS or Windows, or self-host. System requirements, setup, and permissions.",
   path: "/docs/getting-started/installation",
 });
 

--- a/clients/docs/src/app/docs/(documentation)/hosting-options/local-hosting/page.tsx
+++ b/clients/docs/src/app/docs/(documentation)/hosting-options/local-hosting/page.tsx
@@ -4,7 +4,7 @@ import { createMetadata } from "@/lib/metadata";
 export const metadata = createMetadata({
   title: "Local hosting - Vellum Docs",
   description:
-    "Run your assistant locally on your Mac with setup guidance, tradeoffs, and best practices.",
+    "Run your assistant locally on your Mac or Windows PC with setup guidance, tradeoffs, and best practices.",
   path: "/docs/hosting-options/local-hosting",
 });
 

--- a/clients/docs/src/app/docs/(documentation)/hosting-options/page.tsx
+++ b/clients/docs/src/app/docs/(documentation)/hosting-options/page.tsx
@@ -4,7 +4,7 @@ import { createMetadata } from "@/lib/metadata";
 export const metadata = createMetadata({
   title: "Hosting options - Vellum Docs",
   description:
-    "Choose where your assistant runs: Vellum Cloud (recommended), local on your Mac, or self-hosted on your own infrastructure.",
+    "Choose where your assistant runs: Vellum Cloud (recommended), local on your Mac or Windows PC, or self-hosted on your own infrastructure.",
   path: "/docs/hosting-options",
 });
 

--- a/clients/docs/src/app/docs/(documentation)/skills-reference/computer-use/page.tsx
+++ b/clients/docs/src/app/docs/(documentation)/skills-reference/computer-use/page.tsx
@@ -4,7 +4,7 @@ import { createMetadata } from "@/lib/metadata";
 export const metadata = createMetadata({
   title: "Computer Use - Vellum Docs",
   description:
-    "Computer Use skill for Vellum — control your Mac directly with screen observation, clicking, typing, and AppleScript.",
+    "Computer Use skill for Vellum: control supported apps on macOS and Windows with screen observation, clicking, and typing.",
   path: "/docs/skills-reference/computer-use",
 });
 

--- a/clients/docs/src/app/docs/_components/developer-guide-contributing-content.tsx
+++ b/clients/docs/src/app/docs/_components/developer-guide-contributing-content.tsx
@@ -44,7 +44,7 @@ export function DeveloperGuideContributingContent() {
               only hard requirement. The setup script handles everything else.
             </li>
             <li>
-              <strong>macOS or Linux</strong> — the assistant runtime supports both. macOS uses{" "}
+              <strong>macOS or Linux for the shell-based setup below.</strong> macOS uses{" "}
               <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">sandbox-exec</code> for sandboxing,
               Linux uses <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">bwrap</code> (bubblewrap).
             </li>
@@ -52,6 +52,14 @@ export function DeveloperGuideContributingContent() {
               <strong>Git</strong> — the setup script configures custom git hooks automatically.
             </li>
           </ul>
+          <p className="mb-4 text-zinc-600">
+            For Windows desktop development, start with the{" "}
+            <a href="https://github.com/vellum-ai/vellum-assistant/blob/main/clients/windows/README.md">
+              Windows client README
+            </a>. It covers Git Bash or WSL for POSIX scripts, a PowerShell development
+            flow, and native packaging. The packaged Windows app includes its runtime
+            and does not require this contributor setup.
+          </p>
           <p className="text-sm text-zinc-500">
             Docker Desktop is optional but needed if you want full sandbox isolation on Linux. On macOS, the native{" "}
             <code className="text-sm">sandbox-exec</code> is used and requires no extra setup.
@@ -86,7 +94,7 @@ cd vellum-assistant
             <pre className="mb-4 overflow-x-auto rounded-lg bg-zinc-900 p-4 text-sm text-zinc-100">
 {`├── assistant/            # Bun-based assistant runtime (core logic, HTTP API)
 ├── cli/                  # Vellum CLI (multi-assistant management)
-├── clients/              # Native macOS client (menu bar app)
+├── clients/              # Web, desktop (macOS, Windows, Linux), and mobile clients
 ├── gateway/              # Channel gateway (Telegram, Twilio, OAuth, reverse proxy)
 ├── credential-executor/  # Credential Execution Service (isolated RPC)
 ├── packages/             # Shared private packages

--- a/clients/docs/src/app/docs/_components/developer-guide-get-started-content.tsx
+++ b/clients/docs/src/app/docs/_components/developer-guide-get-started-content.tsx
@@ -46,7 +46,7 @@ export function DeveloperGuideGetStartedContent() {
           <ul className="mb-0 list-disc space-y-2 pl-6 text-zinc-600">
             <li>
               <strong>Contributors</strong> working on the assistant
-              runtime, the macOS or iOS clients, the gateway, the CLI,
+              runtime, the macOS, Windows, or iOS clients, the gateway, the CLI,
               or the platform web app.
             </li>
             <li>
@@ -128,6 +128,9 @@ export function DeveloperGuideGetStartedContent() {
             </li>
             <li>
               <code>clients/macos/</code>: the macOS desktop app
+            </li>
+            <li>
+              <code>clients/windows/</code>: the Windows desktop app
             </li>
           </ul>
           <p className="mb-0 text-zinc-600">

--- a/clients/docs/src/app/docs/_components/getting-started-content.tsx
+++ b/clients/docs/src/app/docs/_components/getting-started-content.tsx
@@ -38,8 +38,13 @@ export function GettingStartedContent() {
               Connects to your cloud assistant.
             </li>
             <li>
-              <strong>For the desktop app:</strong> macOS 15 (Sequoia) or later, Apple Silicon
+              <strong>For the Mac app:</strong> macOS 15 (Sequoia) or later, Apple Silicon
               or Intel, plus ~500 MB free disk space. Connects to a cloud or local assistant.
+            </li>
+            <li>
+              <strong>For the Windows app:</strong> Windows 10 or later. Choose the x64
+              installer for Intel or AMD PCs, or ARM64 for Windows on Arm. Connects to a
+              cloud or local assistant.
             </li>
             <li>
               Internet connection (your assistant uses cloud AI models to think)
@@ -122,8 +127,8 @@ export function GettingStartedContent() {
             Desktop app
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
-            The desktop app gives you a menu bar presence, voice input with hold-to-talk, and
-            the ability to control your Mac through accessibility APIs. It connects to a
+            The desktop app is available on macOS and Windows, with a menu bar or system tray
+            presence, voice input, and computer control. It connects to a
             cloud assistant by default (so your conversations and memory show up in both the
             web and desktop apps), but it can also run a local assistant entirely on your
             machine. See{" "}
@@ -131,6 +136,12 @@ export function GettingStartedContent() {
               Hosting options
             </a>{" "}
             for the local-only setup.
+          </p>
+          <p className="mb-4 text-zinc-600">
+            The Windows download is currently a <strong>dev build</strong>. It connects
+            to Vellum&apos;s development environment, so your production cloud assistant
+            and its history will not appear there. The main download is x64; select
+            Other downloads for ARM64.
           </p>
           <ol className="mb-4 list-decimal space-y-2 pl-6 text-zinc-600">
             <li>
@@ -140,18 +151,25 @@ export function GettingStartedContent() {
               for Vellum if you haven&apos;t already.
             </li>
             <li>
-              Download the macOS <code>.dmg</code> from your account dashboard.
+              Download the macOS <code>.dmg</code> or Windows <code>.exe</code> from the{" "}
+              <a href="https://www.vellum.ai/download" className="font-semibold text-emerald-700 underline hover:text-emerald-800">
+                download page
+              </a>.
             </li>
             <li>
-              Open the <code>.dmg</code>, drag Vellum to Applications, and launch it.
+              On macOS, open the <code>.dmg</code>, drag Vellum to Applications, and launch it.
+              On Windows, run the <code>.exe</code> installer and open Vellum from Start.
             </li>
             <li>
-              Sign in with your Vellum account. Your cloud assistant shows up automatically.
+              Sign in with your Vellum account. Production builds connect to your existing
+              cloud assistant; the Windows dev build connects to the development environment.
             </li>
           </ol>
           <p className="mb-6 text-zinc-600">
-            That&apos;s the whole process. No terminal commands, no package managers, no YAML
-            files. Standard <code>.dmg</code>, signed and notarized.
+            The installers include everything needed to run the app. macOS downloads are signed
+            and notarized; Windows downloads are Authenticode-signed. No terminal setup is
+            needed. On Windows, the app also installs the <code>vellum</code> CLI for your
+            user account. Open a new terminal after the first launch to use it.
           </p>
         </section>
 
@@ -187,7 +205,7 @@ export function GettingStartedContent() {
             <li>
               <strong>Bring your own API key</strong> — Self-host the runtime and connect it to
               your own Anthropic API key. Useful if you want to run everything on your own
-              machine. Your key is stored in your macOS Keychain.
+              machine. Vellum manages your credentials separately from the assistant.
             </li>
           </ul>
         </section>
@@ -235,7 +253,7 @@ export function GettingStartedContent() {
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
             Vellum doesn&apos;t ask for all its permissions upfront. Instead, permissions are
-            requested only when they&apos;re actually needed:
+            requested only when they&apos;re actually needed. The table below describes macOS:
           </p>
           <div className="mb-6 overflow-x-auto">
             <table className="min-w-full text-sm">
@@ -311,10 +329,16 @@ export function GettingStartedContent() {
               </tbody>
             </table>
           </div>
+          <p className="mb-4 text-zinc-600">
+            On Windows, open Settings &gt; Permissions &amp; Privacy in Vellum to check
+            microphone, screen capture, speech, and notification access. Use the settings
+            link beside a permission to open the corresponding Windows settings page.
+            Accessibility, Input Monitoring, and Automation permissions are macOS-only
+            and do not appear on Windows. Computer control cannot interact with elevated
+            or protected windows.
+          </p>
           <p className="mb-6 rounded-lg border border-zinc-200 bg-zinc-50 p-4 text-zinc-700">
-            <strong>Worth knowing:</strong> The app accesses files through normal sandbox
-            entitlements, not Full Disk Access. Individual file and shell actions still require
-            your approval through the in-app permission system. Check out{" "}
+            Individual file and shell actions are governed by the in-app permission system. Check out{" "}
             <a href="/docs/trust-security">Trust &amp; Security</a> for the full picture.
           </p>
         </section>

--- a/clients/docs/src/app/docs/_components/glossary-content.tsx
+++ b/clients/docs/src/app/docs/_components/glossary-content.tsx
@@ -34,7 +34,7 @@ const GLOSSARY_ENTRIES: GlossaryEntry[] = [
   {
     term: "Client",
     definition:
-      "A device or application used to interact with the assistant. The Vellum macOS app, iOS app, web interface, and Chrome extension are all clients. A client connects to the assistant through a channel.",
+      "A device or application used to interact with the assistant. The Vellum macOS and Windows apps, iOS app, web interface, and Chrome extension are all clients. A client connects to the assistant through a channel.",
   },
   {
     term: "Contact",

--- a/clients/docs/src/app/docs/_components/help-common-issues-content.tsx
+++ b/clients/docs/src/app/docs/_components/help-common-issues-content.tsx
@@ -11,6 +11,7 @@ const TOC_ITEMS = [
   { id: "signing-in", label: "Signing in", level: 2 },
   { id: "iphone-app", label: "iPhone app", level: 2 },
   { id: "desktop-app", label: "Desktop app (Mac)", level: 2 },
+  { id: "windows-desktop-app", label: "Desktop app (Windows)", level: 2 },
   { id: "approvals", label: "Approvals", level: 2 },
   { id: "memory", label: "Memory", level: 2 },
   { id: "voice", label: "Voice", level: 2 },
@@ -210,6 +211,52 @@ export function HelpCommonIssuesContent() {
               writing local files
             </li>
           </ul>
+        </section>
+
+        <section id="windows-desktop-app" className="mt-12">
+          <SectionHeading id="windows-desktop-app" level={2}>
+            Desktop app (Windows)
+          </SectionHeading>
+          <SectionHeading id="windows-installation" level={3}>
+            Installation or startup fails
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            Download the Windows installer from the{" "}
+            <a href="https://www.vellum.ai/download">Vellum download page</a>.
+            Use x64 for Intel or AMD PCs and ARM64 for Windows on Arm. Check the
+            system tray for Vellum if the main window is closed. The tray menu offers
+            a restart action.
+          </p>
+          <SectionHeading id="windows-permissions" level={3}>
+            Voice, screen capture, or computer control is unavailable
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            Open Settings &gt; Permissions &amp; Privacy in Vellum and use the settings
+            link beside the affected permission. Windows controls microphone, screen
+            capture, speech, and notification access. There is no Accessibility
+            permission to enable. Elevated apps, UAC prompts, and protected windows
+            cannot be controlled; use a normal, non-administrator app window.
+          </p>
+          <SectionHeading id="windows-cli" level={3}>
+            The vellum command is not found
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            Launch Vellum once to provision its bundled CLI, then open a new terminal.
+            The dev build adds <code>{"%LOCALAPPDATA%\\Vellum-dev\\bin"}</code> to
+            your user PATH; production builds use <code>{"%LOCALAPPDATA%\\Vellum\\bin"}</code>. Run <code>where.exe vellum</code> to check which installation
+            your terminal finds if another version takes precedence.
+          </p>
+          <SectionHeading id="windows-logs" level={3}>
+            Finding logs for a bug report
+          </SectionHeading>
+          <p className="mb-0 text-zinc-600">
+            Use Help &gt; Send Feedback in the app to send a report with recent logs.
+            Desktop logs are also available at{" "}
+            <code>{"%APPDATA%\\Vellum Dev\\logs\\vellum.log"}</code> for the dev build
+            or <code>{"%APPDATA%\\Vellum\\logs\\vellum.log"}</code> for production.
+            Include your Windows version, installer architecture, and the steps that
+            reproduce the problem.
+          </p>
         </section>
 
         <section id="approvals" className="mt-12">

--- a/clients/docs/src/app/docs/_components/help-common-issues-content.tsx
+++ b/clients/docs/src/app/docs/_components/help-common-issues-content.tsx
@@ -247,13 +247,10 @@ export function HelpCommonIssuesContent() {
             your terminal finds if another version takes precedence.
           </p>
           <SectionHeading id="windows-logs" level={3}>
-            Finding logs for a bug report
+            Sending logs with a bug report
           </SectionHeading>
           <p className="mb-0 text-zinc-600">
             Use Help &gt; Send Feedback in the app to send a report with recent logs.
-            Desktop logs are also available at{" "}
-            <code>{"%APPDATA%\\Vellum Dev\\logs\\vellum.log"}</code> for the dev build
-            or <code>{"%APPDATA%\\Vellum\\logs\\vellum.log"}</code> for production.
             Include your Windows version, installer architecture, and the steps that
             reproduce the problem.
           </p>

--- a/clients/docs/src/app/docs/_components/help-faq-content.tsx
+++ b/clients/docs/src/app/docs/_components/help-faq-content.tsx
@@ -29,7 +29,7 @@ export function HelpFaqContent() {
           </SectionHeading>
           <p className="mb-6 text-zinc-600">
             A personal AI assistant that lives on your computer. It can take real actions on your
-            behalf: reading files, sending emails, browsing the web, controlling your Mac, building
+            behalf: reading files, sending emails, browsing the web, controlling your Mac or Windows PC, building
             apps, managing your schedule, making phone calls, and more. It has its own identity,
             personality, and long-term memory that persists across conversations. See{" "}
             <a href="/docs/getting-started/what-is-vellum">What is Vellum?</a> for the full
@@ -84,7 +84,7 @@ export function HelpFaqContent() {
             >
               vellum.ai
             </Link>
-            , the iPhone and iPad app, the macOS desktop app, and a
+            , the iPhone and iPad app, the macOS and Windows desktop apps, and a
             command-line interface. Beyond those first-party surfaces,
             channels include Telegram, Slack, email, and phone calls.
           </p>
@@ -119,7 +119,7 @@ export function HelpFaqContent() {
                   Local hosting
                 </Link>
               </strong>
-              . The assistant runs on your Mac. Your data stays on your
+              . The assistant runs on your computer. Your data stays on your
               machine, and the assistant has direct access to your local
               files and tools. The right pick if you want maximum data
               control or fully offline operation, and you&apos;re okay
@@ -301,9 +301,10 @@ export function HelpFaqContent() {
           <p className="mb-6 text-zinc-600">
             Yes, with your permission. The Computer Use skill lets your assistant see your screen
             (via accessibility APIs and screenshots) and control mouse and keyboard input. This
-            requires macOS Accessibility and Screen Recording permissions, and each action is
-            prompted individually for approval. Sessions are capped at 50 steps with loop detection
-            and destructive action blocking. See{" "}
+            requires Accessibility and Screen Recording permissions on macOS. On Windows,
+            check screen capture access in Settings &gt; Permissions &amp; Privacy; there
+            is no Accessibility permission prompt. Windows computer control cannot act
+            on elevated or protected windows. In-app permissions still apply. See{" "}
             <a href="/docs/skills-reference/computer-use">Computer Use</a>.
           </p>
 

--- a/clients/docs/src/app/docs/_components/help-getting-help-content.tsx
+++ b/clients/docs/src/app/docs/_components/help-getting-help-content.tsx
@@ -58,8 +58,8 @@ export function HelpGettingHelpContent() {
             goes wrong — without logs, we&apos;re guessing.
           </p>
           <p className="mb-4 text-zinc-600">
-            On the <strong>desktop app</strong>, open the <em>Help</em> menu in the macOS menu bar
-            and pick <em>Share Feedback</em>.
+            On macOS, open <em>Help &gt; Share Feedback</em> in the menu bar. On Windows,
+            open <em>Help &gt; Send Feedback</em> in the app&apos;s menu bar.
           </p>
           <div className="mb-6 overflow-hidden rounded-xl border border-zinc-200 bg-white">
             <Image
@@ -165,7 +165,7 @@ export function HelpGettingHelpContent() {
                   <td className="px-3 py-2">The exact text, not a paraphrase</td>
                 </tr>
                 <tr>
-                  <td className="px-3 py-2"><strong>macOS version</strong></td>
+                  <td className="px-3 py-2"><strong>Operating system and version</strong></td>
                   <td className="px-3 py-2">Compatibility issues are real</td>
                 </tr>
                 <tr>

--- a/clients/docs/src/app/docs/_components/homepage-content.tsx
+++ b/clients/docs/src/app/docs/_components/homepage-content.tsx
@@ -116,7 +116,7 @@ export function HomepageContent() {
               so it&apos;s always on and reachable from any browser, ready when you are. Your
               workspace, memories, and config are encrypted, exportable, and yours to delete.
               Want to keep everything on your own machine instead? You can self-host Vellum on
-              macOS or your own infrastructure.
+              macOS, Windows, or your own infrastructure.
             </p>
             <p className="mb-3 text-zinc-600">
               <strong>Personalized to you.</strong> It knows your preferences, your context, your

--- a/clients/docs/src/app/docs/_components/hosting-options-cloud-hosting-content.tsx
+++ b/clients/docs/src/app/docs/_components/hosting-options-cloud-hosting-content.tsx
@@ -233,7 +233,7 @@ export function HostingOptionsCloudHostingContent() {
           <p className="mb-4 text-stone-600 dark:text-stone-400">
             The distinction is between tools that run on the
             assistant&apos;s computer (the cloud container) versus tools
-            that run on yours (your Mac, through the desktop app):
+            that run on yours (your Mac or Windows PC, through the desktop app):
           </p>
           <ul className="mb-4 list-disc space-y-2 pl-6 text-stone-600 dark:text-stone-400">
             <li>

--- a/clients/docs/src/app/docs/_components/hosting-options-content.tsx
+++ b/clients/docs/src/app/docs/_components/hosting-options-content.tsx
@@ -127,14 +127,14 @@ export function HostingOptionsContent() {
               Local
             </SectionHeading>
             <p className="mb-4 text-stone-600 dark:text-stone-400">
-              Your assistant runs on your Mac. Your machine, your data, nothing
-              leaves your computer. This is the option for users who want
-              maximum privacy and direct access to local files and tools.
+              Your assistant runs on your Mac or Windows PC. Your workspace stays on
+              your machine, with direct access to local files and tools. Prompts and
+              relevant context are still sent to your configured AI model provider.
             </p>
             <ul className="mb-4 list-disc space-y-4 pl-6 text-stone-600 dark:text-stone-400">
               <li>
-                <strong>Native</strong> — The assistant runs directly as a
-                process on your Mac. It&apos;s the simplest local setup and
+                <strong>Native</strong>: The assistant runs directly as a
+                process on your Mac or Windows PC. It&apos;s the simplest local setup and
                 gives the assistant full access to your system.
               </li>
               <li>

--- a/clients/docs/src/app/docs/_components/hosting-options-local-hosting-content.tsx
+++ b/clients/docs/src/app/docs/_components/hosting-options-local-hosting-content.tsx
@@ -40,7 +40,7 @@ export function HostingOptionsLocalHostingContent() {
             . If you want local instead, this page is for you.
           </p>
           <p className="mb-4 text-stone-600 dark:text-stone-400">
-            Local hosting means your assistant runs on your Mac. Your data
+            Local hosting means your assistant runs on your Mac or Windows PC. Your data
             stays on your machine, the assistant has direct access to your
             files and tools, and there&apos;s no cloud infrastructure to
             manage. The tradeoff: it&apos;s only available when your computer
@@ -48,7 +48,7 @@ export function HostingOptionsLocalHostingContent() {
           </p>
           <p className="mb-0 text-stone-600 dark:text-stone-400">
             Today, local hosting uses native (the assistant runs directly
-            as a process on your Mac). Docker and Apple Container options are
+            as a process on your Mac or Windows PC). Docker and Apple Container options are
             on the roadmap and will provide better isolation while keeping
             everything local.
           </p>
@@ -67,9 +67,9 @@ export function HostingOptionsLocalHostingContent() {
               </span>
             </SectionHeading>
             <p className="mb-4 text-stone-600 dark:text-stone-400">
-              The assistant runs directly as a process on your Mac. No
-              containers, no virtual machines. This is what you get when you
-              install Vellum today.
+              The assistant runs directly as a process on your Mac or Windows PC. No
+              containers, no virtual machines. Choose local hosting in the desktop app;
+              installing the app alone does not switch a cloud assistant to local hosting.
             </p>
             <dl className="mb-0 space-y-3">
               <div className="rounded-xl border border-stone-200 p-4 dark:border-moss-600/50">
@@ -252,12 +252,12 @@ export function HostingOptionsLocalHostingContent() {
           </SectionHeading>
           <p className="mb-4 text-stone-600 dark:text-stone-400">
             With any local option, the assistant is only available when your
-            computer is awake. If your Mac is asleep or shut down, scheduled
+            computer is awake. If your computer is asleep or shut down, scheduled
             tasks won&apos;t fire and the assistant can&apos;t respond until
             it wakes back up.
           </p>
           <p className="mb-0 text-stone-600 dark:text-stone-400">
-            For most people using their primary Mac, this means the assistant
+            For most people using their primary computer, this means the assistant
             works great during the workday and whenever the computer is active.
             If you need always-on availability without buying dedicated
             hardware, Vellum Cloud is the better fit.

--- a/clients/docs/src/app/docs/_components/integrations-tavily-content.tsx
+++ b/clients/docs/src/app/docs/_components/integrations-tavily-content.tsx
@@ -57,7 +57,7 @@ export function IntegrationsTavilyContent() {
           </SectionHeading>
           <ul className="mb-0 list-disc space-y-2 pl-6 text-zinc-600">
             <li>
-              A running Vellum assistant. Cloud, self-hosted, or the macOS desktop app all work.
+              A running Vellum assistant. Cloud, self-hosted, or the desktop apps all work.
             </li>
             <li>
               A Tavily API key. Create one at{" "}

--- a/clients/docs/src/app/docs/_components/key-concepts-channels-content.tsx
+++ b/clients/docs/src/app/docs/_components/key-concepts-channels-content.tsx
@@ -94,8 +94,8 @@ export function KeyConceptsChannelsContent() {
             Desktop App
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
-            The flagship experience. A native macOS menu bar app with full
-            capabilities:
+            The desktop experience is available on macOS and Windows, with a menu bar
+            presence on Mac and a system tray icon on Windows:
           </p>
           <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600">
             <li>
@@ -104,11 +104,11 @@ export function KeyConceptsChannelsContent() {
             </li>
             <li>
               <strong>Computer use</strong> — your assistant can see your screen
-              and control your Mac directly
+              and control your Mac or Windows PC directly
             </li>
             <li>
-              <strong>Voice input</strong> — hold your activation key and speak,
-              or enable wake word detection
+              <strong>Voice input</strong>: use the in-app voice controls or configure
+              your voice shortcut in Settings
             </li>
             <li>
               <strong>Document editor</strong> — long-form writing with your
@@ -128,8 +128,12 @@ export function KeyConceptsChannelsContent() {
             </li>
           </ul>
           <p className="mb-0 text-zinc-600">
-            Every tool, every skill, every feature is available here. If a
-            capability exists, the desktop app supports it.
+            Some features depend on the operating system. The Fn voice key and floating
+            companion are macOS-only. Windows uses a configurable voice mode shortcut
+            and supports computer control in normal, non-elevated windows. See{" "}
+            <a href="/docs/trust-security/the-permissions-model#windows-system-permissions">
+              Windows system permissions
+            </a>.
           </p>
         </section>
 

--- a/clients/docs/src/app/docs/_components/trust-security-permissions-model-content.tsx
+++ b/clients/docs/src/app/docs/_components/trust-security-permissions-model-content.tsx
@@ -16,6 +16,7 @@ const TOC_ITEMS = [
   { id: "directory-scoped-rules", label: "Directory-scoped rules", level: 3 },
   { id: "skill-tool-permissions", label: "Skill tool permissions", level: 2 },
   { id: "macos-system-permissions", label: "macOS system permissions", level: 2 },
+  { id: "windows-system-permissions", label: "Windows system permissions", level: 2 },
   { id: "cross-channel-approvals", label: "Cross-channel approvals", level: 2 },
   { id: "what-happens-when-you-say-no", label: "What happens when you say no", level: 2 },
 ];
@@ -476,6 +477,25 @@ export function TrustSecurityPermissionsModelContent() {
             These are the &ldquo;can it access this at all&rdquo; layer. The
             assistant&apos;s Allow/Deny prompts are the &ldquo;should it access
             this right now&rdquo; layer. Both must pass for an action to execute.
+          </p>
+        </section>
+
+        <section id="windows-system-permissions" className="mt-12">
+          <SectionHeading id="windows-system-permissions" level={2}>
+            Windows system permissions
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            Windows does not have macOS Accessibility, Input Monitoring, or Automation
+            permission prompts. Those rows are hidden in Vellum on Windows. Open
+            Settings &gt; Permissions &amp; Privacy in Vellum to check microphone, screen
+            capture, speech, and notification access; the settings links open the
+            corresponding Windows settings pages.
+          </p>
+          <p className="mb-0 text-zinc-600">
+            Computer control runs as your Windows user without requesting administrator
+            access. It cannot interact with elevated apps, UAC prompts, or protected
+            windows. An in-app approval does not override that boundary. For tasks in
+            an app you control, use its normal, non-administrator window.
           </p>
         </section>
 

--- a/clients/docs/src/app/docs/_components/web-search-brave-content.tsx
+++ b/clients/docs/src/app/docs/_components/web-search-brave-content.tsx
@@ -44,7 +44,7 @@ export function WebSearchBraveContent() {
           </SectionHeading>
           <ul className="mb-0 list-disc space-y-2 pl-6 text-zinc-600">
             <li>
-              A running Vellum assistant. Cloud, self-hosted, or the macOS desktop app all work.
+              A running Vellum assistant. Cloud, self-hosted, or the desktop apps all work.
             </li>
             <li>
               A Brave Search API key. Create one at{" "}

--- a/clients/docs/src/app/docs/_components/web-search-firecrawl-content.tsx
+++ b/clients/docs/src/app/docs/_components/web-search-firecrawl-content.tsx
@@ -45,7 +45,7 @@ export function WebSearchFirecrawlContent() {
           </SectionHeading>
           <ul className="mb-0 list-disc space-y-2 pl-6 text-zinc-600 dark:text-zinc-400">
             <li>
-              A running Vellum assistant. Cloud, self-hosted, or the macOS desktop app all work.
+              A running Vellum assistant. Cloud, self-hosted, or the desktop apps all work.
             </li>
             <li>
               A Firecrawl API key. Create one at{" "}

--- a/clients/docs/src/app/docs/_components/web-search-perplexity-content.tsx
+++ b/clients/docs/src/app/docs/_components/web-search-perplexity-content.tsx
@@ -44,7 +44,7 @@ export function WebSearchPerplexityContent() {
           </SectionHeading>
           <ul className="mb-0 list-disc space-y-2 pl-6 text-zinc-600">
             <li>
-              A running Vellum assistant. Cloud, self-hosted, or the macOS desktop app all work.
+              A running Vellum assistant. Cloud, self-hosted, or the desktop apps all work.
             </li>
             <li>
               A Perplexity API key. Create one at{" "}

--- a/clients/docs/src/app/docs/_components/what-is-vellum-content.tsx
+++ b/clients/docs/src/app/docs/_components/what-is-vellum-content.tsx
@@ -55,8 +55,8 @@ export function WhatIsVellumContent() {
             <strong>It has tools, not just words.</strong> Your assistant can browse
             the web, read your files, run code, send emails, manage your calendar,
             and interact with dozens of services. It can also see your screen and
-            control your Mac directly — clicking, typing, and navigating apps on
-            your behalf through macOS accessibility APIs. Sensitive actions always
+            control your Mac or Windows PC directly, clicking, typing, and navigating apps
+            through the desktop app. Sensitive actions always
             require your approval first. It doesn&apos;t describe what you{" "}
             <em>could</em> do. It does it.
           </p>
@@ -100,8 +100,8 @@ export function WhatIsVellumContent() {
             handle the plumbing yourself.
           </p>
           <p className="mb-3 text-zinc-600">
-            <strong>It has a real interface.</strong> A polished web app and a
-            native macOS desktop app, not a terminal prompt. You can see your
+            <strong>It has a real interface.</strong> A polished web app and
+            desktop apps for macOS and Windows. You can see your
             memories, browse your skills, manage integrations, and read
             conversation history in a UI designed for humans. OpenClaw and Hermes
             live in the terminal, which works if you&apos;re a developer who lives
@@ -155,7 +155,7 @@ export function WhatIsVellumContent() {
 
           <h3 className="mb-3 text-base font-semibold text-zinc-800">🖥️ Automation &amp; Control</h3>
           <ul className="mb-6 list-disc space-y-2 pl-6 text-zinc-600">
-            <li><strong>Computer Use</strong> — Control your Mac directly: click, type, and navigate apps via macOS accessibility APIs</li>
+            <li><strong>Computer Use</strong>: Control your Mac or Windows PC: click, type, and navigate supported apps</li>
             <li><strong>Browser</strong> — Navigate and interact with web pages using a headless browser</li>
             <li><strong>Screen Watch</strong> — Observe the screen at regular intervals with OCR</li>
             <li><strong>Watcher</strong> — Poll and monitor external sources for changes</li>
@@ -244,16 +244,17 @@ export function WhatIsVellumContent() {
             </ul>
           </div>
           <div className="mb-6">
-            <h3 className="mb-2 text-base font-semibold text-zinc-800">🖥️ macOS desktop app</h3>
+            <h3 className="mb-2 text-base font-semibold text-zinc-800">🖥️ Desktop apps for macOS and Windows</h3>
             <p className="mb-2 text-zinc-600">
-              Native macOS app with a menu bar presence. Same assistant as the
-              web app, plus the ability to control your computer through macOS
-              accessibility APIs. Supports macOS 15 (Sequoia) and above.
+              A menu bar app on macOS and a system tray app on Windows. Same assistant as the
+              web app, plus computer control and voice input. See the{" "}
+              <a href="/docs/getting-started/installation">installation guide</a> for
+              system requirements and setup.
             </p>
             <ul className="list-disc space-y-1 pl-6 text-zinc-600">
-              <li>One-click DMG install</li>
-              <li>Desktop automation via macOS accessibility APIs</li>
-              <li>Voice input with hold-to-talk (Fn key)</li>
+              <li>macOS DMG or Windows EXE installer</li>
+              <li>Desktop automation through macOS accessibility APIs or Windows UI Automation</li>
+              <li>Voice input with platform-specific shortcuts</li>
               <li>Connects to your Vellum Cloud assistant, or run a fully self-hosted local workspace</li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary

- Document Windows x64 and ARM64 installation, including the current dev-build download and its separate development environment.
- Add Windows permissions, computer-control limits, CLI/PATH setup, feedback, and log troubleshooting; update Mac-only desktop and local-hosting descriptions across the public docs and README.
- Point Windows contributors to the native client guide while retaining macOS-specific instructions where they apply.

## Validation

- Generated the docs search index (89 pages) and Markdown mirrors (90 pages), and inspected the Windows setup, troubleshooting, and permissions output.
- Checked new internal links against the route tree and ran `git diff --check`.
- Documentation only. No runtime behavior or API changes. The optional release feed was unavailable during local generation; the generator completed using its existing fallback.

## Original prompt

Check both vellum-assistant-platform and vellum-assistant for documentation that needs Windows information. Add the missing guidance using the /do workflow in isolated worktrees and open PRs for review.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->