### PR TITLE
fix: point every download link at the canonical /downloads page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you've set up a Personal AI on OpenClaw, Hermes Agent, or Claude Code, you kn
 
 ## Get Started
 
-**1. [Sign up](https://vellum.ai/signup) or [download the app](https://vellum.ai/download)**
+**1. [Sign up](https://vellum.ai/signup) or [download the app](https://vellum.ai/downloads)**
 
 **2. Pick your mode**
 

--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -307,7 +307,7 @@ describe("formatModeSelectionFailure", () => {
     expect(formatted).toContain("Setup details:");
     expect(formatted).toContain("Chrome extension");
     expect(formatted).toContain(CHROME_WEB_STORE_INSTALL_URL);
-    expect(formatted).toContain("www.vellum.ai/download");
+    expect(formatted).toContain("www.vellum.ai/downloads");
     expect(formatted).toContain("Offer those first");
   });
 
@@ -348,17 +348,15 @@ describe("formatModeSelectionFailure", () => {
       },
     ];
 
-    const error = new CdpError(
-      "transport_error",
-      "Host bridge unreachable",
-      { attemptDiagnostics: diagnostics },
-    );
+    const error = new CdpError("transport_error", "Host bridge unreachable", {
+      attemptDiagnostics: diagnostics,
+    });
 
     const formatted = formatModeSelectionFailure("auto", error);
 
     expect(formatted).toContain("Setup details:");
     expect(formatted).toContain(CHROME_WEB_STORE_INSTALL_URL);
-    expect(formatted).toContain("www.vellum.ai/download");
+    expect(formatted).toContain("www.vellum.ai/downloads");
   });
 
   test("phone surfaces do not invent an in-app browser panel", () => {
@@ -381,7 +379,7 @@ describe("formatModeSelectionFailure", () => {
     expect(formatted).toContain("no in-app browser");
     expect(formatted).toContain("Do not describe a browser panel");
     expect(formatted).toContain(CHROME_WEB_STORE_INSTALL_URL);
-    expect(formatted).toContain("www.vellum.ai/download");
+    expect(formatted).toContain("www.vellum.ai/downloads");
   });
 });
 
@@ -440,7 +438,7 @@ describe("browser_mode wiring through tool execution", () => {
     expect(result.content).toContain("Navigation failed");
     expect(result.content).toContain("timed out");
     expect(result.content).toContain(CHROME_WEB_STORE_INSTALL_URL);
-    expect(result.content).toContain("www.vellum.ai/download");
+    expect(result.content).toContain("www.vellum.ai/downloads");
     expect(result.content).toContain("Offer those first");
   });
 

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -27,7 +27,7 @@ When the user wants something checked on a cadence (a status page, dashboard, si
 - Recurrence, cutoff times, escalation, and notifications are schedule and notification primitives. Do not reimplement them in a workspace file the user has to run.
 - Prefer **execute** mode: the scheduled message browses or fetches the source, applies the user's rules, and notifies on exceptions. Use **script** mode only for a cheap deterministic check against a live source the assistant can already reach (curl an API, read a file in the workspace). A script-mode job is still a schedule, not a file you hand the user.
 - Looking at a page, pasting HTML, or gathering a roster is setup for the schedule, not a reason to skip creating one.
-- If browsing cannot reach the page, still create the schedule. Offer the desktop app (https://www.vellum.ai/download) or the Chrome extension (https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne) so a logged-in browser session can run it. Do not replace the schedule with a parser against a pasted export, and do not assign comparison-run homework before anything is scheduled.
+- If browsing cannot reach the page, still create the schedule. Offer the desktop app (https://www.vellum.ai/downloads) or the Chrome extension (https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne) so a logged-in browser session can run it. Do not replace the schedule with a parser against a pasted export, and do not assign comparison-run homework before anything is scheduled.
 - Watchers cover Gmail, Google Calendar, GitHub, Linear, and Outlook event polling. An arbitrary web page or status dashboard is this skill, not the watcher skill.
 
 ## Schedule Syntax
@@ -243,7 +243,7 @@ If any required capability is missing:
 
 1. **Still create the schedule** so timing is preserved. Do not tell the user it is ready to run.
 2. Explain what is missing and why the next fire will fail until that is fixed.
-3. Offer to set up the missing integration first. For a page the assistant cannot reach, offer the desktop app (https://www.vellum.ai/download) or the Chrome extension (https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne) before asking for a screenshot or pasted export.
+3. Offer to set up the missing integration first. For a page the assistant cannot reach, offer the desktop app (https://www.vellum.ai/downloads) or the Chrome extension (https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne) before asking for a screenshot or pasted export.
 4. Do not replace the schedule with a workspace script the user has to run themselves.
 
 ## Delivering Results

--- a/assistant/src/tools/capability-offer.ts
+++ b/assistant/src/tools/capability-offer.ts
@@ -1,7 +1,7 @@
 import type { ClientOs, InterfaceId } from "../channels/types.js";
 
 /** Public download page for the desktop apps. */
-export const DESKTOP_APP_DOWNLOAD_URL = "https://www.vellum.ai/download";
+export const DESKTOP_APP_DOWNLOAD_URL = "https://www.vellum.ai/downloads";
 
 /** Chrome Web Store listing for the Vellum Assistant browser extension. */
 export const CHROME_WEB_STORE_INSTALL_URL =

--- a/clients/docs/src/app/docs/_components/developer-guide-get-started-content.tsx
+++ b/clients/docs/src/app/docs/_components/developer-guide-get-started-content.tsx
@@ -155,7 +155,7 @@ export function DeveloperGuideGetStartedContent() {
           <ol className="mb-4 list-decimal space-y-2 pl-6 text-zinc-600">
             <li>
               Install the{" "}
-              <Link href="https://www.vellum.ai/download" className={linkClass}>
+              <Link href="https://www.vellum.ai/downloads" className={linkClass}>
                 desktop app
               </Link>{" "}
               and walk through onboarding. Your workspace will live at{" "}

--- a/clients/docs/src/app/docs/_components/hosting-options-cloud-hosting-content.tsx
+++ b/clients/docs/src/app/docs/_components/hosting-options-cloud-hosting-content.tsx
@@ -352,7 +352,7 @@ export function HostingOptionsCloudHostingContent() {
             <li>
               Optional: install the{" "}
               <Link
-                href="https://www.vellum.ai/download"
+                href="https://www.vellum.ai/downloads"
                 className="font-semibold text-emerald-700 underline hover:text-emerald-800"
               >
                 desktop app

--- a/clients/docs/src/app/docs/_components/quick-start-content.tsx
+++ b/clients/docs/src/app/docs/_components/quick-start-content.tsx
@@ -105,7 +105,7 @@ export function QuickStartContent() {
             </li>
             <li>
               <strong>Mac</strong>: install the{" "}
-              <Link href="https://www.vellum.ai/download" className={linkClass}>
+              <Link href="https://www.vellum.ai/downloads" className={linkClass}>
                 desktop app
               </Link>
               . Same assistant, with the added ability to read your

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "6046473662aa1c510ab84fd315b8d38214d6e2eab7ec27f75ace3e809f76a83e"
+      "sha256": "b3a7303a5ab8482c61a02f46a333ba26a075241173b3ea810064bd852345dca4"
     },
     "skill-management": {
       "docsSlug": "skill-management",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -579,7 +579,7 @@
         }
       },
       "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
-      "updatedAt": "2026-09-02T21:36:48.000Z"
+      "updatedAt": "2026-09-09T20:26:37.000Z"
     },
     {
       "id": "meme-generator",
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T20:25:55.000Z"
+      "updatedAt": "2026-09-09T20:26:37.000Z"
     },
     {
       "id": "public-ingress",
@@ -880,7 +880,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T14:57:33.000Z"
+      "updatedAt": "2026-09-09T20:37:43.000Z"
     },
     {
       "id": "slack-app-setup",
@@ -1055,7 +1055,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T20:59:52.000Z"
+      "updatedAt": "2026-09-09T22:41:36.000Z"
     },
     {
       "id": "vellum-client-capabilities",
@@ -1078,7 +1078,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-08T20:59:52.000Z"
+      "updatedAt": "2026-09-09T22:41:36.000Z"
     },
     {
       "id": "vellum-conversation-management",

--- a/skills/vellum-browser-use/SKILL.md
+++ b/skills/vellum-browser-use/SKILL.md
@@ -82,7 +82,7 @@ If navigate, curl, or any fetch times out, hits an auth wall, or cannot reach a 
 
 1. Tell the user a connected desktop app or Chrome extension can open the page in a browser where they are already logged in.
 2. Give the install links:
-   - Desktop app: https://www.vellum.ai/download
+   - Desktop app: https://www.vellum.ai/downloads
    - Chrome extension: https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne
 3. Offer those first. Only ask for a screenshot or pasted page content if they cannot install either.
 4. On iOS or Android there is no in-app browser and no extension to install on the phone. Offer the desktop app or Chrome extension on a computer. Do not describe a browser panel.

--- a/skills/vellum-client-capabilities/SKILL.md
+++ b/skills/vellum-client-capabilities/SKILL.md
@@ -44,7 +44,7 @@ It does not exist today in any client. The honest answer is that they can mentio
 
 When a task needs a logged-in browser or a host computer (internal pages, company SSO, VPN-only dashboards, local files, or host shell):
 
-1. Offer the desktop app: https://www.vellum.ai/download
+1. Offer the desktop app: https://www.vellum.ai/downloads
 2. For browser sessions, also offer the Chrome extension: https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne
 3. Offer those first. Only ask for a screenshot or pasted page content if the user cannot install either.
 


### PR DESCRIPTION
## Why

`https://www.vellum.ai/download` 308-redirects to `/downloads`. Every link spelled the singular way costs a redirect hop, and the two spellings had already diverged across the repo:

- `clients/web/src/utils/external-urls.ts` held `/downloads` (correct)
- `assistant/src/tools/capability-offer.ts` held `/download`

That second one matters most: `DESKTOP_APP_DOWNLOAD_URL` is the shared constant behind the assistant's capability offers and browser status hints, so every "install the desktop app" message the assistant emits carried the redirecting URL.

## What

One constant plus eight standalone literals, 13 lines total:

| Where | |
|---|---|
| `assistant/src/tools/capability-offer.ts` | the shared constant, fixes every message built from it |
| `assistant/src/config/bundled-skills/schedule/SKILL.md` | 2 literals |
| `skills/vellum-browser-use/`, `skills/vellum-client-capabilities/` | 2 literals |
| `clients/docs/` | 3 links |
| `README.md` | 1 link |
| `assistant/src/__tests__/headless-browser-mode.test.ts` | 4 assertions follow the constant |

After this, `grep -rn "vellum\.ai/download\b"` returns nothing outside `node_modules`.

## Testing

- `bunx tsc --noEmit` in `assistant/` - clean
- `capability-offer.test.ts`, `headless-browser-mode.test.ts`, `skill-docs-sync-guard.test.ts` - 35 pass
- eslint on all changed `assistant/` and `clients/docs/` files - clean
- Both `https://www.vellum.ai/downloads` and `https://vellum.ai/downloads` verified 200 with `curl`

Skill docs-sync fingerprint re-recorded for the schedule wording change, per `assistant/src/config/bundled-skills/AGENTS.md`. `skills/catalog.json` carries no URLs, so it needs no regeneration.

## Context

Split out of #42426, which put the downloads page into `assistant clients --help`. The URL fix started there and was dropped when it kept conflicting on the docs-sync fingerprint; it belongs in its own change anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zrfzA2VX4Bxhb85MUS6kH

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->