### PR TITLE
chore(skills): refresh the catalog timestamp after the docs squash

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1189,7 +1189,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-09T18:36:25.000Z"
+      "updatedAt": "2026-09-09T18:45:23.000Z"
     },
     {
       "id": "vellum-self-knowledge",


### PR DESCRIPTION
## Summary

- `skills/catalog.json` derives each skill's `updatedAt` from `git log -1` on its directory, so squash-merging #42448 (which edited `skills/vellum-oauth-integrations/references/MAKING_REQUESTS.md`) moved that timestamp again and left the catalog check red on this branch.
- Regenerated. This commit touches only `skills/catalog.json`, which sits outside every skill directory, so its own squash cannot re-stale the entry.

Follow-up to #42448.