### PR TITLE
fix(windows): prevent per-user installer folder lookup crash

### DIFF
--- a/patches/app-builder-lib@26.8.1.patch
+++ b/patches/app-builder-lib@26.8.1.patch
@@ -15,3 +15,31 @@ diff --git a/out/winPackager.js b/out/winPackager.js
              await (0, builder_util_1.executeAppBuilder)(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry three times */);
          }
          else if (this.info.framework.name === "electron") {
+diff --git a/templates/nsis/multiUser.nsh b/templates/nsis/multiUser.nsh
+--- a/templates/nsis/multiUser.nsh
++++ b/templates/nsis/multiUser.nsh
+@@ -28,14 +28,19 @@ Var installMode
+       StrCpy $INSTDIR $perUserInstallationFolder
+     ${else}
+       StrCpy $0 "$LocalAppData\Programs"
+-      System::Store S
+-      # Win7 has a per-user programfiles known folder and this can be a non-default location
++      Push $1
++      Push $2
++      # UserProgramFiles can be a non-default location.
++      StrCpy $2 0
+       System::Call 'SHELL32::SHGetKnownFolderPath(g "${FOLDERID_UserProgramFiles}", i ${KF_FLAG_CREATE}, p 0, *p .r2)i.r1'
+       ${If} $1 == 0
+-        System::Call '*$2(&w${NSIS_MAX_STRLEN} .s)'
+-        StrCpy $0 $1
++        System::Call 'KERNEL32::lstrcpynW(w .r0, p r2, i ${NSIS_MAX_STRLEN})p'
++      ${endif}
++      # The API may allocate memory even on failure.
++      ${If} $2 != 0
+         System::Call 'OLE32::CoTaskMemFree(p r2)'
+       ${endif}
+-      System::Store L
++      Pop $2
++      Pop $1
+       StrCpy $INSTDIR "$0\${APP_FILENAME}"
+     ${endif}


### PR DESCRIPTION
## Summary

- Fix the Windows installer crash after choosing "Only for me" by backporting the upstream NSIS per-user folder lookup fix into the existing `app-builder-lib@26.8.1` patch. The reported `System.dll` access violation (`c0000005`, offset `0x1581`) matches [electron-builder #7921](https://github.com/electron-userland/electron-builder/issues/7921).
- Replace the fixed-size memory read with a bounded, null-terminated string copy, preserve temporary registers explicitly, and free the returned allocation even when the folder API fails. Existing install locations, redirected per-user Programs folders, and the all-users path retain their behavior.
- Verified that Bun applies the patch with the frozen lockfile and that Git patch application exactly matches the resulting installed package. A rebuilt installer still needs an interactive Windows ARM check; no release was dispatched.

## Original prompt

The Windows ARM dev installer closed after clicking Next with "Only for me" selected, while "Install for all users" progressed further. The crash report identified an access violation in the NSIS System.dll plugin. Fix the installer through the /do workflow in an isolated worktree and open a PR for review.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->