### PR TITLE
fix(runtime): enforce policy on shareable pages and tighten the proxy auth bypass

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24411,19 +24411,14 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/octet-stream:
-            schema: &a1
-              type: string
-              format: binary
       responses:
         "200":
           description: Successful response
           content:
             application/octet-stream:
-              schema: *a1
+              schema: &a1
+                type: string
+                format: binary
         "400":
           description: Malformed provider segment or proxied path
         "402":
@@ -24550,11 +24545,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/octet-stream:
-            schema: *a1
       responses:
         "200":
           description: Successful response
@@ -24599,11 +24589,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/octet-stream:
-            schema: *a1
       responses:
         "200":
           description: Successful response
@@ -24648,11 +24633,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/octet-stream:
-            schema: *a1
       responses:
         "200":
           description: Successful response

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -14,7 +14,7 @@
  */
 
 import { getLogger } from "../util/logger.js";
-import { checkUnrecognizedEnvVars } from "./env-registry.js";
+import { checkUnrecognizedEnvVars, getIsPlatform } from "./env-registry.js";
 import { getConfig } from "./loader.js";
 
 const log = getLogger("env");
@@ -95,6 +95,21 @@ export function getRuntimeHttpHost(): string {
  */
 export function isHttpAuthDisabled(): boolean {
   return str("DISABLE_HTTP_AUTH")?.toLowerCase() === "true";
+}
+
+/**
+ * True when the platform-managed auth bypass is in effect: DISABLE_HTTP_AUTH
+ * and IS_PLATFORM both set, the pair a vembda pod runs with.
+ *
+ * The narrow reading of the bypass, for authorization decisions that must not
+ * turn off on a host the platform does not manage. `DISABLE_HTTP_AUTH` alone
+ * is a dev flag whose whole meaning is "the platform handles auth", so a leak
+ * of it onto another host must not also surrender a route's policy or a
+ * grant's binding. Mirrors `isPlatformAuthBypassActive` in
+ * `gateway/src/http/middleware/auth.ts`.
+ */
+export function isPlatformAuthBypassActive(): boolean {
+  return isHttpAuthDisabled() && getIsPlatform();
 }
 
 // ── Qdrant ───────────────────────────────────────────────────────────────────

--- a/assistant/src/runtime/__tests__/pages-route-policy.test.ts
+++ b/assistant/src/runtime/__tests__/pages-route-policy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Shareable app pages are served outside the /v1/ namespace, at
+ * `GET /pages/:appId`, but they are an ordinary entry in the shared ROUTES
+ * array and carry an ordinary policy (`settings.read`, actor principals).
+ *
+ * These tests pin that the bare path dispatches through the router, so the
+ * declared policy is enforced there: a single-route grant handed to a
+ * third-party binary is refused, and a normal client still gets its page.
+ */
+
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+const APP_ID = "app-under-test";
+const appDir = mkdtempSync(join(tmpdir(), "vellum-pages-"));
+mkdirSync(join(appDir, "dist"), { recursive: true });
+writeFileSync(
+  join(appDir, "dist", "index.html"),
+  '<!DOCTYPE html><html><body><script src="./main.js"></script></body></html>',
+);
+
+const appStore = await import("../../apps/app-store.js");
+mock.module("../../apps/app-store.js", () => ({
+  ...appStore,
+  resolveAppSource: (id: string) =>
+    id === APP_ID
+      ? {
+          id: APP_ID,
+          name: "Test App",
+          dirName: APP_ID,
+          sourceDir: appDir,
+          origin: { kind: "workspace" },
+        }
+      : null,
+}));
+
+const { setDbReady } = await import("../../daemon/daemon-readiness.js");
+const { CURRENT_POLICY_EPOCH } = await import("../auth/policy.js");
+const { mintToken } = await import("../auth/token-service.js");
+const { RuntimeHttpServer } = await import("../http-server.js");
+
+/** A desktop/web client token: `actor_client_v1` carries settings.read. */
+const ACTOR_JWT = mintToken({
+  aud: "vellum-daemon",
+  sub: "actor:self:test-principal",
+  scope_profile: "actor_client_v1",
+  policy_epoch: CURRENT_POLICY_EPOCH,
+  ttlSeconds: 3600,
+});
+
+/** The grant `assistant oauth proxy-url` hands to a third-party binary. */
+const PROXY_GRANT_JWT = mintToken({
+  aud: "vellum-daemon",
+  sub: "local:self:oauth-proxy.stripe_link",
+  scope_profile: "oauth_proxy_v1",
+  policy_epoch: CURRENT_POLICY_EPOCH,
+  ttlSeconds: 3600,
+});
+
+describe("GET /pages/:appId enforces its route policy", () => {
+  let server: InstanceType<typeof RuntimeHttpServer>;
+  let port = 0;
+
+  beforeAll(async () => {
+    setDbReady(true);
+    server = new RuntimeHttpServer({ port: await getFreePort() });
+    await server.start();
+    port = server.actualPort;
+  });
+
+  afterAll(async () => {
+    await server?.stop();
+  });
+
+  function fetchPage(token: string, appId = APP_ID): Promise<Response> {
+    return fetch(`http://127.0.0.1:${port}/pages/${appId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+
+  test("serves the page to a client holding settings.read", async () => {
+    const response = await fetchPage(ACTOR_JWT);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    // Relative asset paths are rewritten onto the HTTP dist route.
+    expect(await response.text()).toContain(
+      `src="/v1/apps/${APP_ID}/dist/main.js"`,
+    );
+  });
+
+  test("refuses an oauth_proxy_v1 grant", async () => {
+    const response = await fetchPage(PROXY_GRANT_JWT);
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  test("refuses a request with no token at all", async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/pages/${APP_ID}`);
+
+    expect(response.status).toBe(401);
+  });
+
+  test("an unknown app is a 404, not a 500", async () => {
+    const response = await fetchPage(ACTOR_JWT, "no-such-app");
+
+    expect(response.status).toBe(404);
+  });
+});
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      probe.close(() => {
+        if (address && typeof address === "object") {
+          resolve(address.port);
+        } else {
+          reject(new Error("Failed to allocate free port"));
+        }
+      });
+    });
+  });
+}

--- a/assistant/src/runtime/auth/__tests__/route-policy.test.ts
+++ b/assistant/src/runtime/auth/__tests__/route-policy.test.ts
@@ -75,7 +75,7 @@ const OAUTH_PROXY_POLICY: RoutePolicy = {
 };
 
 describe("enforcePolicy", () => {
-  test("policy: null is treated as unprotected (always allowed)", () => {
+  test("policy: null is unprotected for a broad scope profile", () => {
     authDisabled = false;
     const ctx = buildTestContext({ scopes: [] });
     const result = enforcePolicy("_internal/health", null, ctx);
@@ -189,7 +189,7 @@ describe("enforcePolicy", () => {
     expect(result!.status).toBe(403);
   });
 
-  test("empty requiredScopes admits any principal of allowed type", () => {
+  test("empty requiredScopes admits a broad-profile principal of allowed type", () => {
     authDisabled = false;
     const openPolicy: RoutePolicy = {
       requiredScopes: [],

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -65,7 +65,6 @@ import {
   isPrivateNetworkOrigin,
   isPrivateNetworkPeer,
 } from "./middleware/auth.js";
-import { withErrorHandling } from "./middleware/error-handler.js";
 import {
   extractClientIp,
   ipRateLimiter,
@@ -83,7 +82,6 @@ import {
   TWILIO_WEBHOOK_RE,
   validateTwilioWebhook,
 } from "./middleware/twilio-validation.js";
-import { ROUTES as APP_ROUTES } from "./routes/app-routes.js";
 import { ROUTES as AUDIO_ROUTES } from "./routes/audio-routes.js";
 import { RouteError } from "./routes/errors.js";
 import {
@@ -134,6 +132,24 @@ function dbMigrationUnavailableForPath(path: string): Response | null {
   }
 
   return dbMigrationUnavailableResponse();
+}
+
+/** Shareable app pages are the one route served outside the /v1/ namespace. */
+const PAGES_PATH_RE = /^\/pages\/[^/]+$/;
+
+/**
+ * Router endpoint for a request path, or null when the path names no route.
+ * Only /v1/ and the shareable-page path resolve, so a bare path can never
+ * reach a /v1 route.
+ */
+function routerEndpointForPath(path: string): string | null {
+  if (path.startsWith("/v1/")) {
+    // Strip trailing slashes so routes match regardless of whether the caller
+    // includes one (e.g. platform proxy paths use Django's trailing-slash
+    // convention, so the gateway may forward paths with a trailing /).
+    return path.slice("/v1/".length).replace(/\/$/, "");
+  }
+  return PAGES_PATH_RE.test(path) ? path.slice(1) : null;
 }
 
 /**
@@ -840,21 +856,11 @@ export class RuntimeHttpServer {
     }
     const authContext = authResult.context;
 
-    // Serve shareable app pages (outside /v1/ namespace, no rate limiting)
-    const pagesMatch = path.match(/^\/pages\/([^/]+)$/);
-    if (pagesMatch && req.method === "GET") {
-      return withErrorHandling("pages", async () => {
-        const pageDef = APP_ROUTES.find(
-          (r) => r.operationId === "pages_serve",
-        )!;
-        const args = { pathParams: { appId: pagesMatch[1] } };
-        const body = pageDef.handler(args) as string;
-        const headers =
-          typeof pageDef.responseHeaders === "function"
-            ? pageDef.responseHeaders(args)
-            : pageDef.responseHeaders;
-        return new Response(body, { headers });
-      });
+    // Every remaining path dispatches through the router, so a route's policy
+    // is enforced wherever it is served from.
+    const endpoint = routerEndpointForPath(path);
+    if (endpoint === null) {
+      return httpError("NOT_FOUND", "Not found", 404);
     }
 
     // Per-client-IP rate limiting for /v1/* endpoints. Authenticated requests
@@ -862,17 +868,9 @@ export class RuntimeHttpServer {
     // abuse surface. We key on IP rather than bearer token because the gateway
     // uses a single shared token for all proxied requests, which would collapse
     // all users into one bucket.
-    // Skip rate limiting entirely when HTTP auth is disabled (local Docker dev).
-    if (!path.startsWith("/v1/")) {
-      return httpError("NOT_FOUND", "Not found", 404);
-    }
-
-    // Strip trailing slashes so routes match regardless of whether the
-    // caller includes one (e.g. platform proxy paths use Django's trailing-
-    // slash convention, so the gateway may forward paths with a trailing /).
-    const endpoint = path.slice("/v1/".length).replace(/\/$/, "");
-
-    if (!isHttpAuthDisabled()) {
+    // Shareable app pages are outside the limiter, as is local Docker dev with
+    // HTTP auth disabled.
+    if (path.startsWith("/v1/") && !isHttpAuthDisabled()) {
       const clientIp = extractClientIp(req, server);
       const token = extractBearerToken(req);
       // Authenticated loopback clients (desktop app, CLI — anything on the

--- a/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
@@ -140,11 +140,16 @@ mock.module("../../../oauth/connection-resolver.js", () => ({
 }));
 
 // Spread the real module so the rest of the import graph keeps its env
-// readers; only the auth bypass is pinned.
+// readers; only the two auth-bypass readings are pinned. They move
+// independently: DISABLE_HTTP_AUTH is set on any host, the platform-managed
+// bypass only on a vembda pod.
+let httpAuthDisabled = false;
+let platformAuthBypass = false;
 const env = await import("../../../config/env.js");
 mock.module("../../../config/env.js", () => ({
   ...env,
-  isHttpAuthDisabled: () => false,
+  isHttpAuthDisabled: () => httpAuthDisabled,
+  isPlatformAuthBypassActive: () => platformAuthBypass,
 }));
 
 const { handleOAuthProxy, ROUTES } = await import("../oauth-proxy-routes.js");
@@ -188,6 +193,10 @@ async function callProxy(params: {
   const segment = params.segment ?? "stripe_link";
   const path = params.path ?? "v1/payment_methods";
 
+  // An empty path leaves the provider segment as the whole URL, the shape the
+  // route answers with its own 400.
+  const suffix = path === "" ? "" : `/${path}`;
+
   const init: RequestInit = { method, headers: params.headers ?? {} };
   if (params.body !== undefined) {
     init.body = params.body;
@@ -196,7 +205,7 @@ async function callProxy(params: {
     init.signal = params.signal;
   }
   const req = new Request(
-    `http://daemon.local/v1/oauth/proxy/${segment}/${path}${params.search ?? ""}`,
+    `http://daemon.local/v1/oauth/proxy/${segment}${suffix}${params.search ?? ""}`,
     init,
   );
   lastRequest = req;
@@ -257,6 +266,8 @@ function requireCaptured(): OAuthConnectionRequest {
 }
 
 beforeEach(() => {
+  httpAuthDisabled = false;
+  platformAuthBypass = false;
   captured = undefined;
   upstreamBytes = undefined;
   requestError = undefined;
@@ -566,6 +577,23 @@ describe("response emission", () => {
     );
   });
 
+  test("emits a 204 with no body through the route adapter", async () => {
+    // The adapter's own null-body short-circuit reads the route's declared
+    // status, which is 200 here, so a provider 204 has to survive the
+    // handler-supplied-response branch instead.
+    upstream = {
+      status: 204,
+      headers: { "x-request-id": "req_1" },
+      body: null,
+    };
+
+    const response = await callProxy({ method: "DELETE" });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("x-request-id")).toBe("req_1");
+    expect(await response.text()).toBe("");
+  });
+
   test("emits a string body as UTF-8", async () => {
     upstream = {
       status: 200,
@@ -582,21 +610,6 @@ describe("response emission", () => {
 // ── Connection selection ────────────────────────────────────────────────────
 
 describe("connection selection", () => {
-  test("pins the account from the provider segment", async () => {
-    await callProxy({ segment: PINNED_SEGMENT, subject: PINNED_SUBJECT });
-
-    expect(resolverCalls).toEqual([
-      { provider: "stripe_link", options: { account: "user@example.com" } },
-    ]);
-  });
-
-  test("resolves without options when no account is pinned", async () => {
-    await callProxy({});
-    expect(resolverCalls).toEqual([
-      { provider: "stripe_link", options: undefined },
-    ]);
-  });
-
   test("refuses to pick when several accounts match", async () => {
     resolution = {
       connection: byoConnection,
@@ -684,7 +697,7 @@ describe("failure mapping", () => {
   });
 });
 
-// ── Grant binding and path safety ───────────────────────────────────────────
+// ── Grant binding, path safety, transport guard ─────────────────────────────
 
 describe("grant binding", () => {
   /** Nothing downstream of the subject check ran. */
@@ -755,14 +768,33 @@ describe("grant binding", () => {
     await expectRefusedBeforeResolution(response);
   });
 
-  test("a provider segment the subject cannot hold is a 400", async () => {
-    const response = await callProxy({
-      segment: "vendor%3Aregion",
-      subject: "local:self:oauth-proxy.vendor:region",
-    });
+  test("a colon in the provider segment fails parsing before any subject check", async () => {
+    const response = await callProxy({ segment: "vendor%3Aregion" });
 
     expect(response.status).toBe(400);
+    const { error } = await envelope(response);
+    expect(error.code).toBe("BAD_REQUEST");
+    expect(error.message).toContain("Invalid OAuth proxy provider segment");
     expect(resolverCalls).toHaveLength(0);
+  });
+
+  test("a platform-managed pod skips the comparison it has no subject for", async () => {
+    // The pod's daemon discards the token and synthesizes a context, so the
+    // grant's subject never reaches the handler.
+    httpAuthDisabled = true;
+    platformAuthBypass = true;
+
+    const response = await callProxy({ subject: "actor:self:dev-bypass" });
+
+    expect(response.status).toBe(200);
+  });
+
+  test("DISABLE_HTTP_AUTH off a platform pod still binds the grant", async () => {
+    httpAuthDisabled = true;
+
+    const response = await callProxy({ subject: "actor:self:dev-bypass" });
+
+    await expectRefusedBeforeResolution(response);
   });
 });
 
@@ -785,6 +817,18 @@ describe("path safety", () => {
     expect(resolverCalls).toHaveLength(0);
   });
 
+  test("a provider segment with no API path after it is a 400", async () => {
+    const response = await callProxy({ path: "" });
+
+    expect(response.status).toBe(400);
+    const { error } = await envelope(response);
+    expect(error.code).toBe("BAD_REQUEST");
+    expect(error.message).toContain("A provider API path is required");
+    expect(resolverCalls).toHaveLength(0);
+  });
+});
+
+describe("transport guard", () => {
   test("an IPC invocation never reaches the provider and asks for HTTP", async () => {
     const args: RouteHandlerArgs = {
       pathParams: { provider: "stripe_link" },

--- a/assistant/src/runtime/routes/oauth-proxy-routes.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-routes.ts
@@ -11,7 +11,7 @@
  * `oauth-proxy-passthrough.ts`; this module is the wiring around them.
  */
 
-import { isHttpAuthDisabled } from "../../config/env.js";
+import { isPlatformAuthBypassActive } from "../../config/env.js";
 import {
   isIdempotentHttpMethod,
   type OAuthConnectionResponse,
@@ -72,11 +72,11 @@ export async function handleOAuthProxy(
 
   // A grant names one provider and, when it pinned one, one account. The
   // subject is re-derived from this request's own segment, so rewriting or
-  // dropping `@account` no longer matches the grant. The bypass is the one
-  // `enforcePolicy` honors: platform pods discard the token and build a
-  // synthetic context rather than one derived from the grant.
+  // dropping `@account` no longer matches the grant. Only a platform-managed
+  // pod skips the comparison: there the daemon discards the token and builds a
+  // synthetic context that carries no grant subject to compare against.
   if (
-    !isHttpAuthDisabled() &&
+    !isPlatformAuthBypassActive() &&
     args.headers?.["x-vellum-subject"] !== proxyGrantSubject(provider, account)
   ) {
     throw new ForbiddenError(
@@ -169,7 +169,7 @@ export async function handleOAuthProxy(
  */
 const METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"] as const;
 
-/** GET and HEAD carry no request body, on the wire or in the spec. */
+/** GET and HEAD carry no request body. */
 function carriesBody(method: string): boolean {
   return method !== "GET" && method !== "HEAD";
 }
@@ -207,7 +207,8 @@ export const ROUTES: RouteDefinition[] = METHODS.map((method) => ({
   description:
     "Forwards the remainder path, query, headers, and body to the provider's API base through the connection resolved from the provider segment; the grant minted by oauth_proxy_grant is the only credential accepted, and it is honored only for the provider and account its subject names.",
   tags: ["oauth"],
-  ...(carriesBody(method) ? { requestBody: BINARY_BODY } : {}),
+  // No `requestBody`: the spec generator marks every declared body required,
+  // and a proxied POST, PUT, PATCH, or DELETE may carry none.
   responseBody: BINARY_BODY,
   additionalResponses: ERROR_RESPONSES,
   handler: (args: RouteHandlerArgs) => handleOAuthProxy(method, args),


### PR DESCRIPTION
## Summary

- `GET /pages/:appId` was matched and served by a branch in `routeRequest` that ran before `HttpRouter.dispatch`, the only caller of `enforcePolicy`, so `pages_serve`'s declared `settings.read` policy was never checked. The branch is gone: the bare path now resolves to the `pages/:appId` router endpoint and dispatches like every other route, so no pre-router surface can skip policy. Rate-limit exemption and the computed response headers are preserved, and a thrown `NotFoundError` now maps to 404 instead of the 500 the old branch produced.
- The daemon's OAuth passthrough skipped its provider/account subject comparison whenever `DISABLE_HTTP_AUTH=true`, on any host. It now skips only under the platform-managed bypass (`DISABLE_HTTP_AUTH` **and** `IS_PLATFORM`, the pair a vembda pod sets), via a new `isPlatformAuthBypassActive()` in `config/env.ts` that mirrors the gateway's helper. A leaked dev flag on a non-platform host no longer turns `/v1/oauth/proxy/<provider>/<path>` into an unbound credential spender.
- The proxy's `requestBody` declaration is dropped, so the spec no longer claims a proxied DELETE (or POST/PUT/PATCH) must carry a body. Runtime behavior is unchanged: `rawRequestBody: true` still forwards whatever bytes arrive.
- Test hygiene: two `route-policy` test names qualified as broad-profile cases; the proxy segment-parsing 400 renamed and asserted by code and message; the duplicated "connection selection" cases collapsed into "grant binding"; the transport-guard cases split out of "path safety"; new route-level coverage for a provider 204 through the adapter, a bare provider segment, and both readings of the auth bypass.

### Known residual

On a platform pod the bypass stays active by design, so `enforcePolicy` and the proxy's subject check are still skipped there. The binding cannot be enforced on platform as written: `authenticateRequest` discards the token and `buildDevBypassContext()` synthesizes `actor:self:dev-bypass`, which the HTTP adapter then stamps onto `x-vellum-subject`, so a grant's subject never reaches the handler. `authenticateRequest` and `enforcePolicy` still read the broad `isHttpAuthDisabled()`; narrowing those is a daemon-wide posture change (about 10 test files drive the router with the bypass mocked on) and belongs in its own PR.

Fixes gaps found in the final self-review of plan oauth-proxy-passthrough.md.