### PR TITLE
feat(web): list conversation attachments and camera frames from the daemon

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -296,6 +296,7 @@ const emDashEnforcedPaths = [
   "src/domains/chat/components/chat-info*.{ts,tsx}",
   "src/domains/chat/components/mobile-chat-info-overlay*.tsx",
   "src/domains/chat/components/conversation-asset*.{ts,tsx}",
+  "src/domains/chat/hooks/daemon-source-state.ts",
   "src/domains/chat/hooks/use-conversation-assets*.{ts,tsx}",
   "src/domains/chat/hooks/use-conversation-attachments*.{ts,tsx}",
   "src/domains/chat/chat-layout-header.stories.tsx",

--- a/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
@@ -1,17 +1,19 @@
 /**
- * The Chat Info panel: a conversation's apps, its documents and images, and
- * the See All grid each category drills into.
+ * The Chat Info panel: a conversation's apps, its documents and images, its
+ * camera frames, and the See All grid each category drills into.
  *
- * Nothing here is a stand-in. Every story seeds the two sources the panel's
- * real hooks read (the query cache for apps and documents, the chat-session
- * store for the transcript the attachments come from), so the rows are built
- * by the shipped code path and the app tiles render live previews. One
- * decorator does that seeding for every story; a story that wants a different
- * conversation names it in `parameters.chatInfo`.
+ * Nothing here is a stand-in. Every story seeds the sources the panel's real
+ * hooks read, so the rows are built by the shipped code path and the app tiles
+ * render live previews. One decorator does that seeding for every story; a
+ * story that wants a different conversation names it in `parameters.chatInfo`.
  *
- * There is no Camera Frames story. The seeded transcript carries no frame tag,
- * so that row has nothing to build from until frames come from the daemon's
- * attachment list.
+ * The four frame stories (`WithCameraFrames`, `FramesSeeAll`,
+ * `FramesLoadMore`, `WithCameraFramesMobile`) run the daemon path: they report
+ * a version the attachment-listing gate opens on and seed the daemon's two
+ * lists, so the counts are exact, the Camera Frames row is populated with
+ * capture-time labels, and the tiles fetch their pictures under the shared
+ * attachment-content key. Every other story runs the transcript path, where
+ * the attachments come from the loaded rows and no frame can be told apart.
  *
  * The last three stories are the states the sources put the panel in: still
  * loading, loaded and empty, and one source down.
@@ -40,6 +42,7 @@ import {
   inChatInfoConversation,
 } from "@/domains/chat/components/chat-info-story-fixtures";
 import { DetailPanelStoryFrame } from "@/domains/chat/components/detail-panel-story-frame";
+import { ATTACHMENT_PAGE_SIZE } from "@/domains/chat/hooks/use-conversation-attachments";
 import type { ChatInfoCategory } from "@/stores/viewer-store";
 
 import { ChatInfoPanel } from "./chat-info-panel";
@@ -57,6 +60,11 @@ const FILE_HEAVY: Partial<ChatInfoStoryConversation> = {
     ...makePreviewableImages(8),
     ...makeMixedAttachments().slice(1),
   ],
+};
+
+/** One Live session listed by the daemon, alongside the default conversation. */
+const WITH_FRAMES: Partial<ChatInfoStoryConversation> = {
+  daemonListing: { frameCount: 12, frameTotal: 12 },
 };
 
 const inDrawer: Decorator = (Story) => (
@@ -131,6 +139,49 @@ export const FilesSeeAll: Story = {
   },
 };
 
+/**
+ * The daemon's listing, so Camera Frames is the third row: a Live session's
+ * captures, newest first, labelled with the time each was taken. The counts on
+ * every row are the conversation's exact totals rather than what is loaded.
+ */
+export const WithCameraFrames: Story = {
+  parameters: { chatInfo: WITH_FRAMES },
+};
+
+/** Drilled into Camera Frames, where the tiles wrap rather than grid. */
+export const FramesSeeAll: Story = {
+  parameters: { chatInfo: WITH_FRAMES },
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: "frames",
+    },
+  },
+};
+
+/**
+ * A long session: the daemon holds 260 frames and has answered with the first
+ * page, so the grid ends on the control that fetches the next one.
+ */
+export const FramesLoadMore: Story = {
+  parameters: {
+    chatInfo: {
+      daemonListing: {
+        frameCount: ATTACHMENT_PAGE_SIZE,
+        frameTotal: 260,
+      },
+    },
+  },
+  args: {
+    payload: {
+      assistantId: CHAT_INFO_ASSISTANT_ID,
+      conversationId: CHAT_INFO_CONVERSATION_ID,
+      category: "frames",
+    },
+  },
+};
+
 /** The phone treatment: each row scrolls horizontally past the screen edge. */
 export const Mobile: Story = {
   globals: { viewport: { value: "sbMobile", isRotated: false } },
@@ -139,6 +190,12 @@ export const Mobile: Story = {
 /** The same strips on the narrowest phone the app runs on. */
 export const NarrowPhone: Story = {
   globals: { viewport: { value: "sbNarrowPhone", isRotated: false } },
+};
+
+/** The camera frames as a phone strip, running past the screen edge. */
+export const WithCameraFramesMobile: Story = {
+  parameters: { chatInfo: WITH_FRAMES },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
 };
 
 /**

--- a/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
@@ -11,8 +11,10 @@
  * level renders, what it says while the sources are unresolved, and the
  * sequence each tile runs when it is opened.
  *
- * Camera frames and paged categories are not exercised here: the transcript is
- * the hook's only source today and it can produce neither.
+ * Camera frames and paged categories are not exercised here: these tests seed
+ * the transcript rather than the daemon's attachment listing, and the
+ * transcript can produce neither. The listing itself is covered by
+ * `use-conversation-attachments.test.tsx`.
  */
 
 import {

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -3,11 +3,16 @@
  * the client that answers their queries, the seeded-conversation decorator, and
  * the two page frames the rows are read inside.
  *
- * The panel reads its assets through the real hooks, so a story has to fill
- * the two sources those hooks go to: the query cache holds the conversation's
- * apps and documents, and the chat-session store holds the transcript the
- * attachments are derived from. {@link inChatInfoConversation} fills both, on a
- * client of the story's own, before the story's first paint.
+ * The panel reads its assets through the real hooks, so a story has to fill the
+ * sources those hooks go to: the query cache holds the conversation's apps and
+ * documents, and the chat-session store holds the transcript the attachments
+ * are derived from. {@link inChatInfoConversation} fills both, on a client of
+ * the story's own, before the story's first paint.
+ *
+ * A conversation asking for {@link ChatInfoDaemonListing} fills a third source
+ * and reports a version the listing gate opens on, so the panel takes its
+ * daemon path: exact totals, a populated Camera Frames category, and the tiles
+ * fetching their bytes under the shared attachment-content key.
  *
  * A story declares its conversation through `parameters.chatInfo` rather than
  * by wrapping itself in a second decorator, so the panel, the mobile overlay,
@@ -34,12 +39,15 @@ import {
   clearTranscriptMessages,
   holdOrgHeaderUnresolved,
   makeAppSummary,
+  makeAttachmentSummary,
   makeChatInfoQueryClient,
   makeDocumentAsset,
   makeDocumentSummary,
   makeFileAsset,
   makeFrameAsset,
   makePendingChatInfoQueryClient,
+  reportAssistantVersion,
+  seedAttachmentList,
   seedChatInfoConversation,
   seedQueryFailure,
   seedTranscriptMessages,
@@ -48,6 +56,7 @@ import type { ConversationFileAsset } from "@/domains/chat/hooks/use-conversatio
 import type { DisplayAttachment } from "@/domains/chat/types/types";
 import { documentsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { AppSummary } from "@/types/app-types";
+import type { ConversationAttachmentSummary } from "@/types/attachment-types";
 import type { DocumentSummary } from "@/types/document-types";
 import { primeAppHtmlCache } from "@/utils/app-html-cache";
 import { decodeBase64Payload } from "@/utils/base64";
@@ -101,18 +110,39 @@ export const CHAT_INFO_STORY_FILES = {
   ),
 };
 
-/** One Live session: `count` captures three minutes apart, newest first. */
-export function chatInfoStoryFrames(count: number): ConversationFileAsset[] {
+/**
+ * One Live session as the daemon lists it: `count` captures three minutes
+ * apart, newest first, metadata only. The bytes live behind the content
+ * endpoint, so a tile draws a picture only for a frame a story seeds.
+ */
+function chatInfoFrameSummaries(
+  count: number,
+): ConversationAttachmentSummary[] {
   return Array.from({ length: count }, (_, index) =>
+    makeAttachmentSummary({
+      id: `camera-frame-${index + 1}`,
+      filename: `camera-frame-${index + 1}.jpg`,
+      mimeType: "image/jpeg",
+      sizeBytes: 98_304 + index * 2_048,
+      messageId: `msg-camera-frame-${index + 1}`,
+      createdAt: CHAT_INFO_T0 - index * 180_000,
+      sightFrame: true,
+    }),
+  );
+}
+
+/** The same session as the assets a presentational story renders directly. */
+export function chatInfoStoryFrames(count: number): ConversationFileAsset[] {
+  return chatInfoFrameSummaries(count).map((summary, index) =>
     makeFrameAsset(
       makeDisplayAttachment({
-        id: `camera-frame-${index + 1}`,
-        filename: `camera-frame-${index + 1}.jpg`,
-        mimeType: "image/jpeg",
-        sizeBytes: 98_304 + index * 2_048,
+        id: summary.id,
+        filename: summary.filename,
+        mimeType: summary.mimeType,
+        sizeBytes: summary.sizeBytes,
         previewUrl: SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
       }),
-      CHAT_INFO_T0 - index * 180_000,
+      summary.createdAt,
     ),
   );
 }
@@ -284,6 +314,54 @@ function chatInfoDocuments(
   );
 }
 
+/** How many camera frames the daemon's listing answers with, and holds. */
+export interface ChatInfoDaemonListing {
+  /** Frame rows the camera-frames list returns. */
+  frameCount: number;
+  /** The category's exact total, which the rows returned need not reach. */
+  frameTotal: number;
+}
+
+/** Frames whose bytes a story seeds; the rest fall back to the file glyph. */
+const FRAMES_WITH_BYTES = 4;
+
+/**
+ * The bytes the daemon would return for one attachment, under the key every
+ * tile fetches with. Anything but a base64 data URI is left unseeded, so that
+ * tile draws its glyph.
+ */
+function seedAttachmentBytes(
+  client: QueryClient,
+  assistantId: string,
+  attachmentId: string,
+  source: string,
+): void {
+  const bytes = decodeBase64Payload(source);
+  if (!bytes) {
+    return;
+  }
+  client.setQueryData(
+    attachmentContentQueryKey(assistantId, attachmentId),
+    new Blob([bytes], { type: "image/png" }),
+  );
+}
+
+/** The conversation's own files as the daemon lists them, frames left out. */
+function chatInfoFileSummaries(
+  attachments: DisplayAttachment[],
+): ConversationAttachmentSummary[] {
+  return attachments.map((attachment, index) =>
+    makeAttachmentSummary({
+      id: attachment.id,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sizeBytes: attachment.sizeBytes,
+      messageId: `msg-${index + 1}`,
+      createdAt: CHAT_INFO_T0 + index * 1_000,
+    }),
+  );
+}
+
 /** The conversation a story asks for through `parameters.chatInfo`. */
 export interface ChatInfoStoryConversation {
   assistantId: string;
@@ -293,6 +371,8 @@ export interface ChatInfoStoryConversation {
   attachments: DisplayAttachment[];
   /** Leaves both daemon queries unresolved, on a client whose queries never run. */
   pendingSources?: boolean;
+  /** Answers the panel from the daemon's attachment listing, gate opened. */
+  daemonListing?: ChatInfoDaemonListing;
   /** Runs on the seeded client, to leave one source in a state the daemon would. */
   afterSeed?: (
     client: QueryClient,
@@ -360,6 +440,49 @@ function seedChatInfoQueries(
   primeChatInfoAppPreviews(assistantId, apps);
 }
 
+/**
+ * Fills the two list reads the daemon path takes, and the bytes behind the
+ * tiles that draw a picture: the conversation's own files, and one Live
+ * session's frames.
+ */
+function seedChatInfoDaemonListing(
+  client: QueryClient,
+  { assistantId, conversationId, attachments }: ChatInfoStoryConversation,
+  { frameCount, frameTotal }: ChatInfoDaemonListing,
+): void {
+  seedAttachmentList(client, {
+    assistantId,
+    conversationId,
+    sightFrames: "exclude",
+    attachments: chatInfoFileSummaries(attachments),
+  });
+  for (const attachment of attachments) {
+    seedAttachmentBytes(
+      client,
+      assistantId,
+      attachment.id,
+      attachment.previewUrl ?? "",
+    );
+  }
+
+  const frames = chatInfoFrameSummaries(frameCount);
+  seedAttachmentList(client, {
+    assistantId,
+    conversationId,
+    sightFrames: "only",
+    attachments: frames,
+    total: frameTotal,
+  });
+  for (const [index, frame] of frames.slice(0, FRAMES_WITH_BYTES).entries()) {
+    seedAttachmentBytes(
+      client,
+      assistantId,
+      frame.id,
+      SAMPLE_PREVIEWS[index % SAMPLE_PREVIEWS.length]!,
+    );
+  }
+}
+
 /** Installs the story's attachments as the rendered transcript, under its owner. */
 function seedChatInfoTranscript({
   assistantId,
@@ -384,7 +507,7 @@ function seedChatInfoTranscript({
  */
 export const inChatInfoConversation: Decorator =
   function InChatInfoConversation(Story, { parameters }) {
-    const [{ client, releaseOrgHeader }] = useState(() => {
+    const [{ client, restoreStores }] = useState(() => {
       const conversation: ChatInfoStoryConversation = {
         ...DEFAULT_CONVERSATION,
         ...(parameters.chatInfo as
@@ -392,26 +515,41 @@ export const inChatInfoConversation: Decorator =
           | undefined),
       };
       let created: QueryClient;
-      let release = () => {};
+      const restores: Array<() => void> = [];
       if (conversation.pendingSources) {
         created = makePendingChatInfoQueryClient();
-        // The org header is the gate the two daemon queries wait on, so an
+        // The org header is the gate the daemon queries wait on, so an
         // unresolved one is what leaves this story's sources unanswered.
-        release = holdOrgHeaderUnresolved();
+        restores.push(holdOrgHeaderUnresolved());
       } else {
         created = makeChatInfoQueryClient();
         seedChatInfoQueries(created, conversation);
+        if (conversation.daemonListing) {
+          seedChatInfoDaemonListing(
+            created,
+            conversation,
+            conversation.daemonListing,
+          );
+          restores.push(reportAssistantVersion());
+        }
       }
       conversation.afterSeed?.(created, conversation);
       seedChatInfoTranscript(conversation);
-      return { client: created, releaseOrgHeader: release };
+      return {
+        client: created,
+        restoreStores: () => {
+          for (const restore of restores) {
+            restore();
+          }
+        },
+      };
     });
     useEffect(() => {
       return () => {
         clearTranscriptMessages();
-        releaseOrgHeader();
+        restoreStores();
       };
-    }, [releaseOrgHeader]);
+    }, [restoreStores]);
 
     return (
       <QueryClientProvider client={client}>

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -1,8 +1,10 @@
 /**
  * Fixtures and the shared harness for the Chat Info suites: the two daemon
  * summaries the panel lists, the assets it renders as tiles, the transcript
- * rows those assets come from, the query client its hooks read, the modules a
- * suite hands `mock.module`, and the browser APIs happy-dom leaves out.
+ * rows and the daemon attachment listing those assets come from, the query
+ * client its hooks read, the assistant version its listing gate reads, the
+ * modules a suite hands `mock.module`, and the browser APIs happy-dom leaves
+ * out.
  *
  * Every asset goes through `toConversationFileAssets`, the mapping the hook
  * itself runs, so a fixture cannot drift from the ids and shapes the panel
@@ -17,22 +19,32 @@
 import { QueryClient } from "@tanstack/react-query";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-attachment-list";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import {
   type ConversationFileAsset,
   toConversationFileAssets,
 } from "@/domains/chat/hooks/use-conversation-assets";
-import type { ConversationAttachmentEntry } from "@/domains/chat/hooks/use-conversation-attachments";
+import {
+  type ConversationAttachmentEntry,
+  conversationAttachmentListArgs,
+  type SightFrameFilter,
+} from "@/domains/chat/hooks/use-conversation-attachments";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import {
   appsGetQueryKey,
+  attachmentsGetInfiniteQueryKey,
   documentsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import type * as ElementSizeModule from "@/hooks/use-element-size";
 import { makeAppSummary as makeSharedAppSummary } from "@/types/app-summary.test-helper";
 import type { AppSummary } from "@/types/app-types";
-import type { DisplayAttachment } from "@/types/attachment-types";
+import type {
+  ConversationAttachmentSummary,
+  DisplayAttachment,
+} from "@/types/attachment-types";
 import type { DocumentSummary } from "@/types/document-types";
 import * as appHtmlCache from "@/utils/app-html-cache";
 
@@ -341,6 +353,73 @@ export function seedChatInfoConversation(
   client.setQueryData(
     documentsGetQueryKey({ path, query: { conversationId } }),
     { documents },
+  );
+}
+
+/**
+ * Reports `version` as the connected assistant's, which is the gate the daemon
+ * attachment listing is read behind. Defaults to the version that opens it.
+ * Returns the restore fn, so one test or story cannot leak a version into the
+ * next.
+ */
+export function reportAssistantVersion(version = MIN_VERSION): () => void {
+  const previous = useAssistantIdentityStore.getState();
+  const { setIdentity } = previous;
+  setIdentity(previous.name, version, previous.assistantId);
+  return () => {
+    setIdentity(previous.name, previous.version, previous.assistantId);
+  };
+}
+
+/** One row of the daemon's attachment listing, defaults under `overrides`. */
+export function makeAttachmentSummary(
+  overrides: Partial<ConversationAttachmentSummary> = {},
+): ConversationAttachmentSummary {
+  const id = overrides.id ?? "att-1";
+  return {
+    id,
+    filename: `${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 1_024,
+    kind: "image",
+    messageId: "msg-1",
+    createdAt: CHAT_INFO_T0,
+    sightFrame: false,
+    ambientKeep: false,
+    ...overrides,
+  };
+}
+
+/**
+ * One answered page of the daemon's attachment listing, under the key the hook
+ * reads it back from, so a seed and the hook cannot land on different keys.
+ * `total` defaults to the rows given, which is a listing with nothing beyond
+ * them; a larger one is what the second level's Load more control appears for.
+ */
+export function seedAttachmentList(
+  client: QueryClient,
+  {
+    assistantId,
+    conversationId,
+    sightFrames,
+    attachments,
+    total = attachments.length,
+  }: {
+    assistantId: string;
+    conversationId: string;
+    sightFrames: SightFrameFilter;
+    attachments: ConversationAttachmentSummary[];
+    total?: number;
+  },
+): void {
+  client.setQueryData(
+    attachmentsGetInfiniteQueryKey(
+      conversationAttachmentListArgs(assistantId, conversationId, sightFrames),
+    ),
+    {
+      pages: [{ attachments, total, hasMore: total > attachments.length }],
+      pageParams: [0],
+    },
   );
 }
 

--- a/clients/web/src/domains/chat/hooks/daemon-source-state.ts
+++ b/clients/web/src/domains/chat/hooks/daemon-source-state.ts
@@ -1,0 +1,55 @@
+/**
+ * How far one daemon read behind the chat-info panel has got, in the terms the
+ * panel's status is built from. The apps list, the documents list, and the two
+ * attachment lists all settle by this one rule, so a panel that reports pending
+ * or failed means the same thing whichever source is speaking.
+ */
+
+import { onlineManager } from "@tanstack/react-query";
+
+import { isTransientNetworkError } from "@/utils/is-transient-network-error";
+
+export type DaemonSourceState = "ready" | "unresolved" | "failed";
+
+/**
+ * A network error thrown while the browser is offline is the one failure still
+ * on its way: TanStack refetches every query on reconnect. The same error while
+ * the browser is online is a refused connection that has already spent its
+ * retries, and it settles like any other answer.
+ */
+function waitsForReconnect(error: Error | null): boolean {
+  return isTransientNetworkError(error) && !onlineManager.isOnline();
+}
+
+/**
+ * A failed background refetch keeps the last data, so a source is failed or
+ * unresolved only while it has nothing to show. Of the errors that leave it
+ * with nothing, only the one {@link waitsForReconnect} names is still coming.
+ */
+export function daemonSourceState(query: {
+  data: unknown;
+  isError: boolean;
+  error: Error | null;
+}): DaemonSourceState {
+  if (query.data !== undefined) {
+    return "ready";
+  }
+  if (query.isError && !waitsForReconnect(query.error)) {
+    return "failed";
+  }
+  return "unresolved";
+}
+
+/** The worse of two sources: unresolved outranks failed, failed outranks ready. */
+export function worstSourceState(
+  first: DaemonSourceState,
+  second: DaemonSourceState,
+): DaemonSourceState {
+  if (first === "unresolved" || second === "unresolved") {
+    return "unresolved";
+  }
+  if (first === "failed" || second === "failed") {
+    return "failed";
+  }
+  return "ready";
+}

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.test.tsx
@@ -1,11 +1,12 @@
 /**
  * Tests for `useConversationAssets`.
  *
- * Apps and documents come from two TanStack queries and the attachments from
- * the chat-session store, so the suite seeds all three rather than mocking
- * anything: nothing refetches on mount, no request leaves the process, and the
- * derived lists are exactly what a test asks for. All three are sources the
- * reported status answers for.
+ * Apps and documents come from two TanStack queries, and the attachments from
+ * the daemon's two list queries where the connected version serves them and
+ * from the chat-session store otherwise, so the suite seeds each source rather
+ * than mocking anything: nothing refetches on mount, no request leaves the
+ * process, and the derived lists are exactly what a test asks for. Every one of
+ * them is a source the reported status answers for.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -21,9 +22,12 @@ import {
   clearTranscriptMessages,
   holdOrgHeaderUnresolved,
   makeAppSummary,
+  makeAttachmentSummary,
   makeChatInfoQueryClient,
   makeDocumentSummary,
   makePendingChatInfoQueryClient,
+  reportAssistantVersion,
+  seedAttachmentList,
   seedChatInfoConversation,
   seedQueryFailure,
   seedTranscriptMessages,
@@ -33,8 +37,10 @@ import {
   useConversationAssets,
 } from "@/domains/chat/hooks/use-conversation-assets";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import { conversationAttachmentListArgs } from "@/domains/chat/hooks/use-conversation-attachments";
 import {
   appsGetQueryKey,
+  attachmentsGetInfiniteQueryKey,
   documentsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { AppSummary } from "@/types/app-types";
@@ -138,6 +144,19 @@ function ownWithoutSnapshot(loading: boolean): void {
 }
 
 let releaseOrgHeader = () => {};
+let restoreAssistantVersion = () => {};
+
+/** Reports a version the attachment-listing gate opens on, restored after. */
+function openAttachmentListGate(): void {
+  restoreAssistantVersion = reportAssistantVersion();
+}
+
+/** The two list keys the attachments hook reads, files first. */
+const LIST_KEYS = (["exclude", "only"] as const).map((sightFrames) =>
+  attachmentsGetInfiniteQueryKey(
+    conversationAttachmentListArgs(ASSISTANT_ID, CONVERSATION_ID, sightFrames),
+  ),
+);
 
 beforeEach(() => {
   // Both daemon queries gate on the org header, so holding it unresolved is
@@ -151,6 +170,8 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   releaseOrgHeader();
+  restoreAssistantVersion();
+  restoreAssistantVersion = () => {};
   clearTranscriptMessages();
   // The store is a module singleton, so its loading flag goes back to the
   // value a fresh chat session starts on, and so does TanStack's online
@@ -453,6 +474,103 @@ describe("useConversationAssets status", () => {
     const { result } = renderAssets({ client });
 
     expect(result.current.status).toBe("error");
+  });
+});
+
+describe("useConversationAssets on the daemon attachment lists", () => {
+  const PHOTO = makeAttachmentSummary({ id: "photo-1" });
+  const FRAME = makeAttachmentSummary({
+    id: "frame-1",
+    filename: "frame-1.jpg",
+    mimeType: "image/jpeg",
+    createdAt: 4_000,
+    sightFrame: true,
+  });
+
+  /** Apps and documents answered, so only the attachments are left to settle. */
+  function seedWithDocuments(documents: DocumentSummary[] = []): QueryClient {
+    return seedClient({
+      documents,
+      client: makePendingChatInfoQueryClient(),
+    });
+  }
+
+  test("counts the daemon's totals alongside the documents", () => {
+    openAttachmentListGate();
+    const client = seedWithDocuments([makeDocument("doc-1", 1_000)]);
+    seedAttachmentList(client, {
+      assistantId: ASSISTANT_ID,
+      conversationId: CONVERSATION_ID,
+      sightFrames: "exclude",
+      attachments: [PHOTO],
+      total: 4,
+    });
+    seedAttachmentList(client, {
+      assistantId: ASSISTANT_ID,
+      conversationId: CONVERSATION_ID,
+      sightFrames: "only",
+      attachments: [FRAME],
+      total: 12,
+    });
+
+    const { result } = renderAssets({ client });
+
+    expect(result.current.counts).toEqual({ apps: 0, files: 5, frames: 12 });
+    expect(result.current.frames.map((frame) => frame.id)).toEqual([
+      "frame-frame-1",
+    ]);
+    expect(result.current.status).toBe("ready");
+  });
+
+  // An empty category means "nothing here" only once every source has said so,
+  // and a list still on its way is a source that has not.
+  test("is pending while a list is unresolved", () => {
+    openAttachmentListGate();
+    const client = seedWithDocuments();
+    seedAttachmentList(client, {
+      assistantId: ASSISTANT_ID,
+      conversationId: CONVERSATION_ID,
+      sightFrames: "exclude",
+      attachments: [PHOTO],
+    });
+
+    const { result } = renderAssets({ client });
+
+    expect(result.current.status).toBe("pending");
+  });
+
+  test("is error when a list settled with nothing cached", () => {
+    openAttachmentListGate();
+    const client = seedWithDocuments();
+    seedAttachmentList(client, {
+      assistantId: ASSISTANT_ID,
+      conversationId: CONVERSATION_ID,
+      sightFrames: "exclude",
+      attachments: [PHOTO],
+    });
+    seedQueryFailure(client, LIST_KEYS[1]!);
+
+    const { result } = renderAssets({ client });
+
+    expect(result.current.status).toBe("error");
+  });
+
+  test("is ready once both lists have answered", () => {
+    openAttachmentListGate();
+    const client = seedWithDocuments();
+    for (const sightFrames of ["exclude", "only"] as const) {
+      seedAttachmentList(client, {
+        assistantId: ASSISTANT_ID,
+        conversationId: CONVERSATION_ID,
+        sightFrames,
+        attachments: [],
+      });
+    }
+
+    const { result } = renderAssets({ client });
+
+    expect(result.current.status).toBe("ready");
+    expect(result.current.count).toBe(0);
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-assets.ts
@@ -4,13 +4,13 @@
  * frames), and camera frames. Frames stay empty while attachments come from
  * the transcript, which cannot see the camera-frame tag.
  *
- * The two daemon queries wait for the org header and retry both the statuses a
+ * The daemon queries wait for the org header and retry both the statuses a
  * restarting assistant answers with and a refused connection, so anything that
  * settles failed here is a failure the panel can name, and it is named only
  * once every source has settled.
  */
 
-import { onlineManager, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
 
 import {
@@ -19,6 +19,7 @@ import {
   documentsGetOptions,
   documentsGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
+import { daemonSourceState } from "@/domains/chat/hooks/daemon-source-state";
 import {
   type ConversationAttachmentEntry,
   useConversationAttachments,
@@ -28,7 +29,6 @@ import type { AppSummary } from "@/types/app-types";
 import type { DisplayAttachment } from "@/types/attachment-types";
 import type { DocumentSummary } from "@/types/document-types";
 import { shouldRetryDaemonOrNetworkError } from "@/utils/daemon-errors";
-import { isTransientNetworkError } from "@/utils/is-transient-network-error";
 
 export type ConversationFileAsset =
   | { kind: "document"; id: string; title: string; doc: DocumentSummary }
@@ -47,9 +47,9 @@ export type ConversationFileAsset =
     };
 
 /**
- * How far the panel's three sources have got: the two daemon queries and the
- * conversation's own transcript, which is loaded rather than fetched and is
- * unsettled until the chat session's history load for this conversation ends.
+ * How far the panel's three sources have got: the apps query, the documents
+ * query, and the conversation's attachments, which are read from the daemon's
+ * lists or, below the gate, from the transcript that carries them.
  */
 export type ConversationAssetsStatus = "pending" | "error" | "ready";
 
@@ -82,38 +82,6 @@ interface ConversationAssetsTarget {
 /** Stable empties, so an unresolved query does not thrash the memos below. */
 const NO_APPS: AppSummary[] = [];
 const NO_DOCUMENTS: DocumentSummary[] = [];
-
-/** How far one daemon query has got, in the terms the panel's status is built from. */
-type DaemonSourceState = "ready" | "unresolved" | "failed";
-
-/**
- * A network error thrown while the browser is offline is the one failure still
- * on its way: TanStack refetches every query on reconnect. The same error while
- * the browser is online is a refused connection that has already spent its
- * retries, and it settles like any other answer.
- */
-function waitsForReconnect(error: Error | null): boolean {
-  return isTransientNetworkError(error) && !onlineManager.isOnline();
-}
-
-/**
- * A failed background refetch keeps the last data, so a source is failed or
- * unresolved only while it has nothing to show. Of the errors that leave it
- * with nothing, only the one {@link waitsForReconnect} names is still coming.
- */
-function daemonSourceState(query: {
-  data: unknown;
-  isError: boolean;
-  error: Error | null;
-}): DaemonSourceState {
-  if (query.data !== undefined) {
-    return "ready";
-  }
-  if (query.isError && !waitsForReconnect(query.error)) {
-    return "failed";
-  }
-  return "unresolved";
-}
 
 /**
  * Ids are prefixed per kind so a document, an attachment, and a frame that
@@ -203,9 +171,13 @@ export function useConversationAssets({
     });
   }, [refreshKey, queryClient, assistantId, conversationId]);
 
+  // The attachment lists are this hook's third daemon source, and the one that
+  // owns their invalidation, so `refreshKey` reaches them there rather than
+  // being re-implemented against their keys here.
   const attachments = useConversationAttachments({
     assistantId,
     conversationId,
+    refreshKey,
   });
 
   const apps = appsQuery.data ?? NO_APPS;
@@ -213,16 +185,19 @@ export function useConversationAssets({
 
   const appsState = daemonSourceState(appsQuery);
   const documentsState = daemonSourceState(documentsQuery);
-  // The transcript counts as a source too: without it a conversation whose only
-  // assets are attachments would read ready and empty until the snapshot lands.
-  // Every source settles before one of them speaks for the panel, since a
-  // failure named while another source is still coming would be taken back the
-  // moment it lands.
+  // The attachments count as a source too: without them a conversation whose
+  // only assets are attachments would read ready and empty until the lists or
+  // the snapshot land. Every source settles before one of them speaks for the
+  // panel, since a failure named while another source is still coming would be
+  // taken back the moment it lands.
   const unresolved =
     appsState === "unresolved" ||
     documentsState === "unresolved" ||
-    !attachments.transcriptSettled;
-  const failed = appsState === "failed" || documentsState === "failed";
+    attachments.sourceState === "unresolved";
+  const failed =
+    appsState === "failed" ||
+    documentsState === "failed" ||
+    attachments.sourceState === "failed";
   let status: ConversationAssetsStatus = "ready";
   if (unresolved) {
     status = "pending";

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.test.tsx
@@ -1,30 +1,112 @@
 /**
- * Tests for `useConversationAttachments` on its transcript path.
+ * Tests for `useConversationAttachments` on both of its paths.
  *
- * The rows are seeded into the chat-session store in the shape the store
- * itself holds, so the hook runs its real subscription: what is asserted here
- * is the walk over those rows, and that a streaming turn does not disturb it.
+ * The transcript rows are seeded into the chat-session store in the shape the
+ * store itself holds and the daemon's two lists into the query cache under the
+ * keys the hook reads them from, so the hook runs its real subscription and its
+ * real queries: what is asserted is the walk over those rows, that a streaming
+ * turn does not disturb it, and which path answers for a given assistant
+ * version. The gate is opened through the identity store rather than mocked,
+ * since a `mock.module` call is process-global.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { type QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import { makeDisplayAttachment } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import {
   clearTranscriptMessages,
   clearTranscriptOwner,
+  makeAttachmentSummary,
+  holdOrgHeaderUnresolved,
+  makeChatInfoQueryClient,
   makeTranscriptRow,
+  reportAssistantVersion,
+  seedAttachmentList,
+  seedQueryFailure,
   seedTranscriptMessages,
 } from "@/domains/chat/components/chat-info.test-helper";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
-import { useConversationAttachments } from "@/domains/chat/hooks/use-conversation-attachments";
+import {
+  conversationAttachmentListArgs,
+  useConversationAttachments,
+} from "@/domains/chat/hooks/use-conversation-attachments";
 import type { DisplayMessage } from "@/domains/chat/types/types";
+import { attachmentsGetInfiniteQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import type { ConversationAttachmentSummary } from "@/types/attachment-types";
+import { ApiError } from "@/utils/api-errors";
 
 const TARGET = { assistantId: "asst-1", conversationId: "conv-1" };
+
+/** A version below the gate's floor: the assistant serves no list route. */
+const BELOW_GATE_VERSION = "0.11.9";
+
+/** The two list keys the hook reads, files first. */
+const LIST_KEYS = (["exclude", "only"] as const).map((sightFrames) =>
+  attachmentsGetInfiniteQueryKey(
+    conversationAttachmentListArgs(
+      TARGET.assistantId,
+      TARGET.conversationId,
+      sightFrames,
+    ),
+  ),
+);
 
 /** Seeds `messages` as the transcript the target conversation owns. */
 function seed(messages: DisplayMessage[]): void {
   seedTranscriptMessages(TARGET.assistantId, TARGET.conversationId, messages);
+}
+
+/**
+ * The hook under a client of the test's own. Every test renders through this,
+ * so the two list queries always have a client, whichever path answers.
+ */
+function renderAttachments({
+  client = makeChatInfoQueryClient(),
+  onRender = () => {},
+}: { client?: QueryClient; onRender?: () => void } = {}) {
+  const view = renderHook(
+    () => {
+      onRender();
+      return useConversationAttachments(TARGET);
+    },
+    {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      ),
+    },
+  );
+  return { ...view, client };
+}
+
+/** Seeds both list reads, so the daemon path has an answer for each. */
+function seedLists(
+  client: QueryClient,
+  {
+    files = [],
+    frames = [],
+    totalFiles,
+    totalFrames,
+  }: {
+    files?: ConversationAttachmentSummary[];
+    frames?: ConversationAttachmentSummary[];
+    totalFiles?: number;
+    totalFrames?: number;
+  },
+): void {
+  seedAttachmentList(client, {
+    ...TARGET,
+    sightFrames: "exclude",
+    attachments: files,
+    total: totalFiles,
+  });
+  seedAttachmentList(client, {
+    ...TARGET,
+    sightFrames: "only",
+    attachments: frames,
+    total: totalFrames,
+  });
 }
 
 /** The target owns the transcript, with no snapshot and history `loading`. */
@@ -38,17 +120,31 @@ function ownWithoutSnapshot(loading: boolean): void {
   });
 }
 
+let restoreAssistantVersion = () => {};
+let releaseOrgHeader = () => {};
+
 beforeEach(() => {
   seed([]);
 });
 
 afterEach(() => {
+  // Both restores run after the render is torn down, so no query can enable
+  // itself on the way out and reach a daemon this suite does not run.
   cleanup();
   clearTranscriptMessages();
+  restoreAssistantVersion();
+  restoreAssistantVersion = () => {};
+  releaseOrgHeader();
+  releaseOrgHeader = () => {};
   // The store is a module singleton, so its loading flag goes back to the
   // value a fresh chat session starts on.
   useChatSessionStore.setState({ isLoadingHistory: true });
 });
+
+/** Reports a version the gate opens on, restored when the test is over. */
+function openGate(version?: string): void {
+  restoreAssistantVersion = reportAssistantVersion(version);
+}
 
 describe("useConversationAttachments", () => {
   test("walks the transcript newest first", () => {
@@ -65,7 +161,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
       "new",
@@ -80,7 +176,7 @@ describe("useConversationAttachments", () => {
     expect(result.current.totalFiles).toBe(2);
     // The transcript never carries the frame tag, so this source has none.
     expect(result.current.totalFrames).toBe(0);
-    expect(result.current.transcriptSettled).toBe(true);
+    expect(result.current.sourceState).toBe("ready");
     expect(result.current.hasMoreFiles).toBe(false);
     expect(result.current.hasMoreFrames).toBe(false);
   });
@@ -103,7 +199,7 @@ describe("useConversationAttachments", () => {
       ],
     });
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
       "sending",
@@ -127,7 +223,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries).toHaveLength(1);
     // The newer row's timestamp: the first sighting of a shared id wins.
@@ -154,7 +250,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries.map((entry) => entry.key)).toEqual([
       "msg-new:0",
@@ -179,7 +275,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries).toHaveLength(2);
     expect(new Set(result.current.entries.map((entry) => entry.key)).size).toBe(
@@ -201,7 +297,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(
       result.current.entries.map((entry) => entry.attachment.filename),
@@ -225,7 +321,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
       "kept",
@@ -239,7 +335,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries[0]!.capturedAt).toBeNull();
   });
@@ -247,9 +343,7 @@ describe("useConversationAttachments", () => {
   test("hands back the same empty array across renders", () => {
     seed([makeTranscriptRow({})]);
 
-    const { result, rerender } = renderHook(() =>
-      useConversationAttachments(TARGET),
-    );
+    const { result, rerender } = renderAttachments();
     const first = result.current.entries;
     rerender();
 
@@ -275,9 +369,10 @@ describe("useConversationAttachments", () => {
     ]);
 
     let renders = 0;
-    const { result } = renderHook(() => {
-      renders += 1;
-      return useConversationAttachments(TARGET);
+    const { result } = renderAttachments({
+      onRender: () => {
+        renders += 1;
+      },
     });
     const first = result.current.entries;
     const rendersAfterMount = renders;
@@ -309,9 +404,10 @@ describe("useConversationAttachments", () => {
     ]);
 
     let renders = 0;
-    const { result } = renderHook(() => {
-      renders += 1;
-      return useConversationAttachments(TARGET);
+    const { result } = renderAttachments({
+      onRender: () => {
+        renders += 1;
+      },
     });
     const first = result.current.entries;
     const rendersAfterMount = renders;
@@ -342,7 +438,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries.map((entry) => entry.attachment.id)).toEqual([
       "mine",
@@ -356,11 +452,11 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries).toHaveLength(0);
     expect(result.current.totalFiles).toBe(0);
-    expect(result.current.transcriptSettled).toBe(false);
+    expect(result.current.sourceState).toBe("unresolved");
   });
 
   test("lists nothing when another assistant owns the snapshot", () => {
@@ -370,7 +466,7 @@ describe("useConversationAttachments", () => {
       }),
     ]);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries).toHaveLength(0);
     expect(result.current.totalFiles).toBe(0);
@@ -384,11 +480,11 @@ describe("useConversationAttachments", () => {
     ]);
     clearTranscriptOwner();
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
     expect(result.current.entries).toHaveLength(0);
     expect(result.current.totalFiles).toBe(0);
-    expect(result.current.transcriptSettled).toBe(false);
+    expect(result.current.sourceState).toBe("unresolved");
   });
 
   // An owned conversation with no snapshot yet is the first paint of a chat:
@@ -396,9 +492,9 @@ describe("useConversationAttachments", () => {
   test("is unsettled while the history load is in flight", () => {
     ownWithoutSnapshot(true);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
-    expect(result.current.transcriptSettled).toBe(false);
+    expect(result.current.sourceState).toBe("unresolved");
     expect(result.current.entries).toHaveLength(0);
   });
 
@@ -408,20 +504,266 @@ describe("useConversationAttachments", () => {
   test("settles once a failed history load is over", () => {
     ownWithoutSnapshot(false);
 
-    const { result } = renderHook(() => useConversationAttachments(TARGET));
+    const { result } = renderAttachments();
 
-    expect(result.current.transcriptSettled).toBe(true);
+    expect(result.current.sourceState).toBe("ready");
     expect(result.current.entries).toHaveLength(0);
   });
 
   test("keeps the load-more callbacks stable", () => {
-    const { result, rerender } = renderHook(() =>
-      useConversationAttachments(TARGET),
-    );
+    const { result, rerender } = renderAttachments();
     const { loadMoreFiles, loadMoreFrames } = result.current;
     rerender();
 
     expect(result.current.loadMoreFiles).toBe(loadMoreFiles);
     expect(result.current.loadMoreFrames).toBe(loadMoreFrames);
+  });
+});
+
+describe("useConversationAttachments on the daemon path", () => {
+  const PHOTO = makeAttachmentSummary({
+    id: "photo-1",
+    filename: "photo-1.png",
+    createdAt: 1_000,
+  });
+  const FRAME = makeAttachmentSummary({
+    id: "frame-1",
+    filename: "frame-1.jpg",
+    mimeType: "image/jpeg",
+    createdAt: 4_000,
+    sightFrame: true,
+    thumbnailData: "dGh1bWI=",
+  });
+
+  /** Puts one list into the state the daemon client leaves behind for `status`. */
+  function failList(
+    client: QueryClient,
+    queryKey: readonly unknown[],
+    status: number,
+  ): void {
+    seedQueryFailure(client, queryKey);
+    client
+      .getQueryCache()
+      .find({ queryKey })!
+      .setState({ error: new ApiError(status, `HTTP ${status}`) });
+  }
+
+  test("lists both of the daemon's lists, files first", () => {
+    openGate();
+    const client = makeChatInfoQueryClient();
+    seedLists(client, { files: [PHOTO], frames: [FRAME] });
+
+    const { result } = renderAttachments({ client });
+
+    expect(result.current.source).toBe("daemon");
+    expect(result.current.entries.map((entry) => entry.key)).toEqual([
+      "photo-1",
+      "frame-1",
+    ]);
+    expect(result.current.sourceState).toBe("ready");
+  });
+
+  test("carries a frame's tag, its capture time, and its thumbnail", () => {
+    openGate();
+    const client = makeChatInfoQueryClient();
+    seedLists(client, { files: [PHOTO], frames: [FRAME] });
+
+    const { result } = renderAttachments({ client });
+    const frame = result.current.entries[1]!;
+
+    expect(frame.sightFrame).toBe(true);
+    expect(frame.capturedAt).toBe(4_000);
+    // The bytes are fetched lazily under the shared attachment-content key, so
+    // the listing itself hands the tile a thumbnail and nothing else.
+    expect(frame.attachment.previewUrl).toBeNull();
+    expect(frame.attachment.thumbnailUrl).toBe(
+      "data:image/jpeg;base64,dGh1bWI=",
+    );
+    expect(result.current.entries[0]!.sightFrame).toBe(false);
+  });
+
+  test("reports each category's total and what is left beyond it", () => {
+    openGate();
+    const client = makeChatInfoQueryClient();
+    seedLists(client, {
+      files: [PHOTO],
+      frames: [FRAME],
+      totalFiles: 3,
+      totalFrames: 260,
+    });
+
+    const { result } = renderAttachments({ client });
+
+    expect(result.current.totalFiles).toBe(3);
+    expect(result.current.totalFrames).toBe(260);
+    expect(result.current.hasMoreFiles).toBe(true);
+    expect(result.current.hasMoreFrames).toBe(true);
+  });
+
+  test("asks for nothing more once a list is complete", () => {
+    openGate();
+    const client = makeChatInfoQueryClient();
+    seedLists(client, { files: [PHOTO], frames: [FRAME] });
+
+    const { result } = renderAttachments({ client });
+
+    expect(result.current.hasMoreFiles).toBe(false);
+    expect(result.current.hasMoreFrames).toBe(false);
+  });
+
+  test("requests the next page of frames from the offset it has loaded", async () => {
+    openGate();
+    const client = makeChatInfoQueryClient();
+    seedLists(client, { files: [PHOTO], frames: [FRAME], totalFrames: 2 });
+    const requested: string[] = [];
+    const realFetch = globalThis.fetch;
+    const stub: typeof fetch = (input) => {
+      requested.push(input instanceof Request ? input.url : String(input));
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            attachments: [makeAttachmentSummary({ id: "frame-2" })],
+            total: 2,
+            hasMore: false,
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      );
+    };
+    stub.preconnect = realFetch.preconnect;
+    globalThis.fetch = stub;
+
+    try {
+      const { result } = renderAttachments({ client });
+      act(() => {
+        result.current.loadMoreFrames();
+      });
+      await waitFor(() => {
+        expect(result.current.entries).toHaveLength(3);
+      });
+
+      expect(requested).toHaveLength(1);
+      expect(requested[0]).toContain("sightFrames=only");
+      expect(requested[0]).toContain("offset=1");
+      expect(result.current.entries.map((entry) => entry.key)).toEqual([
+        "photo-1",
+        "frame-1",
+        "frame-2",
+      ]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("re-reads both lists when the transcript's attachments change", () => {
+    openGate();
+    const client = makeChatInfoQueryClient();
+    seedLists(client, { files: [PHOTO], frames: [FRAME] });
+    const invalidated: unknown[] = [];
+    client.invalidateQueries = (filters) => {
+      invalidated.push(filters);
+      return Promise.resolve();
+    };
+
+    renderAttachments({ client });
+
+    expect(invalidated).toEqual([]);
+    // A frame kept while the panel is open reaches the transcript over SSE.
+    act(() => {
+      useChatSessionStore.getState().patchSnapshotMessages((prev) => [
+        ...prev,
+        makeTranscriptRow({
+          id: "msg-kept",
+          timestamp: 5_000,
+          attachments: [makeDisplayAttachment({ id: "frame-2" })],
+        }),
+      ]);
+    });
+
+    expect(invalidated).toEqual([
+      { queryKey: LIST_KEYS[0] },
+      { queryKey: LIST_KEYS[1] },
+    ]);
+  });
+
+  test("lists the transcript unchanged below the gate", () => {
+    openGate(BELOW_GATE_VERSION);
+    seed([
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "from-transcript" })],
+      }),
+    ]);
+    const client = makeChatInfoQueryClient();
+    seedLists(client, { files: [PHOTO], frames: [FRAME], totalFrames: 9 });
+
+    const { result } = renderAttachments({ client });
+
+    expect(result.current.source).toBe("transcript");
+    expect(result.current.entries.map((entry) => entry.key)).toEqual([
+      "from-transcript",
+    ]);
+    expect(result.current.totalFiles).toBe(1);
+    expect(result.current.totalFrames).toBe(0);
+    expect(result.current.hasMoreFrames).toBe(false);
+    expect(result.current.sourceState).toBe("ready");
+  });
+
+  // A build carrying the gated version but cut before the route landed is the
+  // gate's blind spot, and it is the old behavior rather than a failure.
+  test("falls back to the transcript when the route answers 404", () => {
+    openGate();
+    seed([
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "from-transcript" })],
+      }),
+    ]);
+    const client = makeChatInfoQueryClient();
+    for (const queryKey of LIST_KEYS) {
+      failList(client, queryKey, 404);
+    }
+
+    const { result } = renderAttachments({ client });
+
+    expect(result.current.source).toBe("transcript");
+    expect(result.current.entries.map((entry) => entry.key)).toEqual([
+      "from-transcript",
+    ]);
+    expect(result.current.sourceState).toBe("ready");
+  });
+
+  test("reports a settled list failure as a failed source", () => {
+    openGate();
+    const client = makeChatInfoQueryClient();
+    seedAttachmentList(client, {
+      ...TARGET,
+      sightFrames: "exclude",
+      attachments: [PHOTO],
+    });
+    failList(client, LIST_KEYS[1]!, 500);
+
+    const { result } = renderAttachments({ client });
+
+    expect(result.current.sourceState).toBe("failed");
+  });
+
+  // The panel is never empty on open: the transcript's own files are on screen
+  // from the first paint, and the lists replace them once both have answered.
+  test("shows the transcript's files while the lists are unresolved", () => {
+    openGate();
+    // The org header is the gate the list reads wait on, so an unresolved one
+    // leaves them unanswered with nothing requested.
+    releaseOrgHeader = holdOrgHeaderUnresolved();
+    seed([
+      makeTranscriptRow({
+        attachments: [makeDisplayAttachment({ id: "from-transcript" })],
+      }),
+    ]);
+
+    const { result } = renderAttachments();
+
+    expect(result.current.entries.map((entry) => entry.key)).toEqual([
+      "from-transcript",
+    ]);
+    expect(result.current.sourceState).toBe("unresolved");
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-attachments.ts
@@ -1,9 +1,18 @@
 /**
- * Every attachment a conversation carries: rows newest first, and the
- * attachments within one row in the order they were sent.
+ * Every attachment a conversation carries, from the daemon's own listing where
+ * the assistant serves it and from the loaded transcript rows otherwise.
  *
- * Read from the transcript rows that carry attachments, which is the loaded
- * pages only, so `totalFiles` counts what is loaded rather than what the
+ * The daemon path reads `GET /v1/attachments?conversationId=` twice, once
+ * leaving the camera frames out and once taking only them, so each category
+ * reports the conversation's exact total and the frames the transcript cannot
+ * see. It is taken only while {@link useSupportsAttachmentList} allows it, and
+ * a 404 (a build cut before the route landed) puts that target back on the
+ * transcript for the life of the component. Rows keep the response's order,
+ * which is newest first, and carry no bytes: a tile fetches those lazily under
+ * the shared attachment-content key.
+ *
+ * The transcript path reads the rows that carry attachments, which is the
+ * loaded pages only, so `totalFiles` counts what is loaded rather than what the
  * conversation holds. Subscribing to those rows alone rather than to the whole
  * transcript keeps the always-mounted header trigger still while a turn
  * streams: older rows keep their identity and the streaming assistant row
@@ -13,19 +22,59 @@
  * `docs/CONVENTIONS.md` keeps out of a streaming conversation.
  * The transcript also cannot see the camera-frame tag: that lives in daemon
  * message metadata which never crosses the message wire, so `sightFrame` is
- * always false and `totalFrames` is always 0 on this source.
+ * always false and `totalFrames` always 0 on that source.
  */
 
-import { useMemo } from "react";
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 import {
   type ChatSessionStore,
   useChatSessionStore,
 } from "@/domains/chat/chat-session-store";
+import {
+  type DaemonSourceState,
+  daemonSourceState,
+  worstSourceState,
+} from "@/domains/chat/hooks/daemon-source-state";
 import { selectTranscriptMessages } from "@/domains/chat/transcript/select-transcript-messages";
 import type { DisplayMessage } from "@/domains/chat/types/types";
-import type { DisplayAttachment } from "@/types/attachment-types";
+import {
+  attachmentsGetInfiniteOptions,
+  attachmentsGetInfiniteQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type { AttachmentsGetResponse } from "@/generated/daemon/types.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useSupportsAttachmentList } from "@/lib/backwards-compat/use-supports-attachment-list";
+import type {
+  ConversationAttachmentSummary,
+  DisplayAttachment,
+} from "@/types/attachment-types";
+import { ApiError } from "@/utils/api-errors";
+import { deriveDisplayUrls } from "@/utils/attachment-urls";
+import { shouldRetryDaemonOrNetworkError } from "@/utils/daemon-errors";
+
+/** Rows per list request, and what one Load more adds. The route's default. */
+export const ATTACHMENT_PAGE_SIZE = 200;
+
+/** Which half of a conversation's attachments one list request answers with. */
+export type SightFrameFilter = "exclude" | "only";
+
+/**
+ * The request one list read is made with, so a caller seeding the cache and the
+ * hook reading it cannot land on different keys.
+ */
+export function conversationAttachmentListArgs(
+  assistantId: string,
+  conversationId: string,
+  sightFrames: SightFrameFilter,
+) {
+  return {
+    path: { assistant_id: assistantId },
+    query: { conversationId, sightFrames, limit: ATTACHMENT_PAGE_SIZE },
+  };
+}
 
 export interface ConversationAttachmentEntry {
   /**
@@ -48,12 +97,13 @@ export interface ConversationAttachments {
   totalFiles: number;
   totalFrames: number;
   /**
-   * Whether the target's own transcript has stopped loading: its chat session
-   * owns it, and either a snapshot is loaded or the history fetch is over.
-   * Empty entries mean "no files" only once this is true, and a history load
-   * that failed settles here rather than staying unready for good.
+   * How far the active path has got. The daemon path reports the two list
+   * reads; the transcript path is ready once the target's own transcript has
+   * stopped loading (its chat session owns it, and either a snapshot is loaded
+   * or the history fetch is over) and never failed, since a history load that
+   * failed settles rather than staying unready for good.
    */
-  transcriptSettled: boolean;
+  sourceState: DaemonSourceState;
   hasMoreFiles: boolean;
   hasMoreFrames: boolean;
   loadMoreFiles: () => void;
@@ -94,18 +144,147 @@ function selectAttachmentRows(state: ChatSessionStore): DisplayMessage[] {
   );
 }
 
+/**
+ * One listed row as the panel's entry. Daemon ids are unique across the
+ * conversation, so the row-scoped key the transcript path mints is not needed
+ * here. `previewUrl` stays null so the tile fetches the bytes lazily.
+ */
+function toDaemonEntry(
+  summary: ConversationAttachmentSummary,
+): ConversationAttachmentEntry {
+  return {
+    key: summary.id,
+    attachment: {
+      id: summary.id,
+      filename: summary.filename,
+      mimeType: summary.mimeType,
+      sizeBytes: summary.sizeBytes,
+      ...deriveDisplayUrls(
+        summary.mimeType,
+        undefined,
+        summary.thumbnailData,
+        true,
+      ),
+    },
+    capturedAt: summary.createdAt,
+    sightFrame: summary.sightFrame,
+  };
+}
+
+/** The offset of the row after everything loaded, while the daemon holds more. */
+function nextAttachmentOffset(
+  lastPage: AttachmentsGetResponse,
+  pages: AttachmentsGetResponse[],
+): number | undefined {
+  if (!lastPage.hasMore) {
+    return undefined;
+  }
+  return pages.reduce((loaded, page) => loaded + page.attachments.length, 0);
+}
+
+/** A route the assistant does not serve, which is what the gate could not tell. */
+function isRouteMissing(error: Error | null): boolean {
+  return error instanceof ApiError && error.status === 404;
+}
+
 export function useConversationAttachments(target: {
   assistantId: string;
   conversationId: string;
+  /** Bumped externally to re-read the daemon's lists. */
+  refreshKey?: number;
 }): ConversationAttachments {
+  const { assistantId, conversationId, refreshKey } = target;
+  const queryClient = useQueryClient();
+  const supportsList = useSupportsAttachmentList();
+  // The same gate the panel's other daemon reads wait on: a request sent
+  // before the org header can be produced fails for a reason the conversation
+  // has nothing to do with.
+  const isOrgReady = useIsOrgReady();
+
+  // A 404 is the gate's blind spot: a build carrying the gated version but cut
+  // before the route landed. Remembered per target so the fallback holds for
+  // the life of this component rather than being re-learned every render.
+  const targetKey = `${assistantId}/${conversationId}`;
+  const [routeMissingFor, setRouteMissingFor] = useState<string | null>(null);
+
+  const filesArgs = useMemo(
+    () =>
+      conversationAttachmentListArgs(assistantId, conversationId, "exclude"),
+    [assistantId, conversationId],
+  );
+  const framesArgs = useMemo(
+    () => conversationAttachmentListArgs(assistantId, conversationId, "only"),
+    [assistantId, conversationId],
+  );
+
+  const listsRequested =
+    supportsList && isOrgReady && routeMissingFor !== targetKey;
+  const filesQuery = useInfiniteQuery({
+    ...attachmentsGetInfiniteOptions(filesArgs),
+    initialPageParam: 0,
+    getNextPageParam: nextAttachmentOffset,
+    enabled: listsRequested,
+    retry: shouldRetryDaemonOrNetworkError,
+  });
+  const framesQuery = useInfiniteQuery({
+    ...attachmentsGetInfiniteOptions(framesArgs),
+    initialPageParam: 0,
+    getNextPageParam: nextAttachmentOffset,
+    enabled: listsRequested,
+    retry: shouldRetryDaemonOrNetworkError,
+  });
+
+  const routeMissing =
+    isRouteMissing(filesQuery.error) || isRouteMissing(framesQuery.error);
+  useEffect(() => {
+    if (routeMissing) {
+      setRouteMissingFor(targetKey);
+    }
+  }, [routeMissing, targetKey]);
+  const listsActive =
+    supportsList && !routeMissing && routeMissingFor !== targetKey;
+  const listsEnabled = listsActive && isOrgReady;
+
+  const fetchNextFiles = filesQuery.fetchNextPage;
+  const fetchNextFrames = framesQuery.fetchNextPage;
+  const loadMoreFiles = useCallback(() => {
+    void fetchNextFiles();
+  }, [fetchNextFiles]);
+  const loadMoreFrames = useCallback(() => {
+    void fetchNextFrames();
+  }, [fetchNextFrames]);
+
+  const filesPages = filesQuery.data?.pages;
+  const framesPages = framesQuery.data?.pages;
+  const daemonLists = useMemo(() => {
+    if (filesPages === undefined || framesPages === undefined) {
+      return null;
+    }
+    const filesTail = filesPages[filesPages.length - 1]!;
+    const framesTail = framesPages[framesPages.length - 1]!;
+    return {
+      entries: [
+        ...filesPages.flatMap((page) => page.attachments.map(toDaemonEntry)),
+        ...framesPages.flatMap((page) => page.attachments.map(toDaemonEntry)),
+      ],
+      totalFiles: filesTail.total,
+      totalFrames: framesTail.total,
+      hasMoreFiles: filesTail.hasMore,
+      hasMoreFrames: framesTail.hasMore,
+    };
+  }, [filesPages, framesPages]);
+  const listsState = worstSourceState(
+    daemonSourceState(filesQuery),
+    daemonSourceState(framesQuery),
+  );
+
   // The chat-session store names the conversation its snapshot was loaded for.
   // The navigation selection flips a render before that snapshot is cleared, so
   // gating on it would list the outgoing conversation's files under the new id.
   const ownerAssistantId = useChatSessionStore.use.previousAssistantId();
   const ownerConversationId = useChatSessionStore.use.previousConversationId();
   const ownsTranscript =
-    ownerAssistantId === target.assistantId &&
-    ownerConversationId === target.conversationId;
+    ownerAssistantId === assistantId && ownerConversationId === conversationId;
 
   const hasSnapshot = useChatSessionStore((state) => state.snapshot !== null);
   // The store's own loading flag, never its `error` field: a failed send sets
@@ -150,19 +329,80 @@ export function useConversationAttachments(target: {
     return collected.length === 0 ? NO_ENTRIES : collected;
   }, [messages, ownsTranscript]);
 
-  return useMemo(
-    () => ({
+  const invalidateLists = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: attachmentsGetInfiniteQueryKey(filesArgs),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: attachmentsGetInfiniteQueryKey(framesArgs),
+    });
+  }, [queryClient, filesArgs, framesArgs]);
+
+  // A frame kept while the panel is open reaches the transcript over SSE, so
+  // that set changing is the signal the lists are behind.
+  const transcriptIds = useMemo(
+    () => entries.map((entry) => entry.attachment.id).join(","),
+    [entries],
+  );
+  const listedTranscriptIds = useRef(transcriptIds);
+  useEffect(() => {
+    if (listedTranscriptIds.current === transcriptIds) {
+      return;
+    }
+    listedTranscriptIds.current = transcriptIds;
+    if (listsEnabled) {
+      invalidateLists();
+    }
+  }, [transcriptIds, listsEnabled, invalidateLists]);
+
+  useEffect(() => {
+    if (refreshKey === undefined || !listsEnabled) {
+      return;
+    }
+    invalidateLists();
+  }, [refreshKey, listsEnabled, invalidateLists]);
+
+  const transcriptState: DaemonSourceState =
+    ownsTranscript && (hasSnapshot || !isLoadingHistory)
+      ? "ready"
+      : "unresolved";
+
+  return useMemo(() => {
+    if (listsActive && daemonLists) {
+      return {
+        entries: daemonLists.entries,
+        totalFiles: daemonLists.totalFiles,
+        totalFrames: daemonLists.totalFrames,
+        sourceState: listsState,
+        hasMoreFiles: daemonLists.hasMoreFiles,
+        hasMoreFrames: daemonLists.hasMoreFrames,
+        loadMoreFiles,
+        loadMoreFrames,
+        source: "daemon" as const,
+      };
+    }
+    return {
       entries,
       totalFiles: entries.length,
       // The transcript path cannot produce a frame: it never sees the tag.
       totalFrames: 0,
-      transcriptSettled: ownsTranscript && (hasSnapshot || !isLoadingHistory),
+      // A list still on its way speaks for the panel even though the entries
+      // below it are the transcript's, so an open panel is never empty and
+      // never reads settled before the daemon has answered.
+      sourceState: listsActive ? listsState : transcriptState,
       hasMoreFiles: false,
       hasMoreFrames: false,
       loadMoreFiles: NOOP,
       loadMoreFrames: NOOP,
-      source: "transcript",
-    }),
-    [entries, hasSnapshot, isLoadingHistory, ownsTranscript],
-  );
+      source: "transcript" as const,
+    };
+  }, [
+    daemonLists,
+    entries,
+    listsActive,
+    listsState,
+    loadMoreFiles,
+    loadMoreFrames,
+    transcriptState,
+  ]);
 }

--- a/clients/web/src/types/attachment-types.ts
+++ b/clients/web/src/types/attachment-types.ts
@@ -1,4 +1,7 @@
-import type { AttachmentsByIdGetResponse } from "@/generated/daemon/types.gen";
+import type {
+  AttachmentsByIdGetResponse,
+  AttachmentsGetResponse,
+} from "@/generated/daemon/types.gen";
 
 /**
  * Server-canonical attachment metadata, sourced from the daemon's generated
@@ -10,6 +13,14 @@ export type AttachmentMetadata = Pick<
   AttachmentsByIdGetResponse,
   "id" | "filename" | "mimeType" | "sizeBytes"
 >;
+
+/**
+ * One row of the daemon's conversation attachment listing: the metadata every
+ * attachment linked to a conversation carries, camera-frame tag included.
+ * Bytes are never in it; a reader fetches those from the content endpoint.
+ */
+export type ConversationAttachmentSummary =
+  AttachmentsGetResponse["attachments"][number];
 
 /** Display metadata for a file attachment (user-uploaded or assistant-generated),
  *  used to render the chip inside a message bubble. For live sessions, populated


### PR DESCRIPTION
## Summary
- `useConversationAttachments` reads `GET /v1/attachments?conversationId=` when `useSupportsAttachmentList()` allows it: exact totals, a populated Camera Frames row, Load more on the second level; a 404 falls back to the transcript path.
- `useConversationAssets` counts the attachment lists as sources for the panel's pending, error, and ready states; the lists are invalidated when the transcript's attachment set changes and on `refreshKey`.
- Stories `WithCameraFrames`, `FramesSeeAll`, `FramesLoadMore`, `WithCameraFramesMobile` run the daemon path.

Stacked on the PR 11 gate, which is stacked on #42291 (the daemon route). This PR's base is the PR 11 branch and retargets as the stack merges.

Part of plan: chat-info-assets-panel.md (PR 12 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hgD7bhzXbP7HoXUPuaB9c