### PR TITLE
docs(clients): document shipped install surfaces

### DIFF
--- a/assistant/src/tools/capability-offer.test.ts
+++ b/assistant/src/tools/capability-offer.test.ts
@@ -71,10 +71,9 @@ describe("formatLoggedInBrowserOffer", () => {
     });
     expect(offer).toContain("no in-app browser");
     expect(offer).toContain("Do not describe a browser panel");
-    expect(offer).toContain("macOS desktop app");
+    expect(offer).toContain("Mac or Windows PC");
     expect(offer).toContain(DESKTOP_APP_DOWNLOAD_URL);
     expect(offer).toContain(CHROME_WEB_STORE_INSTALL_URL);
-    expect(offer).not.toContain("Windows PC");
   });
 });
 

--- a/assistant/src/tools/capability-offer.test.ts
+++ b/assistant/src/tools/capability-offer.test.ts
@@ -71,8 +71,10 @@ describe("formatLoggedInBrowserOffer", () => {
     });
     expect(offer).toContain("no in-app browser");
     expect(offer).toContain("Do not describe a browser panel");
+    expect(offer).toContain("macOS desktop app");
     expect(offer).toContain(DESKTOP_APP_DOWNLOAD_URL);
     expect(offer).toContain(CHROME_WEB_STORE_INSTALL_URL);
+    expect(offer).not.toContain("Windows PC");
   });
 });
 

--- a/assistant/src/tools/capability-offer.ts
+++ b/assistant/src/tools/capability-offer.ts
@@ -56,7 +56,7 @@ export function formatLoggedInBrowserOffer(
       "This page needs a logged-in browser on a computer. There is no in-app browser on this phone, and the Chrome extension cannot be installed here.",
     );
     lines.push(
-      `Install the desktop app on a Mac or Windows PC (${DESKTOP_APP_DOWNLOAD_URL}) or the Chrome extension in Chrome on that computer (${CHROME_WEB_STORE_INSTALL_URL}).`,
+      `Install the macOS desktop app (${DESKTOP_APP_DOWNLOAD_URL}) or the Chrome extension in Chrome on a computer (${CHROME_WEB_STORE_INSTALL_URL}).`,
     );
     lines.push(
       "Offer those first. Do not describe a browser panel here. Only ask for a screenshot or pasted page content if the user cannot install either.",
@@ -65,9 +65,9 @@ export function formatLoggedInBrowserOffer(
   }
 
   lines.push(
-    "A connected desktop app or Chrome extension can open this page in a browser where you are already logged in.",
+    "A connected macOS desktop app or Chrome extension can open this page in a browser where you are already logged in.",
   );
-  lines.push(`Desktop app: ${DESKTOP_APP_DOWNLOAD_URL}`);
+  lines.push(`macOS desktop app: ${DESKTOP_APP_DOWNLOAD_URL}`);
   lines.push(`Chrome extension: ${CHROME_WEB_STORE_INSTALL_URL}`);
   lines.push(
     "Offer those first. Only ask for a screenshot or pasted page content if the user cannot install either.",

--- a/assistant/src/tools/capability-offer.ts
+++ b/assistant/src/tools/capability-offer.ts
@@ -56,7 +56,7 @@ export function formatLoggedInBrowserOffer(
       "This page needs a logged-in browser on a computer. There is no in-app browser on this phone, and the Chrome extension cannot be installed here.",
     );
     lines.push(
-      `Install the macOS desktop app (${DESKTOP_APP_DOWNLOAD_URL}) or the Chrome extension in Chrome on a computer (${CHROME_WEB_STORE_INSTALL_URL}).`,
+      `Install the desktop app on a Mac or Windows PC (${DESKTOP_APP_DOWNLOAD_URL}) or the Chrome extension in Chrome on that computer (${CHROME_WEB_STORE_INSTALL_URL}).`,
     );
     lines.push(
       "Offer those first. Do not describe a browser panel here. Only ask for a screenshot or pasted page content if the user cannot install either.",
@@ -65,9 +65,9 @@ export function formatLoggedInBrowserOffer(
   }
 
   lines.push(
-    "A connected macOS desktop app or Chrome extension can open this page in a browser where you are already logged in.",
+    "A connected desktop app or Chrome extension can open this page in a browser where you are already logged in.",
   );
-  lines.push(`macOS desktop app: ${DESKTOP_APP_DOWNLOAD_URL}`);
+  lines.push(`Desktop app: ${DESKTOP_APP_DOWNLOAD_URL}`);
   lines.push(`Chrome extension: ${CHROME_WEB_STORE_INSTALL_URL}`);
   lines.push(
     "Offer those first. Only ask for a screenshot or pasted page content if the user cannot install either.",

--- a/clients/docs/src/app/docs/(documentation)/getting-started/installation/page.tsx
+++ b/clients/docs/src/app/docs/(documentation)/getting-started/installation/page.tsx
@@ -4,7 +4,7 @@ import { createMetadata } from "@/lib/metadata";
 export const metadata = createMetadata({
   title: "Installation - Vellum Docs",
   description:
-    "Get started with Vellum: sign up for Vellum Cloud, install the desktop app on macOS or Windows, or self-host. System requirements, setup, and permissions.",
+    "Get started with Vellum: sign up for Vellum Cloud, install the iOS or Android app, the macOS or Windows desktop app, or self-host. System requirements, setup, and permissions.",
   path: "/docs/getting-started/installation",
 });
 

--- a/clients/docs/src/app/docs/_components/getting-started-content.test.tsx
+++ b/clients/docs/src/app/docs/_components/getting-started-content.test.tsx
@@ -1,7 +1,7 @@
 /**
  * `/docs/getting-started/installation` lists the shipped clients. These
- * tests lock the public install matrix: iOS, Android, macOS, web, and
- * self-host, with no shipped Windows or Linux desktop client.
+ * tests lock the public install matrix: iOS, Android, macOS, Windows, web,
+ * and self-host, with no shipped Linux desktop client.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -27,22 +27,22 @@ describe("GettingStartedContent", () => {
     expect(html).toContain("apps.apple.com/us/app/vellum-assistant/id6759934423");
   });
 
-  test("points macOS install at the public downloads page", () => {
+  test("points desktop install at the public downloads page", () => {
     expect(html).toContain("vellum.ai/downloads");
     expect(html).toContain("/downloads");
-    expect(html).toContain("Desktop app (macOS)");
+    expect(html).toContain("Desktop app (macOS and Windows)");
   });
 
-  test("states there is no shipped Windows or Linux desktop client", () => {
-    expect(html).toContain("no shipped Windows or Linux desktop client");
-    expect(html).toContain("Windows and Linux");
-    expect(html).toContain("self-host the assistant runtime");
+  test("states there is no shipped Linux desktop client", () => {
+    expect(html).toContain("no shipped Linux desktop client");
+    expect(html).toContain("Self-host the assistant runtime");
+    expect(html).not.toContain("no shipped Windows");
   });
 
   test("carries no contents entry for a section that is not on the page", () => {
     const targets = tocTargets(html);
     expect(targets).toContain("android-app");
-    expect(targets).toContain("windows-and-linux");
+    expect(targets).toContain("linux");
     for (const target of targets) {
       expect(html).toContain(`id="${target}"`);
     }

--- a/clients/docs/src/app/docs/_components/getting-started-content.test.tsx
+++ b/clients/docs/src/app/docs/_components/getting-started-content.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * `/docs/getting-started/installation` lists the shipped clients. These
+ * tests lock the public install matrix: iOS, Android, macOS, web, and
+ * self-host, with no shipped Windows or Linux desktop client.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { GettingStartedContent } from "@/app/docs/_components/getting-started-content";
+
+const html = renderToStaticMarkup(<GettingStartedContent />);
+
+function tocTargets(markup: string): string[] {
+  const listStart = markup.indexOf("On this page");
+  expect(listStart).toBeGreaterThan(-1);
+  const list = markup.slice(listStart, markup.indexOf("</ul>", listStart));
+  return [...list.matchAll(/href="#([^"]+)"/g)].map((match) => match[1]!);
+}
+
+describe("GettingStartedContent", () => {
+  test("names the shipped mobile clients and store listings", () => {
+    expect(html).toContain("Android app");
+    expect(html).toContain("Google Play");
+    expect(html).toContain("play.google.com/store/apps/details?id=ai.vellum.assistant");
+    expect(html).toContain("App Store");
+    expect(html).toContain("apps.apple.com/us/app/vellum-assistant/id6759934423");
+  });
+
+  test("points macOS install at the public downloads page", () => {
+    expect(html).toContain("vellum.ai/downloads");
+    expect(html).toContain("/downloads");
+    expect(html).toContain("Desktop app (macOS)");
+  });
+
+  test("states there is no shipped Windows or Linux desktop client", () => {
+    expect(html).toContain("no shipped Windows or Linux desktop client");
+    expect(html).toContain("Windows and Linux");
+    expect(html).toContain("self-host the assistant runtime");
+  });
+
+  test("carries no contents entry for a section that is not on the page", () => {
+    const targets = tocTargets(html);
+    expect(targets).toContain("android-app");
+    expect(targets).toContain("windows-and-linux");
+    for (const target of targets) {
+      expect(html).toContain(`id="${target}"`);
+    }
+  });
+});

--- a/clients/docs/src/app/docs/_components/getting-started-content.tsx
+++ b/clients/docs/src/app/docs/_components/getting-started-content.tsx
@@ -11,7 +11,9 @@ const TOC_ITEMS = [
   { id: "what-you-need", label: "What you need", level: 2 },
   { id: "web", label: "Web", level: 2 },
   { id: "ios-app", label: "iOS app", level: 2 },
-  { id: "desktop-app", label: "Desktop app", level: 2 },
+  { id: "android-app", label: "Android app", level: 2 },
+  { id: "desktop-app", label: "Desktop app (macOS and Windows)", level: 2 },
+  { id: "linux", label: "Linux", level: 2 },
   { id: "self-hosting", label: "Self-hosting", level: 2 },
   { id: "two-ways-to-connect", label: "Two ways to connect", level: 2 },
   { id: "what-gets-installed", label: "What gets installed", level: 2 },
@@ -30,11 +32,15 @@ export function GettingStartedContent() {
           </SectionHeading>
           <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600">
             <li>
-              <strong>For the web app:</strong> any modern browser. No install, no setup. The
-              fastest way in. Connects to a cloud assistant.
+              <strong>For the web app:</strong> any modern browser on Mac, Windows, Linux, or
+              a phone. No install, no setup. The fastest way in. Connects to a cloud assistant.
             </li>
             <li>
               <strong>For the iOS app:</strong> an iPhone or iPad and your Vellum account.
+              Connects to your cloud assistant.
+            </li>
+            <li>
+              <strong>For the Android app:</strong> Android 7.0 or later and your Vellum account.
               Connects to your cloud assistant.
             </li>
             <li>
@@ -45,6 +51,9 @@ export function GettingStartedContent() {
               <strong>For the Windows app:</strong> Windows 10 or later. Choose the x64
               installer for Intel or AMD PCs, or ARM64 for Windows on Arm. Connects to a
               cloud or local assistant.
+            </li>
+            <li>
+              There is no shipped Linux desktop client.
             </li>
             <li>
               Internet connection (your assistant uses cloud AI models to think)
@@ -106,7 +115,7 @@ export function GettingStartedContent() {
             <li>
               Install Vellum Assistant from the{" "}
               <a
-                href="https://apps.apple.com/us/app/vellum-assistant/id6759934423"
+                href={routes.iosAppStore}
                 className="font-semibold text-emerald-700 underline hover:text-emerald-800"
               >
                 App Store
@@ -122,9 +131,42 @@ export function GettingStartedContent() {
           </p>
         </section>
 
+        <section id="android-app" className="mt-12">
+          <SectionHeading id="android-app" level={2}>
+            Android app
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            Install Vellum Assistant on your Android phone or tablet to use the same
+            assistant, conversations, memories, tools, and workspace you have on the web
+            and Mac.
+          </p>
+          <ol className="mb-4 list-decimal space-y-2 pl-6 text-zinc-600">
+            <li>
+              Install Vellum Assistant from{" "}
+              <a
+                href={routes.androidPlayStore}
+                className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+              >
+                Google Play
+              </a>
+              .
+            </li>
+            <li>Open the app and sign in with your Vellum account.</li>
+            <li>Your cloud assistant appears automatically. Say hi.</li>
+          </ol>
+          <p className="mb-6 text-zinc-600">
+            The Android app is a client for your cloud assistant. It does not run a local
+            assistant on the phone. See{" "}
+            <a href={routes.downloads} className="font-semibold text-emerald-700 underline hover:text-emerald-800">
+              Downloads
+            </a>
+            .
+          </p>
+        </section>
+
         <section id="desktop-app" className="mt-12">
           <SectionHeading id="desktop-app" level={2}>
-            Desktop app
+            Desktop app (macOS and Windows)
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
             The desktop app is available on macOS and Windows, with a menu bar or system tray
@@ -151,10 +193,11 @@ export function GettingStartedContent() {
               for Vellum if you haven&apos;t already.
             </li>
             <li>
-              Download the macOS <code>.dmg</code> or Windows <code>.exe</code> from the{" "}
-              <a href="https://www.vellum.ai/download" className="font-semibold text-emerald-700 underline hover:text-emerald-800">
-                download page
-              </a>.
+              Download the macOS <code>.dmg</code> or Windows <code>.exe</code> from{" "}
+              <a href={routes.downloads} className="font-semibold text-emerald-700 underline hover:text-emerald-800">
+                vellum.ai/downloads
+              </a>
+              .
             </li>
             <li>
               On macOS, open the <code>.dmg</code>, drag Vellum to Applications, and launch it.
@@ -169,7 +212,54 @@ export function GettingStartedContent() {
             The installers include everything needed to run the app. macOS downloads are signed
             and notarized; Windows downloads are Authenticode-signed. No terminal setup is
             needed. On Windows, the app also installs the <code>vellum</code> CLI for your
-            user account. Open a new terminal after the first launch to use it.
+            user account. Open a new terminal after the first launch to use it. The same page
+            also offers the{" "}
+            <a href={routes.chromeWebStore} className="font-semibold text-emerald-700 underline hover:text-emerald-800">
+              Chrome extension
+            </a>{" "}
+            for browser automation.
+          </p>
+        </section>
+
+        <section id="linux" className="mt-12">
+          <SectionHeading id="linux" level={2}>
+            Linux
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            There is no shipped Linux desktop client. A Linux desktop shell is in
+            development and is not distributed.
+          </p>
+          <p className="mb-4 text-zinc-600">
+            On a Linux computer you can:
+          </p>
+          <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600">
+            <li>
+              Use the web app in any modern browser after you{" "}
+              <a href={routes.signup} className="font-semibold text-emerald-700 underline hover:text-emerald-800">
+                sign up
+              </a>
+              .
+            </li>
+            <li>
+              Install the{" "}
+              <a href={routes.chromeWebStore} className="font-semibold text-emerald-700 underline hover:text-emerald-800">
+                Chrome extension
+              </a>{" "}
+              so the assistant can drive a logged-in Chrome session on that computer.
+            </li>
+            <li>
+              Self-host the assistant runtime on that machine. That is the server, not a
+              desktop app. See{" "}
+              <a href="/docs/hosting-options" className="font-semibold text-emerald-700 underline hover:text-emerald-800">
+                Hosting options
+              </a>
+              .
+            </li>
+          </ul>
+          <p className="mb-6 text-zinc-600">
+            Do not wait for a Linux desktop installer, and do not treat a self-hosted
+            Linux runtime as a replacement for the Mac or Windows desktop app&apos;s
+            computer-use features.
           </p>
         </section>
 
@@ -253,7 +343,7 @@ export function GettingStartedContent() {
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
             Vellum doesn&apos;t ask for all its permissions upfront. Instead, permissions are
-            requested only when they&apos;re actually needed. The table below describes macOS:
+            requested only when they&apos;re actually needed:
           </p>
           <div className="mb-6 overflow-x-auto">
             <table className="min-w-full text-sm">
@@ -338,7 +428,9 @@ export function GettingStartedContent() {
             or protected windows.
           </p>
           <p className="mb-6 rounded-lg border border-zinc-200 bg-zinc-50 p-4 text-zinc-700">
-            Individual file and shell actions are governed by the in-app permission system. Check out{" "}
+            <strong>Worth knowing:</strong> The app accesses files through normal sandbox
+            entitlements, not Full Disk Access. Individual file and shell actions still require
+            your approval through the in-app permission system. Check out{" "}
             <a href="/docs/trust-security">Trust &amp; Security</a> for the full picture.
           </p>
         </section>

--- a/clients/docs/src/app/docs/_components/help-faq-content.test.tsx
+++ b/clients/docs/src/app/docs/_components/help-faq-content.test.tsx
@@ -19,11 +19,12 @@ describe("HelpFaqContent", () => {
   });
 
   test("is honest about Windows and Linux desktop clients", () => {
-    expect(html).toContain("no shipped Windows or Linux desktop client");
     expect(html).toContain("Is there a Windows app?");
+    expect(html).toContain("Yes. Download the Windows desktop app");
     expect(html).toContain("Does it run on Linux?");
+    expect(html).toContain("no shipped Linux desktop client");
     expect(html).toContain("self-host the assistant runtime on a Linux");
-    expect(html).not.toContain("download the Windows");
+    expect(html).not.toContain("no shipped Windows");
   });
 
   test("describes Base as the free plan and points at Pricing", () => {

--- a/clients/docs/src/app/docs/_components/help-faq-content.test.tsx
+++ b/clients/docs/src/app/docs/_components/help-faq-content.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * `/docs/help/faq` is the public platform list the assistant is told to
+ * fetch. These tests lock Android, Windows/Linux honesty, and the Base plan.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { HelpFaqContent } from "@/app/docs/_components/help-faq-content";
+
+const html = renderToStaticMarkup(<HelpFaqContent />);
+
+describe("HelpFaqContent", () => {
+  test("lists Android next to iOS and links the stores", () => {
+    expect(html).toContain("Android app");
+    expect(html).toContain("Google Play");
+    expect(html).toContain("play.google.com/store/apps/details?id=ai.vellum.assistant");
+    expect(html).toContain("apps.apple.com/us/app/vellum-assistant/id6759934423");
+  });
+
+  test("is honest about Windows and Linux desktop clients", () => {
+    expect(html).toContain("no shipped Windows or Linux desktop client");
+    expect(html).toContain("Is there a Windows app?");
+    expect(html).toContain("Does it run on Linux?");
+    expect(html).toContain("self-host the assistant runtime on a Linux");
+    expect(html).not.toContain("download the Windows");
+  });
+
+  test("describes Base as the free plan and points at Pricing", () => {
+    expect(html).toContain("Is Vellum free?");
+    expect(html).toContain("Base");
+    expect(html).toContain("/docs/pricing");
+  });
+});

--- a/clients/docs/src/app/docs/_components/help-faq-content.tsx
+++ b/clients/docs/src/app/docs/_components/help-faq-content.tsx
@@ -53,9 +53,19 @@ export function HelpFaqContent() {
             Is Vellum free?
           </SectionHeading>
           <p className="mb-6 text-zinc-600">
-            You can run Vellum locally with your own Anthropic API key at no cost beyond your API
-            usage. Vellum also offers a managed mode where you sign in with a Vellum account and
-            the assistant runs on our platform.
+            You can start without paying. Vellum Cloud has a free{" "}
+            <strong>Base</strong> plan, and you can also run Vellum locally with your own
+            model API key at no cost beyond that API usage. Paid{" "}
+            <strong>Pro</strong> packages add a larger machine, more storage, and included
+            monthly credits. See{" "}
+            <Link
+              href="/docs/pricing"
+              className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+            >
+              Pricing
+            </Link>{" "}
+            for the current plans. For this assistant&apos;s live plan and credit balance,
+            ask it here rather than guessing from the docs page.
           </p>
 
           <SectionHeading id="why-does-it-cost-money-when-im-not-using-it" level={3}>
@@ -84,9 +94,19 @@ export function HelpFaqContent() {
             >
               vellum.ai
             </Link>
-            , the iPhone and iPad app, the macOS and Windows desktop apps, and a
-            command-line interface. Beyond those first-party surfaces,
-            channels include Telegram, Slack, email, and phone calls.
+            , the iPhone and iPad app, the Android app, the macOS and Windows desktop
+            apps, and a command-line interface. There is no shipped Linux desktop client.
+            On Linux, use the web app or the Chrome extension. The assistant runtime can
+            self-host on a Linux machine; that is hosting, not a desktop app.
+            Download the shipped clients from{" "}
+            <Link
+              href={routes.downloads}
+              className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+            >
+              vellum.ai/downloads
+            </Link>
+            . Beyond those first-party surfaces, channels include Telegram, Slack, email,
+            and phone calls.
           </p>
 
           <SectionHeading id="where-should-i-host" level={3}>
@@ -157,16 +177,67 @@ export function HelpFaqContent() {
           <SectionHeading id="can-i-use-it-on-my-phone" level={3}>
             Can I use it on my phone?
           </SectionHeading>
-          <p className="mb-0 text-zinc-600">
-            Yes. There&apos;s a native iPhone and iPad app on the{" "}
+          <p className="mb-6 text-zinc-600">
+            Yes. There is a native iPhone and iPad app on the{" "}
             <Link
-              href="https://apps.apple.com/us/app/vellum-assistant/id6759934423"
+              href={routes.iosAppStore}
               className="font-semibold text-emerald-700 underline hover:text-emerald-800"
             >
               App Store
             </Link>
-            , and you can also reach your assistant through Telegram or
-            phone calls from any device.
+            {" "}and an Android app on{" "}
+            <Link
+              href={routes.androidPlayStore}
+              className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+            >
+              Google Play
+            </Link>
+            . You can also reach your assistant through Telegram or phone calls from any
+            device.
+          </p>
+
+          <SectionHeading id="is-there-a-windows-app" level={3}>
+            Is there a Windows app?
+          </SectionHeading>
+          <p className="mb-6 text-zinc-600">
+            Yes. Download the Windows desktop app from{" "}
+            <Link
+              href={routes.downloads}
+              className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+            >
+              vellum.ai/downloads
+            </Link>
+            . You can also open{" "}
+            <Link
+              href="https://vellum.ai"
+              className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+            >
+              vellum.ai
+            </Link>{" "}
+            in a browser, or install the{" "}
+            <Link
+              href={routes.chromeWebStore}
+              className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+            >
+              Chrome extension
+            </Link>{" "}
+            so the assistant can use your Chrome session.
+          </p>
+
+          <SectionHeading id="does-it-run-on-linux" level={3}>
+            Does it run on Linux?
+          </SectionHeading>
+          <p className="mb-0 text-zinc-600">
+            The web app and Chrome extension work on Linux. There is no Linux desktop
+            client to install. You can self-host the assistant runtime on a Linux
+            machine if you want the server itself on that host. See{" "}
+            <Link
+              href="/docs/hosting-options"
+              className="font-semibold text-emerald-700 underline hover:text-emerald-800"
+            >
+              Hosting options
+            </Link>
+            .
           </p>
         </section>
 

--- a/clients/docs/src/app/docs/_components/key-concepts-channels-content.tsx
+++ b/clients/docs/src/app/docs/_components/key-concepts-channels-content.tsx
@@ -3,11 +3,13 @@
 import { DocsContent } from "@/app/docs/_components/docs-content";
 import { SectionHeading } from "@/app/docs/_components/section-heading";
 import { TableOfContents } from "@/app/docs/_components/table-of-contents";
+import { routes } from "@/lib/routes";
 
 const TOC_ITEMS = [
   { id: "web", label: "Web", level: 2 },
   { id: "desktop-app", label: "Desktop App", level: 2 },
   { id: "ios", label: "iOS", level: 2 },
+  { id: "android", label: "Android", level: 2 },
   { id: "cli", label: "CLI", level: 2 },
   { id: "telegram", label: "Telegram", level: 2 },
   { id: "slack", label: "Slack", level: 2 },
@@ -174,10 +176,29 @@ export function KeyConceptsChannelsContent() {
           </p>
           <p className="mb-0 text-zinc-600">
             Available on the{" "}
-            <a href="https://apps.apple.com/us/app/vellum-assistant/id6759934423">
+            <a href={routes.iosAppStore}>
               App Store
             </a>{" "}
             for iPhone and iPad.
+          </p>
+        </section>
+
+        <section id="android" className="mt-12">
+          <SectionHeading id="android" level={2}>
+            Android
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            The Android app is the same kind of pocket client as iOS: it signs
+            into your Vellum Cloud account and carries the same assistant,
+            memory, and conversations. Host file access, shell commands,
+            computer use, and screen watch stay on the Mac desktop app.
+          </p>
+          <p className="mb-0 text-zinc-600">
+            Available on{" "}
+            <a href={routes.androidPlayStore}>
+              Google Play
+            </a>
+            .
           </p>
         </section>
 

--- a/clients/docs/src/app/docs/_components/key-concepts-channels-content.tsx
+++ b/clients/docs/src/app/docs/_components/key-concepts-channels-content.tsx
@@ -191,7 +191,7 @@ export function KeyConceptsChannelsContent() {
             The Android app is the same kind of pocket client as iOS: it signs
             into your Vellum Cloud account and carries the same assistant,
             memory, and conversations. Host file access, shell commands,
-            computer use, and screen watch stay on the Mac desktop app.
+            computer use, and screen watch stay on the desktop app.
           </p>
           <p className="mb-0 text-zinc-600">
             Available on{" "}

--- a/clients/docs/src/app/docs/_components/quick-start-content.tsx
+++ b/clients/docs/src/app/docs/_components/quick-start-content.tsx
@@ -7,6 +7,7 @@ import { DocsContent } from "@/app/docs/_components/docs-content";
 import { DocsVideo } from "@/app/docs/_components/docs-video";
 import { SectionHeading } from "@/app/docs/_components/section-heading";
 import { TableOfContents } from "@/app/docs/_components/table-of-contents";
+import { routes } from "@/lib/routes";
 
 const TOC_ITEMS = [
   { id: "your-assistant-is-ready", label: "Your assistant is ready", level: 2 },
@@ -96,7 +97,7 @@ export function QuickStartContent() {
               <strong>iPhone or iPad</strong>: install the Vellum
               Assistant app from the{" "}
               <a
-                href="https://apps.apple.com/us/app/vellum-assistant/id6759934423"
+                href={routes.iosAppStore}
                 className={linkClass}
               >
                 App Store
@@ -104,12 +105,27 @@ export function QuickStartContent() {
               and sign in.
             </li>
             <li>
+              <strong>Android</strong>: install the app from{" "}
+              <a href={routes.androidPlayStore} className={linkClass}>
+                Google Play
+              </a>{" "}
+              and sign in.
+            </li>
+            <li>
               <strong>Mac</strong>: install the{" "}
-              <Link href="https://www.vellum.ai/downloads" className={linkClass}>
+              <Link href={routes.downloads} className={linkClass}>
                 desktop app
               </Link>
               . Same assistant, with the added ability to read your
               local files and control your Mac when you ask it to.
+            </li>
+            <li>
+              <strong>Windows or Linux</strong>: use the web app, or the{" "}
+              <a href={routes.chromeWebStore} className={linkClass}>
+                Chrome extension
+              </a>
+              . There is no shipped desktop client for those operating
+              systems.
             </li>
           </ul>
           <p className="mb-0 text-zinc-600">

--- a/clients/docs/src/app/docs/_components/quick-start-content.tsx
+++ b/clients/docs/src/app/docs/_components/quick-start-content.tsx
@@ -120,12 +120,22 @@ export function QuickStartContent() {
               local files and control your Mac when you ask it to.
             </li>
             <li>
-              <strong>Windows or Linux</strong>: use the web app, or the{" "}
+              <strong>Windows</strong>: install the{" "}
+              <Link href={routes.downloads} className={linkClass}>
+                desktop app
+              </Link>
+              , or use the{" "}
               <a href={routes.chromeWebStore} className={linkClass}>
                 Chrome extension
               </a>
-              . There is no shipped desktop client for those operating
-              systems.
+              .
+            </li>
+            <li>
+              <strong>Linux</strong>: use the web app, or the{" "}
+              <a href={routes.chromeWebStore} className={linkClass}>
+                Chrome extension
+              </a>
+              . There is no shipped Linux desktop client.
             </li>
           </ul>
           <p className="mb-0 text-zinc-600">

--- a/clients/docs/src/lib/routes.ts
+++ b/clients/docs/src/lib/routes.ts
@@ -21,4 +21,10 @@ export const routes = {
   login: `https://${WWW_DOMAIN}/account/login`,
   assistant: `https://${WWW_DOMAIN}/assistant`,
   plugins: `https://${WWW_DOMAIN}/plugins`,
+  downloads: `https://${WWW_DOMAIN}/downloads`,
+  iosAppStore: "https://apps.apple.com/us/app/vellum-assistant/id6759934423",
+  androidPlayStore:
+    "https://play.google.com/store/apps/details?id=ai.vellum.assistant",
+  chromeWebStore:
+    "https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne",
 } as const;

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-10T15:01:09.000Z"
+      "updatedAt": "2026-09-10T16:59:39.000Z"
     },
     {
       "id": "public-ingress",
@@ -1078,7 +1078,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-09T23:37:12.000Z"
+      "updatedAt": "2026-09-09T20:47:04.000Z"
     },
     {
       "id": "vellum-conversation-management",
@@ -1215,7 +1215,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T20:03:58.000Z"
+      "updatedAt": "2026-09-09T20:47:04.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/vellum-client-capabilities/SKILL.md
+++ b/skills/vellum-client-capabilities/SKILL.md
@@ -12,6 +12,8 @@ metadata:
       - "whether the app can access a device sensor, permission, or hardware feature"
       - "browsing failed, timed out, or could not reach a page that needs a login"
       - "whether to install the desktop app or Chrome extension"
+      - "how do I install you, Windows app, or do you run on my PC"
+      - "Linux desktop client or AppImage"
     avoid-when:
       - "the user already gave a location as text (just use it)"
 ---
@@ -22,7 +24,7 @@ Never claim that a permission prompt, sheet, dialog, or button is on the user's 
 
 ## Device Location
 
-No Vellum client can read the device's location. Not the web app, not the macOS or Windows desktop apps, not the iOS or Android apps, not the CLI. There is no GPS access, no geolocation integration, and no location permission flow that could be triggered or approved.
+No Vellum client can read the device's location. Not the web app, not the macOS desktop app, not the iOS or Android apps, not the CLI. There is no GPS access, no geolocation integration, and no location permission flow that could be triggered or approved.
 
 When the user asks you to use their current, live, or nearby location:
 
@@ -40,15 +42,31 @@ Settings has a "Timezone" field, set by searching for a city or UTC offset. If i
 
 It does not exist today in any client. The honest answer is that they can mention a place per request, or set the Timezone field in Settings as a standing default.
 
+## Shipped Clients
+
+Tell the user only what is actually downloadable. Do not invent a Windows or Linux desktop installer.
+
+| Surface | Status | Where |
+| --- | --- | --- |
+| Web app | Shipped | https://www.vellum.ai |
+| iOS | Shipped | https://apps.apple.com/us/app/vellum-assistant/id6759934423 |
+| Android | Shipped | https://play.google.com/store/apps/details?id=ai.vellum.assistant |
+| macOS desktop | Shipped | https://www.vellum.ai/downloads |
+| Chrome extension | Shipped | https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne |
+| Windows desktop | Not shipped | Use the web app or Chrome extension on that PC |
+| Linux desktop | Not shipped | Use the web app or Chrome extension. The runtime can self-host on Linux; that is the server, not a desktop app |
+
+For install, pricing, or "how do I install you" questions, also load `vellum-self-knowledge` and fetch Installation, FAQ, and Pricing from the docs. Do not answer those from memory.
+
 ## Desktop App And Chrome Extension
 
 When a task needs a logged-in browser or a host computer (internal pages, company SSO, VPN-only dashboards, local files, or host shell):
 
-1. Offer the desktop app: https://www.vellum.ai/downloads
+1. Offer the macOS desktop app: https://www.vellum.ai/downloads
 2. For browser sessions, also offer the Chrome extension: https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne
 3. Offer those first. Only ask for a screenshot or pasted page content if the user cannot install either.
 
-On iOS or Android there is no in-app browser, no Chrome extension to install on the phone, and no host computer. Offer the desktop app or Chrome extension on a computer. Do not describe a browser panel, local browser session picker, or other UI that is not on this phone.
+On iOS or Android there is no in-app browser, no Chrome extension to install on the phone, and no host computer. Offer the macOS desktop app or the Chrome extension on a computer. Do not describe a browser panel, local browser session picker, or other UI that is not on this phone.
 
 ## Other Device Capabilities
 

--- a/skills/vellum-client-capabilities/SKILL.md
+++ b/skills/vellum-client-capabilities/SKILL.md
@@ -12,8 +12,6 @@ metadata:
       - "whether the app can access a device sensor, permission, or hardware feature"
       - "browsing failed, timed out, or could not reach a page that needs a login"
       - "whether to install the desktop app or Chrome extension"
-      - "how do I install you, Windows app, or do you run on my PC"
-      - "Linux desktop client or AppImage"
     avoid-when:
       - "the user already gave a location as text (just use it)"
 ---
@@ -24,7 +22,7 @@ Never claim that a permission prompt, sheet, dialog, or button is on the user's 
 
 ## Device Location
 
-No Vellum client can read the device's location. Not the web app, not the macOS desktop app, not the iOS or Android apps, not the CLI. There is no GPS access, no geolocation integration, and no location permission flow that could be triggered or approved.
+No Vellum client can read the device's location. Not the web app, not the macOS or Windows desktop apps, not the iOS or Android apps, not the CLI. There is no GPS access, no geolocation integration, and no location permission flow that could be triggered or approved.
 
 When the user asks you to use their current, live, or nearby location:
 
@@ -44,17 +42,14 @@ It does not exist today in any client. The honest answer is that they can mentio
 
 ## Shipped Clients
 
-Tell the user only what is actually downloadable. Do not invent a Windows or Linux desktop installer.
+Tell the user only what is actually downloadable. Do not invent a Linux desktop installer.
 
-| Surface | Status | Where |
-| --- | --- | --- |
-| Web app | Shipped | https://www.vellum.ai |
-| iOS | Shipped | https://apps.apple.com/us/app/vellum-assistant/id6759934423 |
-| Android | Shipped | https://play.google.com/store/apps/details?id=ai.vellum.assistant |
-| macOS desktop | Shipped | https://www.vellum.ai/downloads |
-| Chrome extension | Shipped | https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne |
-| Windows desktop | Not shipped | Use the web app or Chrome extension on that PC |
-| Linux desktop | Not shipped | Use the web app or Chrome extension. The runtime can self-host on Linux; that is the server, not a desktop app |
+- Web app: https://www.vellum.ai
+- iOS: https://apps.apple.com/us/app/vellum-assistant/id6759934423
+- Android: https://play.google.com/store/apps/details?id=ai.vellum.assistant
+- macOS and Windows desktop: https://www.vellum.ai/downloads
+- Chrome extension: https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne
+- Linux desktop: not shipped. Use the web app or Chrome extension. The runtime can self-host on Linux; that is the server, not a desktop app.
 
 For install, pricing, or "how do I install you" questions, also load `vellum-self-knowledge` and fetch Installation, FAQ, and Pricing from the docs. Do not answer those from memory.
 
@@ -62,11 +57,11 @@ For install, pricing, or "how do I install you" questions, also load `vellum-sel
 
 When a task needs a logged-in browser or a host computer (internal pages, company SSO, VPN-only dashboards, local files, or host shell):
 
-1. Offer the macOS desktop app: https://www.vellum.ai/downloads
+1. Offer the desktop app for Mac or Windows: https://www.vellum.ai/downloads
 2. For browser sessions, also offer the Chrome extension: https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne
 3. Offer those first. Only ask for a screenshot or pasted page content if the user cannot install either.
 
-On iOS or Android there is no in-app browser, no Chrome extension to install on the phone, and no host computer. Offer the macOS desktop app or the Chrome extension on a computer. Do not describe a browser panel, local browser session picker, or other UI that is not on this phone.
+On iOS or Android there is no in-app browser, no Chrome extension to install on the phone, and no host computer. Offer the desktop app or Chrome extension on a computer. Do not describe a browser panel, local browser session picker, or other UI that is not on this phone.
 
 ## Other Device Capabilities
 

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -14,11 +14,6 @@ metadata:
       - "what it can do or which skills/tools exist"
       - "whether a service is connected, and in which sense"
       - "its credits, plan allowance, spend, or daily limit"
-      - "pricing, plans, or whether Vellum is free"
-      - "how to install the desktop, iOS, or Android app"
-      - "how do I install you"
-      - "whether there is a Windows or Linux desktop app"
-      - "do you run on my PC"
       - "how to self-host or use your own model API key"
     avoid-when:
       - "changing configuration"

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -14,6 +14,11 @@ metadata:
       - "what it can do or which skills/tools exist"
       - "whether a service is connected, and in which sense"
       - "its credits, plan allowance, spend, or daily limit"
+      - "pricing, plans, or whether Vellum is free"
+      - "how to install the desktop, iOS, or Android app"
+      - "how do I install you"
+      - "whether there is a Windows or Linux desktop app"
+      - "do you run on my PC"
       - "how to self-host or use your own model API key"
     avoid-when:
       - "changing configuration"
@@ -138,6 +143,8 @@ Base URL: `https://www.vellum.ai/docs`
 | Getting help             | `/help/getting-help`                      |
 | Skills reference index   | `/skills-reference`                       |
 | Specific skill reference | `/skills-reference/<skill-name>`          |
+
+Install, platform, and "how do I install you" questions belong on Installation and FAQ, not memory. Pricing and "is it free" belong on Pricing, then the `assistant platform credits|subscription|plans` commands for this assistant's live plan.
 
 Use `web_fetch` to pull the page content. If a URL 404s, try fetching the docs homepage and navigating from the sidebar.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Give the assistant real answers about installing desktop and mobile apps.

- Closes JARVIS-1565

## Summary

- Installation, FAQ, Quick Start, and Channels list the shipped clients: web, iOS (App Store), Android (Play), macOS and Windows desktop (`/downloads`), and the Chrome extension.
- Linux has no shipped desktop client. Linux self-host is the runtime, not a desktop app.
- `vellum-self-knowledge` still routes install and pricing questions to docs and the CLI.
- `vellum-client-capabilities` lists the shipped-client matrix.

Rebased onto latest `main`, including the Windows desktop setup docs from #42446. This PR keeps Android, Linux honesty, skill grounding, and the install-matrix tests, and retains the Windows details from main (dev build, x64/ARM64, Authenticode).

## Test plan

- `cd clients/docs && bun test src/app/docs/_components/getting-started-content.test.tsx src/app/docs/_components/help-faq-content.test.tsx src/app/docs/_components/pricing-content.test.tsx`
- `cd assistant && bun test src/tools/capability-offer.test.ts`
- `bunx prettier@3.8.1 --check --ignore-unknown skills/vellum-client-capabilities/** skills/vellum-self-knowledge/**`
- `node scripts/skills/check-catalog.mjs`

## Risk

Low. Copy and activation-hints. No API or schema changes.

## CLI verb checklist

No new IPC routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3162648d-26a7-40c1-86ed-a069d2ae469f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3162648d-26a7-40c1-86ed-a069d2ae469f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

