### PR TITLE
feat(companion): the pill's captions name the in-call keys, and Option+M / Option+A mute (JARVIS-1779)

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -499,6 +499,14 @@ final class MacHelper: @unchecked Sendable {
         guard let key = chordKey(for: event) else {
             return false
         }
+        // A key held down repeats as further key-downs. The press was answered
+        // on the first of them; the repeats are still this app's (left alone
+        // they would type the key's character into the front app) and are
+        // taken without being reported, so a chord that toggles something
+        // toggles it once per press rather than once per repeat.
+        if event.getIntegerValueField(.keyboardEventAutorepeat) != 0 {
+            return true
+        }
         writeNotification(
             method: "hotkey.event",
             params: ["kind": "chord", "state": "down", "key": key]

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 
 import { CompanionCapturePicker } from "@/components/companion-capture-picker";
 import { CompanionDictationOffer } from "@/components/companion-dictation-offer";
@@ -34,6 +34,8 @@ import {
   toggleCompanionWatch,
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
+import { supportsChords } from "@/runtime/hotkey";
+import { callChordHints } from "@/domains/chat/voice/live-voice/call-chord-keys";
 import { useTranslation } from "@/i18n";
 import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 import type {
@@ -272,6 +274,14 @@ export function CompanionSurfacePage() {
    */
   const inCall = call !== null || dialing;
   const sharing = screenShare !== undefined;
+  // What the captions say beside Share, Draw and the mutes. Named only where
+  // the host watches a chord: a caption promising a key on a host that takes
+  // none would be a key that does nothing. Spelt once, since both the host and
+  // the spelling are fixed for the life of the window.
+  const shortcuts = useMemo(
+    () => (supportsChords() ? callChordHints() : undefined),
+    [],
+  );
   useEffect(() => {
     if (!inCall) {
       sourcesRequestRef.current += 1;
@@ -836,6 +846,7 @@ export function CompanionSurfacePage() {
         onAnnotate={(next) => {
           setCompanionAnnotating(next);
         }}
+        shortcuts={shortcuts}
         // Beside the bar while the choice is open, on the canvas main
         // reserves for a card. The pick leaves this window the way every
         // press does; the frame that answers it is main's.

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -482,10 +482,22 @@ export const InCallWhileWatching: Story = {
 /**
  * Mid-call with the screen shared: Share held down beside Teach, since the
  * two are the same gesture aimed at different ends, and the call is being
- * shown what a Teach session would be reading.
+ * shown what a Teach session would be reading. The captions carry the keys
+ * the desktop app's helper answers for these four controls.
  */
 export const InCallSharing: Story = {
-  args: { phase: "call", shareEnabled: true, sharing: true, call: DEMO_CALL },
+  args: {
+    phase: "call",
+    shareEnabled: true,
+    sharing: true,
+    call: DEMO_CALL,
+    shortcuts: {
+      share: "⌥S",
+      draw: "⌥D",
+      muteMicrophone: "⌥M",
+      muteAssistant: "⌥A",
+    },
+  },
 };
 
 /**

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -554,6 +554,78 @@ describe("the companion surface's control captions", () => {
     }
   });
 
+  const SHORTCUTS = {
+    share: "⌥S",
+    draw: "⌥D",
+    muteMicrophone: "⌥M",
+    muteAssistant: "⌥A",
+  };
+
+  const shortcutOf = (container: HTMLElement, name: string): string | null =>
+    captionOf(container, name)?.querySelector("[data-shortcut]")?.textContent ??
+    null;
+
+  /**
+   * The key after the name and inside the same caption, so the pointer that
+   * learns what a control is learns in the same glance how to reach it from
+   * another application. The accessible name stays the name alone: the caption
+   * is hidden from a reader, and a key written into `aria-label` would be read
+   * out as part of what the control is.
+   */
+  test("writes each control's key into its caption when the host has one", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        call={LISTENING_CALL}
+        shareEnabled
+        sharing
+        shortcuts={SHORTCUTS}
+      />,
+    );
+    expect(shortcutOf(container, "Share")).toBe("⌥S");
+    expect(shortcutOf(container, "Draw")).toBe("⌥D");
+    expect(shortcutOf(container, "Mute microphone")).toBe("⌥M");
+    expect(shortcutOf(container, "Mute assistant")).toBe("⌥A");
+    expect(shortcutOf(container, "End session")).toBeNull();
+    expect(buttonOf(container, "Share").getAttribute("aria-label")).toBe(
+      "Share",
+    );
+  });
+
+  /** Off a host that watches no chord, the captions are the names alone. */
+  test("names the controls alone when the host has no keys for them", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        call={LISTENING_CALL}
+        shareEnabled
+        sharing
+      />,
+    );
+    expect(shortcutOf(container, "Share")).toBeNull();
+    expect(shortcutOf(container, "Mute microphone")).toBeNull();
+  });
+
+  /**
+   * A share that outlives the answer that offered it keeps its stop and its
+   * pen, but the keys for both are armed on that answer, so the captions stop
+   * promising them. The mutes are the call's and keep theirs.
+   */
+  test("withholds the share and pen keys once the call cannot be shown the screen", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        call={LISTENING_CALL}
+        shareEnabled={false}
+        sharing
+        shortcuts={SHORTCUTS}
+      />,
+    );
+    expect(shortcutOf(container, "Share")).toBeNull();
+    expect(shortcutOf(container, "Draw")).toBeNull();
+    expect(shortcutOf(container, "Mute microphone")).toBe("⌥M");
+  });
+
   /**
    * The variant and the thing it resolves against, together. `group-hover:` on
    * a button that is not a `group` is a word that never appears, and that is

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -428,6 +428,18 @@ export const FALLBACK_WIDTHS: Record<
   call: 4 + CALL_LINE_WIDTH + CALL_CONTROLS_WIDTH,
 };
 
+/**
+ * The keys that make the call row's presses from anywhere on the desktop, as
+ * the caption spells them (`⌥S`). One per control that has a key; the row's
+ * other controls have none and are named alone.
+ */
+export interface CompanionCallShortcuts {
+  share: string;
+  draw: string;
+  muteMicrophone: string;
+  muteAssistant: string;
+}
+
 export interface CompanionSurfaceProps {
   phase: CompanionSurfacePhase;
   /**
@@ -624,6 +636,14 @@ export interface CompanionSurfaceProps {
    */
   onAnnotate?: (annotating: boolean) => void;
   /**
+   * The keys the call row's controls also answer to, as the caption spells
+   * them (`⌥S`). Absent where the host watches no chord, so the caption never
+   * names a key that does nothing. The share and the pen are shown their key
+   * only while the row offers Share at all, since that is the answer the
+   * binding is armed on too.
+   */
+  shortcuts?: CompanionCallShortcuts;
+  /**
    * Press the avatar. Idle, that starts a call; on a call, it goes back to
    * Vellum, on the conversation the call is in. The caller decides which,
    * since it is the side holding the session; this side only names the press
@@ -792,6 +812,7 @@ export function CompanionSurface({
   onStopShare,
   annotating = false,
   onAnnotate,
+  shortcuts,
   onAvatarClick,
   working = false,
   watching = false,
@@ -1125,6 +1146,7 @@ export function CompanionSurface({
                 onShare={onShare}
                 onStopShare={onStopShare}
                 onAnnotate={onAnnotate}
+                shortcuts={shortcuts}
               />
             ) : phase === "dictating" && dictating !== undefined ? (
               <DictatingBody
@@ -1351,6 +1373,11 @@ const NAME_CAPTION_GLASS = "backdrop-blur-md backdrop-saturate-150";
  * Dock's own tooltip carries nothing but the name. A small rectangle rather
  * than the pill's stadium shape, so the two never share a silhouette.
  *
+ * `shortcut` is the key that does the same thing, after the name and dimmer
+ * than it, the way a menu writes its accelerator: the name is what the control
+ * is, the key is a second way to it. Glyphs rather than copy, so it is not
+ * translated.
+ *
  * Placed by the caller: `className` carries whether it is shown and any lift
  * off the thing it names, `style` any offsets the layout works out. Absolute
  * with no offsets of its own, so a caller that sets none gets the static
@@ -1363,11 +1390,13 @@ function Caption({
   className,
   style,
   label,
+  shortcut,
   ...data
 }: {
   className: string;
   style?: CSSProperties;
   label: string;
+  shortcut?: string;
 } & Partial<Record<`data-${string}`, string>>) {
   return (
     <span
@@ -1377,6 +1406,11 @@ function Caption({
       {...data}
     >
       {label}
+      {shortcut === undefined ? null : (
+        <span className="ml-1.5 font-normal text-white/60" data-shortcut>
+          {shortcut}
+        </span>
+      )}
       {/* Flush with the rectangle's own bottom edge (`top-full`) rather than
           nudged down to meet it, so the two blurred panes meet at a seam
           rather than compositing on top of each other. Centred under the
@@ -1846,6 +1880,7 @@ function CallBody({
   onShare,
   onStopShare,
   onAnnotate,
+  shortcuts,
 }: {
   call?: VoiceActivityState;
   assistantName: string;
@@ -1862,6 +1897,7 @@ function CallBody({
   onShare?: () => void;
   onStopShare?: () => void;
   onAnnotate?: (annotating: boolean) => void;
+  shortcuts?: CompanionCallShortcuts;
 }) {
   const { t } = useTranslation();
   // The dial: Talk has been pressed and no session has answered. The mutes
@@ -1944,6 +1980,7 @@ function CallBody({
         sharing={sharing}
         shareEnabled={shareEnabled}
         sharePicking={sharePicking}
+        shortcut={shareEnabled ? shortcuts?.share : undefined}
         onShare={onShare}
         onStopShare={onStopShare}
       />
@@ -1952,6 +1989,7 @@ function CallBody({
       <DrawButton
         sharing={sharing}
         annotating={annotating}
+        shortcut={shareEnabled ? shortcuts?.draw : undefined}
         onAnnotate={onAnnotate}
       />
       <PillButton
@@ -1963,6 +2001,7 @@ function CallBody({
             ? t("companionSurface.unmuteMicrophone")
             : t("companionSurface.muteMicrophone")
         }
+        shortcut={shortcuts?.muteMicrophone}
         onClick={() => {
           onControl?.(muted ? "unmuteMicrophone" : "muteMicrophone");
         }}
@@ -1980,6 +2019,7 @@ function CallBody({
             ? t("companionSurface.unmuteAssistant")
             : t("companionSurface.muteAssistant")
         }
+        shortcut={shortcuts?.muteAssistant}
         onClick={() => {
           onControl?.(
             outputMuted ? "unmuteAssistantAudio" : "muteAssistantAudio",
@@ -2009,12 +2049,14 @@ function ShareButton({
   sharing,
   shareEnabled,
   sharePicking,
+  shortcut,
   onShare,
   onStopShare,
 }: {
   sharing: boolean;
   shareEnabled: boolean;
   sharePicking: boolean;
+  shortcut?: string;
   onShare?: () => void;
   onStopShare?: () => void;
 }) {
@@ -2026,6 +2068,7 @@ function ShareButton({
     <PillButton
       icon={<ScreenShare className="size-4" />}
       label={t("companionSurface.share")}
+      shortcut={shortcut}
       pressed={sharing || sharePicking}
       onClick={sharing ? onStopShare : onShare}
     />
@@ -2050,10 +2093,12 @@ function ShareButton({
 function DrawButton({
   sharing,
   annotating,
+  shortcut,
   onAnnotate,
 }: {
   sharing: boolean;
   annotating: boolean;
+  shortcut?: string;
   onAnnotate?: (annotating: boolean) => void;
 }) {
   const { t } = useTranslation();
@@ -2064,6 +2109,7 @@ function DrawButton({
     <PillButton
       icon={<Pencil className="size-4" />}
       label={t("companionSurface.draw")}
+      shortcut={shortcut}
       pressed={annotating}
       onClick={() => {
         onAnnotate?.(!annotating);
@@ -2226,6 +2272,7 @@ const CONTROL_CAPTION_LIFT = "-translate-y-[calc(50%+22px)]";
 function PillButton({
   icon,
   label,
+  shortcut,
   tone,
   showLabel = false,
   pressed,
@@ -2233,6 +2280,8 @@ function PillButton({
 }: {
   icon: ReactNode;
   label: string;
+  /** The key that makes the same press, written into the caption after the name. */
+  shortcut?: string;
   tone?: "positive" | "negative";
   showLabel?: boolean;
   pressed?: boolean;
@@ -2269,6 +2318,7 @@ function PillButton({
         // hold that this word is hidden until the pointer arrives.
         <Caption
           label={label}
+          shortcut={shortcut}
           className={`opacity-0 group-hover:opacity-100 ${CONTROL_CAPTION_LIFT}`}
           data-label="hover"
         />

--- a/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The caption's spelling of each chord comes from the same constants the
+ * binding is armed with, so what the pill promises and what the host listens
+ * for cannot drift apart.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  CALL_DRAW_KEY,
+  CALL_MUTE_ASSISTANT_KEY,
+  CALL_MUTE_MIC_KEY,
+  CALL_SHARE_KEY,
+  callChordHints,
+} from "@/domains/chat/voice/live-voice/call-chord-keys";
+
+describe("the call chords' captions", () => {
+  test("spell each key under Option, in the host's glyphs", () => {
+    // A test DOM reports no platform, which the formatter reads as a Mac.
+    expect(callChordHints()).toEqual({
+      share: `⌥${CALL_SHARE_KEY.toUpperCase()}`,
+      draw: `⌥${CALL_DRAW_KEY.toUpperCase()}`,
+      muteMicrophone: `⌥${CALL_MUTE_MIC_KEY.toUpperCase()}`,
+      muteAssistant: `⌥${CALL_MUTE_ASSISTANT_KEY.toUpperCase()}`,
+    });
+  });
+
+  /** The helper matches a press by the character on its cap, and caps are single characters. */
+  test("names single keycap characters", () => {
+    for (const key of [
+      CALL_SHARE_KEY,
+      CALL_DRAW_KEY,
+      CALL_MUTE_MIC_KEY,
+      CALL_MUTE_ASSISTANT_KEY,
+    ]) {
+      expect(key).toHaveLength(1);
+    }
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.test.ts
@@ -15,14 +15,24 @@ import {
 } from "@/domains/chat/voice/live-voice/call-chord-keys";
 
 describe("the call chords' captions", () => {
-  test("spell each key under Option, in the host's glyphs", () => {
-    // A test DOM reports no platform, which the formatter reads as a Mac.
-    expect(callChordHints()).toEqual({
+  /**
+   * The platform is named rather than detected: the test DOM reports whichever
+   * machine runs it, and the spelling under test is the Mac's.
+   */
+  test("spell each key under Option, in the Mac's glyphs", () => {
+    expect(callChordHints("mac")).toEqual({
       share: `⌥${CALL_SHARE_KEY.toUpperCase()}`,
       draw: `⌥${CALL_DRAW_KEY.toUpperCase()}`,
       muteMicrophone: `⌥${CALL_MUTE_MIC_KEY.toUpperCase()}`,
       muteAssistant: `⌥${CALL_MUTE_ASSISTANT_KEY.toUpperCase()}`,
     });
+  });
+
+  /** The same keys, in the words a host without the glyphs would write. */
+  test("spell them as Alt on a host that writes modifiers as words", () => {
+    expect(callChordHints("windows").share).toBe(
+      `Alt+${CALL_SHARE_KEY.toUpperCase()}`,
+    );
   });
 
   /** The helper matches a press by the character on its cap, and caps are single characters. */

--- a/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.ts
@@ -6,7 +6,10 @@
  * shows a user what to press, and it has no session of its own.
  */
 
-import { formatAcceleratorHint } from "@vellumai/design-library";
+import {
+  detectShortcutPlatform,
+  formatAcceleratorHint,
+} from "@vellumai/design-library";
 
 import type { CompanionCallShortcuts } from "@/components/companion-surface";
 
@@ -22,15 +25,22 @@ export const CALL_MUTE_MIC_KEY = "m";
 /** Mute the assistant's audio, or unmute it. */
 export const CALL_MUTE_ASSISTANT_KEY = "a";
 
+/** The key-cap vocabulary a hint is written in, as the design library names it. */
+type ShortcutPlatform = NonNullable<
+  Parameters<typeof formatAcceleratorHint>[1]
+>;
+
 /**
  * Each chord as the pill writes it beside the control's name (`⌥S`), in the
  * vocabulary of the host the pill is drawn on. Spelt from the same constants
  * the binding is armed with, so the caption cannot promise a key the host is
  * not listening for.
  */
-export function callChordHints(): CompanionCallShortcuts {
+export function callChordHints(
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): CompanionCallShortcuts {
   const hint = (key: string): string =>
-    formatAcceleratorHint(`Alt+${key.toUpperCase()}`);
+    formatAcceleratorHint(`Alt+${key.toUpperCase()}`, platform);
   return {
     share: hint(CALL_SHARE_KEY),
     draw: hint(CALL_DRAW_KEY),

--- a/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/call-chord-keys.ts
@@ -1,0 +1,40 @@
+/**
+ * The keys a call answers under Option, and how the pill spells them.
+ *
+ * Apart from the handler so the surface that draws the controls can name the
+ * keys without importing the session the handler acts on: the companion pill
+ * shows a user what to press, and it has no session of its own.
+ */
+
+import { formatAcceleratorHint } from "@vellumai/design-library";
+
+import type { CompanionCallShortcuts } from "@/components/companion-surface";
+
+/** Share the screen the pointer is on, or stop the share that is running. */
+export const CALL_SHARE_KEY = "s";
+
+/** Draw on the shared surface, or give the mouse back to the desktop. */
+export const CALL_DRAW_KEY = "d";
+
+/** Mute the microphone, or unmute it. */
+export const CALL_MUTE_MIC_KEY = "m";
+
+/** Mute the assistant's audio, or unmute it. */
+export const CALL_MUTE_ASSISTANT_KEY = "a";
+
+/**
+ * Each chord as the pill writes it beside the control's name (`⌥S`), in the
+ * vocabulary of the host the pill is drawn on. Spelt from the same constants
+ * the binding is armed with, so the caption cannot promise a key the host is
+ * not listening for.
+ */
+export function callChordHints(): CompanionCallShortcuts {
+  const hint = (key: string): string =>
+    formatAcceleratorHint(`Alt+${key.toUpperCase()}`);
+  return {
+    share: hint(CALL_SHARE_KEY),
+    draw: hint(CALL_DRAW_KEY),
+    muteMicrophone: hint(CALL_MUTE_MIC_KEY),
+    muteAssistant: hint(CALL_MUTE_ASSISTANT_KEY),
+  };
+}

--- a/clients/web/src/domains/chat/voice/live-voice/call-chords.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/call-chords.test.ts
@@ -1,10 +1,10 @@
 /**
- * What the two chords a call answers do: which press starts a share, which
- * stops it, and what a press does when there is no call to act on.
+ * What the chords a call answers do: which press starts a share, which stops
+ * it, which mutes what, and what a press does when there is no call to act on.
  *
- * The host is replaced, since every press leaves this renderer immediately and
- * what is under test is which of them leave. The store is real: the toggle's
- * whole question is whether a share is already running.
+ * The host is replaced, since every press that leaves this renderer leaves it
+ * immediately and what is under test is which of them leave. The store is real:
+ * the toggles' whole question is what is already running or already muted.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -18,37 +18,79 @@ mock.module("@/runtime/companion-surface", () => ({
   toggleCompanionAnnotating,
 }));
 
+let canBeShownTheScreen = true;
+mock.module(
+  "@/domains/chat/voice/live-voice/screen-share-availability",
+  () => ({
+    liveVoiceCanBeShownTheScreen: () => canBeShownTheScreen,
+  }),
+);
+
 const { useLiveVoiceStore } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
-const { CALL_CHORDS, CALL_DRAW_KEY, CALL_SHARE_KEY, handleCallChord } =
+const {
+  CALL_DRAW_KEY,
+  CALL_MUTE_ASSISTANT_KEY,
+  CALL_MUTE_MIC_KEY,
+  CALL_SHARE_KEY,
+} = await import("@/domains/chat/voice/live-voice/call-chord-keys");
+const { callChords, handleCallChord } =
   await import("@/domains/chat/voice/live-voice/call-chords");
+
+/** The session's controls, which is where a mute lands. */
+const setMuted = mock((_muted: boolean) => {});
+const setOutputMuted = mock((_muted: boolean) => {});
 
 const onACall = (): void => {
   useLiveVoiceStore.getState().setState("listening");
+  useLiveVoiceStore.getState().setControls({
+    stop: () => {},
+    release: () => {},
+    interrupt: () => {},
+    setMuted,
+    setOutputMuted,
+    updateConfig: () => {},
+  } as unknown as Parameters<
+    ReturnType<typeof useLiveVoiceStore.getState>["setControls"]
+  >[0]);
 };
 
 describe("the chords a call answers", () => {
   beforeEach(() => {
     setCompanionScreenShare.mockClear();
     toggleCompanionAnnotating.mockClear();
-    useLiveVoiceStore.getState().setState("idle");
-    useLiveVoiceStore.getState().setScreenShareTarget(null);
+    setMuted.mockClear();
+    setOutputMuted.mockClear();
+    canBeShownTheScreen = true;
+    useLiveVoiceStore.getState().reset();
   });
 
   afterEach(() => {
-    useLiveVoiceStore.getState().setState("idle");
-    useLiveVoiceStore.getState().setScreenShareTarget(null);
+    useLiveVoiceStore.getState().reset();
+    useLiveVoiceStore.getState().setControls(null);
   });
 
   /**
    * Option alone, and exactly Option: the host lets Option+Shift+S past, so
    * the shortcuts the user already has under those keep working.
    */
-  test("asks for Option and the two keys", () => {
-    expect(CALL_CHORDS).toEqual({
+  test("asks for Option and all four keys on a call that can be shown the screen", () => {
+    expect(callChords(true)).toEqual({
       kind: "chord",
       modifiers: ["option"],
-      keys: ["s", "d"],
+      keys: ["s", "d", "m", "a"],
+    });
+  });
+
+  /**
+   * The share and the pen are controls the row does not offer on such a call,
+   * and a key taken for a control that is not there is a key taken for nothing.
+   */
+  test("asks for only the mutes on a call that cannot be", () => {
+    expect(callChords(false)).toEqual({
+      kind: "chord",
+      modifiers: ["option"],
+      keys: ["m", "a"],
     });
   });
 
@@ -93,11 +135,14 @@ describe("the chords a call answers", () => {
   });
 
   /**
-   * The binding is armed only while a call is running, so a press arriving
-   * with none is one made in the gap before the host heard the call end. It
-   * belongs to whatever the user has moved on to.
+   * The binding drops these two keys when the answer turns negative, so a
+   * press arriving after it is one made in the gap before the host heard. It
+   * would start a share the row no longer offers.
    */
-  test("does nothing with no call running", () => {
+  test("refuses the share and the pen once the call cannot be shown the screen", () => {
+    onACall();
+    canBeShownTheScreen = false;
+
     handleCallChord(CALL_SHARE_KEY);
     handleCallChord(CALL_DRAW_KEY);
 
@@ -106,16 +151,75 @@ describe("the chords a call answers", () => {
   });
 
   /**
-   * The host was asked for two keys. A third arriving means the two sides
-   * disagree about which, and the press is better left alone than spent on a
-   * guess.
+   * One press for both directions, the way the share is: the mute control
+   * that would undo it is on a surface the user is not looking at.
    */
-  test("does nothing with a key that is neither", () => {
+  test("mutes the microphone, and unmutes it on the next press", () => {
+    onACall();
+
+    handleCallChord(CALL_MUTE_MIC_KEY);
+    expect(setMuted).toHaveBeenLastCalledWith(true);
+
+    useLiveVoiceStore.getState().setMuted(true);
+    handleCallChord(CALL_MUTE_MIC_KEY);
+    expect(setMuted).toHaveBeenLastCalledWith(false);
+
+    expect(setOutputMuted).not.toHaveBeenCalled();
+  });
+
+  test("mutes the assistant's audio, and unmutes it on the next press", () => {
+    onACall();
+
+    handleCallChord(CALL_MUTE_ASSISTANT_KEY);
+    expect(setOutputMuted).toHaveBeenLastCalledWith(true);
+
+    useLiveVoiceStore.getState().setOutputMuted(true);
+    handleCallChord(CALL_MUTE_ASSISTANT_KEY);
+    expect(setOutputMuted).toHaveBeenLastCalledWith(false);
+
+    expect(setMuted).not.toHaveBeenCalled();
+  });
+
+  /** The mutes are the call's, whatever the call can be shown. */
+  test("mutes on a call that cannot be shown the screen", () => {
+    onACall();
+    canBeShownTheScreen = false;
+
+    handleCallChord(CALL_MUTE_MIC_KEY);
+
+    expect(setMuted).toHaveBeenCalledWith(true);
+  });
+
+  /**
+   * The binding is armed only while a call is running, so a press arriving
+   * with none is one made in the gap before the host heard the call end. It
+   * belongs to whatever the user has moved on to.
+   */
+  test("does nothing with no call running", () => {
+    handleCallChord(CALL_SHARE_KEY);
+    handleCallChord(CALL_DRAW_KEY);
+    handleCallChord(CALL_MUTE_MIC_KEY);
+    handleCallChord(CALL_MUTE_ASSISTANT_KEY);
+
+    expect(setCompanionScreenShare).not.toHaveBeenCalled();
+    expect(toggleCompanionAnnotating).not.toHaveBeenCalled();
+    expect(setMuted).not.toHaveBeenCalled();
+    expect(setOutputMuted).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The host was asked for a fixed set of keys. Another arriving means the two
+   * sides disagree about which, and the press is better left alone than spent
+   * on a guess.
+   */
+  test("does nothing with a key that is none of them", () => {
     onACall();
 
     handleCallChord("q");
 
     expect(setCompanionScreenShare).not.toHaveBeenCalled();
     expect(toggleCompanionAnnotating).not.toHaveBeenCalled();
+    expect(setMuted).not.toHaveBeenCalled();
+    expect(setOutputMuted).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/call-chords.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/call-chords.ts
@@ -1,11 +1,11 @@
 /**
- * The keyboard's version of the two in-call controls: show the assistant a
- * screen, and draw on what it is being shown.
+ * The keyboard's version of the call row's controls: show the assistant a
+ * screen, draw on what it is being shown, and mute either side of the call.
  *
- * Both are on the companion's call row, and the call row is on a surface the
- * user is looking away from while a call runs: the screen worth showing is the
- * one in front of them, and reaching for the pill means leaving it. So both
- * are reachable from wherever they are working.
+ * All four are on the companion's call row, and the call row is on a surface
+ * the user is looking away from while a call runs: the screen worth showing is
+ * the one in front of them, and reaching for the pill means leaving it. So all
+ * four are reachable from wherever they are working.
  *
  * **Option, not the voice key.** The voice key is call control (tap, hold,
  * double tap) and these are things a call does, so they are a family of their
@@ -18,19 +18,22 @@
 import type { ChordBinding } from "@vellumai/ipc-contract";
 
 import {
+  CALL_DRAW_KEY,
+  CALL_MUTE_ASSISTANT_KEY,
+  CALL_MUTE_MIC_KEY,
+  CALL_SHARE_KEY,
+} from "@/domains/chat/voice/live-voice/call-chord-keys";
+import {
   isLiveVoiceSessionActive,
+  setLiveVoiceMuted,
+  setLiveVoiceOutputMuted,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { liveVoiceCanBeShownTheScreen } from "@/domains/chat/voice/live-voice/screen-share-availability";
 import {
   setCompanionScreenShare,
   toggleCompanionAnnotating,
 } from "@/runtime/companion-surface";
-
-/** Share the screen the pointer is on, or stop the share that is running. */
-export const CALL_SHARE_KEY = "s";
-
-/** Draw on the shared surface, or give the mouse back to the desktop. */
-export const CALL_DRAW_KEY = "d";
 
 /**
  * What a call listens for.
@@ -39,12 +42,25 @@ export const CALL_DRAW_KEY = "d";
  * by accident and short enough to make while talking. Exactly Option: the host
  * lets Option+Shift+S past, so the shortcuts the user already has under those
  * combinations keep working.
+ *
+ * The mutes for any call, the share and the pen only for a call that can be
+ * shown the screen: a key taken for a control the row does not offer is a key
+ * taken for nothing, and the pill offers Share on exactly this answer.
  */
-export const CALL_CHORDS: ChordBinding = {
-  kind: "chord",
-  modifiers: ["option"],
-  keys: [CALL_SHARE_KEY, CALL_DRAW_KEY],
-};
+export function callChords(canBeShownTheScreen: boolean): ChordBinding {
+  return {
+    kind: "chord",
+    modifiers: ["option"],
+    keys: canBeShownTheScreen
+      ? [
+          CALL_SHARE_KEY,
+          CALL_DRAW_KEY,
+          CALL_MUTE_MIC_KEY,
+          CALL_MUTE_ASSISTANT_KEY,
+        ]
+      : [CALL_MUTE_MIC_KEY, CALL_MUTE_ASSISTANT_KEY],
+  };
+}
 
 /**
  * Show the assistant the screen the pointer is on, or stop showing it.
@@ -70,14 +86,28 @@ function toggleShare(): void {
  *
  * Refused with no session running. The binding is armed only while there is
  * one, so this is the gap between a call ending and the host hearing about it,
- * and a press landing in it belongs to whatever the user has moved on to.
+ * and a press landing in it belongs to whatever the user has moved on to. The
+ * share and the pen are refused the same way once the call can no longer be
+ * shown the screen, for the same gap.
  *
- * A key that is neither of ours does nothing rather than throwing: the host
- * was asked for two, and a third arriving means the two sides disagree about
- * which, which is a reason to leave the press alone.
+ * A key that is none of ours does nothing rather than throwing: the host was
+ * asked for a fixed set, and another arriving means the two sides disagree
+ * about which, which is a reason to leave the press alone.
  */
 export function handleCallChord(key: string): void {
-  if (!isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
+  const session = useLiveVoiceStore.getState();
+  if (!isLiveVoiceSessionActive(session.state)) {
+    return;
+  }
+  if (key === CALL_MUTE_MIC_KEY) {
+    setLiveVoiceMuted(!session.muted);
+    return;
+  }
+  if (key === CALL_MUTE_ASSISTANT_KEY) {
+    setLiveVoiceOutputMuted(!session.outputMuted);
+    return;
+  }
+  if (!liveVoiceCanBeShownTheScreen()) {
     return;
   }
   if (key === CALL_SHARE_KEY) {

--- a/clients/web/src/domains/chat/voice/live-voice/use-call-chords.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-call-chords.test.tsx
@@ -30,12 +30,25 @@ mock.module("@/runtime/hotkey", () => ({
 }));
 
 const handleCallChord = mock((_key: string) => {});
-/** The binding as the real module shapes it, by the one answer it varies on. */
-const callChords = (canBeShownTheScreen: boolean): ChordBinding => ({
+/**
+ * Stand-ins for the two bindings the real builder returns, one per answer it
+ * is asked. Sentinels rather than a copy of the builder: what this hook owns is
+ * which answer it asks with and when, and the keys are the builder's own test.
+ */
+const ALL_CHORDS: ChordBinding = {
   kind: "chord",
   modifiers: ["option"],
-  keys: canBeShownTheScreen ? ["s", "d", "m", "a"] : ["m", "a"],
-});
+  keys: ["all"],
+};
+const MUTE_CHORDS: ChordBinding = {
+  kind: "chord",
+  modifiers: ["option"],
+  keys: ["mutes"],
+};
+const callChords = mock(
+  (canBeShownTheScreen: boolean): ChordBinding =>
+    canBeShownTheScreen ? ALL_CHORDS : MUTE_CHORDS,
+);
 mock.module("@/domains/chat/voice/live-voice/call-chords", () => ({
   handleCallChord,
   callChords,
@@ -71,6 +84,7 @@ describe("the call's chords", () => {
     canBeShownTheScreen = false;
     setChordBinding.mockClear();
     handleCallChord.mockClear();
+    callChords.mockClear();
     useLiveVoiceStore.getState().setState("idle");
   });
 
@@ -91,7 +105,8 @@ describe("the call's chords", () => {
 
     setCall(true);
 
-    expect(armedWith()).toEqual(callChords(true));
+    expect(callChords).toHaveBeenLastCalledWith(true);
+    expect(armedWith()).toBe(ALL_CHORDS);
   });
 
   /**
@@ -105,7 +120,8 @@ describe("the call's chords", () => {
       useLiveVoiceStore.getState().setState("listening");
     });
 
-    expect(armedWith()).toEqual(callChords(false));
+    expect(callChords).toHaveBeenLastCalledWith(false);
+    expect(armedWith()).toBe(MUTE_CHORDS);
   });
 
   test("adds the share and the pen when the call can be shown the screen", () => {
@@ -121,7 +137,8 @@ describe("the call's chords", () => {
       useLiveVoiceStore.getState().setState("speaking");
     });
 
-    expect(armedWith()).toEqual(callChords(true));
+    expect(callChords).toHaveBeenLastCalledWith(true);
+    expect(armedWith()).toBe(ALL_CHORDS);
   });
 
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-call-chords.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-call-chords.test.tsx
@@ -30,13 +30,15 @@ mock.module("@/runtime/hotkey", () => ({
 }));
 
 const handleCallChord = mock((_key: string) => {});
+/** The binding as the real module shapes it, by the one answer it varies on. */
+const callChords = (canBeShownTheScreen: boolean): ChordBinding => ({
+  kind: "chord",
+  modifiers: ["option"],
+  keys: canBeShownTheScreen ? ["s", "d", "m", "a"] : ["m", "a"],
+});
 mock.module("@/domains/chat/voice/live-voice/call-chords", () => ({
   handleCallChord,
-  CALL_CHORDS: {
-    kind: "chord",
-    modifiers: ["option"],
-    keys: ["s", "d"],
-  } satisfies ChordBinding,
+  callChords,
 }));
 
 let canBeShownTheScreen = false;
@@ -89,11 +91,37 @@ describe("the call's chords", () => {
 
     setCall(true);
 
-    expect(armedWith()).toEqual({
-      kind: "chord",
-      modifiers: ["option"],
-      keys: ["s", "d"],
+    expect(armedWith()).toEqual(callChords(true));
+  });
+
+  /**
+   * The mutes are the call's whatever it can be shown. The share and the pen
+   * are armed on the same answer the pill offers Share on, and follow it.
+   */
+  test("arms only the mutes for a call that cannot be shown the screen", () => {
+    renderHook(() => useCallChords());
+
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
     });
+
+    expect(armedWith()).toEqual(callChords(false));
+  });
+
+  test("adds the share and the pen when the call can be shown the screen", () => {
+    renderHook(() => useCallChords());
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+
+    act(() => {
+      canBeShownTheScreen = true;
+      // The answer is read through the store, so a change to it reaches the
+      // hook with the next store update, the way the real conjunction's terms do.
+      useLiveVoiceStore.getState().setState("speaking");
+    });
+
+    expect(armedWith()).toEqual(callChords(true));
   });
 
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/use-call-chords.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-call-chords.ts
@@ -16,10 +16,13 @@
 import { useEffect } from "react";
 
 import {
+  callChords,
   handleCallChord,
-  CALL_CHORDS,
 } from "@/domains/chat/voice/live-voice/call-chords";
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  isLiveVoiceSessionActive,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { liveVoiceCanBeShownTheScreen } from "@/domains/chat/voice/live-voice/screen-share-availability";
 import {
   setChordBinding,
@@ -28,10 +31,16 @@ import {
 } from "@/runtime/hotkey";
 
 export function useCallChords(): void {
-  // Subscribed through the store so the binding follows the session, and read
-  // through the shared conjunction so it is armed exactly when the pill's own
+  // Subscribed through the store so the binding follows the session. The
+  // mutes are armed for the whole of a call; the share and the pen join them
+  // on the shared conjunction, so they are armed exactly when the pill's own
   // Share control is: a chord that could do nothing is a key taken for nothing.
-  const onCall = useLiveVoiceStore(() => liveVoiceCanBeShownTheScreen());
+  const onCall = useLiveVoiceStore((session) =>
+    isLiveVoiceSessionActive(session.state),
+  );
+  const canBeShownTheScreen = useLiveVoiceStore(() =>
+    liveVoiceCanBeShownTheScreen(),
+  );
 
   useEffect(() => {
     if (!onCall || !supportsChords()) {
@@ -44,7 +53,7 @@ export function useCallChords(): void {
       }
       handleCallChord(event.key);
     });
-    void setChordBinding(CALL_CHORDS);
+    void setChordBinding(callChords(canBeShownTheScreen));
 
     return () => {
       unsubscribe();
@@ -52,5 +61,5 @@ export function useCallChords(): void {
       // between the two, a press of these keys is the user's own.
       void setChordBinding({ kind: "off" });
     };
-  }, [onCall]);
+  }, [onCall, canBeShownTheScreen]);
 }


### PR DESCRIPTION
## Summary

- The companion pill's hover captions for **Share** and **Draw** now show the key that makes the same press from any application: `⌥S` and `⌥D`, dimmer than the name, the way a menu writes its accelerator.
- Two new in-call chords in the same Option family: **`⌥M` mutes the microphone**, **`⌥A` mutes the assistant's audio**. Each is a toggle, like the share. Their captions name them too.
- The mutes are armed for the whole of a call. The share and the pen stay armed on the same answer the pill offers Share on (`liveVoiceCanBeShownTheScreen`), so the binding never takes a key for a control the row does not have. The handler refuses a share or pen press that lands after that answer turned negative.
- The keys and their spelling live in one module, `call-chord-keys.ts`, so the caption and the binding cannot drift. The page passes spellings down only where the host watches chords (`supportsChords()`), so a host with no helper shows names alone.
- Helper (Swift): a chord key's autorepeat key-downs are taken without being reported, so a held chord toggles once per press. This also closes the same exposure on the existing `⌥S` / `⌥D`.

The helper already accepts up to eight keys under a modifier set, so the key set change itself needs no Electron or Swift work; the one Swift change is the autorepeat guard above. CI builds no Swift, so that part is covered by a local `swift build` and `swift test` only. Follows up JARVIS-1748 (#42189), which left the shortcuts undiscoverable.

Resolves JARVIS-1779

## Test plan

- [x] `bun test` on `call-chords.test.ts`, `call-chord-keys.test.ts`, `use-call-chords.test.tsx`, `companion-surface.test.tsx`, `companion-surface-page.test.tsx`
- [x] `bun run typecheck` in `clients/web`
- [x] eslint + prettier@3.8.1 on the changed files
- [x] `swift build` and `swift test` in `clients/macos/native/mac-helper` (79 tests)
- [ ] On the dev app with a rebuilt helper, in a call: hover Share / Draw / the two mutes on the pill and read the captions; press and hold ⌥M from another app and watch the mute flip once

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj544numFqnyhiL9kfiwJJ
