### PR TITLE
docs(oauth): correct the passthrough surface after review

### DIFF
--- a/assistant/ARCHITECTURE.md
+++ b/assistant/ARCHITECTURE.md
@@ -70,6 +70,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | `svc:gateway:<assistantId>`              | `svc_gateway`  | Gateway service (ingress, webhooks) |
 | `svc:internal:<assistantId>:<sessionId>` | `svc_internal` | Internal service connections        |
 | `svc:daemon:<identifier>`                | `svc_daemon`   | Daemon service token (local)        |
+| `local:<assistantId>:<conversationId>`   | `local`        | Local session or single-route grant |
 
 **Scope profiles:**
 
@@ -79,6 +80,7 @@ All HTTP API requests use a single `Authorization: Bearer <jwt>` header for auth
 | `gateway_ingress_v1` | `ingress.write`, `internal.write`                                                                                                                     | Gateway channel inbound + webhook forwarding |
 | `gateway_service_v1` | `chat.{read,write}`, `settings.{read,write}`, `attachments.{read,write}`, `internal.write`                                                            | Gateway service-to-daemon calls              |
 | `local_v1`           | `local.all`                                                                                                                                           | Local (loopback) conversation sessions       |
+| `oauth_proxy_v1`     | `oauth.proxy`                                                                                                                                         | OAuth passthrough proxy route only           |
 | `speech_relay_v1`    | `speech.relay`                                                                                                                                        | Daemon dial of the gateway speech relay only |
 | `ui_page_v1`         | `settings.read`                                                                                                                                       | Served UI pages                              |
 

--- a/assistant/src/oauth/AGENTS.md
+++ b/assistant/src/oauth/AGENTS.md
@@ -67,7 +67,7 @@ A stock third-party CLI reaches a provider's API through the daemon without ever
 
 ### Route
 
-`oauth/proxy/:provider/:path*` (`../runtime/routes/oauth-proxy-routes.ts`), registered once per forwarded method (GET, POST, PUT, PATCH, DELETE, HEAD) under operation IDs `oauth_proxy_get`, `oauth_proxy_post`, and so on. OPTIONS is absent: a CORS preflight has no meaning for a CLI calling a loopback daemon. Every registration requires the `oauth.proxy` scope and a local principal.
+`oauth/proxy/:provider/:path*` (`../runtime/routes/oauth-proxy-routes.ts`), registered once per forwarded method (GET, POST, PUT, PATCH, DELETE, HEAD) under operation IDs `oauth_proxy_get`, `oauth_proxy_post`, and so on. Those ids are what IPC dispatch uses; `openapi.yaml` derives its own from the path, so the same routes read there as `oauth_proxy_by_provider_by_path_get` and the mint as `oauth_proxygrant_post`. OPTIONS is absent: a CORS preflight has no meaning for a CLI calling a loopback daemon. Every registration requires the `oauth.proxy` scope and a local principal.
 
 Only the HTTP adapter supplies the wire-exact URL the route forwards, so an IPC dispatch throws `HttpTransportRequiredError` (421, `BINARY_UNSUPPORTED_OVER_IPC`). That is the gateway's existing retry signal: its IPC proxy falls through to the HTTP proxy, so the caller is served rather than failed. The refusal precedes the provider lookup and the resolution, so upstream still runs exactly once.
 
@@ -90,39 +90,52 @@ The proxy re-derives that subject from the segment on the request and compares i
 
 A grant is pinned when the caller passed `--account` or the resolved connection carries an `accountInfo`. An unpinned grant is therefore bound to the provider, not to the connection row it was minted against: revoke that connection and replace it inside the grant's lifetime and the grant reaches the replacement. That is accepted, given the TTL.
 
+### Containment
+
+The grant carries one scope for one route, and three checks hold it there:
+
+- **Gateway edge auth** (`gateway/src/http/middleware/auth.ts`) refuses it on every gateway-native route, with no loopback fallback. `isSingleRouteGrant` reads any profile outside the `EDGE_AUTH_PROFILES` allowlist as a single-route grant, and also catches a proxy subject carrying some other profile. The passthrough itself never passes through edge auth: it falls to the runtime-proxy catch-all, which re-mints the grant's own profile for the daemon.
+- **The gateway's IPC fast path** (`gateway/src/http/routes/ipc-runtime-proxy.ts`) refuses it against any daemon route naming no scope. The daemon's IPC server runs no policy check of its own, so this is the only enforcement an IPC-served request gets.
+- **`enforcePolicy`** (`../runtime/auth/route-policy.ts`) refuses the same on the HTTP path, then applies the route's own scopes. `oauth.proxy` reaches the passthrough and nothing else.
+
+The two `UNSCOPED_ROUTE_PROFILES` sets, one per package, are hand-kept copies: the cross-package import boundary forbids sharing a module, so widening one means editing both. A new profile lands outside both and fails closed.
+
 ### CLI
 
 `assistant oauth proxy-url <provider>` mints a grant and prints it as JSON, or with `--export` as `export` lines for `eval`: `VELLUM_OAUTH_PROXY_BASE_URL`, `VELLUM_OAUTH_PROXY_TOKEN`, `VELLUM_OAUTH_PROXY_EXPIRES_AT`, and `VELLUM_OAUTH_PROXY_ACCOUNT` when the grant pinned one. The names are provider-neutral by design; the calling skill or wrapper maps them onto whatever its CLI reads (the command's help shows the Link example). The command is `medium` risk in the gateway's bash command registry (`gateway/src/risk/command-registry/commands/assistant.ts`).
 
 ### Byte fidelity and managed-mode limits
 
-The route asks each connection for `rawResponseBody: true` and `manualRedirect: true`.
+The route asks each connection for `rawResponseBody: true`, `manualRedirect: true`, the wire-exact `rawQuery`, and `singleAttempt` on every non-idempotent method.
 
-A BYO connection honors both. The provider's bytes come back untouched, and a 3xx is returned verbatim with its `Location` intact instead of being followed: following it would replay a POST upstream as a GET the caller never asked for and hide the 3xx from the client whose job it is to handle it.
+A BYO connection honors the first three: the provider's bytes come back untouched, the query reaches the provider as the caller wrote it, and a 3xx is surfaced rather than followed, since following it would replay a POST upstream as a GET the caller never asked for and hide the 3xx from the client whose job it is to handle it. It needs no `singleAttempt`, having made its one attempt already; its only retry follows a provider 401, which rejected the request before it took effect.
 
-A managed connection cannot honor `rawResponseBody`, because the platform proxy parses the response server-side. A managed JSON response is therefore parsed and re-serialized, which drops duplicate keys and rounds integers past `Number.MAX_SAFE_INTEGER`. Managed mode inherits the platform proxy's other limits too:
+The 3xx status survives; its target does not stay in `location`. `materializeProxyResponse` moves it onto `x-vellum-proxy-location` and drops `location`, so nothing auto-follows the redirect back to the provider carrying the grant as its bearer token. A client that keeps `Authorization` across hosts (`curl --location-trusted`, a hand-rolled redirect loop) would otherwise hand a live daemon credential to the third party on the first hop. The target stays readable under a name nothing follows.
+
+A managed connection is proxied by the platform, which parses the response and rebuilds the request server-side, so most of that does not survive:
+
+- **Response bytes.** `rawResponseBody` cannot be honored. A managed JSON response is parsed and re-serialized, which drops duplicate keys and rounds integers past `Number.MAX_SAFE_INTEGER`.
+- **Query fidelity.** `rawQuery` cannot be honored either; the parsed `query` record travels instead and the platform rebuilds the string. Interleaved repeated keys are regrouped, `%20` becomes `+`, and a valueless `?flag` becomes `flag=`. A provider that signs its own query string therefore works over BYO and cannot work over managed.
+- **Redirects.** The platform follows a 3xx itself, so the caller gets the destination's response and never the 3xx. `manualRedirect` does not apply.
+- **HEAD.** Not forwarded; the route answers 405 before calling a managed connection.
+
+`singleAttempt` is the one that does apply, which is why the route sets it: the platform retries a 502 it returns only after already calling the provider, so a proxied write the caller cannot repeat would otherwise be replayed.
+
+Managed mode inherits the platform proxy's narrowing too:
 
 - Request headers are narrowed to `content-type`, `accept`, `user-agent`, and `x-request-id`, plus the provider's configured defaults.
-- HEAD is not forwarded; the route answers 405 before calling a managed connection.
 - Response headers are narrowed to `Content-Type`, `X-Rate-Limit-Remaining`, and `X-Rate-Limit-Reset`.
 - Request and response bodies are size-capped platform-side.
 
-These are known limits: the proxy is byte-exact on BYO connections only. `stripe_link`, the connection it was built for, is managed.
+The proxy is byte-exact on BYO connections only, and `stripe_link`, the connection it was built for, is managed-only, so these limits are live rather than theoretical.
 
 ### Security invariants
 
 - The caller's `authorization` never reaches the provider. `sanitizeInboundHeaders` also drops proxy-auth, hop-by-hop framing, `host`, `cookie`, `accept-encoding`, forwarding hints, every `x-forwarded-*`, and every `x-vellum-*`, so an inbound header cannot forge a gateway signal. Content type, accept, user agent, and other custom `x-*` headers pass through.
+- The response is stripped in the same spirit. `set-cookie` and `set-cookie2` go, so a provider cannot plant state on the daemon's own origin; the request side already drops an inbound `cookie`, so one could never round-trip anyway. Every provider-supplied `x-vellum-*` goes, since that namespace is this daemon's on both sides of the hop. `location` is relocated to `x-vellum-proxy-location`. Framing headers go because the response is re-framed on the way out.
 - Nothing logs the grant or the credential. The proxy logs provider, method, path, and status; the mint logs provider, account, and TTL.
 - The route calls `connection.request()` only, so the raw token stays inside the connection.
 
 ### Error mapping
 
-- 400: malformed provider segment or proxied path.
-- 402: the managed account is out of balance.
-- 403: the grant names another provider or account.
-- 404: unknown provider.
-- 405: HEAD against a managed connection.
-- 409: several accounts connected, none pinned.
-- 421: dispatched over IPC; retry over HTTP.
-- 424: no usable connection. The details carry `assistant oauth connect <provider>`.
-- 502: the provider API could not be reached.
+`ERROR_RESPONSES` in `../runtime/routes/oauth-proxy-routes.ts` is the list, and it generates the `openapi.yaml` entries; do not copy it here. Two mappings are worth knowing without opening it: 421 means the request was dispatched over IPC and the gateway retries it over HTTP on the caller's behalf, and 424 carries `assistant oauth connect <provider>` in its details.

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -950,7 +950,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-09T14:45:13.000Z"
+      "updatedAt": "2026-09-09T15:00:26.000Z"
     },
     {
       "id": "stripe-link-wallet",
@@ -970,7 +970,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-09T14:45:13.000Z"
+      "updatedAt": "2026-09-09T15:00:26.000Z"
     },
     {
       "id": "telegram-setup",
@@ -1189,7 +1189,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-04T16:57:56.000Z"
+      "updatedAt": "2026-09-09T18:36:25.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
+++ b/skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md
@@ -88,11 +88,46 @@ esac
 
 For read-only requests (fetching data, listing resources), no confirmation gate is needed.
 
+### Pointing a Third-Party CLI at the Proxy
+
+Some tools cannot be driven with `assistant oauth request`: a vendor CLI, an SDK, or a script that builds its own requests and expects to be handed an API base URL and an access token. Point it at the passthrough proxy instead of handing it the real token:
+
+```bash
+eval "$(assistant oauth proxy-url <provider-key> --export)"
+```
+
+That mints a short-lived grant and exports:
+
+- `VELLUM_OAUTH_PROXY_BASE_URL`: the base URL to point the tool at
+- `VELLUM_OAUTH_PROXY_TOKEN`: the grant, to use as the tool's bearer token
+- `VELLUM_OAUTH_PROXY_EXPIRES_AT`: when the grant stops working
+- `VELLUM_OAUTH_PROXY_ACCOUNT`: the account it resolved to (omitted when the connection carries none)
+
+Map them onto whatever the tool reads:
+
+```bash
+eval "$(assistant oauth proxy-url stripe_link --export)"
+LINK_API_BASE_URL="$VELLUM_OAUTH_PROXY_BASE_URL" \
+  LINK_ACCESS_TOKEN="$VELLUM_OAUTH_PROXY_TOKEN" \
+  LINK_NO_REFRESH=1 \
+  link-cli payment-methods list --format json
+```
+
+The tool sends the grant as its own bearer token; the proxy strips it, substitutes the provider credential, and forwards the request, so the provider token never reaches the tool. The grant opens one provider (and one account, when several are connected) and nothing else, and it expires: 900 seconds by default, `--ttl <seconds>` to change it within 60 to 3600. Pin an account with `--account`, and run `assistant oauth status <provider-key>` to find the identifier.
+
+A side-effect request made through the proxy still needs the `assistant ui confirm` gate described above.
+
+**Fidelity depends on the connection's mode.** On a bring-your-own connection the passthrough is byte-exact: the provider's response bytes and the query string arrive as written. A managed connection is proxied by the Vellum platform, which parses the response and rebuilds the query, so duplicate JSON keys and integers past 2^53 can change, `%20` becomes `+`, a valueless `?flag` becomes `flag=`, redirects are followed server-side instead of handed back, and HEAD is rejected. A provider that signs its own query string therefore works only on a bring-your-own connection. Check the mode with `assistant oauth mode <provider-key>`.
+
+A 3xx that does reach you keeps its status, but its target moves to the `x-vellum-proxy-location` response header, so nothing follows it automatically while carrying the grant. A tool that must follow one reads that header.
+
 ### OAuth Token Escape Hatch
 
-In some rare cases, you may need access to the OAuth token directly. This is heavily discouraged and should generally be avoided, but it is a valid escape hatch if:
+In some rare cases, you may need access to the OAuth token directly. This is heavily discouraged and should generally be avoided. Reach for `proxy-url` above first: a script that "needs the token to run" almost always needs a base URL and a bearer token, which is exactly what the proxy hands it without exposing the credential. The proxy is also the only option on a managed connection, where `assistant oauth token` returns an error by design.
 
-1. You need it outside of the context of a standalone curl-like request (e.g. you're writing a script and the script needs the token to run)
+The escape hatch is valid only if:
+
+1. The proxy genuinely cannot serve the case: the tool offers no way to override its API base URL, the token has to go somewhere a request header cannot reach (a request signature, a websocket handshake, an SDK that refreshes its own credential), or the call targets a host outside the connection's configured API base
 2. You've asked explicit permission from your user to use the token for a specific reason
 3. You don't use the token for anything other than that reason.
 


### PR DESCRIPTION
## Summary

- **Redirects.** The doc claimed a 3xx comes back verbatim with `Location` intact. The proxy now moves the target onto `x-vellum-proxy-location` and drops `location`, so a client that keeps `Authorization` across hosts cannot hand a live daemon grant to the provider. Documented, with the reason.
- **Response stripping.** `set-cookie` / `set-cookie2` and provider-supplied `x-vellum-*` are now in the stripped set; "Security invariants" listed only the request side and now covers both.
- **Managed-mode limits.** Added query fidelity (BYO appends the wire-exact `rawQuery`; managed sends the parsed record the platform rebuilds, so signed query strings cannot work over managed), redirects (managed returns the destination's response, never the 3xx), and retries (the route sets `singleAttempt` for non-idempotent methods because the platform retries a 502 it returns after already calling the provider). `stripe_link` is managed-only, so these are live limits.
- **Error table removed.** `ERROR_RESPONSES` in `oauth-proxy-routes.ts` already generates the `openapi.yaml` entries; the doc now points at it instead of keeping a third copy, retaining only the 421 and 424 details the code does not state.
- **Operation ids.** Noted that the `RouteDefinition` ids are the IPC ones and that `openapi.yaml` derives its own path-based ids.
- **Containment.** New section covering the gateway's `EDGE_AUTH_PROFILES` + single-route-grant refusal, the IPC fast path's refusal against unscoped routes, and `enforcePolicy`, plus the hand-synced `UNSCOPED_ROUTE_PROFILES` pair the package boundary forces.
- **Scope-profile row.** `assistant/ARCHITECTURE.md` gains `oauth_proxy_v1` / `oauth.proxy`, and the subject-patterns table gains `local:<assistantId>:<conversationId>`, which `parseSub` supports and the grant relies on.
- **Runtime skill doc.** `MAKING_REQUESTS.md` gains a `proxy-url` section (the `--export` one-liner, the `VELLUM_OAUTH_PROXY_*` names, the BYO-vs-managed fidelity caveat) ahead of the raw-token escape hatch, whose trigger is narrowed to the cases the proxy genuinely cannot serve.

Brings the passthrough docs back in line with the code after eight review fixes, adds the scope-profile row, and points the runtime skill doc at proxy-url instead of the raw-token escape hatch.