### PR TITLE
fix(companion): lend the watch frame key status while annotating, so the pencil cursor can show (JARVIS-1778)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -387,6 +387,12 @@ type GlowWindow = {
     ignore: boolean,
     options?: { forward?: boolean },
   ) => void;
+  /** Whether it may become key, which is what lets its cursor show. */
+  focusable: boolean;
+  setFocusable: (focusable: boolean) => void;
+  /** Whether it is key: `focus` makes it so, and nothing here resigns it. */
+  key: boolean;
+  focus: () => void;
 };
 let glow: GlowWindow | null = null;
 const glowPushes: CompanionSurfaceState[] = [];
@@ -440,6 +446,17 @@ const openGlow = (options: {
     setIgnoreMouseEvents: (ignore, options) => {
       window.clickThrough = ignore;
       window.forwarded = ignore && options?.forward === true;
+    },
+    focusable: options.browserWindow?.focusable !== false,
+    setFocusable: (focusable) => {
+      window.focusable = focusable;
+    },
+    key: false,
+    focus: () => {
+      // The real one refuses a window that may not become key.
+      if (window.focusable) {
+        window.key = true;
+      }
     },
   };
   glow = window;
@@ -3336,6 +3353,55 @@ describe("companion window: drawing on what is shared", () => {
     send("vellum:companion:setAnnotating", true);
     expect(glow?.clickThrough).toBe(false);
     expect(glow?.forwarded).toBe(false);
+  });
+
+  /**
+   * Chromium on macOS puts a page's cursor on the pointer only for the key
+   * window, and the frame opens unable to become one. So the mode lends it
+   * key status, or the pencil the layer hangs on the pointer never shows and
+   * nothing on screen says a press is now a mark.
+   */
+  test("drawing on lends the frame key status, so its pencil can show", () => {
+    shareDisplay();
+    expect(glow?.focusable).toBe(false);
+    expect(glow?.key).toBe(false);
+    send("vellum:companion:setAnnotating", true);
+    expect(glow?.focusable).toBe(true);
+    expect(glow?.key).toBe(true);
+  });
+
+  /**
+   * Off the mode the frame may not become key again: a click-through window
+   * that still could would take the keyboard on the next press that reached
+   * it. Resigning key is not something main can ask for on macOS, so what it
+   * can do is stop the frame taking it back.
+   */
+  test("drawing off makes the frame unfocusable again", () => {
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setAnnotating", false);
+    expect(glow?.focusable).toBe(false);
+  });
+
+  /** The mode is still on across a scroll, and the mouse is coming back. */
+  test("a scroll the frame steps aside for leaves its key status alone", () => {
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setFrameScrolling", true);
+    expect(glow?.focusable).toBe(true);
+    expect(glow?.key).toBe(true);
+  });
+
+  /** A window that replaces the frame mid-mode is lent key the same way. */
+  test("a frame opened afresh is lent key status with the mouse", () => {
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    send("vellum:companion:setContext", context());
+    expect(glow).toBeNull();
+    shareDisplay();
+    send("vellum:companion:setAnnotating", true);
+    expect(glow?.focusable).toBe(true);
+    expect(glow?.key).toBe(true);
   });
 
   /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1126,6 +1126,18 @@ let frameScrolling = false;
  * holding it, so it can ask for the mouse back. Off the mode, nothing is
  * forwarded, since there is nothing on the frame to point at and a forwarded
  * move over a display-sized window is a move on every pixel of the screen.
+ *
+ * Key status goes with the mouse. Chromium on macOS puts a page's cursor on
+ * the pointer only while the page's window is the key window, and a window
+ * opened `focusable: false` can never be one, so the pencil the layer hangs
+ * on the pointer would never show and the user would have nothing to say the
+ * mode took. Lent with `setFocusable` and then `focus`, which on a panel
+ * makes it key without bringing Vellum forward, and released with
+ * `setFocusable` alone: `blur` would flash the frame and drop it to the back
+ * of its level, and `setFocusable(false)` does not resign key on macOS, so
+ * the keyboard returns to the user's app on their next press in it rather
+ * than the moment the mode ends. Left key across a scroll the frame stepped
+ * aside for, since the mode is still on and the mouse is coming back.
  */
 const applyFrameMouse = (): void => {
   const frame = getFloatingWindow(WATCH_FRAME_KIND);
@@ -1134,6 +1146,7 @@ const applyFrameMouse = (): void => {
   }
   if (!annotating) {
     frame.setIgnoreMouseEvents(true);
+    frame.setFocusable(false);
     return;
   }
   if (frameScrolling) {
@@ -1141,6 +1154,8 @@ const applyFrameMouse = (): void => {
     return;
   }
   frame.setIgnoreMouseEvents(false);
+  frame.setFocusable(true);
+  frame.focus();
 };
 
 /**


### PR DESCRIPTION
## Problem

The pencil cursor from JARVIS-1774 (#42435) is in the Dev build, but the pointer over the shared screen stays an arrow.

Chromium on macOS puts a page's cursor on the pointer only while the page's window is the key window (`shouldChangeCurrentCursor` in `render_widget_host_view_cocoa.mm`: "do not set cursor if it's not a key window"). The watch frame opens `focusable: false`, which Electron maps to `setDisableKeyOrMainWindow:YES`, so it can never be key. No CSS cursor on that window, pencil or crosshair fallback, ever reaches the OS.

## Fix

Drawing mode lends the frame key status, the same way the composer lends the canvas the keyboard: `setFocusable(true)` then `focus()` when the mode goes on, `setFocusable(false)` when it goes off. `focus()` on a panel makes it key without bringing Vellum forward. `blur()` stays out: it flashes the window and drops it to the back of its level. Key status is left alone across a scroll the frame steps aside for, and a frame opened afresh mid-mode is lent it with the mouse.

Accepted cost: `setFocusable(false)` does not resign key on macOS, so after the mode ends the keyboard returns to the user's app on their next press in it rather than the moment the mode ends.

## Tests

- `clients/macos/src/main/companion-window.test.ts`: the frame fake learns `setFocusable`/`focus`; four new cases cover lend on, release off, left alone across a scroll, and lent to a fresh frame.
- `bun test src/main/companion-window.test.ts`: 245 pass. `tsc --noEmit` clean.

Verified on the local dev app with a real display share (2026-09-09): the pointer over the shared surface becomes the pencil, the user's own ink stays visible on the frame, and the frame goes back to being unfocusable when the mode ends. Probed from the main process over the Node inspector while the mode was on: the frame reads `focusable: true`, `focused: true`, the annotation layer carries the pencil cursor and the strokes, and paints made after the lend still reach the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jcx6uD6548gStGbVSQkin

