### PR TITLE
feat(avatar): emit an avatar_changed telemetry event from the store

### DIFF
--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -50,8 +50,13 @@ mock.module("../../runtime/sync/resource-sync-events.js", () => ({
 
 /** Every telemetry event the store records, in order. */
 const recorded: Array<{ name: string; fields: Record<string, unknown> }> = [];
+/** When set, the outbox throws it instead of recording (an unmigrated DB). */
+let recordFailure: Error | null = null;
 mock.module("../../telemetry/telemetry-events-outbox.js", () => ({
   recordTelemetryEvent: (name: string, fields: Record<string, unknown>) => {
+    if (recordFailure) {
+      throw recordFailure;
+    }
     recorded.push({ name, fields });
     return { id: "evt", createdAt: 0 };
   },
@@ -107,6 +112,7 @@ describe("avatar-store", () => {
     mkdirSync(avatarDir, { recursive: true });
     publishedOrigins.length = 0;
     recorded.length = 0;
+    recordFailure = null;
   });
 
   afterEach(() => {
@@ -498,6 +504,16 @@ describe("avatar-store", () => {
   describe("avatar_changed telemetry", () => {
     const RED_ACCENT = { accent_hex: "#c81e1e", accent_source: "derived" };
     const events = () => recorded.map((entry) => entry.fields);
+
+    test("a failed record never fails the change: the manifest and fan-out stand", async () => {
+      recordFailure = new Error("no such table: telemetry_events");
+
+      await setImage(RED_PNG, "upload", { originClientId: "web-1" });
+
+      expect(readManifestFile()?.kind).toBe("image");
+      expect(publishedOrigins).toEqual(["web-1"]);
+      expect(recorded).toEqual([]);
+    });
 
     test("an upload over an empty workspace records one image event carrying the client OS", async () => {
       await setImage(RED_PNG, "upload", { clientOs: "macos" });

--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -7,9 +7,11 @@
  *   - setImage      → PNG on disk, character sidecars removed, `image` manifest
  *   - clearAvatar   → everything removed, `none` manifest
  *
- * Every successful mutation also leaves a `## Avatar` note in IDENTITY.md and
- * hands the change to the client/platform fan-out; the fan-out module is
- * mocked so the origin ids it receives can be asserted.
+ * Every successful mutation also leaves a `## Avatar` note in IDENTITY.md,
+ * hands the change to the client/platform fan-out, and records an
+ * `avatar_changed` telemetry event unless the avatar came out identical; the
+ * fan-out and outbox modules are mocked so the origin ids and event payloads
+ * they receive can be asserted.
  *
  * The avatar directory is controlled per-test via VELLUM_WORKSPACE_DIR, which
  * `getAvatarDir()` resolves live. Per the test-isolation rule in
@@ -43,6 +45,15 @@ const publishedOrigins: Array<string | undefined> = [];
 mock.module("../../runtime/sync/resource-sync-events.js", () => ({
   publishAvatarChanged: (originClientId?: string) => {
     publishedOrigins.push(originClientId);
+  },
+}));
+
+/** Every telemetry event the store records, in order. */
+const recorded: Array<{ name: string; fields: Record<string, unknown> }> = [];
+mock.module("../../telemetry/telemetry-events-outbox.js", () => ({
+  recordTelemetryEvent: (name: string, fields: Record<string, unknown>) => {
+    recorded.push({ name, fields });
+    return { id: "evt", createdAt: 0 };
   },
 }));
 
@@ -95,6 +106,7 @@ describe("avatar-store", () => {
     // into it before the store's own mkdir runs.
     mkdirSync(avatarDir, { recursive: true });
     publishedOrigins.length = 0;
+    recorded.length = 0;
   });
 
   afterEach(() => {
@@ -272,15 +284,16 @@ describe("avatar-store", () => {
     });
   });
 
-  describe("backfillAccent", () => {
-    const imageState = (etag: string) => ({
-      kind: "image" as const,
-      traits: null,
-      source: "upload" as const,
-      image: { updatedAt: "2026-01-01T00:00:00.000Z", etag },
-      accent: null,
-    });
+  /** An image manifest written before accents existed, as read-time repair sees it. */
+  const imageState = (etag: string) => ({
+    kind: "image" as const,
+    traits: null,
+    source: "upload" as const,
+    image: { updatedAt: "2026-01-01T00:00:00.000Z", etag },
+    accent: null,
+  });
 
+  describe("backfillAccent", () => {
     test("reads an image's accent out of the PNG on disk and persists it", async () => {
       writeFileSync(path(IMAGE_FILENAME), RED_PNG);
       const state = imageState("backfill-red");
@@ -473,18 +486,159 @@ describe("avatar-store", () => {
 
     test("backfillAccent is a read-time repair and publishes nothing", async () => {
       writeFileSync(path(IMAGE_FILENAME), RED_PNG);
-      const state = {
-        kind: "image" as const,
-        traits: null,
-        source: "upload" as const,
-        image: { updatedAt: "2026-01-01T00:00:00.000Z", etag: "quiet-red" },
-        accent: null,
-      };
+      const state = imageState("quiet-red");
       writeFileSync(path(MANIFEST_FILENAME), JSON.stringify(state));
 
       await backfillAccent(state);
 
       expect(publishedOrigins).toEqual([]);
+    });
+  });
+
+  describe("avatar_changed telemetry", () => {
+    const RED_ACCENT = { accent_hex: "#c81e1e", accent_source: "derived" };
+    const events = () => recorded.map((entry) => entry.fields);
+
+    test("an upload over an empty workspace records one image event carrying the client OS", async () => {
+      await setImage(RED_PNG, "upload", { clientOs: "macos" });
+
+      expect(recorded.map((entry) => entry.name)).toEqual(["avatar_changed"]);
+      expect(events()).toEqual([
+        {
+          action: "upload_image",
+          kind: "image",
+          previous_kind: "none",
+          ...RED_ACCENT,
+          client_os: "macos",
+        },
+      ]);
+    });
+
+    test("an AI image records generate_image, with no client_os key when none was given", async () => {
+      await setImage(RED_PNG, "ai");
+
+      expect(events()).toEqual([
+        {
+          action: "generate_image",
+          kind: "image",
+          previous_kind: "none",
+          ...RED_ACCENT,
+        },
+      ]);
+    });
+
+    test("the same bytes uploaded twice count once; different bytes count again", async () => {
+      await setImage(RED_PNG, "upload");
+      await setImage(RED_PNG, "upload");
+      expect(events()).toHaveLength(1);
+
+      await setImage(Buffer.from("v2"), "upload");
+      expect(events()).toHaveLength(2);
+      expect(events()[1]).toMatchObject({
+        action: "upload_image",
+        kind: "image",
+        previous_kind: "image",
+      });
+    });
+
+    test("the same bytes from a different source count again", async () => {
+      await setImage(RED_PNG, "upload");
+      await setImage(RED_PNG, "ai");
+
+      expect(events().map((fields) => fields.action)).toEqual([
+        "upload_image",
+        "generate_image",
+      ]);
+    });
+
+    test(
+      "a character records its traits and palette accent once, and an identical re-set not at all",
+      () => {
+        const result = setCharacter(VALID_TRAITS);
+        if (!result.ok) {
+          expect(result.reason).toBe("native_unavailable");
+          expect(recorded).toEqual([]);
+          return;
+        }
+
+        expect(events()).toEqual([
+          {
+            action: "set_character",
+            kind: "character",
+            previous_kind: "none",
+            body_shape: "blob",
+            eye_style: "curious",
+            color: "green",
+            accent_hex: "#4C9B50",
+            accent_source: "palette",
+          },
+        ]);
+
+        expect(setCharacter(VALID_TRAITS).ok).toBe(true);
+        expect(events()).toHaveLength(1);
+      },
+      NATIVE_RENDER_TEST_TIMEOUT_MS,
+    );
+
+    test("an accent counts only when it lands somewhere new", async () => {
+      await setImage(RED_PNG, "upload");
+      recorded.length = 0;
+
+      await setAccent("#123456");
+      expect(events()).toEqual([
+        {
+          action: "set_accent",
+          kind: "image",
+          previous_kind: "image",
+          accent_hex: "#123456",
+          accent_source: "custom",
+        },
+      ]);
+
+      await setAccent("#123456");
+      expect(events()).toHaveLength(1);
+
+      await setAccent(null);
+      expect(events()).toHaveLength(2);
+      expect(events()[1]).toEqual({
+        action: "set_accent",
+        kind: "image",
+        previous_kind: "image",
+        ...RED_ACCENT,
+      });
+
+      await setAccent(null);
+      expect(events()).toHaveLength(2);
+    });
+
+    test("clearing an image records a bare clear; clearing nothing publishes but records nothing", async () => {
+      await setImage(RED_PNG, "upload");
+      recorded.length = 0;
+
+      clearAvatar();
+      expect(events()).toEqual([
+        { action: "clear", kind: "none", previous_kind: "image" },
+      ]);
+
+      const publishedBefore = publishedOrigins.length;
+      clearAvatar();
+      expect(events()).toHaveLength(1);
+      expect(publishedOrigins.length).toBe(publishedBefore + 1);
+    });
+
+    test("backfillAccent records nothing", async () => {
+      writeFileSync(path(IMAGE_FILENAME), RED_PNG);
+      const state = imageState("quiet-red");
+      writeFileSync(path(MANIFEST_FILENAME), JSON.stringify(state));
+
+      await backfillAccent(state);
+
+      expect(recorded).toEqual([]);
+    });
+
+    test("a refused accent records nothing", async () => {
+      expect(await setAccent("#123456")).toBeNull();
+      expect(recorded).toEqual([]);
     });
   });
 });

--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -505,6 +505,19 @@ describe("avatar-store", () => {
     const RED_ACCENT = { accent_hex: "#c81e1e", accent_source: "derived" };
     const events = () => recorded.map((entry) => entry.fields);
 
+    test("an identical re-upload above the raster serving cap is still not a change", async () => {
+      const big = Buffer.alloc(5 * 1024 * 1024 + 1, 7);
+
+      await setImage(big, "upload");
+      await setImage(big, "upload");
+      await setImage(Buffer.concat([big, Buffer.from([8])]), "upload");
+
+      expect(events().map((fields) => fields.previous_kind)).toEqual([
+        "none",
+        "image",
+      ]);
+    });
+
     test("a failed record never fails the change: the manifest and fan-out stand", async () => {
       recordFailure = new Error("no such table: telemetry_events");
 

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -94,7 +94,8 @@ interface AvatarTransition {
 
 /**
  * The side effects every persisted change owes. An identical re-set still
- * notifies but is not counted.
+ * notifies but is not counted. Telemetry is best effort: the avatar is
+ * already written and announced, so a failed record is logged, not thrown.
  */
 function announceChange(
   transition: AvatarTransition,
@@ -106,11 +107,16 @@ function announceChange(
   }
   publishAvatarChanged(options?.originClientId);
   const { action, previous, next, sameImageBytes } = transition;
-  if (!isSameAvatar(previous, next, sameImageBytes)) {
+  if (isSameAvatar(previous, next, sameImageBytes)) {
+    return;
+  }
+  try {
     recordTelemetryEvent(
       "avatar_changed",
       avatarChangedFields(action, previous, next, options?.clientOs),
     );
+  } catch (err) {
+    log.warn({ err, action }, "Failed to record the avatar_changed event");
   }
 }
 

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -175,8 +175,12 @@ export async function setImage(
 
   const pngPath = join(avatarDir, AVATAR_IMAGE_FILENAME);
   const previous = readAvatarState();
+  // Capped at the upload's own size: a larger file cannot be identical, and
+  // the serving cap must not turn a big re-upload into a counted change.
   const previousBytes =
-    previous.kind === "image" ? readContainedAvatarRaster(pngPath) : null;
+    previous.kind === "image"
+      ? readContainedAvatarRaster(pngPath, pngBuffer.length)
+      : null;
   const pngTmp = `${pngPath}.${randomUUID()}.tmp`;
   writeFileSync(pngTmp, pngBuffer);
   renameSync(pngTmp, pngPath);

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -10,11 +10,12 @@
  *
  * This module is the single writer of avatar state and the single place a
  * change is announced: every successful mutation leaves the `## Avatar` note
- * in IDENTITY.md and runs the client + platform fan-out
- * (`publishAvatarChanged`). Callers (HTTP/IPC routes) go through it rather
- * than touching artifacts or the manifest directly, and never publish on
- * their own. The read-time accent repair in `accent-backfill.ts` is the one
- * other manifest write, and announces nothing.
+ * in IDENTITY.md, runs the client + platform fan-out
+ * (`publishAvatarChanged`), and records an `avatar_changed` telemetry event
+ * unless the avatar came out identical. Callers (HTTP/IPC routes) go through
+ * it rather than touching artifacts or the manifest directly, and never
+ * publish or record on their own. The read-time accent repair in
+ * `accent-backfill.ts` is the one other manifest write, and announces nothing.
  */
 import { randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -27,6 +28,7 @@ import {
 } from "@vellumai/avatar-manifest";
 
 import { publishAvatarChanged } from "../runtime/sync/resource-sync-events.js";
+import { recordTelemetryEvent } from "../telemetry/telemetry-events-outbox.js";
 import { getLogger } from "../util/logger.js";
 import { getAvatarDir, getAvatarImagePath } from "../util/platform.js";
 import { automaticAccent } from "./accent-backfill.js";
@@ -36,12 +38,20 @@ import {
   paletteAccent,
 } from "./avatar-accent.js";
 import {
+  type AvatarChangeAction,
+  avatarChangedFields,
+  IMAGE_ACTIONS,
+  isSameAvatar,
+} from "./avatar-changed-telemetry.js";
+import {
   type AvatarSource,
   type AvatarState,
   computeImageMeta,
+  NONE_AVATAR_STATE,
   readAvatarState,
   writeManifest,
 } from "./avatar-manifest.js";
+import { readContainedAvatarRaster } from "./ensure-raster.js";
 import {
   describeAvatarState,
   NO_AVATAR_IDENTITY_NOTE,
@@ -59,6 +69,11 @@ const log = getLogger("avatar-store");
 export interface AvatarChangeOptions {
   /** The client that made the change, so it can ignore its own sync echo. */
   originClientId?: string;
+  /**
+   * The caller's OS as reported by the client-metadata header, already
+   * sanitized; carried on the telemetry event.
+   */
+  clientOs?: string;
 }
 
 export interface ImageChangeOptions extends AvatarChangeOptions {
@@ -66,13 +81,37 @@ export interface ImageChangeOptions extends AvatarChangeOptions {
   imageDescription?: string;
 }
 
-/** The side effects every persisted change owes. */
+interface AvatarTransition {
+  action: AvatarChangeAction;
+  previous: AvatarState;
+  next: AvatarState;
+  /**
+   * Image over image only: the PNG the next state points at is byte-identical
+   * to the previous one.
+   */
+  sameImageBytes?: boolean;
+}
+
+/**
+ * The side effects every persisted change owes. An identical re-set still
+ * notifies but is not counted.
+ */
 function announceChange(
-  identityNote: string,
+  transition: AvatarTransition,
+  identityNote: string | null,
   options?: AvatarChangeOptions,
 ): void {
-  updateIdentityAvatarSection(identityNote);
+  if (identityNote !== null) {
+    updateIdentityAvatarSection(identityNote);
+  }
   publishAvatarChanged(options?.originClientId);
+  const { action, previous, next, sameImageBytes } = transition;
+  if (!isSameAvatar(previous, next, sameImageBytes)) {
+    recordTelemetryEvent(
+      "avatar_changed",
+      avatarChangedFields(action, previous, next, options?.clientOs),
+    );
+  }
 }
 
 /**
@@ -90,6 +129,7 @@ export function setCharacter(
   traits: CharacterTraits,
   options?: AvatarChangeOptions,
 ): TraitsSyncResult {
+  const previous = readAvatarState();
   const result = writeTraitsAndRenderAvatar(traits);
   if (!result.ok) {
     return result;
@@ -103,7 +143,11 @@ export function setCharacter(
     accent: paletteAccent(traits.color),
   };
   writeManifest(state);
-  announceChange(describeAvatarState(state), options);
+  announceChange(
+    { action: "set_character", previous, next: state },
+    describeAvatarState(state),
+    options,
+  );
   return result;
 }
 
@@ -116,7 +160,7 @@ export function setCharacter(
  */
 export async function setImage(
   pngBuffer: Buffer,
-  source: AvatarSource,
+  source: Exclude<AvatarSource, "builder">,
   options?: ImageChangeOptions,
 ): Promise<void> {
   const accent = derivedAccent(await deriveAccentHexFromImage(pngBuffer));
@@ -124,6 +168,9 @@ export async function setImage(
   mkdirSync(avatarDir, { recursive: true });
 
   const pngPath = join(avatarDir, AVATAR_IMAGE_FILENAME);
+  const previous = readAvatarState();
+  const previousBytes =
+    previous.kind === "image" ? readContainedAvatarRaster(pngPath) : null;
   const pngTmp = `${pngPath}.${randomUUID()}.tmp`;
   writeFileSync(pngTmp, pngBuffer);
   renameSync(pngTmp, pngPath);
@@ -145,6 +192,12 @@ export async function setImage(
     "Set avatar from image and removed character sidecars",
   );
   announceChange(
+    {
+      action: IMAGE_ACTIONS[source],
+      previous,
+      next: state,
+      sameImageBytes: previousBytes?.equals(pngBuffer) ?? false,
+    },
     describeAvatarState(state, options?.imageDescription),
     options,
   );
@@ -155,7 +208,7 @@ export async function setImage(
  * `null` to go back to the automatic one. Returns the state as written, or
  * null when there is no avatar to colour. Only the manifest changes; the
  * artifacts are untouched, and so is the IDENTITY.md note, since the avatar
- * itself did not change.
+ * itself did not change. An accent that did not change is not counted.
  */
 export async function setAccent(
   hex: string | null,
@@ -170,7 +223,11 @@ export async function setAccent(
     accent: hex ? { hex, source: "custom" } : await automaticAccent(state),
   };
   writeManifest(next);
-  publishAvatarChanged(options?.originClientId);
+  announceChange(
+    { action: "set_accent", previous: state, next, sameImageBytes: true },
+    null,
+    options,
+  );
   return next;
 }
 
@@ -188,11 +245,16 @@ export function clearAvatar(options?: AvatarChangeOptions): void {
   const avatarDir = getAvatarDir();
   mkdirSync(avatarDir, { recursive: true });
 
+  const previous = readAvatarState();
   rmSync(join(avatarDir, AVATAR_IMAGE_FILENAME), { force: true });
   rmSync(join(avatarDir, AVATAR_TRAITS_FILENAME), { force: true });
   rmSync(join(avatarDir, ASCII_FILENAME), { force: true });
   rmSync(join(avatarDir, AVATAR_MANIFEST_FILENAME), { force: true });
 
   log.info("Cleared avatar — removed all artifacts");
-  announceChange(NO_AVATAR_IDENTITY_NOTE, options);
+  announceChange(
+    { action: "clear", previous, next: NONE_AVATAR_STATE },
+    NO_AVATAR_IDENTITY_NOTE,
+    options,
+  );
 }

--- a/assistant/src/avatar/ensure-raster.ts
+++ b/assistant/src/avatar/ensure-raster.ts
@@ -32,9 +32,13 @@ function isWithin(dir: string, filePath: string): boolean {
  * share one descriptor so a concurrent swap of the path cannot slip a
  * different file past the checks, and the descriptor's location is
  * revalidated after the open. Returns null when the file is missing,
- * symlinked, outside the avatar dir, not a regular file, or over the cap.
+ * symlinked, outside the avatar dir, not a regular file, or over `maxBytes`,
+ * which defaults to the serving cap.
  */
-export function readContainedAvatarRaster(rasterPath: string): Buffer | null {
+export function readContainedAvatarRaster(
+  rasterPath: string,
+  maxBytes: number = AVATAR_RASTER_MAX_BYTES,
+): Buffer | null {
   let fd: number | undefined;
   try {
     // Anchored on the real workspace root: a data/avatar symlink pointing at
@@ -57,7 +61,7 @@ export function readContainedAvatarRaster(rasterPath: string): Buffer | null {
       !stats.isFile() ||
       stats.dev !== linkStats.dev ||
       stats.ino !== linkStats.ino ||
-      stats.size > AVATAR_RASTER_MAX_BYTES
+      stats.size > maxBytes
     ) {
       return null;
     }
@@ -78,7 +82,7 @@ export function readContainedAvatarRaster(rasterPath: string): Buffer | null {
       return null;
     }
     const bytes = readFileSync(fd);
-    return bytes.length > AVATAR_RASTER_MAX_BYTES ? null : bytes;
+    return bytes.length > maxBytes ? null : bytes;
   } catch {
     return null;
   } finally {

--- a/assistant/src/runtime/routes/__tests__/avatar-routes-telemetry.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-routes-telemetry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The avatar routes hand the store who made a change and from which OS, and
+ * the store records the `avatar_changed` event. The fan-out and outbox
+ * modules are mocked so the origin id and the event payload can be asserted
+ * against the request headers that produced them.
+ */
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+/** The origin id handed to the fan-out, one entry per announced change. */
+const publishedOrigins: Array<string | undefined> = [];
+mock.module("../../sync/resource-sync-events.js", () => ({
+  getOriginClientId: (headers: Record<string, string> | undefined) =>
+    headers?.["x-vellum-client-id"]?.trim() || undefined,
+  publishAvatarChanged: (originClientId?: string) => {
+    publishedOrigins.push(originClientId);
+  },
+}));
+
+/** Every telemetry event the store records, in order. */
+const recorded: Array<{ name: string; fields: Record<string, unknown> }> = [];
+mock.module("../../../telemetry/telemetry-events-outbox.js", () => ({
+  recordTelemetryEvent: (name: string, fields: Record<string, unknown>) => {
+    recorded.push({ name, fields });
+    return { id: "evt", createdAt: 0 };
+  },
+}));
+
+import { ROUTES } from "../avatar-routes.js";
+import type { RouteHandlerArgs } from "../types.js";
+
+/** A 4x4 PNG of one red (#c81e1e), so an accent can be read out of it. */
+const RED_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAEklEQVQImWM4ISf3HxkzkC4AAEG4IDHG8wOiAAAAAElFTkSuQmCC";
+
+/** Resolve a handler from the route registry by operationId. */
+function getHandler(operationId: string) {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`${operationId} route not registered`);
+  }
+  return route.handler as (
+    args: RouteHandlerArgs,
+  ) => unknown | Promise<unknown>;
+}
+
+describe("avatar routes pass the caller to the store", () => {
+  let workspaceDir: string;
+  let prevWorkspaceDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "avatar-routes-telemetry-"));
+    mkdirSync(join(workspaceDir, "data", "avatar"), { recursive: true });
+    prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+    publishedOrigins.length = 0;
+    recorded.length = 0;
+  });
+
+  afterEach(() => {
+    if (prevWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+    }
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  const upload = (headers?: Record<string, string>) =>
+    getHandler("avatar_upload_image")({
+      body: { content: RED_PNG_BASE64 },
+      headers,
+    });
+
+  test("the client-os header reaches the event, sanitized", async () => {
+    await upload({ "x-vellum-client-os": " macOS " });
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]!.name).toBe("avatar_changed");
+    expect(recorded[0]!.fields).toMatchObject({
+      action: "upload_image",
+      client_os: "macos",
+    });
+  });
+
+  test("an out-of-bounds client-os header is dropped, not forwarded", async () => {
+    await upload({ "x-vellum-client-os": "a".repeat(65) });
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]!.fields).not.toHaveProperty("client_os");
+  });
+
+  test("no headers yields an event without client_os", async () => {
+    await upload();
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]!.fields).not.toHaveProperty("client_os");
+  });
+
+  test("the client id still reaches the fan-out", async () => {
+    await upload({ "x-vellum-client-id": "web-1" });
+
+    expect(publishedOrigins).toEqual(["web-1"]);
+  });
+});

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -6,6 +6,10 @@ import {
   AVATAR_TRAITS_FILENAME,
   normalizeAvatarAccentHex,
 } from "@vellumai/avatar-manifest";
+import {
+  CLIENT_METADATA_HEADERS,
+  sanitizeClientMetadataValue,
+} from "@vellumai/service-contracts/client-metadata";
 import { z } from "zod";
 
 import { backfillAccent } from "../../avatar/accent-backfill.js";
@@ -17,6 +21,7 @@ import {
   writeManifest,
 } from "../../avatar/avatar-manifest.js";
 import {
+  type AvatarChangeOptions,
   clearAvatar,
   setAccent,
   setCharacter,
@@ -51,6 +56,18 @@ import {
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("avatar-routes");
+
+/** What every mutation hands the store: who made the change, from which OS. */
+function changeOptions(
+  headers: RouteHandlerArgs["headers"],
+): AvatarChangeOptions {
+  return {
+    originClientId: getOriginClientId(headers),
+    clientOs: sanitizeClientMetadataValue(
+      headers?.[CLIENT_METADATA_HEADERS.os],
+    ),
+  };
+}
 
 function handleGetCharacterComponents() {
   return getCharacterComponents();
@@ -117,9 +134,7 @@ async function handleSetAvatarAccent({ body, headers }: RouteHandlerArgs) {
     }
   }
 
-  const state = await setAccent(hex, {
-    originClientId: getOriginClientId(headers),
-  });
+  const state = await setAccent(hex, changeOptions(headers));
   if (!state) {
     throw new BadRequestError("No avatar to set an accent on");
   }
@@ -141,9 +156,7 @@ function handleRenderFromTraits({ body, headers }: RouteHandlerArgs) {
     );
   }
 
-  const result = setCharacter(traits, {
-    originClientId: getOriginClientId(headers),
-  });
+  const result = setCharacter(traits, changeOptions(headers));
 
   if (!result.ok) {
     switch (result.reason) {
@@ -182,7 +195,7 @@ async function handleGenerateAvatar({ body, headers }: RouteHandlerArgs) {
   }
 
   await setImage(result.pngBuffer, "ai", {
-    originClientId: getOriginClientId(headers),
+    ...changeOptions(headers),
     imageDescription: description,
   });
   return { ok: true, message: result.content };
@@ -228,9 +241,7 @@ async function handleUploadAvatarImage({ body, headers }: RouteHandlerArgs) {
     );
   }
 
-  await setImage(buffer, "upload", {
-    originClientId: getOriginClientId(headers),
-  });
+  await setImage(buffer, "upload", changeOptions(headers));
   return { ok: true };
 }
 
@@ -258,9 +269,7 @@ async function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
     throw new BadRequestError(`Image file not found: ${normalized}`);
   }
 
-  await setImage(readFileSync(normalized), "upload", {
-    originClientId: getOriginClientId(headers),
-  });
+  await setImage(readFileSync(normalized), "upload", changeOptions(headers));
   return { ok: true };
 }
 
@@ -277,7 +286,7 @@ function handleRemoveAvatar({ headers }: RouteHandlerArgs) {
   // nothing to revert to — the legacy "re-render character from traits" branch
   // has been removed. avatar/remove is now a plain clear, reachable only via
   // CLI/host.
-  clearAvatar({ originClientId: getOriginClientId(headers) });
+  clearAvatar(changeOptions(headers));
   return { ok: true, hadAvatar };
 }
 


### PR DESCRIPTION
## Summary
- `announceChange` in the avatar store now records an `avatar_changed` telemetry event as the third side effect of every persisted change; each mutation reads its previous state and the event is skipped when the avatar came out identical (the re-render, publish, and identity note still run). `setImage` compares old and new PNG bytes, since image metadata changes on a rewrite of the same bytes.
- Routes pass the sanitized `x-vellum-client-os` header through a shared `changeOptions` helper next to the origin client id, so the event carries `client_os`. `backfillAccent`, the config watcher, and `notify_avatar_updated` record nothing.
- Store tests cover the per-action payloads and every identical re-set; a new route test covers header sanitization reaching the event.

Part of plan: avatar-changed-telemetry.md (PR 3 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyMhFjRp3y2XhmreXRhUsP