### PR TITLE
fix(avatar): backfill a legacy accent before rendering the disc, version the removal key

### DIFF
--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -13,9 +13,10 @@
  *
  * The avatar directory is controlled per-test via VELLUM_WORKSPACE_DIR, which
  * `getAvatarDir()` resolves live. Per the test-isolation rule in
- * assistant/AGENTS.md, this file imports ONLY the module under test
- * (`avatar-store`); state is asserted by reading `avatar.json`, the artifact
- * files, and IDENTITY.md directly off the per-test workspace dir via `node:fs`.
+ * assistant/AGENTS.md, this file imports ONLY the modules under test
+ * (`avatar-store` and the accent repair it shares with the read routes); state
+ * is asserted by reading `avatar.json`, the artifact files, and IDENTITY.md
+ * directly off the per-test workspace dir via `node:fs`.
  *
  * `setCharacter` routes through the native @resvg/resvg-js renderer. Rather than
  * stub that native path (which would require importing production machinery), we
@@ -45,8 +46,8 @@ mock.module("../../runtime/sync/resource-sync-events.js", () => ({
   },
 }));
 
+import { backfillAccent } from "../accent-backfill.js";
 import {
-  backfillAccent,
   clearAvatar,
   setAccent,
   setCharacter,

--- a/assistant/src/avatar/accent-backfill.ts
+++ b/assistant/src/avatar/accent-backfill.ts
@@ -1,0 +1,89 @@
+/**
+ * The accent an avatar earns on its own, and the read-time repair that fills
+ * it into a manifest written before accents were persisted.
+ *
+ * Separate from the avatar store so a reader that must announce nothing (the
+ * state route, the platform sync) can repair the accent without reaching the
+ * store's client and platform fan-out.
+ */
+import type { AvatarAccent } from "@vellumai/avatar-manifest";
+
+import { getLogger } from "../util/logger.js";
+import { getAvatarImagePath } from "../util/platform.js";
+import {
+  deriveAccentHexFromImage,
+  derivedAccent,
+  paletteAccent,
+} from "./avatar-accent.js";
+import { type AvatarState, writeManifest } from "./avatar-manifest.js";
+import { readContainedAvatarRaster } from "./ensure-raster.js";
+
+const log = getLogger("accent-backfill");
+
+/**
+ * The accent the current avatar earns on its own: a character's palette
+ * colour, or the colour read out of the image on disk. Null for `none`, and
+ * for an image that cannot be read.
+ */
+export async function automaticAccent(
+  state: AvatarState,
+): Promise<AvatarAccent | null> {
+  if (state.kind === "character" && state.traits) {
+    return paletteAccent(state.traits.color);
+  }
+  if (state.kind === "image") {
+    const bytes = readContainedAvatarRaster(getAvatarImagePath());
+    return bytes ? derivedAccent(await deriveAccentHexFromImage(bytes)) : null;
+  }
+  return null;
+}
+
+/**
+ * Image etags whose accent derivation came back empty. Remembered so a read
+ * of an unreadable image does not decode it again on every request; a new
+ * upload carries a new etag and is tried afresh.
+ */
+const accentlessImageEtags = new Set<string>();
+/** The one derivation in flight per etag, so concurrent reads share it. */
+const pendingAccents = new Map<string, Promise<AvatarAccent | null>>();
+
+/**
+ * Fills in the accent of a state written before accents existed, persisting
+ * it so later reads are manifest-only. The one exception to the manifest
+ * being written only by the avatar store's mutations, for the same reason the
+ * read handlers self-heal a missing manifest: the accent is derivable from
+ * what is on disk, and deriving it once beats every client deriving it on
+ * every read. The persist is best-effort; a read-only workspace still gets
+ * the accent.
+ */
+export async function backfillAccent(state: AvatarState): Promise<AvatarState> {
+  if (state.kind === "none" || state.accent !== null) {
+    return state;
+  }
+  const etag = state.image?.etag ?? null;
+  if (etag && accentlessImageEtags.has(etag)) {
+    return state;
+  }
+  const key = etag ?? state.kind;
+  let pending = pendingAccents.get(key);
+  if (!pending) {
+    pending = automaticAccent(state).finally(() => {
+      pendingAccents.delete(key);
+    });
+    pendingAccents.set(key, pending);
+  }
+  const accent = await pending;
+  if (!accent) {
+    if (etag) {
+      accentlessImageEtags.add(etag);
+    }
+    return state;
+  }
+  const next: AvatarState = { ...state, accent };
+  try {
+    writeManifest(next);
+  } catch (err) {
+    log.warn({ err }, "Failed to persist the backfilled avatar accent");
+  }
+  return next;
+}

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -13,7 +13,8 @@
  * in IDENTITY.md and runs the client + platform fan-out
  * (`publishAvatarChanged`). Callers (HTTP/IPC routes) go through it rather
  * than touching artifacts or the manifest directly, and never publish on
- * their own.
+ * their own. The read-time accent repair in `accent-backfill.ts` is the one
+ * other manifest write, and announces nothing.
  */
 import { randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -23,12 +24,12 @@ import {
   AVATAR_IMAGE_FILENAME,
   AVATAR_MANIFEST_FILENAME,
   AVATAR_TRAITS_FILENAME,
-  type AvatarAccent,
 } from "@vellumai/avatar-manifest";
 
 import { publishAvatarChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import { getAvatarDir, getAvatarImagePath } from "../util/platform.js";
+import { automaticAccent } from "./accent-backfill.js";
 import {
   deriveAccentHexFromImage,
   derivedAccent,
@@ -41,7 +42,6 @@ import {
   readAvatarState,
   writeManifest,
 } from "./avatar-manifest.js";
-import { readContainedAvatarRaster } from "./ensure-raster.js";
 import {
   describeAvatarState,
   NO_AVATAR_IDENTITY_NOTE,
@@ -151,24 +151,6 @@ export async function setImage(
 }
 
 /**
- * The accent the current avatar earns on its own: a character's palette
- * colour, or the colour read out of the image on disk. Null for `none`, and
- * for an image that cannot be read.
- */
-async function automaticAccent(
-  state: AvatarState,
-): Promise<AvatarAccent | null> {
-  if (state.kind === "character" && state.traits) {
-    return paletteAccent(state.traits.color);
-  }
-  if (state.kind === "image") {
-    const bytes = readContainedAvatarRaster(getAvatarImagePath());
-    return bytes ? derivedAccent(await deriveAccentHexFromImage(bytes)) : null;
-  }
-  return null;
-}
-
-/**
  * Sets the accent over the current avatar: a `#rrggbb` the user chose, or
  * `null` to go back to the automatic one. Returns the state as written, or
  * null when there is no avatar to colour. Only the manifest changes; the
@@ -189,55 +171,6 @@ export async function setAccent(
   };
   writeManifest(next);
   publishAvatarChanged(options?.originClientId);
-  return next;
-}
-
-/**
- * Image etags whose accent derivation came back empty. Remembered so a read
- * of an unreadable image does not decode it again on every request; a new
- * upload carries a new etag and is tried afresh.
- */
-const accentlessImageEtags = new Set<string>();
-/** The one derivation in flight per etag, so concurrent reads share it. */
-const pendingAccents = new Map<string, Promise<AvatarAccent | null>>();
-
-/**
- * Fills in the accent of a state written before accents existed, persisting
- * it so later reads are manifest-only. The one exception to the manifest
- * being written only by the mutations above, for the same reason the read
- * handlers self-heal a missing manifest: the accent is derivable from what is
- * on disk, and deriving it once beats every client deriving it on every read.
- * The persist is best-effort; a read-only workspace still gets the accent.
- */
-export async function backfillAccent(state: AvatarState): Promise<AvatarState> {
-  if (state.kind === "none" || state.accent !== null) {
-    return state;
-  }
-  const etag = state.image?.etag ?? null;
-  if (etag && accentlessImageEtags.has(etag)) {
-    return state;
-  }
-  const key = etag ?? state.kind;
-  let pending = pendingAccents.get(key);
-  if (!pending) {
-    pending = automaticAccent(state).finally(() => {
-      pendingAccents.delete(key);
-    });
-    pendingAccents.set(key, pending);
-  }
-  const accent = await pending;
-  if (!accent) {
-    if (etag) {
-      accentlessImageEtags.add(etag);
-    }
-    return state;
-  }
-  const next: AvatarState = { ...state, accent };
-  try {
-    writeManifest(next);
-  } catch (err) {
-    log.warn({ err }, "Failed to persist the backfilled avatar accent");
-  }
   return next;
 }
 

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -22,6 +22,8 @@ import {
   test,
 } from "bun:test";
 
+import { NOTIFICATION_AVATAR_SPEC_VERSION } from "@vellumai/avatar-manifest/notification-avatar";
+
 import type { AvatarState } from "../avatar/avatar-manifest.js";
 import * as realAvatarManifest from "../avatar/avatar-manifest.js";
 import * as realEnsureRaster from "../avatar/ensure-raster.js";
@@ -48,6 +50,8 @@ let mockClient: {
   platformAssistantId: string;
   fetch: (path: string, init: RequestInit) => Promise<Response>;
 } | null;
+/** Manifest states the accent backfill persisted during a test. */
+let manifestWrites: AvatarState[] = [];
 let mockResvgAvailable = false;
 let mockRenderThrows = false;
 let mockRenderedPng = Buffer.from("small");
@@ -64,6 +68,9 @@ function installMocks(): void {
     computeImageMeta: (path: string) => {
       const stats = statSync(path);
       return { updatedAt: "", etag: `${stats.size}:${stats.mtimeMs}` };
+    },
+    writeManifest: (state: AvatarState) => {
+      manifestWrites.push(state);
     },
   }));
 
@@ -118,6 +125,19 @@ import {
 } from "./sync-avatar.js";
 
 const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** The versioned key a removal records; the legacy one carried no version. */
+const REMOVAL_KEY = `none:${NOTIFICATION_AVATAR_SPEC_VERSION}`;
+/** That legacy key, scoped to the destination the default client names. */
+const LEGACY_REMOVAL_KEY = "https://platform.a|asst-1|none";
+
+/** A 4x4 PNG of one red (#c81e1e), so an accent can be read out of it. */
+const RED_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAEklEQVQImWM4ISf3HxkzkC4AAEG4IDHG8wOiAAAAAElFTkSuQmCC",
+  "base64",
+);
+/** The disc fill `#c81e1e` mixes into, so a neutral fallback cannot pass. */
+const RED_DISC_HEX = "#F7E0E0";
 
 /** Small PNG-signed raster whose tail makes the bytes distinguishable. */
 function png(label: string): Buffer {
@@ -225,6 +245,7 @@ describe("syncAvatarToPlatform", () => {
     mkdirSync(avatarDir, { recursive: true });
     _resetSyncAvatarStateForTests();
     patches = [];
+    manifestWrites = [];
     rasterCalls = 0;
     respond = () => new Response("{}", { status: 200 });
     mockClient = makeClient();
@@ -339,13 +360,40 @@ describe("syncAvatarToPlatform", () => {
     expect(patches[1].body).toEqual({ avatar_base64: null });
     // The removal key, so a later enqueue reads as already synced.
     expect(JSON.parse(readFileSync(syncStatePath, "utf-8")).key).toEndWith(
-      "|none",
+      `|${REMOVAL_KEY}`,
     );
 
     syncAvatarToPlatform();
     await settle();
 
     expect(patches).toHaveLength(2);
+  });
+
+  test("a removal key recorded before the notification field re-sends once", async () => {
+    mockState = NONE;
+    mockRasterPath = null;
+    mkdirSync(dirname(syncStatePath), { recursive: true });
+    writeFileSync(
+      syncStatePath,
+      JSON.stringify({ key: LEGACY_REMOVAL_KEY, syncedAt: Date.now() }),
+    );
+
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].body).toEqual({
+      avatar_base64: null,
+      notification_avatar_base64: null,
+    });
+    expect(JSON.parse(readFileSync(syncStatePath, "utf-8")).key).toEndWith(
+      `|${REMOVAL_KEY}`,
+    );
+
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
   });
 
   test("an image avatar with a missing PNG is skipped, not cleared", async () => {
@@ -533,6 +581,27 @@ describe("syncAvatarToPlatform", () => {
       Buffer.from("disc-green").toString("base64"),
     );
     expect(lastResvgSvg).toContain('fill="#E6F1E7"');
+  });
+
+  test("derives and persists an accent the manifest predates, then draws it", async () => {
+    mockResvgAvailable = true;
+    mockRenderedPng = Buffer.from("disc-red");
+    mockState = imageState("etag-legacy");
+    mockRasterPath = writeRaster("avatar-image.png", RED_PNG);
+
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].body.notification_avatar_base64).toBe(
+      Buffer.from("disc-red").toString("base64"),
+    );
+    expect(lastResvgSvg).toContain(`fill="${RED_DISC_HEX}"`);
+    expect(manifestWrites).toEqual([
+      expect.objectContaining({
+        accent: { hex: "#c81e1e", source: "derived" },
+      }),
+    ]);
   });
 
   test("a render that failed after the key promised a disc re-uploads next sync", async () => {

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -19,7 +19,10 @@
  * re-render unavailable) is skipped so the platform keeps the last synced
  * copy. A removal nulls the notification field too, and falls back to nulling
  * the display avatar alone, so a platform that rejects the notification field
- * cannot block clearing the avatar.
+ * cannot block clearing the avatar. Its key carries the spec version as the
+ * non-empty key does, so an installation still holding the key of a removal
+ * that predates the notification field re-sends once instead of deduping
+ * against it and leaving a disc up that nothing else clears.
  * The same PATCH carries `notification_avatar_base64`, the disc render the
  * push pipeline shows as the sender. The dedup key carries the accent,
  * `NOTIFICATION_AVATAR_SPEC_VERSION` and whether a disc can be drawn at all,
@@ -31,7 +34,10 @@
  * codec for the source) from latching for the key's whole lifetime: the key
  * changes the moment the cause clears, so the disc goes up on the next sync.
  * When the render is unavailable the key is omitted rather than nulled, so
- * the platform keeps the copy it holds.
+ * the platform keeps the copy it holds. The state is read through the accent
+ * backfill, so a manifest written before accents were persisted has its
+ * accent derived and stored before the key is built and the disc is drawn,
+ * rather than shipping the neutral fallback until something else repairs it.
  * A render that fails inside the body, after the key promised a disc, hands
  * the queue the disc-less key instead, so the next sync tries again rather
  * than recording a disc that never went up. If the platform rejects the field
@@ -48,6 +54,7 @@ import { dirname, join } from "node:path";
 
 import { NOTIFICATION_AVATAR_SPEC_VERSION } from "@vellumai/avatar-manifest/notification-avatar";
 
+import { backfillAccent } from "../avatar/accent-backfill.js";
 import { readAvatarState } from "../avatar/avatar-manifest.js";
 import {
   ensureAvatarRasterPath,
@@ -82,6 +89,8 @@ const MAX_AVATAR_UPLOAD_BYTES = 256 * 1024;
 const DOWNSCALE_PX = 128;
 const NONE_KEY = "none";
 const DISC_KEY = "disc";
+/** The removal payload's key, versioned with the disc spec it also clears. */
+const REMOVAL_KEY = `${NONE_KEY}:${NOTIFICATION_AVATAR_SPEC_VERSION}`;
 /** The PATCH field carrying the disc, and what a 400 rejecting it names. */
 const NOTIFICATION_FIELD = "notification_avatar_base64";
 /** Only bytes that sniff as a raster image are ever uploaded. */
@@ -151,12 +160,12 @@ function persistKey(synced: SyncedKey): void {
 }
 
 async function buildPayload(): Promise<PatchPayload | undefined> {
-  const state = readAvatarState();
+  const state = await backfillAccent(readAvatarState());
   if (state.kind === "none") {
     return {
-      key: NONE_KEY,
+      key: REMOVAL_KEY,
       // A removal that had to drop the notification field still records
-      // NONE_KEY, as the non-empty reduced send records its full body's key.
+      // REMOVAL_KEY, as the non-empty reduced send records its full body's key.
       body: async () => withNotificationFallback({ avatar_base64: null }, null),
     };
   }

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -8,6 +8,7 @@ import {
 } from "@vellumai/avatar-manifest";
 import { z } from "zod";
 
+import { backfillAccent } from "../../avatar/accent-backfill.js";
 import { renderCharacterAscii } from "../../avatar/ascii-renderer.js";
 import {
   type AvatarState,
@@ -16,7 +17,6 @@ import {
   writeManifest,
 } from "../../avatar/avatar-manifest.js";
 import {
-  backfillAccent,
   clearAvatar,
   setAccent,
   setCharacter,


### PR DESCRIPTION
## Summary

- The platform avatar sync reads its state through `backfillAccent()`, so an image manifest that predates accent persistence has its accent derived and stored before the dedup key is built and the disc is drawn. Previously such an avatar shipped the neutral fallback disc until the user happened to hit the avatar state route, and the disc key latched that for the TTL.
- `backfillAccent()` and `automaticAccent()` move from `avatar-store.ts` into `avatar/accent-backfill.ts`, unchanged. The store reaches the client and platform fan-out (`resource-sync-events` calls `syncAvatarToPlatform`), so importing it from the sync would have closed a cycle; the repair announces nothing, so it lives on its own where either reader can take it.
- The removal payload's dedup key carries `NOTIFICATION_AVATAR_SPEC_VERSION` the way the non-empty key already does. An installation whose persisted state still holds the unversioned `none` key no longer dedupes the removal that also nulls `notification_avatar_base64`, so the platform's sender image is cleared once after the upgrade.

Tests: a legacy image manifest derives, persists and draws its accent; a persisted legacy `none` key does not dedupe the new removal, and the new key dedupes itself on the second enqueue.

Addresses the two Codex findings on #42336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U2q56txsvJoRvjTTPSYc1