### PR TITLE
fix(surfaces): keep task_progress cards from spinning after the turn ends (JARVIS-1700)

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-settle-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-settle-task-progress.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for `settleRunningTaskProgressSurfaces`: the turn-end floor that keeps
+ * a task_progress card from spinning after the turn it belonged to is over.
+ *
+ * Covers:
+ * - A card or step still `in_progress` becomes `pending`, via a real
+ *   `ui_surface_update` and the stored surface state.
+ * - Steps already `completed` or `failed` keep their status; nothing is
+ *   promoted to `completed`.
+ * - A card in a terminal state, a card with no running step, and non-card /
+ *   non-task_progress surfaces are left untouched.
+ * - A card from an earlier turn (absent from `currentTurnSurfaces`) is settled
+ *   too; the settle is idempotent.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type pino from "pino";
+
+import type { AssistantEvent } from "../api/index.js";
+import type { Conversation } from "../daemon/conversation.js";
+import {
+  createSurfaceMutex,
+  settleRunningTaskProgressSurfaces,
+  surfaceProxyResolver,
+} from "../daemon/conversation-surfaces.js";
+import type {
+  CardSurfaceData,
+  SurfaceType,
+  UISurfaceUpdateEvent,
+} from "../daemon/message-protocol.js";
+import { asConversation } from "./helpers/mock-conversation.js";
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as pino.Logger;
+
+function makeContext(sent: AssistantEvent[] = []): Conversation {
+  return asConversation({
+    conversationId: "session-1",
+    emit: (msg) => sent.push(msg),
+    pendingSurfaceActions: new Map<string, { surfaceType: SurfaceType }>(),
+    lastSurfaceAction: new Map<
+      string,
+      { actionId: string; data?: Record<string, unknown> }
+    >(),
+    surfaceState: new Map(),
+    surfaceUndoStacks: new Map<string, string[]>(),
+    accumulatedSurfaceState: new Map<string, Record<string, unknown>>(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "req-1" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "ok",
+    withSurface: createSurfaceMutex(),
+  });
+}
+
+async function showTaskProgress(
+  ctx: Conversation,
+  templateData: Record<string, unknown>,
+): Promise<string> {
+  const result = await surfaceProxyResolver(ctx, "ui_show", {
+    surface_type: "card",
+    title: "Working",
+    data: { template: "task_progress", templateData },
+  });
+  expect(result.isError).toBe(false);
+  return (JSON.parse(result.content as string) as { surfaceId: string })
+    .surfaceId;
+}
+
+function updatesFor(sent: AssistantEvent[], surfaceId: string) {
+  return sent.filter(
+    (msg): msg is UISurfaceUpdateEvent =>
+      msg.type === "ui_surface_update" && msg.surfaceId === surfaceId,
+  );
+}
+
+function storedTemplateData(
+  ctx: Conversation,
+  surfaceId: string,
+): Record<string, unknown> {
+  const stored = ctx.surfaceState.get(surfaceId);
+  if (!stored || stored.surfaceType !== "card") {
+    throw new Error(`no stored card for ${surfaceId}`);
+  }
+  return (stored.data as CardSurfaceData).templateData as Record<
+    string,
+    unknown
+  >;
+}
+
+describe("settleRunningTaskProgressSurfaces", () => {
+  test("settles a running card and its running step to pending, keeping finished steps", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+    const surfaceId = await showTaskProgress(ctx, {
+      title: "Send the follow-up",
+      status: "in_progress",
+      steps: [
+        { label: "Draft email", status: "completed" },
+        { label: "Send to contact", status: "in_progress" },
+        { label: "Log it", status: "pending" },
+        { label: "Archive", status: "failed" },
+      ],
+    });
+
+    settleRunningTaskProgressSurfaces(ctx, noopLogger);
+
+    const updates = updatesFor(sent, surfaceId);
+    expect(updates).toHaveLength(1);
+    const templateData = (updates[0].data as CardSurfaceData)
+      .templateData as Record<string, unknown>;
+    expect(templateData.status).toBe("pending");
+    expect(templateData.steps).toEqual([
+      { label: "Draft email", status: "completed" },
+      { label: "Send to contact", status: "pending" },
+      { label: "Log it", status: "pending" },
+      { label: "Archive", status: "failed" },
+    ]);
+    expect(storedTemplateData(ctx, surfaceId)).toEqual(templateData);
+  });
+
+  test("settles a running step under a card whose own status is already terminal", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+    const surfaceId = await showTaskProgress(ctx, {
+      status: "failed",
+      steps: [{ label: "Only step", status: "in_progress" }],
+    });
+
+    settleRunningTaskProgressSurfaces(ctx, noopLogger);
+
+    const templateData = storedTemplateData(ctx, surfaceId);
+    expect(templateData.status).toBe("failed");
+    expect(templateData.steps).toEqual([
+      { label: "Only step", status: "pending" },
+    ]);
+  });
+
+  test("leaves a card alone when nothing on it is running", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+    const completed = await showTaskProgress(ctx, {
+      status: "completed",
+      steps: [{ label: "Done", status: "completed" }],
+    });
+    const parked = await showTaskProgress(ctx, {
+      status: "pending",
+      steps: [{ label: "Later", status: "pending" }],
+    });
+    sent.length = 0;
+
+    settleRunningTaskProgressSurfaces(ctx, noopLogger);
+
+    expect(updatesFor(sent, completed)).toHaveLength(0);
+    expect(updatesFor(sent, parked)).toHaveLength(0);
+    expect(storedTemplateData(ctx, parked).status).toBe("pending");
+  });
+
+  test("ignores surfaces that are not task_progress cards", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+    const plainCard = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      data: { title: "Note", body: "status: in_progress" },
+    });
+    const workResult = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "work_result",
+      data: { status: "in_progress", summary: "Crunching" },
+    });
+    expect(plainCard.isError).toBe(false);
+    expect(workResult.isError).toBe(false);
+    sent.length = 0;
+
+    settleRunningTaskProgressSurfaces(ctx, noopLogger);
+
+    expect(sent.filter((msg) => msg.type === "ui_surface_update")).toHaveLength(
+      0,
+    );
+  });
+
+  test("settles a card shown on an earlier turn and is idempotent", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+    const surfaceId = await showTaskProgress(ctx, {
+      status: "in_progress",
+      steps: [{ label: "Step", status: "in_progress" }],
+    });
+    // The prior turn's snapshot has been persisted and cleared.
+    ctx.currentTurnSurfaces = [];
+    sent.length = 0;
+
+    settleRunningTaskProgressSurfaces(ctx, noopLogger);
+    settleRunningTaskProgressSurfaces(ctx, noopLogger);
+
+    expect(updatesFor(sent, surfaceId)).toHaveLength(1);
+    const templateData = storedTemplateData(ctx, surfaceId);
+    expect(templateData.status).toBe("pending");
+    expect(templateData.steps).toEqual([{ label: "Step", status: "pending" }]);
+  });
+
+  test("a card shown with a pending status keeps it", async () => {
+    const sent: AssistantEvent[] = [];
+    const ctx = makeContext(sent);
+    const surfaceId = await showTaskProgress(ctx, {
+      status: "pending",
+      steps: [{ label: "Step", status: "pending" }],
+    });
+
+    expect(storedTemplateData(ctx, surfaceId).status).toBe("pending");
+  });
+});

--- a/assistant/src/__tests__/surface-completion-nudge-hook.test.ts
+++ b/assistant/src/__tests__/surface-completion-nudge-hook.test.ts
@@ -12,6 +12,9 @@
  *   turn, and a non-main-agent call site.
  * - The signal is scoped to the current response cycle — a surface left open in
  *   a prior cycle (before the last genuine user prompt) does not trigger it.
+ * - The `surface_id` correlation reads the tool result the real `ui_show` tool
+ *   produces, including the update hint it carries on a task_progress card, so
+ *   the producer and this consumer cannot drift apart unnoticed.
  * - The one-shot bound is split across the two hooks: `post-model-call` marks it
  *   (nudging at most once per run) and `stop` clears it so the next run nudges
  *   afresh.
@@ -36,6 +39,7 @@ import {
   resetSurfaceCompletionNudgeStoreForTests,
 } from "../plugins/defaults/surface-completion-nudge/nudge-state-store.js";
 import type { ContentBlock, Message } from "../providers/types.js";
+import { uiShowTool } from "../tools/ui-surface/definitions.js";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -54,7 +58,11 @@ let surfaceCounter = 0;
  * An assistant `ui_show` turn paired with its `{ surfaceId }` tool result.
  * Returns both messages plus the assigned surface id.
  */
-function showSurface(input: Record<string, unknown>): {
+function showSurface(
+  input: Record<string, unknown>,
+  resultContent: (surfaceId: string) => string = (surfaceId) =>
+    JSON.stringify({ surfaceId }),
+): {
   messages: Message[];
   surfaceId: string;
 } {
@@ -74,12 +82,34 @@ function showSurface(input: Record<string, unknown>): {
           {
             type: "tool_result",
             tool_use_id: toolUseId,
-            content: JSON.stringify({ surfaceId }),
+            content: resultContent(surfaceId),
           },
         ],
       },
     ],
   };
+}
+
+/**
+ * The tool result the real `ui_show` tool hands the model for `input`, with
+ * the daemon's proxy answering `{ surfaceId }`. Exercises the same code path
+ * production history is written from, hint and all.
+ */
+async function realUiShowResult(
+  input: Record<string, unknown>,
+  surfaceId: string,
+): Promise<string> {
+  const result = await uiShowTool.execute(input, {
+    conversationId: "conv-scn",
+    workingDir: "/tmp",
+    trustClass: "guardian",
+    proxyToolResolver: async () => ({
+      content: JSON.stringify({ surfaceId }),
+      isError: false,
+    }),
+  });
+  expect(result.isError).toBe(false);
+  return result.content as string;
 }
 
 function updateSurface(
@@ -188,6 +218,26 @@ describe("surface-completion-nudge — nudges on a dangling progress surface", (
       text: SURFACE_COMPLETION_NUDGE_TEXT,
     });
     expect(isSurfaceCompletionNudged("conv-scn")).toBe(true);
+  });
+
+  test("task_progress card shown via the real ui_show tool result → continue with nudge", async () => {
+    const input = taskProgressShow("in_progress");
+    const shown = showSurface(input, () => "placeholder");
+    const content = await realUiShowResult(input, shown.surfaceId);
+    // The real result carries the ui_update hint alongside the id.
+    expect(content).toContain("ui_update");
+    const result = shown.messages[1].content[0];
+    if (result.type !== "tool_result") {
+      throw new Error("expected a tool_result block");
+    }
+    result.content = content;
+    const ctx = makeCtx({
+      messages: [userPrompt("do the thing"), ...shown.messages],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("continue");
   });
 
   test("task_progress card shown with no explicit status → continue with nudge", async () => {

--- a/assistant/src/api/surface-show-result.test.ts
+++ b/assistant/src/api/surface-show-result.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseSurfaceShowResultId,
+  withSurfaceShowNote,
+} from "./surface-show-result.js";
+
+const HINT_WITH_BRACES =
+  'As each step finishes, call ui_update { surface_id: "<id>", data: { templateData: { steps: [{ label: "x", status: "completed" }] } } }';
+
+describe("parseSurfaceShowResultId", () => {
+  test("reads the id from a bare envelope", () => {
+    expect(parseSurfaceShowResultId('{"surfaceId":"s-1"}')).toBe("s-1");
+  });
+
+  test("reads the id from an envelope carrying advisory fields", () => {
+    expect(
+      parseSurfaceShowResultId(
+        JSON.stringify({ surfaceId: "s-2", note: "hi", status: "displayed" }),
+      ),
+    ).toBe("s-2");
+  });
+
+  test("tolerates prose appended after the envelope, even prose with braces", () => {
+    expect(
+      parseSurfaceShowResultId(`{"surfaceId":"s-3"}\n\n${HINT_WITH_BRACES}`),
+    ).toBe("s-3");
+  });
+
+  test("ignores braces inside string values when finding the envelope end", () => {
+    expect(
+      parseSurfaceShowResultId(
+        '{"surfaceId":"s-4","note":"use { and } freely \\" }"} trailing',
+      ),
+    ).toBe("s-4");
+  });
+
+  test("returns undefined for non-envelope content", () => {
+    expect(parseSurfaceShowResultId("Surface updated")).toBeUndefined();
+    expect(parseSurfaceShowResultId("")).toBeUndefined();
+    expect(parseSurfaceShowResultId('{"surfaceId":1}')).toBeUndefined();
+    expect(parseSurfaceShowResultId('{"other":"x"}')).toBeUndefined();
+    expect(parseSurfaceShowResultId('{"surfaceId":"unterminated')).toBe(
+      undefined,
+    );
+  });
+});
+
+describe("withSurfaceShowNote", () => {
+  test("carries the note inside the envelope so the id stays parseable", () => {
+    const content = withSurfaceShowNote(
+      JSON.stringify({ surfaceId: "s-1" }),
+      HINT_WITH_BRACES,
+    );
+    expect(JSON.parse(content)).toEqual({
+      surfaceId: "s-1",
+      note: HINT_WITH_BRACES,
+    });
+    expect(parseSurfaceShowResultId(content)).toBe("s-1");
+  });
+
+  test("appends to an existing note rather than replacing it", () => {
+    const content = withSurfaceShowNote(
+      JSON.stringify({ surfaceId: "s-1", note: "first" }),
+      "second",
+    );
+    expect(JSON.parse(content)).toEqual({
+      surfaceId: "s-1",
+      note: "first\n\nsecond",
+    });
+  });
+
+  test("appends as prose when the content is not a surface envelope", () => {
+    expect(withSurfaceShowNote("Surface displayed", "note")).toBe(
+      "Surface displayed\n\nnote",
+    );
+  });
+});

--- a/assistant/src/api/surface-show-result.ts
+++ b/assistant/src/api/surface-show-result.ts
@@ -23,7 +23,7 @@ export interface SurfaceShowResult {
  *
  * Trailing prose after the JSON object is tolerated: guidance belongs in a
  * `note` field, but a caller that appends it instead must not silently cost
- * the reader its `surfaceId` — losing the id makes a live progress surface
+ * the reader its `surfaceId`: losing the id makes a live progress surface
  * invisible to the completion nudge, and the user watches it spin forever.
  */
 export function parseSurfaceShowResultId(content: string): string | undefined {

--- a/assistant/src/api/surface-show-result.ts
+++ b/assistant/src/api/surface-show-result.ts
@@ -1,0 +1,118 @@
+/**
+ * The `ui_show` tool-result envelope.
+ *
+ * A successful `ui_show` reports the created surface back to the model as a
+ * JSON object carrying the `surfaceId`, optionally alongside advisory fields
+ * (`status`, `note`, `message`) that coach the model on what to do next.
+ *
+ * The envelope is a contract, not just a string: the surface-completion nudge
+ * reads `surfaceId` back out of tool history to tell which progress surfaces
+ * the model left spinning. Producer and consumer therefore share this module,
+ * so guidance can only ever be added in a way the parser still understands.
+ */
+
+/** Fields a `ui_show` result envelope may carry beyond the surface id. */
+export interface SurfaceShowResult {
+  surfaceId: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Read the `surfaceId` out of a `ui_show` tool result, or `undefined` when the
+ * content is not a surface envelope.
+ *
+ * Trailing prose after the JSON object is tolerated: guidance belongs in a
+ * `note` field, but a caller that appends it instead must not silently cost
+ * the reader its `surfaceId` — losing the id makes a live progress surface
+ * invisible to the completion nudge, and the user watches it spin forever.
+ */
+export function parseSurfaceShowResultId(content: string): string | undefined {
+  const parsed = parseLeadingJsonObject(content);
+  return typeof parsed?.surfaceId === "string" ? parsed.surfaceId : undefined;
+}
+
+/**
+ * Attach advisory guidance to a `ui_show` result as a `note` field, keeping the
+ * content a single parseable JSON envelope. Content that is not a surface
+ * envelope (an error string, a non-JSON acknowledgment) falls back to appending
+ * the note as prose, which is still the right thing for the model to read.
+ */
+export function withSurfaceShowNote(content: string, note: string): string {
+  const parsed = parseLeadingJsonObject(content);
+  if (parsed === undefined || typeof parsed.surfaceId !== "string") {
+    return `${content}\n\n${note}`;
+  }
+  const existing = typeof parsed.note === "string" ? parsed.note : undefined;
+  return JSON.stringify({
+    ...parsed,
+    note: existing ? `${existing}\n\n${note}` : note,
+  });
+}
+
+/**
+ * Parse `content` as a JSON object, tolerating trailing text after the closing
+ * brace. Returns `undefined` for anything that is not a leading JSON object.
+ *
+ * The object's extent is found by matching braces rather than by scanning for
+ * the last `}`, because appended guidance routinely contains braces of its own
+ * (a worked `ui_update { ... }` example, say).
+ */
+function parseLeadingJsonObject(
+  content: string,
+): Record<string, unknown> | undefined {
+  const trimmed = content.trim();
+  const end = endOfLeadingJsonObject(trimmed);
+  if (end === undefined) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed.slice(0, end + 1));
+    return parsed !== null && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Index of the `}` closing the object that opens `text`, or `undefined` when
+ * `text` does not open with an object or the braces never balance. String
+ * literals (and their escapes) are skipped so braces inside values don't count.
+ */
+function endOfLeadingJsonObject(text: string): number | undefined {
+  if (!text.startsWith("{")) {
+    return undefined;
+  }
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") {
+      depth++;
+      continue;
+    }
+    if (char === "}") {
+      depth--;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+  return undefined;
+}

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -123,7 +123,10 @@ import {
   type SlackChronologicalContext,
 } from "./conversation-runtime-assembly.js";
 import type { CurrentTurnSurface } from "./conversation-surfaces.js";
-import { markSurfaceCompleted } from "./conversation-surfaces.js";
+import {
+  markSurfaceCompleted,
+  settleRunningTaskProgressSurfaces,
+} from "./conversation-surfaces.js";
 import {
   runDeferredTurnTail,
   settleTurnContent,
@@ -1803,6 +1806,12 @@ export async function runAgentLoopImpl(
       turnCronRunId,
     );
 
+    // Generation is over for every outcome below (reply, hand-off, or
+    // cancellation), so a progress card still spinning would be lying.
+    // Settle before the terminal SSE so the client sees the card at rest by
+    // the time it re-enables the composer.
+    settleRunningTaskProgressSurfaces(ctx, rlog);
+
     // Fast-path: when the user cancelled, skip expensive post-loop work
     // (attachment resolution) and emit the cancellation event immediately
     // so the client can re-enable the UI without delay. Disk sync and the rest
@@ -1940,6 +1949,8 @@ export async function runAgentLoopImpl(
     );
   } catch (err) {
     clearConversationNotices(ctx.conversationId);
+    // A turn that threw out of the loop is over too; see the happy path.
+    settleRunningTaskProgressSurfaces(ctx, rlog);
     const errorCtx = {
       phase: "agent_loop" as const,
       aborted: abortController.signal.aborted,

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1,3 +1,4 @@
+import type pino from "pino";
 import { v4 as uuid, v7 as uuidv7 } from "uuid";
 import { z } from "zod";
 
@@ -613,6 +614,7 @@ export function removeSurfaceBlock(
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;
 
 const TASK_PROGRESS_CARD_STATUSES = new Set([
+  "pending",
   "in_progress",
   "completed",
   "failed",
@@ -2940,6 +2942,181 @@ function ensureHostCuProxy(ctx: Conversation): HostCuProxy | undefined {
 }
 
 /**
+ * Merge a partial `patch` into a live surface's data and push the result to
+ * every consumer that tracks it: the in-memory `surfaceState`, the client (via
+ * `ui_surface_update`), the current turn's snapshot, and the persisted
+ * `ui_surface` block. The single writer behind the model's `ui_update` tool
+ * and the daemon's own surface mutations.
+ */
+export function applySurfaceUpdate(
+  ctx: Conversation,
+  surfaceId: string,
+  patch: Record<string, unknown>,
+): ToolExecutionResult {
+  // Merge the partial patch into the stored full surface data
+  const stored = ctx.surfaceState.get(surfaceId);
+  let mergedData: AnySurfaceData;
+  let mergedPair: SurfaceShowPair | undefined;
+  if (stored) {
+    if (stored.surfaceType === "card") {
+      patch = normalizeTaskProgressCardPatch(stored.data, patch);
+    }
+    // Push current HTML to undo stack for dynamic pages
+    if (stored.surfaceType === "dynamic_page") {
+      pushUndoState(ctx.surfaceUndoStacks, surfaceId, stored.data.html);
+    }
+    const rawMerged = { ...stored.data, ...patch };
+    if (!isKnownSurfaceType(stored.surfaceType)) {
+      // Restore preserves an unknown-but-non-empty persisted `surfaceType`
+      // verbatim (a newer/custom client-rendered surface). There is no
+      // canonical schema to validate or normalize against (and indexing
+      // `SURFACE_DATA_SCHEMAS` with it would read `undefined` and throw), so
+      // forward the merge opaquely rather than dropping the update, mirroring
+      // restore's verbatim handling of the same types.
+      mergedData = rawMerged as AnySurfaceData;
+      ctx.surfaceState.set(surfaceId, {
+        ...stored,
+        data: rawMerged,
+      } as SurfaceStateEntry);
+    } else {
+      // Validate the merged data through the surface type's canonical schema
+      // so malformed patches (e.g. metadata as a string) are caught here
+      // instead of crashing the client's safeParse. Keep unmodeled
+      // client-owned keys from the raw merge, but take the schema-NORMALIZED
+      // value for every modeled field: a tolerant field (e.g. dynamic_page
+      // `html` is `z.string().catch("")`, file_upload `acceptedTypes` coerces
+      // to `string[]`) can accept a malformed input and coerce it, and later
+      // daemon code (active-workspace injection's `truncateHtml`, undo-stack
+      // pushes) assumes the canonical shape, so storing the raw value would
+      // poison `surfaceState`. `mergedPair.data` holds only modeled keys, so
+      // spreading it over `rawMerged` normalizes those while preserving the
+      // client-owned ones. Only a failed parse reverts to the stored data.
+      mergedPair = buildSurfaceShowPair(stored.surfaceType, rawMerged);
+      if (mergedPair !== undefined) {
+        const normalized = { ...rawMerged, ...mergedPair.data };
+        mergedData = normalized as AnySurfaceData;
+        ctx.surfaceState.set(surfaceId, {
+          ...stored,
+          data: normalized,
+        } as SurfaceStateEntry);
+      } else {
+        log.warn(
+          { surfaceId, surfaceType: stored.surfaceType },
+          "ui_update patch produced invalid merged data; reverting to stored data",
+        );
+        mergedData =
+          safeParseSurfaceData(stored.surfaceType, stored.data) ?? stored.data;
+      }
+    }
+  } else {
+    // No stored state for this surfaceId, so its surface type, and
+    // therefore its canonical schema, is unknown; forward the patch
+    // opaquely rather than dropping the update.
+    mergedData = patch;
+  }
+
+  ctx.emit({
+    type: "ui_surface_update",
+    conversationId: ctx.conversationId,
+    surfaceId,
+    data: mergedData,
+  });
+
+  // Keep the persisted snapshot in sync so updates survive conversation
+  // restart. This must track EVERY branch that changed `mergedData`, not
+  // just the schema-parsed one, because the turn-end persist loop writes
+  // `currentTurnSurfaces[idx].data` to the same `ui_surface` block that the
+  // debounced `scheduleSurfaceDataPersist` below writes. If an unknown-type
+  // (opaquely forwarded) update updated `surfaceState` but not this array,
+  // the two writers would persist divergent data and race on which lands
+  // last. Gating on `idx !== -1` alone keeps all three in lockstep.
+  const idx = ctx.currentTurnSurfaces.findIndex(
+    (s) => s.surfaceId === surfaceId,
+  );
+  if (idx !== -1) {
+    ctx.currentTurnSurfaces[idx] = {
+      ...ctx.currentTurnSurfaces[idx],
+      data: mergedData,
+    } as CurrentTurnSurface;
+  }
+
+  // Persist the merged data back to the assistant message's
+  // `ui_surface` content block so a refresh / restart shows the
+  // current state instead of the original creation-time snapshot.
+  // Debounced to coalesce bursts of rapid updates.
+  scheduleSurfaceDataPersist(ctx.conversationId, surfaceId, mergedData);
+
+  return { content: "Surface updated", isError: false };
+}
+
+/**
+ * A task_progress card, or any of its steps, still reads `in_progress`.
+ * Such a card renders a live spinner, which only means something while a
+ * turn is running.
+ */
+function taskProgressStillRunning(data: Record<string, unknown>): boolean {
+  if (!isTaskProgressCardData(data) || !isPlainObject(data.templateData)) {
+    return false;
+  }
+  const templateData = data.templateData;
+  if (templateData.status === "in_progress") {
+    return true;
+  }
+  const steps = Array.isArray(templateData.steps) ? templateData.steps : [];
+  return steps.some(
+    (step) => isPlainObject(step) && step.status === "in_progress",
+  );
+}
+
+/**
+ * Settle every task_progress card the conversation still shows as running.
+ * Called when a turn reaches its terminal outcome (reply, hand-off to the
+ * user, or cancellation): nothing is executing any more, so a spinner is a
+ * false claim. Each `in_progress` card status and step status becomes
+ * `pending`. Steps the model already marked `completed` or `failed` stand,
+ * and no step is promoted to `completed`: the model is the only party that
+ * can assert an outcome, and its silence is not one.
+ *
+ * Covers cards from earlier turns as well as this one. A card the model
+ * resumes on a later turn is advanced back to `in_progress` by its own
+ * `ui_update`, exactly as it would advance a step it is starting.
+ */
+export function settleRunningTaskProgressSurfaces(
+  ctx: Conversation,
+  rlog: pino.Logger,
+): void {
+  for (const [surfaceId, entry] of ctx.surfaceState) {
+    if (entry.surfaceType !== "card" || !taskProgressStillRunning(entry.data)) {
+      continue;
+    }
+    const templateData = entry.data.templateData as Record<string, unknown>;
+    const steps = Array.isArray(templateData.steps) ? templateData.steps : [];
+    const patch = {
+      templateData: {
+        ...(templateData.status === "in_progress" ? { status: "pending" } : {}),
+        steps: steps.map((step) =>
+          isPlainObject(step) && step.status === "in_progress"
+            ? { ...step, status: "pending" }
+            : step,
+        ),
+      },
+    };
+    rlog.info(
+      { surfaceId },
+      "Turn ended with a task_progress card still in progress; settling it to pending",
+    );
+    try {
+      applySurfaceUpdate(ctx, surfaceId, patch);
+      // A settle is the last write of the turn, with no burst to coalesce, so
+      // land it now rather than leaving it to the debounce window.
+      flushSurfaceDataPersist(surfaceId);
+    } catch (err) {
+      rlog.warn({ err, surfaceId }, "Failed to settle task_progress card");
+    }
+  }
+}
+
+/**
  * Resolve a proxy tool call that targets a UI surface.
  * Handles ui_show, ui_update, ui_dismiss, computer_use_* proxy tools, and app_open.
  */
@@ -3524,103 +3701,11 @@ export async function surfaceProxyResolver(
   if (toolName === "ui_update") {
     const surfaceId =
       typeof input.surface_id === "string" ? input.surface_id : "";
-    let patch = coerceSurfaceDataRecord(input.data);
-
-    // Merge the partial patch into the stored full surface data
-    const stored = ctx.surfaceState.get(surfaceId);
-    let mergedData: AnySurfaceData;
-    let mergedPair: SurfaceShowPair | undefined;
-    if (stored) {
-      if (stored.surfaceType === "card") {
-        patch = normalizeTaskProgressCardPatch(stored.data, patch);
-      }
-      // Push current HTML to undo stack for dynamic pages
-      if (stored.surfaceType === "dynamic_page") {
-        pushUndoState(ctx.surfaceUndoStacks, surfaceId, stored.data.html);
-      }
-      const rawMerged = { ...stored.data, ...patch };
-      if (!isKnownSurfaceType(stored.surfaceType)) {
-        // Restore preserves an unknown-but-non-empty persisted `surfaceType`
-        // verbatim (a newer/custom client-rendered surface). There is no
-        // canonical schema to validate or normalize against — and indexing
-        // `SURFACE_DATA_SCHEMAS` with it would read `undefined` and throw — so
-        // forward the merge opaquely rather than dropping the update, mirroring
-        // restore's verbatim handling of the same types.
-        mergedData = rawMerged as AnySurfaceData;
-        ctx.surfaceState.set(surfaceId, {
-          ...stored,
-          data: rawMerged,
-        } as SurfaceStateEntry);
-      } else {
-        // Validate the merged data through the surface type's canonical schema
-        // so malformed patches (e.g. metadata as a string) are caught here
-        // instead of crashing the client's safeParse. Keep unmodeled
-        // client-owned keys from the raw merge, but take the schema-NORMALIZED
-        // value for every modeled field: a tolerant field (e.g. dynamic_page
-        // `html` is `z.string().catch("")`, file_upload `acceptedTypes` coerces
-        // to `string[]`) can accept a malformed input and coerce it, and later
-        // daemon code (active-workspace injection's `truncateHtml`, undo-stack
-        // pushes) assumes the canonical shape — so storing the raw value would
-        // poison `surfaceState`. `mergedPair.data` holds only modeled keys, so
-        // spreading it over `rawMerged` normalizes those while preserving the
-        // client-owned ones. Only a failed parse reverts to the stored data.
-        mergedPair = buildSurfaceShowPair(stored.surfaceType, rawMerged);
-        if (mergedPair !== undefined) {
-          const normalized = { ...rawMerged, ...mergedPair.data };
-          mergedData = normalized as AnySurfaceData;
-          ctx.surfaceState.set(surfaceId, {
-            ...stored,
-            data: normalized,
-          } as SurfaceStateEntry);
-        } else {
-          log.warn(
-            { surfaceId, surfaceType: stored.surfaceType },
-            "ui_update patch produced invalid merged data; reverting to stored data",
-          );
-          mergedData =
-            safeParseSurfaceData(stored.surfaceType, stored.data) ??
-            stored.data;
-        }
-      }
-    } else {
-      // No stored state for this surfaceId, so its surface type — and
-      // therefore its canonical schema — is unknown; forward the patch
-      // opaquely rather than dropping the update.
-      mergedData = patch;
-    }
-
-    ctx.emit({
-      type: "ui_surface_update",
-      conversationId: ctx.conversationId,
+    return applySurfaceUpdate(
+      ctx,
       surfaceId,
-      data: mergedData,
-    });
-
-    // Keep the persisted snapshot in sync so updates survive conversation
-    // restart. This must track EVERY branch that changed `mergedData` — not
-    // just the schema-parsed one — because the turn-end persist loop writes
-    // `currentTurnSurfaces[idx].data` to the same `ui_surface` block that the
-    // debounced `scheduleSurfaceDataPersist` below writes. If an unknown-type
-    // (opaquely forwarded) update updated `surfaceState` but not this array,
-    // the two writers would persist divergent data and race on which lands
-    // last. Gating on `idx !== -1` alone keeps all three in lockstep.
-    const idx = ctx.currentTurnSurfaces.findIndex(
-      (s) => s.surfaceId === surfaceId,
+      coerceSurfaceDataRecord(input.data),
     );
-    if (idx !== -1) {
-      ctx.currentTurnSurfaces[idx] = {
-        ...ctx.currentTurnSurfaces[idx],
-        data: mergedData,
-      } as CurrentTurnSurface;
-    }
-
-    // Persist the merged data back to the assistant message's
-    // `ui_surface` content block so a refresh / restart shows the
-    // current state instead of the original creation-time snapshot.
-    // Debounced to coalesce bursts of rapid updates.
-    scheduleSurfaceDataPersist(ctx.conversationId, surfaceId, mergedData);
-
-    return { content: "Surface updated", isError: false };
   }
 
   if (toolName === "ui_dismiss") {

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -253,6 +253,12 @@ export { isVisionNotSupportedError } from "../util/provider-error-patterns.js";
 // avoid touching stale tool-result media the sanitizer will replace with its
 // removed-media marker.
 export { lastToolResultUserMessageIndex } from "../context/outbound-sanitize.js";
+// The `surfaceId` a successful `ui_show` tool result reports, read from the
+// envelope the host writes (which may also carry advisory `note`/`status`
+// fields). A `post-model-call` hook correlates a progress surface's `ui_show`
+// with its later `ui_update`/`ui_dismiss` through this id to see whether the
+// model left the surface open.
+export { parseSurfaceShowResultId } from "../api/surface-show-result.js";
 // Refusal quarantine — the canned apology a refusal turn is rewritten into
 // (`REFUSAL_FALLBACK_TEXT`, which doubles as the persisted per-exchange
 // "refused" marker), the tool-result-only user-message classifier the producer

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
@@ -53,6 +53,7 @@ import {
   type PostModelCallContext,
 } from "@vellumai/plugin-api";
 
+import { parseSurfaceShowResultId } from "../../../../api/surface-show-result.js";
 import {
   isSurfaceCompletionNudged,
   markSurfaceCompletionNudged,
@@ -157,17 +158,6 @@ function surfaceIdOf(input: Record<string, unknown>): string | undefined {
   return typeof input.surface_id === "string" ? input.surface_id : undefined;
 }
 
-/** Parse the `{ surfaceId }` JSON a successful `ui_show` returns. */
-function parseSurfaceId(content: string): string | undefined {
-  try {
-    const parsed = JSON.parse(content) as unknown;
-    const record = asRecord(parsed);
-    return typeof record?.surfaceId === "string" ? record.surfaceId : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 interface SurfaceState {
   /** Latest known status, lowercased; `undefined` when never set explicitly. */
   status: string | undefined;
@@ -249,7 +239,7 @@ function hasDanglingProgressSurface(messages: ReadonlyArray<Message>): boolean {
       }
       const initialStatus = pendingShows.get(block.tool_use_id);
       pendingShows.delete(block.tool_use_id);
-      const id = parseSurfaceId(block.content);
+      const id = parseSurfaceShowResultId(block.content);
       if (!id) {
         continue;
       }

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
@@ -50,10 +50,10 @@ import {
   type HookFunction,
   INTERNAL_NUDGE_OUTPUT_SUPPRESSION,
   type Message,
+  parseSurfaceShowResultId,
   type PostModelCallContext,
 } from "@vellumai/plugin-api";
 
-import { parseSurfaceShowResultId } from "../../../../api/surface-show-result.js";
 import {
   isSurfaceCompletionNudged,
   markSurfaceCompletionNudged,

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -7,6 +7,7 @@
  * handled locally by the daemon.
  */
 
+import { withSurfaceShowNote } from "../../api/surface-show-result.js";
 import {
   coerceSurfaceDataRecord,
   normalizeVisualShowData,
@@ -102,7 +103,7 @@ function proxyExecute(toolName: string) {
     ) {
       return {
         ...result,
-        content: `${result.content}\n\n${TASK_PROGRESS_UPDATE_HINT}`,
+        content: withSurfaceShowNote(result.content, TASK_PROGRESS_UPDATE_HINT),
       };
     }
     return result;
@@ -131,10 +132,10 @@ const EMPTY_DYNAMIC_PAGE_DECLARATIVE_REDIRECT =
   'Error: ui_show dynamic_page was not displayed — `data.html` was empty, so the user would see a blank box. Authoring full HTML inline is error-prone; for data, comparisons, results, or metrics prefer a structured surface, which you fill with fields (no HTML) and which never renders blank. Re-show the content as one of: a `table` (ui_show { surface_type: "table", data: { columns: [{ id, label }], rows: [{ id, cells: { <columnId>: "<value>" } }] } }), a `card` ({ title, body, metadata: [{ label, value }] }), or `work_result` ({ summary, metrics: [{ label, value }] }). Only use dynamic_page when you genuinely need custom visual HTML, in which case include the complete markup in `data.html` now.';
 
 /**
- * Worked ui_update example, appended to a successful task_progress `ui_show`
- * result so the model learns the update pattern at the point of use (with the
- * real surface_id in hand) rather than carrying it in the always-present tool
- * description.
+ * Worked ui_update example, carried as a `note` on a successful task_progress
+ * `ui_show` result so the model learns the update pattern at the point of use
+ * (with the real surface_id in hand) rather than carrying it in the
+ * always-present tool description.
  */
 const TASK_PROGRESS_UPDATE_HINT =
   'As each step finishes, call ui_update with this surface_id to advance it — e.g. ui_update { surface_id: "<the surface_id above>", data: { templateData: { steps: [{ label: "Scaffold project", status: "completed" }, { label: "Wire up commands", status: "in_progress" }] } } }';

--- a/assistant/src/tools/ui-surface/surface-shape-docs.ts
+++ b/assistant/src/tools/ui-surface/surface-shape-docs.ts
@@ -81,7 +81,7 @@ interface SurfaceShapeDoc {
 
 /** templateData shape of a task_progress card (shared with channel variants). */
 export const TASK_PROGRESS_TEMPLATE_SHAPE =
-  '{ title, status: "in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }';
+  '{ title, status: "pending"|"in_progress"|"completed"|"failed", steps: [{ label, status: "pending"|"in_progress"|"completed"|"failed", detail? }] }';
 
 /** Data keys the file_upload renderer reads; any other key is silently stripped. */
 const FILE_UPLOAD_KEYS = new Set<string>(

--- a/clients/web/src/domains/chat/components/progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/progress-card.test.tsx
@@ -4,7 +4,8 @@
  * The trigger names its own state, so the label, the glyph and the loading
  * sweep all have to agree with the plan: "Progress" with a step ring and a
  * shimmering label while work is outstanding, "Finished" with a check and a
- * label at rest once it is not.
+ * label at rest once the plan has an outcome, and "Stopped" with the ring at
+ * rest when the plan was parked with neither.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -148,6 +149,24 @@ describe("ProgressCard trigger", () => {
       "Finished",
     );
     expect(screen.queryByTestId("progress-label-shimmer")).toBeNull();
+  });
+
+  test("a parked plan reads Stopped, keeps the ring, and shows no check", () => {
+    // How the daemon leaves a plan when the turn that drove it ends without
+    // the model asserting an outcome: no step in flight, nothing finished.
+    // Calling that "Finished" would claim work the model never confirmed.
+    seedPlan("pending", [
+      { label: "Step 1", status: "completed" },
+      { label: "Step 2", status: "pending" },
+    ]);
+    renderCard();
+
+    const toggle = screen.getByTestId("progress-card-toggle");
+    expect(toggle.textContent).toContain("Stopped");
+    expect(toggle.textContent).not.toContain("Finished");
+    expect(screen.queryByTestId("progress-label-shimmer")).toBeNull();
+    // The ring, at the plan's position, rather than a check.
+    expect(toggle.querySelectorAll("circle")).toHaveLength(2);
   });
 
   test("a step in flight counts as running when the card says nothing", () => {

--- a/clients/web/src/domains/chat/components/progress-card.tsx
+++ b/clients/web/src/domains/chat/components/progress-card.tsx
@@ -67,6 +67,10 @@ export function ProgressCard() {
     !isTerminal &&
     (progress?.status === "in_progress" ||
       (progress?.steps.some((step) => step.status === "in_progress") ?? false));
+  // Neither: the plan was shown and then left with no step in flight and no
+  // outcome asserted, which is how the daemon parks a plan when the turn that
+  // drove it ends. It is not finished, so the pill must not say so.
+  const isStopped = !isTerminal && !isRunning;
 
   const surfaceId = surface?.surfaceId ?? null;
   const acknowledged = useProgressAckStore((s) =>
@@ -103,11 +107,14 @@ export function ProgressCard() {
   // otherwise unmount the panel mid-interaction.
   const visible = progress != null && (isRunning || !acknowledged || open);
 
-  // The control names its own state: a running plan reads "Progress", a settled
-  // one "Finished". The glyph carries the same distinction, and while running
-  // it carries the plan's position too.
+  // The control names its own state: a running plan reads "Progress", a
+  // finished one "Finished", a parked one "Stopped". The glyph carries the same
+  // distinction: a check only once the plan is finished, and otherwise the ring,
+  // which carries the plan's position whether or not it is still moving.
   const label = isRunning
     ? t("progressRail.title")
+    : isStopped
+    ? t("progressRail.titleStopped")
     : t("progressRail.titleFinished");
   const counter = progress
     ? taskProgressCounter(progress.steps)
@@ -126,10 +133,10 @@ export function ProgressCard() {
       aria-label={label}
       data-testid="progress-card-toggle"
       leftIcon={
-        isRunning ? (
-          <StepProgressRing current={counter.current} total={counter.total} />
-        ) : (
+        isTerminal ? (
           <CircleCheck />
+        ) : (
+          <StepProgressRing current={counter.current} total={counter.total} />
         )
       }
       className="px-3"
@@ -154,9 +161,9 @@ export function ProgressCard() {
           <AdaptivePopover
             trigger={trigger}
             title={t("progressRail.title")}
-        // The body leads with the plan's own title; a second heading above it
-        // just said "Progress" over something already named.
-        hideTitle
+            // The body leads with the plan's own title; a second heading above it
+            // just said "Progress" over something already named.
+            hideTitle
             className="w-[min(600px,calc(100vw-2rem))] p-0"
             contentMaxHeightClassName="max-h-[420px]"
             open={open}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1237,7 +1237,8 @@
     "railAria": "Progress",
     "stepCounter": "{current} of {total}",
     "title": "Progress",
-    "titleFinished": "Finished"
+    "titleFinished": "Finished",
+    "titleStopped": "Stopped"
   },
   "promptSubmission": {
     "noActiveSession": "No active session. Please try again."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1237,7 +1237,8 @@
     "railAria": "Progreso",
     "stepCounter": "{current} de {total}",
     "title": "Progreso",
-    "titleFinished": "Terminado"
+    "titleFinished": "Terminado",
+    "titleStopped": "Detenido"
   },
   "promptSubmission": {
     "noActiveSession": "No hay ninguna sesión activa. Inténtalo de nuevo."

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1215,7 +1215,8 @@
     "railAria": "進度",
     "stepCounter": "第 {current} 步，共 {total} 步",
     "title": "進度",
-    "titleFinished": "已完成"
+    "titleFinished": "已完成",
+    "titleStopped": "已停止"
   },
   "promptSubmission": {
     "noActiveSession": "無作用中工作階段。請再試一次。"

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1215,7 +1215,8 @@
     "railAria": "进度",
     "stepCounter": "第 {current} 步，共 {total} 步",
     "title": "进度",
-    "titleFinished": "已完成"
+    "titleFinished": "已完成",
+    "titleStopped": "已停止"
   },
   "promptSubmission": {
     "noActiveSession": "无活动会话。请重试。"


### PR DESCRIPTION
## Summary

A `task_progress` card could sit on its first step, spinner running, long after the assistant had finished the work and replied. This is not model non-compliance. Two defects in code, both fixed here.

Fixes [JARVIS-1700](https://linear.app/vellum/issue/JARVIS-1700).

### 1. The surface-completion nudge never fired for task_progress cards

`assistant/src/plugins/defaults/surface-completion-nudge` already implements "remind the model at turn end to close the card it left open" (#35024). It never ran for the one card type it names.

`ui_show` returns `{"surfaceId":"..."}`. `proxyExecute` appended `TASK_PROGRESS_UPDATE_HINT` to that string as trailing prose, only for task_progress cards (#34951, one day earlier). The hook's `parseSurfaceId` did a bare `JSON.parse` in a swallowing try/catch, returned `undefined`, and the card was never registered as open. `work_result` surfaces, which get no hint, kept nudging fine, which is why this read as selective model misbehaviour. The existing test fixture used clean JSON, so CI stayed green.

Fix: a shared `api/surface-show-result.ts` owns the envelope. The hint now rides inside the JSON as a `note` field (the shape the `visual` surface already uses), and the hook reads the id through the same module, which also tolerates trailing prose so no future appender can silently break it again. The new regression test runs the real `ui_show` tool's result through the real hook; it fails on the old code.

### 2. A visibly answered turn had no path to close the card

Even with the nudge firing, `agent/loop.ts` refuses a `post-model-call` re-query once the reply has streamed, because honoring it would replace the reply the client already rendered. That refusal is correct, and it means the nudge can only help on deferred or no-visible-text turns (Slack, for example). On web and desktop, the exact case reported, nothing could ever advance the card.

Fix: `settleRunningTaskProgressSurfaces` runs when a turn reaches any terminal outcome (reply, hand-off to the user, cancel, or error), before the terminal SSE. Every task_progress card still `in_progress`, on this turn or an earlier one, has its card status and any `in_progress` step set to `pending`. Steps the model marked `completed` or `failed` stand. Nothing is promoted to `completed`: the model is the only party that can assert an outcome, and its silence is not one. `pending` joins the card-level status vocabulary so the settled state survives normalization; the web renderer already draws it (no title glyph, empty step circle).

The `ui_update` merge body is extracted to `applySurfaceUpdate` so the tool and the settle write through one path (state, client event, turn snapshot, persistence).

## Test plan

- [x] `bun test src/api/surface-show-result.test.ts` (8)
- [x] `bun test src/__tests__/surface-completion-nudge-hook.test.ts` (15; new producer→consumer case fails on the old parser)
- [x] `bun test src/__tests__/conversation-surfaces-settle-task-progress.test.ts` (6)
- [x] Neighboring suites: task-progress compat, state-update, data-persist, channel variants, tool-setup, dynamic-page, task-progress-nudge, slack-reply-session, runtime/task-progress. Two files (`surface-completion-compaction-boundary`, `conversation-runtime-assembly`) fail only when co-scheduled with others in one `bun test` invocation and pass alone; pre-existing isolation issue, untouched here.
- [x] `bun run typecheck:fast`, eslint, prettier

## Follow-ups (not in this PR)

- Slack's native plan block is built from the model's `ui_show`/`ui_update` tool calls inside `slack-reply-session` and closes with `stopStream`, so the daemon-side settle does not reach it. If a Slack plan can be left on an in-progress step after the stream closes, that needs its own finalize.
- The nudge still scopes its scan to the current response cycle. The settle covers cards from earlier turns, so this is now cosmetic rather than a stuck spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Z3cEe5BDTxpNstkb1tdys

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->