### PR TITLE
fix(gateway): drop the dead subject write and share one scope-profile classification

### DIFF
--- a/gateway/src/__tests__/scopes.test.ts
+++ b/gateway/src/__tests__/scopes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveScopeProfile } from "../auth/scopes.js";
+import { isNarrowScopeProfile, resolveScopeProfile } from "../auth/scopes.js";
 import type { ScopeProfile } from "../auth/types.js";
 
 describe("resolveScopeProfile", () => {
@@ -45,6 +45,39 @@ describe("resolveScopeProfile", () => {
     ]) {
       const scopes = resolveScopeProfile(profile as never);
       expect(scopes.size).toBe(0);
+    }
+  });
+});
+
+describe("isNarrowScopeProfile", () => {
+  test("classifies every profile", () => {
+    // The source table is exhaustive over ScopeProfile, so a new profile has
+    // to be classified there. This pins the answers it gives today: a `true`
+    // flipped onto a single-route grant would open every unscoped route to it.
+    const narrow: Record<ScopeProfile, boolean> = {
+      actor_client_v1: false,
+      gateway_ingress_v1: false,
+      gateway_service_v1: false,
+      local_v1: false,
+      oauth_proxy_v1: true,
+      speech_relay_v1: true,
+      ui_page_v1: false,
+    };
+    for (const [profile, expected] of Object.entries(narrow)) {
+      expect(isNarrowScopeProfile(profile as ScopeProfile)).toBe(expected);
+    }
+  });
+
+  test("unknown profiles and prototype keys are narrow", () => {
+    // Claims come from JSON, so an unrecognized profile reaches this despite
+    // the type, and a prototype key resolves to an object rather than `true`.
+    for (const profile of [
+      "bogus_v1",
+      "toString",
+      "constructor",
+      "__proto__",
+    ]) {
+      expect(isNarrowScopeProfile(profile as never)).toBe(true);
     }
   });
 });

--- a/gateway/src/auth/scopes.ts
+++ b/gateway/src/auth/scopes.ts
@@ -65,3 +65,38 @@ export function resolveScopeProfile(profile: ScopeProfile): ReadonlySet<Scope> {
   }
   return PROFILE_SCOPES[profile];
 }
+
+// ---------------------------------------------------------------------------
+// Profile breadth
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a profile is broad enough to stand for its caller on a route that
+ * names no scope of its own. A profile marked `false` is minted for a single
+ * route and handed to code outside this install's trust boundary, so it
+ * reaches only a route whose policy names the scope it carries.
+ *
+ * Exhaustive over `ScopeProfile`, so a new profile has to be classified here
+ * rather than inheriting whichever answer the compiler allows.
+ */
+const BROAD_SCOPE_PROFILES: Record<ScopeProfile, boolean> = {
+  actor_client_v1: true,
+  gateway_ingress_v1: true,
+  gateway_service_v1: true,
+  local_v1: true,
+  oauth_proxy_v1: false,
+  speech_relay_v1: false,
+  ui_page_v1: true,
+};
+
+/**
+ * True when the profile reaches only a route whose policy names the scope it
+ * carries.
+ *
+ * Claims come from JSON, so an unrecognized profile reaches this despite the
+ * type. `=== true` keeps those narrow, along with inherited keys
+ * ("constructor", "__proto__") whose values are objects.
+ */
+export function isNarrowScopeProfile(profile: ScopeProfile): boolean {
+  return BROAD_SCOPE_PROFILES[profile] !== true;
+}

--- a/gateway/src/auth/token-exchange.test.ts
+++ b/gateway/src/auth/token-exchange.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Tests for the daemon-subject rewrite every minted exchange token carries.
+ */
+
+import { describe, test, expect } from "bun:test";
+import "../__tests__/test-preload.js";
+
+import { toDaemonSubject } from "./token-exchange.js";
+
+describe("toDaemonSubject", () => {
+  test("rewrites the assistant segment to self", () => {
+    expect(toDaemonSubject("actor:asst_1:user_1")).toBe("actor:self:user_1");
+    expect(toDaemonSubject("svc:gateway:asst_1")).toBe("svc:gateway:self");
+    expect(toDaemonSubject("local:asst_1:conv_1")).toBe("local:self:conv_1");
+  });
+
+  test("falls back to the gateway service sub for unparseable subs", () => {
+    expect(toDaemonSubject("garbage")).toBe("svc:gateway:self");
+    expect(toDaemonSubject("")).toBe("svc:gateway:self");
+  });
+});

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -2,10 +2,13 @@ import type { Server } from "bun";
 
 import { admitActorToken } from "../../auth/actor-token-revocation.js";
 import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
-import { resolveScopeProfile } from "../../auth/scopes.js";
+import {
+  isNarrowScopeProfile,
+  resolveScopeProfile,
+} from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
-import type { Scope, ScopeProfile, TokenClaims } from "../../auth/types.js";
+import type { Scope, TokenClaims } from "../../auth/types.js";
 import { AuthFallbackCountTracker } from "../../auth-fallback-count-tracker.js";
 import { AuthFallbackLogThrottle } from "../../auth-fallback-log-throttle.js";
 import type { AuthRateLimiter } from "../../auth-rate-limiter.js";
@@ -588,30 +591,17 @@ export function wrapWithAuthFailureTracking(
 // Internals
 // ---------------------------------------------------------------------------
 
-/**
- * Scope profiles broad enough to stand for their caller on any edge route.
- * A profile outside this set is minted for a single route, which validates the
- * grant itself, so edge auth refuses it. New profiles land outside the set and
- * therefore fail closed.
- */
-const EDGE_AUTH_PROFILES: ReadonlySet<ScopeProfile> = new Set<ScopeProfile>([
-  "actor_client_v1",
-  "gateway_ingress_v1",
-  "gateway_service_v1",
-  "local_v1",
-  "ui_page_v1",
-]);
-
 /** Conversation component of an OAuth passthrough grant's subject. */
 const OAUTH_PROXY_SUBJECT_PREFIX = "oauth-proxy.";
 
 /**
  * True when the claims name a grant minted for a single route rather than an
- * edge credential. The scope profile is the gate; the subject shape is a
- * second signal, catching a proxy grant that carries some other profile.
+ * edge credential. A narrow scope profile is the gate, since edge auth speaks
+ * for its caller on every route it guards; the subject shape is a second
+ * signal, catching a proxy grant that carries some other profile.
  */
 function isSingleRouteGrant(claims: TokenClaims): boolean {
-  if (!EDGE_AUTH_PROFILES.has(claims.scope_profile)) return true;
+  if (isNarrowScopeProfile(claims.scope_profile)) return true;
   const parsed = parseSub(claims.sub);
   return (
     parsed.ok &&

--- a/gateway/src/http/routes/ipc-runtime-proxy.test.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.test.ts
@@ -9,6 +9,7 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import "../../__tests__/test-preload.js";
 
+import { isNarrowScopeProfile } from "../../auth/scopes.js";
 import type { ScopeProfile } from "../../auth/types.js";
 
 // ---------------------------------------------------------------------------
@@ -109,11 +110,9 @@ mock.module("../../ipc/assistant-client.js", () => ({
   ipcCallAssistant: ipcCallAssistantMock,
 }));
 
-// Stub validateEdgeToken; by default auth passes. The rest of the module
-// (notably toDaemonSubject, which the proxy uses to derive the forwarded
-// subject header) keeps its real implementation.
+// Stub validateEdgeToken; by default auth passes. The rest of the module keeps
+// its real implementation.
 const actualTokenExchange = await import("../../auth/token-exchange.js");
-const { toDaemonSubject } = actualTokenExchange;
 
 const validateEdgeTokenMock = mock(
   (
@@ -203,24 +202,24 @@ function makeRequest(
 
 describe("matchRoute", () => {
   test("matches static endpoint", () => {
-    const m = matchRoute("GET", "health");
-    expect(m).toBeDefined();
-    expect(m!.operationId).toBe("health");
-    expect(m!.pathParams).toEqual({});
+    expect(matchRoute("GET", "health")).toEqual({
+      operationId: "health",
+      pathParams: {},
+    });
   });
 
   test("matches parameterized endpoint and extracts params", () => {
-    const m = matchRoute("POST", "acp/abc123/steer");
-    expect(m).toBeDefined();
-    expect(m!.operationId).toBe("acp_steer");
-    expect(m!.pathParams).toEqual({ id: "abc123" });
+    expect(matchRoute("POST", "acp/abc123/steer")).toEqual({
+      operationId: "acp_steer",
+      pathParams: { id: "abc123" },
+    });
   });
 
   test("matches multi-param endpoint", () => {
-    const m = matchRoute("GET", "apps/myapp/dist/bundle.js");
-    expect(m).toBeDefined();
-    expect(m!.operationId).toBe("apps_dist_file");
-    expect(m!.pathParams).toEqual({ appId: "myapp", filename: "bundle.js" });
+    expect(matchRoute("GET", "apps/myapp/dist/bundle.js")).toEqual({
+      operationId: "apps_dist_file",
+      pathParams: { appId: "myapp", filename: "bundle.js" },
+    });
   });
 
   test("returns undefined for method mismatch", () => {
@@ -236,9 +235,16 @@ describe("matchRoute", () => {
   });
 
   test("decodes percent-encoded path params", () => {
-    const m = matchRoute("POST", "acp/hello%20world/steer");
-    expect(m).toBeDefined();
-    expect(m!.pathParams).toEqual({ id: "hello world" });
+    expect(matchRoute("POST", "acp/hello%20world/steer")).toEqual({
+      operationId: "acp_steer",
+      pathParams: { id: "hello world" },
+    });
+  });
+
+  test("reports a matched route whose param cannot be decoded", () => {
+    expect(matchRoute("POST", "acp/a%zz/steer")).toEqual({
+      malformedPath: true,
+    });
   });
 });
 
@@ -275,6 +281,24 @@ describe("tryIpcProxy", () => {
     const result = await tryIpcProxy(req, makeConfig());
     expect(result).not.toBeNull();
     expect(result!.status).toBe(404);
+  });
+
+  test("returns 400 for malformed percent-encoding in the path", async () => {
+    // The passthrough forwards caller-authored paths, so an undecodable one
+    // is a typo away. It must not surface as an unhandled 500.
+    const req = makeRequest("/v1/oauth/proxy/gh/a%zz");
+    const result = await tryIpcProxy(req, makeConfig());
+    expect(result!.status).toBe(400);
+
+    const body = (await result!.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("the malformed path does not escape the proxy handler as a 500", async () => {
+    const handler = createRuntimeProxyHandler(makeConfig());
+    const response = await handler(makeRequest("/v1/oauth/proxy/gh/a%zz"));
+    expect(response.status).toBe(400);
   });
 
   test("calls IPC with correct operationId and params", async () => {
@@ -447,7 +471,9 @@ describe("tryIpcProxy", () => {
     expect(result!.status).toBe(502);
   });
 
-  test("replaces a spoofed x-vellum-subject with the verified subject", async () => {
+  test("strips a spoofed x-vellum-subject from an authenticated request", async () => {
+    // Nothing downstream consumes the header: the daemon's IPC adapter
+    // (`injectLocalActorHeader`) deletes it on every dispatch.
     validateEdgeTokenMock.mockImplementation(() => ({
       ok: true,
       claims: {
@@ -474,9 +500,27 @@ describe("tryIpcProxy", () => {
       Record<string, unknown>,
     ];
     const headers = params.headers as Record<string, string>;
-    expect(headers["x-vellum-subject"]).toBe(
-      "local:self:oauth-proxy.stripe_link",
-    );
+    expect(headers["x-vellum-subject"]).toBeUndefined();
+  });
+
+  test("derives the principal headers from the verified claims", async () => {
+    const config = makeConfig({ runtimeProxyRequireAuth: true });
+    const req = makeRequest("/v1/health", {
+      headers: {
+        authorization: "Bearer valid",
+        "x-vellum-actor-principal-id": "attacker",
+        "x-vellum-principal-type": "svc_gateway",
+      },
+    });
+    await tryIpcProxy(req, config);
+
+    const [, params] = ipcCallAssistantMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const headers = params.headers as Record<string, string>;
+    expect(headers["x-vellum-principal-type"]).toBe("actor");
+    expect(headers["x-vellum-actor-principal-id"]).toBe("user_1");
   });
 
   test("strips x-vellum-subject when the request is unauthenticated", async () => {
@@ -698,19 +742,14 @@ const SUB_BY_PROFILE: Record<ScopeProfile, string> = {
 };
 
 /**
- * Which profiles may reach a route that names no scope. Exhaustive over
- * ScopeProfile so a new profile has to be classified here rather than
- * inheriting whichever answer the compiler happens to allow.
+ * Every profile, paired with whether it may reach a route that names no scope.
+ * The classification is the source's own (`isNarrowScopeProfile`); these cases
+ * assert the fast path consults it. `SUB_BY_PROFILE` is exhaustive over
+ * ScopeProfile, so a new profile joins the sweep by declaring its subject.
  */
-const REACHES_UNSCOPED_ROUTES: Record<ScopeProfile, boolean> = {
-  actor_client_v1: true,
-  gateway_ingress_v1: true,
-  gateway_service_v1: true,
-  local_v1: true,
-  oauth_proxy_v1: false,
-  speech_relay_v1: false,
-  ui_page_v1: true,
-};
+const REACHES_UNSCOPED_ROUTES = (
+  Object.keys(SUB_BY_PROFILE) as ScopeProfile[]
+).map((profile) => [profile, !isNarrowScopeProfile(profile)] as const);
 
 function mockClaims(profile: ScopeProfile) {
   validateEdgeTokenMock.mockImplementation(() => ({
@@ -735,10 +774,10 @@ describe("single-route grants on the IPC fast path", () => {
     validateEdgeTokenMock.mockReset();
   });
 
-  test.each(Object.entries(REACHES_UNSCOPED_ROUTES))(
+  test.each(REACHES_UNSCOPED_ROUTES)(
     "%s on a null-policy route",
     async (profile, allowed) => {
-      mockClaims(profile as ScopeProfile);
+      mockClaims(profile);
       const req = makeRequest("/v1/health", {
         headers: { authorization: "Bearer valid" },
       });
@@ -747,10 +786,10 @@ describe("single-route grants on the IPC fast path", () => {
     },
   );
 
-  test.each(Object.entries(REACHES_UNSCOPED_ROUTES))(
+  test.each(REACHES_UNSCOPED_ROUTES)(
     "%s on a route whose policy names no scope",
     async (profile, allowed) => {
-      mockClaims(profile as ScopeProfile);
+      mockClaims(profile);
       const req = makeRequest("/v1/debug/ping", {
         headers: { authorization: "Bearer valid" },
       });
@@ -811,22 +850,5 @@ describe("single-route grants on the IPC fast path", () => {
     });
     const result = await tryIpcProxy(req, AUTHED_CONFIG());
     expect(result!.status).toBe(403);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: toDaemonSubject
-// ---------------------------------------------------------------------------
-
-describe("toDaemonSubject", () => {
-  test("rewrites the assistant segment to self", () => {
-    expect(toDaemonSubject("actor:asst_1:user_1")).toBe("actor:self:user_1");
-    expect(toDaemonSubject("svc:gateway:asst_1")).toBe("svc:gateway:self");
-    expect(toDaemonSubject("local:asst_1:conv_1")).toBe("local:self:conv_1");
-  });
-
-  test("falls back to the gateway service sub for unparseable subs", () => {
-    expect(toDaemonSubject("garbage")).toBe("svc:gateway:self");
-    expect(toDaemonSubject("")).toBe("svc:gateway:self");
   });
 });

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -13,13 +13,13 @@
  */
 
 import { admitActorToken } from "../../auth/actor-token-revocation.js";
-import { resolveScopeProfile } from "../../auth/scopes.js";
-import { parseSub } from "../../auth/subject.js";
 import {
-  toDaemonSubject,
-  validateEdgeToken,
-} from "../../auth/token-exchange.js";
-import type { ScopeProfile, TokenClaims } from "../../auth/types.js";
+  isNarrowScopeProfile,
+  resolveScopeProfile,
+} from "../../auth/scopes.js";
+import { parseSub } from "../../auth/subject.js";
+import { validateEdgeToken } from "../../auth/token-exchange.js";
+import type { TokenClaims } from "../../auth/types.js";
 import type { GatewayConfig } from "../../config.js";
 import {
   IpcHandlerError,
@@ -111,6 +111,19 @@ export async function tryIpcProxy(
       { status: 404 },
     );
   }
+  // A passthrough forwards caller-authored paths, so undecodable ones arrive
+  // here routinely. Same answer the daemon's own router gives them.
+  if ("malformedPath" in match) {
+    return Response.json(
+      {
+        error: {
+          code: "BAD_REQUEST",
+          message: "Malformed percent-encoding in URL path parameter",
+        },
+      },
+      { status: 400 },
+    );
+  }
 
   // --- Policy enforcement --------------------------------------------------
   // The policy comes straight from the daemon's route schema (see
@@ -154,19 +167,16 @@ export async function tryIpcProxy(
     }
   });
 
-  // Override caller-supplied identity headers (`x-vellum-actor-principal-id`,
-  // `x-vellum-principal-type`, `x-vellum-subject`) with values derived from
-  // the verified JWT claims. The daemon's IPC adapter
-  // (`injectLocalActorHeader`) preserves any inbound
-  // `x-vellum-actor-principal-id`, so without this step a malicious client
-  // could spoof another user's principal id by setting the header explicitly.
-  // Mirrors the HTTP adapter's behavior in
-  // `assistant/src/runtime/routes/http-adapter.ts`.
+  // Drop the caller-supplied identity headers and re-derive them from the
+  // verified JWT claims. The daemon's IPC adapter (`injectLocalActorHeader`)
+  // preserves any inbound `x-vellum-actor-principal-id`, so without this step
+  // a malicious client could spoof another user's principal id by setting the
+  // header explicitly. `x-vellum-subject` goes too, defense in depth behind
+  // that adapter's own unconditional delete.
   delete headers["x-vellum-actor-principal-id"];
   delete headers["x-vellum-principal-type"];
   delete headers["x-vellum-subject"];
   if (claims) {
-    headers["x-vellum-subject"] = toDaemonSubject(claims.sub);
     const sub = parseSub(claims.sub);
     if (sub.ok) {
       headers["x-vellum-principal-type"] = sub.principalType;
@@ -298,33 +308,14 @@ export async function tryIpcProxy(
 // ---------------------------------------------------------------------------
 
 /**
- * Profiles broad enough to reach a route that names no scope of its own.
- * A profile outside this set is minted for a single route and handed to code
- * outside this install's trust boundary, so it reaches only a route whose
- * policy names the scope it carries. New profiles land outside the set and
- * therefore fail closed.
- *
- * Mirrors `UNSCOPED_ROUTE_PROFILES` in
- * `assistant/src/runtime/auth/route-policy.ts`. The daemon's IPC server runs
- * no policy check of its own, so this fast path is the only place the rule
- * applies to IPC-served requests.
- */
-const UNSCOPED_ROUTE_PROFILES: ReadonlySet<ScopeProfile> =
-  new Set<ScopeProfile>([
-    "actor_client_v1",
-    "gateway_ingress_v1",
-    "gateway_service_v1",
-    "local_v1",
-    "ui_page_v1",
-  ]);
-
-/**
  * Enforce the route's scope/principal policy against the caller's token.
  * Returns a 403 Response when denied, null when allowed.
  *
  * A route naming no scope (`policy` null, or empty `requiredScopes`) is
- * unprotected (e.g. health, debug) for the broad profiles in
- * {@link UNSCOPED_ROUTE_PROFILES}, and closed to every other profile.
+ * unprotected (e.g. health, debug) for a broad profile, and closed to a narrow
+ * one (see {@link isNarrowScopeProfile}). The daemon's IPC server runs no
+ * policy check of its own, so this fast path is the only place that rule
+ * applies to IPC-served requests.
  */
 function enforceRoutePolicy(
   policy: RouteSchemaPolicy | null,
@@ -338,7 +329,7 @@ function enforceRoutePolicy(
   // unprotected one refuses it rather than admitting any valid token.
   if (
     (policy?.requiredScopes.length ?? 0) === 0 &&
-    !UNSCOPED_ROUTE_PROFILES.has(claims.scope_profile)
+    isNarrowScopeProfile(claims.scope_profile)
   ) {
     log.warn(
       { path, scopeProfile: claims.scope_profile },

--- a/gateway/src/ipc/route-schema-cache.test.ts
+++ b/gateway/src/ipc/route-schema-cache.test.ts
@@ -82,6 +82,31 @@ describe("refreshRouteSchema — happy path", () => {
     expect(matchRoute("GET", "health")).toBeDefined();
     expect(matchRoute("GET", "settings")).toBeDefined();
   });
+
+  test("reports a matched route whose param cannot be percent-decoded", async () => {
+    // Callers author these paths verbatim through the OAuth passthrough, so
+    // the decode has to report rather than throw out of the proxy.
+    setSchema([
+      {
+        operationId: "oauth_proxy_get",
+        endpoint: "oauth/proxy/:provider/:path*",
+        method: "GET",
+        policy: {
+          requiredScopes: ["oauth.proxy"],
+          allowedPrincipalTypes: ["local"],
+        },
+      },
+    ]);
+    expect(await refreshRouteSchema()).toBe(true);
+
+    expect(matchRoute("GET", "oauth/proxy/gh/a%zz")).toEqual({
+      malformedPath: true,
+    });
+    expect(matchRoute("GET", "oauth/proxy/gh/a%20b")).toEqual({
+      operationId: "oauth_proxy_get",
+      pathParams: { provider: "gh", path: "a b" },
+    });
+  });
 });
 
 describe("refreshRouteSchema — validation fails closed", () => {

--- a/gateway/src/ipc/route-schema-cache.ts
+++ b/gateway/src/ipc/route-schema-cache.ts
@@ -58,6 +58,11 @@ export interface RouteMatch {
   pathParams: Record<string, string>;
 }
 
+/** A route matched, but a path param carries malformed percent-encoding. */
+export interface MalformedPathMatch {
+  malformedPath: true;
+}
+
 // ---------------------------------------------------------------------------
 // Compiled route — pre-built regex for parameterized endpoint matching
 // ---------------------------------------------------------------------------
@@ -185,13 +190,15 @@ export async function refreshRouteSchema(): Promise<boolean> {
  * The `path` should be the portion after `/v1/` (e.g. `acp/abc123/steer`
  * for a request to `/v1/acp/abc123/steer`).
  *
- * Returns the operationId and extracted path params on match, or
- * `undefined` if no cached route matches.
+ * Returns the operationId and extracted path params on match, `undefined` if
+ * no cached route matches, or {@link MalformedPathMatch} when a matched
+ * route's param cannot be percent-decoded. The caller answers that with a 400,
+ * matching the daemon's own router (`assistant/src/runtime/http-router.ts`).
  */
 export function matchRoute(
   method: string,
   path: string,
-): RouteMatch | undefined {
+): RouteMatch | MalformedPathMatch | undefined {
   const upperMethod = method.toUpperCase();
   for (const compiled of compiledRoutes) {
     if (compiled.entry.method.toUpperCase() !== upperMethod) continue;
@@ -200,7 +207,13 @@ export function matchRoute(
 
     const pathParams: Record<string, string> = {};
     for (let i = 0; i < compiled.paramNames.length; i++) {
-      pathParams[compiled.paramNames[i]] = decodeURIComponent(match[i + 1]);
+      let decoded: string;
+      try {
+        decoded = decodeURIComponent(match[i + 1]);
+      } catch {
+        return { malformedPath: true };
+      }
+      pathParams[compiled.paramNames[i]] = decoded;
     }
     return { operationId: compiled.entry.operationId, pathParams };
   }


### PR DESCRIPTION
## Summary

- Drop the `x-vellum-subject` write on the IPC fast path. The daemon's `injectLocalActorHeader` deletes that exact header on every IPC dispatch, so the value was never read. The three `delete` lines stay as defense in depth, and the comment no longer claims to forward a verified subject.
- Hoist the two byte-identical gateway profile lists (`EDGE_AUTH_PROFILES` in `http/middleware/auth.ts`, `UNSCOPED_ROUTE_PROFILES` in `http/routes/ipc-runtime-proxy.ts`) into one `isNarrowScopeProfile` predicate in `auth/scopes.ts`. Three hand-synced lists become two; only the assistant-side copy remains, kept separate by the cross-package import boundary.
- Declare that hoisted definition as a `Record<ScopeProfile, boolean>` and test membership with `=== true`. Runtime semantics are unchanged and still fail closed (unknown key is `undefined`, `__proto__`/`constructor` yield objects), but adding a member to the `ScopeProfile` union now fails to compile until it is classified. Verified by temporarily widening the union.
- `matchRoute` no longer throws on malformed percent-encoding. It reports the condition and `tryIpcProxy` answers 400 with the same code and message the daemon's own router uses, instead of letting a `URIError` escape `createRuntimeProxyHandler` as a 500. `GET /v1/oauth/proxy/gh/a%zz` with `X-Vellum-Proxy-Server: ipc` reaches this trivially, since a passthrough forwards caller-authored paths.

The `toDaemonSubject` block moves to a new `gateway/src/auth/token-exchange.test.ts`: it is the only coverage of that sub-rewrite, which `mintExchangeToken` still depends on.

Fixes gaps found in the final self-review of plan oauth-proxy-passthrough.md.