### PR TITLE
feat(slack): reject out-of-order edit deliveries using Slack edited.ts

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4460,6 +4460,8 @@ paths:
                         - type
                     slackBotMentioned:
                       type: boolean
+                    slackEditedTs:
+                      type: string
                     account:
                       type: string
                     actorTeamId:

--- a/assistant/src/__tests__/slack-edit-ordering-characterization.test.ts
+++ b/assistant/src/__tests__/slack-edit-ordering-characterization.test.ts
@@ -53,7 +53,11 @@ async function seedMessage(): Promise<string> {
   return inserted.id;
 }
 
-async function applyEdit(eventId: string, content: string): Promise<void> {
+async function applyEdit(
+  eventId: string,
+  content: string,
+  slackEditedTs?: string,
+): Promise<void> {
   await handleEditIntercept({
     sourceChannel: "slack",
     conversationExternalId: CHANNEL,
@@ -61,6 +65,7 @@ async function applyEdit(eventId: string, content: string): Promise<void> {
     sourceMessageId: ORIGINAL_TS,
     assistantId: "self",
     content,
+    slackEditedTs,
   });
 }
 
@@ -90,10 +95,17 @@ describe("Slack edit ordering (characterization)", () => {
     expect(stringifyMessageContent(row!.content)).toBe("revised text");
   });
 
-  test.todo(
-    "GUARD (future PR): an edit whose Slack edited.ts is older than the stored one is ignored",
-    () => {},
-  );
+  test("GUARD: an edit whose Slack edited.ts is older than the stored one is ignored", async () => {
+    const messageId = await seedMessage();
+
+    // The newer edit (ts = .000300) arrives first and is applied.
+    await applyEdit("edit-event-newer", "second revision", "1700000000.000300");
+    // The older edit (ts = .000200) arrives late; the guard must reject it.
+    await applyEdit("edit-event-older", "first revision", "1700000000.000200");
+
+    const row = getMessageById(messageId);
+    expect(stringifyMessageContent(row!.content)).toBe("second revision");
+  });
 
   test.todo(
     "GUARD (future PR): content and mention source data are replaced in the same transaction on every applied edit",

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -799,6 +799,11 @@ export async function handleChannelInbound({
 
   // ── Edit path: update existing message content, no new agent loop ──
   if (isEdit && sourceMessageId) {
+    const slackEditedTs =
+      sourceChannel === "slack" &&
+      typeof sourceMetadata?.slackEditedTs === "string"
+        ? sourceMetadata.slackEditedTs
+        : undefined;
     return handleEditIntercept({
       sourceChannel,
       conversationExternalId,
@@ -808,6 +813,7 @@ export async function handleChannelInbound({
       assistantId,
       content,
       channelId: resolvedMember?.channelId,
+      slackEditedTs,
     });
   }
 

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -54,6 +54,13 @@ export interface EditInterceptParams {
   content: string | undefined;
   /** Channel ID for channel-level interaction tracking. */
   channelId?: string;
+  /**
+   * Slack-only: the `edited.ts` float-string from the `message_changed`
+   * event. When present, edits whose Slack timestamp is older than or equal
+   * to the stored `slackMeta.editedAt` are dropped so out-of-order webhook
+   * deliveries cannot revert a newer revision.
+   */
+  slackEditedTs?: string;
 }
 
 /**
@@ -74,6 +81,7 @@ export async function handleEditIntercept(
     sourceThreadId,
     assistantId,
     content,
+    slackEditedTs,
   } = params;
 
   // Dedup the edit event itself (retried edited_message webhooks) before the
@@ -197,14 +205,33 @@ export async function handleEditIntercept(
     // transcript renderer can surface the edited marker. The merge
     // tolerates rows that lack slackMeta enrichment by synthesizing
     // the minimum-required fields from the lookup data.
-    applySlackEditMetadata({
+    const applied = applySlackEditMetadata({
       messageId: original.messageId,
       existingRow,
       conversationExternalId,
       sourceMessageId,
       sourceThreadId,
       newContent,
+      slackEditedTs,
     });
+    if (!applied) {
+      log.debug(
+        {
+          assistantId,
+          sourceMessageId,
+          messageId: original.messageId,
+          slackEditedTs,
+        },
+        "Slack edit is older than stored revision; skipping",
+      );
+      markProcessed(editResult.eventId);
+      return {
+        accepted: true,
+        duplicate: false,
+        stale: true,
+        eventId: editResult.eventId,
+      };
+    }
   } else {
     // Every channel marks its edits. Slack's envelope carries the extra
     // fields its own renderer needs; the rest stamp the neutral shape that
@@ -254,6 +281,10 @@ export async function handleEditIntercept(
  * Apply a Slack edit to the stored message: update content and stamp
  * `slackMeta.editedAt` in the same transaction.
  *
+ * Returns `false` when `slackEditedTs` is present and names an edit that is
+ * not newer than the one already recorded — the caller should drop the event.
+ * Returns `true` when the write was applied.
+ *
  * If the row already has a valid `slackMeta` sub-object, the merge preserves
  * all existing fields and only sets/refreshes `editedAt`. If the row lacks
  * `slackMeta` enrichment, the helper synthesizes the minimum-required fields
@@ -269,7 +300,8 @@ function applySlackEditMetadata(params: {
   sourceMessageId: string;
   sourceThreadId?: string;
   newContent: string;
-}): void {
+  slackEditedTs?: string;
+}): boolean {
   const {
     messageId,
     existingRow: row,
@@ -277,6 +309,7 @@ function applySlackEditMetadata(params: {
     sourceMessageId,
     sourceThreadId,
     newContent,
+    slackEditedTs,
   } = params;
 
   const outerMetadata: Record<string, unknown> =
@@ -286,8 +319,20 @@ function applySlackEditMetadata(params: {
       ? outerMetadata.slackMeta
       : undefined;
 
-  const editedAt = Date.now();
   const parsedExisting = readSlackMetadata(existingSlackMeta ?? null);
+
+  // Staleness guard: if the incoming edit's Slack timestamp is not strictly
+  // newer than what is already stored, a slower delivery of an older edit
+  // has arrived out of order — drop it to preserve the current revision.
+  if (slackEditedTs !== undefined && parsedExisting?.editedAt !== undefined) {
+    const incomingEditedAt = parseFloat(slackEditedTs) * 1000;
+    if (incomingEditedAt <= parsedExisting.editedAt) {
+      return false;
+    }
+  }
+
+  const editedAt =
+    slackEditedTs !== undefined ? parseFloat(slackEditedTs) * 1000 : Date.now();
 
   // When the row has no valid existing slackMeta, `mergeSlackMetadata`
   // would produce a record missing the required fields and fail subsequent
@@ -309,4 +354,5 @@ function applySlackEditMetadata(params: {
   updateMessageContentAndMetadata(messageId, newContent, {
     slackMeta: mergedSlackMeta,
   });
+  return true;
 }

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -192,6 +192,21 @@ export async function handleEditIntercept(
       },
       "Edit text unchanged; skipping update",
     );
+    // Even though the text is identical, advance the Slack ordering watermark
+    // when slackEditedTs is present and newer. Without this, a future delayed
+    // delivery of an older edit (A→B→A scenario) would pass the staleness
+    // guard and overwrite the latest content — the watermark must always
+    // reflect the highest observed edited.ts, not just writes that changed text.
+    if (sourceChannel === "slack" && slackEditedTs !== undefined) {
+      advanceSlackEditedAtWatermark({
+        messageId: original.messageId,
+        existingRow,
+        conversationExternalId,
+        sourceMessageId,
+        sourceThreadId,
+        slackEditedTs,
+      });
+    }
     markProcessed(editResult.eventId);
     return {
       accepted: true,
@@ -276,6 +291,69 @@ export async function handleEditIntercept(
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Advance `slackMeta.editedAt` for a no-op edit (identical text) whose
+ * `slackEditedTs` is newer than the stored watermark. This keeps the ordering
+ * guard consistent through A→B→A revision sequences: the watermark always
+ * reflects the highest observed Slack `edited.ts`, so a delayed delivery of B
+ * cannot sneak past the guard and overwrite the latest A content.
+ *
+ * Only updates metadata — never touches message content or triggers reindexing.
+ */
+function advanceSlackEditedAtWatermark(params: {
+  messageId: string;
+  existingRow: MessageRow | null;
+  conversationExternalId: string;
+  sourceMessageId: string;
+  sourceThreadId?: string;
+  slackEditedTs: string;
+}): void {
+  const {
+    messageId,
+    existingRow: row,
+    conversationExternalId,
+    sourceMessageId,
+    sourceThreadId,
+    slackEditedTs,
+  } = params;
+
+  const outerMetadata: Record<string, unknown> =
+    row?.metadata != null ? safeParseRecord(row.metadata) : {};
+  const existingSlackMeta =
+    typeof outerMetadata.slackMeta === "string"
+      ? outerMetadata.slackMeta
+      : undefined;
+
+  const parsedExisting = readSlackMetadata(existingSlackMeta ?? null);
+  const incomingEditedAt = parseFloat(slackEditedTs) * 1000;
+
+  if (
+    parsedExisting?.editedAt !== undefined &&
+    incomingEditedAt <= parsedExisting.editedAt
+  ) {
+    return;
+  }
+
+  const mergedSlackMeta = mergeSlackMetadata(existingSlackMeta ?? null, {
+    ...(parsedExisting
+      ? {}
+      : {
+          source: "slack" as const,
+          channelId: conversationExternalId,
+          channelTs: sourceMessageId,
+          ...(sourceThreadId ? { threadTs: sourceThreadId } : {}),
+          eventKind: "message" as const,
+        }),
+    editedAt: incomingEditedAt,
+  });
+
+  updateMessageContentAndMetadata(
+    messageId,
+    row != null ? stringifyMessageContent(row.content) : "",
+    { slackMeta: mergedSlackMeta },
+  );
+}
 
 /**
  * Apply a Slack edit to the stored message: update content and stamp

--- a/gateway/src/slack/message-change-normalizer.ts
+++ b/gateway/src/slack/message-change-normalizer.ts
@@ -90,8 +90,14 @@ export function normalizeSlackMessageEdit(
         })(),
         ...(edited.thread_ts ? { threadId: edited.thread_ts } : {}),
         // Slack's own edit timestamp, used by the runtime to reject out-of-order
-        // deliveries whose edit is older than what is already stored.
-        ...(edited.edited?.ts ? { slackEditedTs: edited.edited.ts } : {}),
+        // deliveries whose edit is older than what is already stored. Only
+        // forwarded when the value parses as a finite number; a malformed string
+        // would yield NaN in the runtime's comparison and silently disable the
+        // ordering guard.
+        ...(edited.edited?.ts !== undefined &&
+        isFinite(parseFloat(edited.edited.ts))
+          ? { slackEditedTs: edited.edited.ts }
+          : {}),
       },
       raw: rawEvent,
     },

--- a/gateway/src/slack/message-change-normalizer.ts
+++ b/gateway/src/slack/message-change-normalizer.ts
@@ -89,6 +89,9 @@ export function normalizeSlackMessageEdit(
           return conversationType ? { conversationType } : {};
         })(),
         ...(edited.thread_ts ? { threadId: edited.thread_ts } : {}),
+        // Slack's own edit timestamp, used by the runtime to reject out-of-order
+        // deliveries whose edit is older than what is already stored.
+        ...(edited.edited?.ts ? { slackEditedTs: edited.edited.ts } : {}),
       },
       raw: rawEvent,
     },

--- a/packages/gateway-client/src/inbound-contract.ts
+++ b/packages/gateway-client/src/inbound-contract.ts
@@ -85,6 +85,12 @@ export const SourceMetadataSchema = z
     commandIntent: CommandIntentSchema.optional(),
     /** Slack-specific: whether the bot was @-mentioned. */
     slackBotMentioned: z.boolean().optional(),
+    /**
+     * Slack-specific: the `edited.ts` float-string from a `message_changed`
+     * event. Used by the daemon to reject out-of-order edit deliveries whose
+     * edit timestamp is older than the one already stored.
+     */
+    slackEditedTs: z.string().optional(),
     /** Slack workspace/team ID. */
     account: z.string().optional(),
     /**


### PR DESCRIPTION
Slack can deliver message_changed webhooks out of order; a slower delivery of an older edit could arrive after a newer one and permanently overwrite the newer text. The LLM would see stale content on the next turn, and any mention source data replaced in the same edit would also be reverted.

The fix threads Slack's own edited.ts float-string through the stack:

- gateway/src/slack/message-change-normalizer.ts: forward message.edited.ts as sourceMetadata.slackEditedTs on every edit event
- packages/gateway-client/src/inbound-contract.ts: declare slackEditedTs on SourceMetadataSchema so the field is typed end-to-end
- assistant/src/runtime/routes/inbound-stages/edit-intercept.ts: add slackEditedTs to EditInterceptParams; in applySlackEditMetadata compare the incoming timestamp against parsedExisting.editedAt and return false (skip) when the incoming edit is not strictly newer
- assistant/src/runtime/routes/inbound-message-handler.ts: extract sourceMetadata.slackEditedTs and pass it to handleEditIntercept
- Promote the test.todo guard in slack-edit-ordering-characterization to a real passing test (3 pass, 1 todo remaining for the future atomicity guard)

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
