### PR TITLE
chore(telemetry): sync the avatar_changed wire schema from platform 65df186708

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -33964,6 +33964,67 @@ paths:
                   required:
                     - type
                     - fields
+                - type: object
+                  properties:
+                    type:
+                      type: string
+                      const: avatar_changed
+                    fields:
+                      type: object
+                      properties:
+                        action:
+                          type: string
+                          minLength: 1
+                          maxLength: 32
+                        kind:
+                          type: string
+                          minLength: 1
+                          maxLength: 16
+                        previous_kind:
+                          type: string
+                          minLength: 1
+                          maxLength: 16
+                        body_shape:
+                          type: string
+                          minLength: 1
+                          maxLength: 256
+                        eye_style:
+                          type: string
+                          minLength: 1
+                          maxLength: 256
+                        color:
+                          type: string
+                          minLength: 1
+                          maxLength: 256
+                        accent_hex:
+                          type: string
+                          minLength: 1
+                          maxLength: 7
+                        accent_source:
+                          type: string
+                          minLength: 1
+                          maxLength: 16
+                        client_os:
+                          type: string
+                          minLength: 1
+                          maxLength: 64
+                      required:
+                        - action
+                        - kind
+                        - previous_kind
+                      description:
+                        Wire event fields, excluding the daemon-stamped base fields (type, daemon_event_id, recorded_at,
+                        assistant_version).
+                    daemon_event_id:
+                      description:
+                        "Optional collapse key: rows sharing an id collapse downstream (e.g. a retried report). Defaults to a fresh
+                        per-row id."
+                      type: string
+                      minLength: 1
+                      maxLength: 128
+                  required:
+                    - type
+                    - fields
               type: object
       responses:
         "200":

--- a/assistant/src/telemetry/AGENTS.md
+++ b/assistant/src/telemetry/AGENTS.md
@@ -16,7 +16,7 @@ The full cross-repo checklist lives with the serializer registry it governs, in 
 
 ### Emitting an outbox-backed event
 
-For a normal (outbox-backed) event, the sync PR is all the daemon needs — **no manual edits in this directory**. `OUTBOX_TELEMETRY_EVENT_NAMES` (in `types.ts`) and its flush source (in `telemetry-event-sources.ts`) are both **derived from the wire contract**, so a newly-synced type is outbox-backed and flushed automatically. Just call the generic, fully-typed recorder from your feature code:
+For a normal (outbox-backed) event, `OUTBOX_TELEMETRY_EVENT_NAMES` (in `types.ts`) and its flush source (in `telemetry-event-sources.ts`) are both **derived from the wire contract**, so a newly-synced type is outbox-backed and flushed automatically. The sync PR still carries three touchpoints whenever it adds a type: a sample in `__tests__/telemetry-event-fixtures.ts` (with a `types.ts` alias when the sample wants one), the payload-order pin in `telemetry-event-sources.test.ts`, and a regenerated `assistant/openapi.yaml`. Then call the generic, fully-typed recorder from your feature code:
 
 ```ts
 import { recordTelemetryEvent } from "./telemetry-events-outbox.js";

--- a/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
+++ b/assistant/src/telemetry/__tests__/telemetry-event-fixtures.ts
@@ -15,6 +15,7 @@
  */
 import type {
   AuthFallbackTelemetryEvent,
+  AvatarChangedTelemetryEvent,
   ConfigSettingTelemetryEvent,
   LifecycleTelemetryEvent,
   LlmUsageTelemetryEvent,
@@ -249,6 +250,22 @@ export const onboardingResearch: OnboardingResearchTelemetryEvent = {
   installed_plugins: ["gmail", "calendar"],
 };
 
+const avatarChanged: AvatarChangedTelemetryEvent = {
+  type: "avatar_changed",
+  daemon_event_id: "evt-avatar-changed-001",
+  recorded_at: RECORDED_AT,
+  assistant_version: "1.2.3",
+  action: "set_character",
+  kind: "character",
+  previous_kind: "none",
+  body_shape: "blob",
+  eye_style: "curious",
+  color: "green",
+  accent_hex: "#4caf50",
+  accent_source: "palette",
+  client_os: "macos",
+};
+
 /** One daemon-typed, wire-valid sample per generated wire event type. */
 export const wireEventSamples = [
   llmUsage,
@@ -261,4 +278,5 @@ export const wireEventSamples = [
   watchdog,
   configSetting,
   onboardingResearch,
+  avatarChanged,
 ] as const;

--- a/assistant/src/telemetry/telemetry-event-sources.test.ts
+++ b/assistant/src/telemetry/telemetry-event-sources.test.ts
@@ -46,6 +46,7 @@ describe("telemetry event source partition", () => {
       "watchdog",
       "config_setting",
       "onboarding_research",
+      "avatar_changed",
       ORPHAN_OUTBOX_DRAIN_SOURCE_ID,
     ]);
   });

--- a/assistant/src/telemetry/telemetry-wire-source.json
+++ b/assistant/src/telemetry/telemetry-wire-source.json
@@ -1,4 +1,4 @@
 {
   "sourceRepo": "vellum-ai/vellum-assistant-platform",
-  "sourceSha": "16dd2b8e758355014768a09f974ae509dcf5dc0d"
+  "sourceSha": "65df18670801af2d86fff3ba9b9bc12007c07d73"
 }

--- a/assistant/src/telemetry/telemetry-wire.generated.ts
+++ b/assistant/src/telemetry/telemetry-wire.generated.ts
@@ -394,6 +394,25 @@ export type OnboardingResearchTelemetryEvent = z.infer<
   typeof onboardingResearchTelemetryEventSchema
 >;
 
+export const avatarChangedTelemetryEventSchema = z.object({
+  type: z.literal("avatar_changed"),
+  daemon_event_id: z.string().trim().min(1).max(128),
+  recorded_at: z.number().int(),
+  assistant_version: z.string().trim().min(1).max(64).nullable().optional(),
+  action: z.string().trim().min(1).max(32),
+  kind: z.string().trim().min(1).max(16),
+  previous_kind: z.string().trim().min(1).max(16),
+  body_shape: z.string().trim().min(1).max(256).optional(),
+  eye_style: z.string().trim().min(1).max(256).optional(),
+  color: z.string().trim().min(1).max(256).optional(),
+  accent_hex: z.string().trim().min(1).max(7).optional(),
+  accent_source: z.string().trim().min(1).max(16).optional(),
+  client_os: z.string().trim().min(1).max(64).optional(),
+});
+export type AvatarChangedTelemetryEvent = z.infer<
+  typeof avatarChangedTelemetryEventSchema
+>;
+
 export type WireEventMap = {
   llm_usage: LlmUsageTelemetryEvent;
   turn: TurnTelemetryEvent;
@@ -405,6 +424,7 @@ export type WireEventMap = {
   watchdog: WatchdogTelemetryEvent;
   config_setting: ConfigSettingTelemetryEvent;
   onboarding_research: OnboardingResearchTelemetryEvent;
+  avatar_changed: AvatarChangedTelemetryEvent;
 };
 
 export const telemetryEventSchema = z.discriminatedUnion("type", [
@@ -418,6 +438,7 @@ export const telemetryEventSchema = z.discriminatedUnion("type", [
   watchdogTelemetryEventSchema,
   configSettingTelemetryEventSchema,
   onboardingResearchTelemetryEventSchema,
+  avatarChangedTelemetryEventSchema,
 ]);
 export type TelemetryEvent = z.infer<typeof telemetryEventSchema>;
 

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -626,6 +626,12 @@ export type AuthFallbackTelemetryEvent = EventMap["auth_fallback"];
  */
 export type ConfigSettingTelemetryEvent = EventMap["config_setting"];
 
+/**
+ * Avatar-changed event, the avatar store's change event. Wire-shaped with no
+ * daemon override; 1:1 with `AvatarChangedTelemetryEventSerializer`.
+ */
+export type AvatarChangedTelemetryEvent = EventMap["avatar_changed"];
+
 // ---- Compile-time drift guards ----
 // Each `Overrides` entry is pinned to its wire type in BOTH directions, so a
 // wire sync PR that moves the platform contract turns red here instead of


### PR DESCRIPTION
## Summary
- Cherry-picks the platform sync workflow's generated `avatar_changed` wire schema (763bf92598) unchanged; the generated files are byte-identical to `automated/sync-telemetry-wire`.
- Adds the `AvatarChangedTelemetryEvent` alias, a wire-valid fixture sample, and the payload-order pin so the wire-validation, types, and event-sources suites pass; regenerates `openapi.yaml` with the new ingest union member.
- Documents in `telemetry/AGENTS.md` the three touchpoints a type-adding sync PR carries (fixture sample, payload-order pin, regenerated spec).

Part of plan: avatar-changed-telemetry.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyMhFjRp3y2XhmreXRhUsP