### PR TITLE
feat(avatar): map an avatar transition onto the avatar_changed wire fields

### DIFF
--- a/assistant/src/avatar/__tests__/avatar-changed-telemetry.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-changed-telemetry.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the pure `avatar_changed` mapper and its no-op predicate. Nothing
+ * here touches the filesystem: states are literals, and every payload the
+ * mapper produces is checked against the synced wire schema.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { avatarChangedTelemetryEventSchema } from "../../telemetry/telemetry-wire.generated.js";
+import {
+  type AvatarChangedFields,
+  avatarChangedFields,
+  isSameAvatar,
+} from "../avatar-changed-telemetry.js";
+import { type AvatarState, NONE_AVATAR_STATE } from "../avatar-manifest.js";
+
+const TRAITS = { bodyShape: "blob", eyeStyle: "curious", color: "green" };
+
+const CHARACTER: AvatarState = {
+  kind: "character",
+  traits: TRAITS,
+  source: "builder",
+  image: null,
+  accent: { hex: "#4caf50", source: "palette" },
+};
+
+const UPLOADED: AvatarState = {
+  kind: "image",
+  traits: null,
+  source: "upload",
+  image: { updatedAt: "2026-01-01T00:00:00.000Z", etag: "etag-1" },
+  accent: { hex: "#c81e1e", source: "derived" },
+};
+
+/** The same PNG written again: fresh metadata, everything else equal. */
+const UPLOADED_REWRITTEN: AvatarState = {
+  ...UPLOADED,
+  image: { updatedAt: "2026-01-02T00:00:00.000Z", etag: "etag-2" },
+};
+
+function parseOnTheWire(fields: AvatarChangedFields) {
+  return avatarChangedTelemetryEventSchema.safeParse({
+    type: "avatar_changed",
+    daemon_event_id: "evt-avatar-changed-001",
+    recorded_at: 1_767_225_600_000,
+    assistant_version: "1.2.3",
+    ...fields,
+  });
+}
+
+describe("avatarChangedFields", () => {
+  test("a character carries its trait ids and palette accent", () => {
+    const fields = avatarChangedFields("set_character", UPLOADED, CHARACTER);
+    expect(fields).toStrictEqual({
+      action: "set_character",
+      kind: "character",
+      previous_kind: "image",
+      body_shape: "blob",
+      eye_style: "curious",
+      color: "green",
+      accent_hex: "#4caf50",
+      accent_source: "palette",
+    });
+  });
+
+  test("an image carries its derived accent and no trait keys", () => {
+    const fields = avatarChangedFields("upload_image", CHARACTER, UPLOADED);
+    expect(fields).toStrictEqual({
+      action: "upload_image",
+      kind: "image",
+      previous_kind: "character",
+      accent_hex: "#c81e1e",
+      accent_source: "derived",
+    });
+  });
+
+  test("a cleared avatar carries only the action and the two kinds", () => {
+    const fields = avatarChangedFields("clear", UPLOADED, NONE_AVATAR_STATE);
+    expect(fields).toStrictEqual({
+      action: "clear",
+      kind: "none",
+      previous_kind: "image",
+    });
+  });
+
+  test("a first set reports a previous kind of none", () => {
+    expect(
+      avatarChangedFields("set_character", NONE_AVATAR_STATE, CHARACTER)
+        .previous_kind,
+    ).toBe("none");
+  });
+
+  test("the client OS rides along only when it is non-empty", () => {
+    const withOs = avatarChangedFields(
+      "generate_image",
+      NONE_AVATAR_STATE,
+      UPLOADED,
+      "macos",
+    );
+    expect(withOs.client_os).toBe("macos");
+
+    const emptyOs = avatarChangedFields(
+      "generate_image",
+      NONE_AVATAR_STATE,
+      UPLOADED,
+      "",
+    );
+    expect(emptyOs).not.toHaveProperty("client_os");
+  });
+
+  test("every payload parses under the synced wire schema", () => {
+    const payloads = [
+      avatarChangedFields("set_character", NONE_AVATAR_STATE, CHARACTER),
+      avatarChangedFields("upload_image", CHARACTER, UPLOADED, "web"),
+      avatarChangedFields("generate_image", NONE_AVATAR_STATE, UPLOADED),
+      avatarChangedFields("set_accent", UPLOADED, {
+        ...UPLOADED,
+        accent: { hex: "#123456", source: "custom" },
+      }),
+      avatarChangedFields("clear", CHARACTER, NONE_AVATAR_STATE),
+    ];
+    for (const payload of payloads) {
+      const parsed = parseOnTheWire(payload);
+      expect(parsed.success).toBe(true);
+    }
+  });
+});
+
+describe("isSameAvatar", () => {
+  test("a character re-set with the same traits is the same", () => {
+    expect(isSameAvatar(CHARACTER, { ...CHARACTER })).toBe(true);
+  });
+
+  test("a character with one trait changed is not", () => {
+    expect(
+      isSameAvatar(CHARACTER, {
+        ...CHARACTER,
+        traits: { ...TRAITS, color: "blue" },
+      }),
+    ).toBe(false);
+  });
+
+  test("the same traits under a custom rather than palette accent is not", () => {
+    expect(
+      isSameAvatar(CHARACTER, {
+        ...CHARACTER,
+        accent: { hex: "#4caf50", source: "custom" },
+      }),
+    ).toBe(false);
+  });
+
+  test("an image rewritten from the same bytes and source is the same", () => {
+    expect(isSameAvatar(UPLOADED, UPLOADED_REWRITTEN, true)).toBe(true);
+  });
+
+  test("an image is not the same without the byte verdict, even when every manifest field matches", () => {
+    expect(isSameAvatar(UPLOADED, UPLOADED)).toBe(false);
+  });
+
+  test("the same bytes from a different source is not", () => {
+    expect(isSameAvatar(UPLOADED, { ...UPLOADED, source: "ai" }, true)).toBe(
+      false,
+    );
+  });
+
+  test("the same bytes under a different accent is not", () => {
+    expect(
+      isSameAvatar(
+        UPLOADED,
+        { ...UPLOADED, accent: { hex: "#c81e1e", source: "custom" } },
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  test("none is always the same as none", () => {
+    expect(isSameAvatar(NONE_AVATAR_STATE, NONE_AVATAR_STATE)).toBe(true);
+    expect(isSameAvatar(NONE_AVATAR_STATE, { ...NONE_AVATAR_STATE }, true)).toBe(
+      true,
+    );
+  });
+
+  test("none is never the same as an avatar", () => {
+    expect(isSameAvatar(NONE_AVATAR_STATE, CHARACTER)).toBe(false);
+    expect(isSameAvatar(NONE_AVATAR_STATE, UPLOADED, true)).toBe(false);
+    expect(isSameAvatar(UPLOADED, NONE_AVATAR_STATE, true)).toBe(false);
+  });
+});

--- a/assistant/src/avatar/avatar-changed-telemetry.ts
+++ b/assistant/src/avatar/avatar-changed-telemetry.ts
@@ -1,0 +1,111 @@
+/**
+ * The pure half of the avatar store's telemetry: maps a before/after avatar
+ * transition onto the `avatar_changed` wire event, so the store stays the one
+ * caller of `recordTelemetryEvent`.
+ */
+import type {
+  AvatarChangedTelemetryEvent,
+  TelemetryEventBase,
+} from "../telemetry/types.js";
+import type {
+  AvatarSource,
+  AvatarState,
+  CharacterTraits,
+} from "./avatar-manifest.js";
+
+export type AvatarChangeAction =
+  | "set_character"
+  | "upload_image"
+  | "generate_image"
+  | "set_accent"
+  | "clear";
+
+/** The action an image write counts as, by where the image came from. */
+export const IMAGE_ACTIONS: Readonly<
+  Record<Exclude<AvatarSource, "builder">, AvatarChangeAction>
+> = { upload: "upload_image", ai: "generate_image" };
+
+/** The `avatar_changed` wire payload minus the fields `recordTelemetryEvent` stamps. */
+export type AvatarChangedFields = Omit<
+  AvatarChangedTelemetryEvent,
+  keyof TelemetryEventBase
+>;
+
+function sameTraits(
+  previous: CharacterTraits | null,
+  next: CharacterTraits | null,
+): boolean {
+  return (
+    previous?.bodyShape === next?.bodyShape &&
+    previous?.eyeStyle === next?.eyeStyle &&
+    previous?.color === next?.color
+  );
+}
+
+function sameAccent(previous: AvatarState, next: AvatarState): boolean {
+  return (
+    previous.accent?.hex === next.accent?.hex &&
+    previous.accent?.source === next.accent?.source
+  );
+}
+
+/**
+ * Whether a mutation left the avatar as it was, so the store can skip the
+ * event. Image metadata (`etag`, `updatedAt`) is ignored: a rewrite of the
+ * same bytes changes it, and two different images can derive the same accent,
+ * so the store compares bytes and passes the verdict as `sameImageBytes`.
+ */
+export function isSameAvatar(
+  previous: AvatarState,
+  next: AvatarState,
+  sameImageBytes = false,
+): boolean {
+  if (previous.kind !== next.kind) {
+    return false;
+  }
+  switch (next.kind) {
+    case "character":
+      return (
+        sameTraits(previous.traits, next.traits) && sameAccent(previous, next)
+      );
+    case "image":
+      return (
+        sameImageBytes &&
+        previous.source === next.source &&
+        sameAccent(previous, next)
+      );
+    case "none":
+      return true;
+  }
+}
+
+/**
+ * The `avatar_changed` fields for a transition. Optional keys are omitted,
+ * never set to `null` or `""`: the wire schema requires at least one
+ * character, and a single failing field makes the server drop the whole event.
+ */
+export function avatarChangedFields(
+  action: AvatarChangeAction,
+  previous: AvatarState,
+  next: AvatarState,
+  clientOs?: string,
+): AvatarChangedFields {
+  const fields: AvatarChangedFields = {
+    action,
+    kind: next.kind,
+    previous_kind: previous.kind,
+  };
+  if (next.kind === "character" && next.traits) {
+    fields.body_shape = next.traits.bodyShape;
+    fields.eye_style = next.traits.eyeStyle;
+    fields.color = next.traits.color;
+  }
+  if (next.accent) {
+    fields.accent_hex = next.accent.hex;
+    fields.accent_source = next.accent.source;
+  }
+  if (clientOs) {
+    fields.client_os = clientOs;
+  }
+  return fields;
+}

--- a/assistant/src/avatar/avatar-manifest.ts
+++ b/assistant/src/avatar/avatar-manifest.ts
@@ -46,6 +46,15 @@ export type {
 };
 export type { CharacterTraits };
 
+/** The state an emptied workspace reads as. */
+export const NONE_AVATAR_STATE: Readonly<AvatarState> = {
+  kind: "none",
+  traits: null,
+  source: null,
+  image: null,
+  accent: null,
+};
+
 /**
  * Reads and validates the avatar manifest. Returns `null` when the manifest is
  * missing, unreadable, unparseable, has an invalid `kind`, or carries a
@@ -155,13 +164,7 @@ export function deriveStateFromLegacyFiles(
         accent: null,
       };
     case "none":
-      return {
-        kind: "none",
-        traits: null,
-        source: null,
-        image: null,
-        accent: null,
-      };
+      return NONE_AVATAR_STATE;
   }
 }
 


### PR DESCRIPTION
## Summary
- `assistant/src/avatar/avatar-changed-telemetry.ts`: `avatarChangedFields` maps a before/after `AvatarState` transition onto the `avatar_changed` wire payload (optional keys omitted, never `null` or `""`), `isSameAvatar` is the no-op predicate the store will use to skip an identical re-set, and `AvatarChangedFields` derives from the synced wire type so a platform-side rename fails typecheck here.
- `NONE_AVATAR_STATE` is exported from `avatar-manifest.ts` and returned by `deriveStateFromLegacyFiles`.
- Pure tests cover the mapper (every payload parses under `avatarChangedTelemetryEventSchema`) and the predicate; no store or telemetry-directory changes.

Part of plan: avatar-changed-telemetry.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyMhFjRp3y2XhmreXRhUsP