### PR TITLE
fix: avatar_changed review polish (docs, test dedupe, single manifest read on remove)

### DIFF
--- a/assistant/src/avatar/__tests__/avatar-changed-telemetry.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-changed-telemetry.test.ts
@@ -196,22 +196,9 @@ describe("isSameAvatar", () => {
     );
   });
 
-  test("a legacy-derived image is not the same once the bytes change", () => {
-    expect(isSameAvatar(UPLOADED_LEGACY, UPLOADED, true)).toBe(false);
-  });
-
   test("a custom accent over one that was never recorded is not", () => {
     expect(
       isSameAvatar(UPLOADED_LEGACY, { ...UPLOADED, accent: CUSTOM_ACCENT }),
-    ).toBe(false);
-  });
-
-  test("a previous custom accent under a derived one is not, even with an unknown source", () => {
-    expect(
-      isSameAvatar(
-        { ...UPLOADED_LEGACY, accent: { hex: "#c81e1e", source: "custom" } },
-        UPLOADED,
-      ),
     ).toBe(false);
   });
 

--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -507,7 +507,7 @@ describe("avatar-store", () => {
     const RED_ACCENT = { accent_hex: "#c81e1e", accent_source: "derived" };
     const events = () => recorded.map((entry) => entry.fields);
 
-    test("an identical re-upload above the raster serving cap is still not a change", async () => {
+    test("an identical re-upload above the raster serving cap is not a change", async () => {
       const big = Buffer.alloc(5 * 1024 * 1024 + 1, 7);
 
       await setImage(big, "upload");

--- a/assistant/src/avatar/avatar-changed-telemetry.ts
+++ b/assistant/src/avatar/avatar-changed-telemetry.ts
@@ -20,10 +20,12 @@ export type AvatarChangeAction =
   | "set_accent"
   | "clear";
 
+/** The sources an image can be set from. */
+export type ImageSource = Exclude<AvatarSource, "builder">;
+
 /** The action an image write counts as, by where the image came from. */
-export const IMAGE_ACTIONS: Readonly<
-  Record<Exclude<AvatarSource, "builder">, AvatarChangeAction>
-> = { upload: "upload_image", ai: "generate_image" };
+export const IMAGE_ACTIONS: Readonly<Record<ImageSource, AvatarChangeAction>> =
+  { upload: "upload_image", ai: "generate_image" };
 
 /** The `avatar_changed` wire payload minus the fields `recordTelemetryEvent` stamps. */
 type AvatarChangedFields = Omit<

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -15,9 +15,11 @@
  * unless the avatar came out identical. Mutating routes (HTTP/IPC) go through
  * it rather than touching artifacts or the manifest directly. The
  * `notify_avatar_updated` route and the avatar watcher in
- * `daemon/config-watcher.ts` republish out-of-band writes and record nothing;
- * the read-time accent repair in `accent-backfill.ts` is the one other
- * manifest write, and announces nothing.
+ * `daemon/config-watcher.ts` republish out-of-band writes and record nothing.
+ * Three other writers touch the manifest and announce and record nothing: the
+ * read-time accent repair in `accent-backfill.ts`, the read routes' self-heal
+ * persist in `runtime/routes/avatar-routes.ts`, and the
+ * `094-seed-avatar-manifest` workspace migration.
  */
 import { randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
@@ -43,10 +45,10 @@ import {
   type AvatarChangeAction,
   avatarChangedFields,
   IMAGE_ACTIONS,
+  type ImageSource,
   isSameAvatar,
 } from "./avatar-changed-telemetry.js";
 import {
-  type AvatarSource,
   type AvatarState,
   computeImageMeta,
   NONE_AVATAR_STATE,
@@ -92,8 +94,8 @@ interface AvatarTransition {
 }
 
 /**
- * The side effects every persisted change owes. An identical re-set still
- * notifies but is not counted. Telemetry is best effort: the avatar is
+ * The side effects every persisted change owes. An identical re-set notifies
+ * and is not counted. Telemetry is best effort: the avatar is
  * already written and announced, so a failed record is logged, not thrown.
  */
 function announceChange(
@@ -165,7 +167,7 @@ export function setCharacter(
  */
 export async function setImage(
   pngBuffer: Buffer,
-  source: Exclude<AvatarSource, "builder">,
+  source: ImageSource,
   options?: ImageChangeOptions,
 ): Promise<void> {
   const accent = derivedAccent(await deriveAccentHexFromImage(pngBuffer));
@@ -238,7 +240,8 @@ export async function setAccent(
 
 /**
  * Clears the avatar entirely: removes the PNG, character sidecars, and the
- * manifest itself. Idempotent — safe to call when nothing exists.
+ * manifest itself. Idempotent: safe to call when nothing exists. Returns the
+ * state it cleared, so a caller can tell whether an avatar was there.
  *
  * "No avatar" is represented by the ABSENCE of a manifest, not a persisted
  * `kind:"none"`. Deleting avatar.json (rather than writing `none`) keeps an
@@ -246,7 +249,7 @@ export async function setAccent(
  * picked up by the read-time self-heal instead of being shadowed by a stale
  * `none` manifest.
  */
-export function clearAvatar(options?: AvatarChangeOptions): void {
+export function clearAvatar(options?: AvatarChangeOptions): AvatarState {
   const avatarDir = getAvatarDir();
   mkdirSync(avatarDir, { recursive: true });
 
@@ -262,4 +265,5 @@ export function clearAvatar(options?: AvatarChangeOptions): void {
     NO_AVATAR_IDENTITY_NOTE,
     options,
   );
+  return previous;
 }

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -11,11 +11,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import * as realSyncEvents from "../../sync/resource-sync-events.js";
+
 /** The origin id handed to the fan-out, one entry per announced change. */
 const publishedOrigins: Array<string | undefined> = [];
 mock.module("../../sync/resource-sync-events.js", () => ({
-  getOriginClientId: (headers: Record<string, string> | undefined) =>
-    headers?.["x-vellum-client-id"]?.trim() || undefined,
+  getOriginClientId: realSyncEvents.getOriginClientId,
   publishAvatarChanged: (originClientId?: string) => {
     publishedOrigins.push(originClientId);
   },
@@ -396,8 +397,7 @@ describe("avatar write/remove handlers", () => {
     });
 
     test("reads the accent out of the uploaded image", async () => {
-      const handler = getHandler("avatar_upload_image");
-      await handler({ body: { content: RED_PNG.toString("base64") } });
+      await uploadRed();
       expect(readManifestFile()!.accent).toEqual({
         hex: "#c81e1e",
         source: "derived",
@@ -604,14 +604,7 @@ describe("avatar write/remove handlers", () => {
       expect(recorded[0]!.fields).not.toHaveProperty("client_os");
     });
 
-    test("no headers yields an event without client_os", async () => {
-      await uploadRed();
-
-      expect(recorded).toHaveLength(1);
-      expect(recorded[0]!.fields).not.toHaveProperty("client_os");
-    });
-
-    test("the client id still reaches the fan-out", async () => {
+    test("the client id reaches the fan-out", async () => {
       await uploadRed({ "x-vellum-client-id": "web-1" });
 
       expect(publishedOrigins).toEqual(["web-1"]);

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -274,19 +274,9 @@ async function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
 }
 
 function handleRemoveAvatar({ headers }: RouteHandlerArgs) {
-  // `hadAvatar` must reflect whether *any* avatar was configured before the
-  // clear — not just a rendered PNG. A character-only workspace (traits present,
-  // no PNG) is still an avatar, and clearAvatar() deletes its traits/ascii too.
-  // Derive from the manifest (self-healing on a manifest-miss) and treat any
-  // non-"none" kind as hadAvatar.
-  const hadAvatar = readManifestSelfHealing().kind !== "none";
-
-  // Clear everything to a manifest-consistent kind:"none". Semantic change
-  // (intentional): traits no longer persist alongside an image, so there is
-  // nothing to revert to — the legacy "re-render character from traits" branch
-  // has been removed. avatar/remove is now a plain clear, reachable only via
-  // CLI/host.
-  clearAvatar(changeOptions(headers));
+  // A character-only workspace (traits, no PNG) is still an avatar, so
+  // `hadAvatar` comes from the cleared state's kind.
+  const hadAvatar = clearAvatar(changeOptions(headers)).kind !== "none";
   return { ok: true, hadAvatar };
 }
 

--- a/assistant/src/telemetry/AGENTS.md
+++ b/assistant/src/telemetry/AGENTS.md
@@ -30,7 +30,7 @@ recordTelemetryEvent(
 
 `recordTelemetryEvent` stamps the base fields (`type`, `daemon_event_id`, `recorded_at`, `assistant_version`) and gates on consent — dropping only on a confirmed `share_analytics` opt-out; an unknown consent state (cold cache) records, because consent is enforced again at flush time and a record-time drop would destroy the event permanently. Unknown-state buffering is bounded: the reporter prunes outbox rows older than `OUTBOX_MAX_ROW_AGE_MS` (30 days) at the start of every flush cycle, in every consent state, so a permanently-unknown state cannot grow the outbox forever. The `fields` argument is typed as everything except the base fields.
 
-Manual edits in this directory are needed **only** to override a default:
+Beyond those sync touchpoints, source edits in this directory are needed **only** to override a default:
 
 - **Watermark-flushed** (the type has its own high-volume table, not the outbox): add it to `WATERMARK_TELEMETRY_EVENT_NAMES` in `types.ts` and add its source to `WATERMARK_TELEMETRY_EVENT_SOURCES`.
 - **Custom flush behavior** (a non-default per-type source — e.g. re-checking consent at flush time): map the type to a custom source factory in `OUTBOX_SOURCE_FACTORY` in `telemetry-event-sources.ts`. (No type currently needs one — every outbox event, `onboarding_research` included, flushes through the default `outboxSource` under `share_analytics`.)

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -627,7 +627,7 @@ export type AuthFallbackTelemetryEvent = EventMap["auth_fallback"];
 export type ConfigSettingTelemetryEvent = EventMap["config_setting"];
 
 /**
- * Avatar-changed event: one per avatar mutation from the avatar store. 1:1
+ * Avatar-changed event: one per avatar mutation that changed the avatar. 1:1
  * with the wire contract (`AvatarChangedTelemetryEventSerializer`).
  */
 export type AvatarChangedTelemetryEvent = EventMap["avatar_changed"];


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for avatar-changed-telemetry.md.

- **Gap 1, telemetry AGENTS.md contradicted itself.** Expected: the sync-touchpoint paragraph and the "only to override a default" line to agree. Found: line 33 still claimed manual edits are needed only for overrides. Reworded to "Beyond those sync touchpoints, source edits in this directory are needed **only** to override a default:".
- **Gap 2, the store's module doc understated the silent manifest writers.** Expected: every writer that persists the manifest without announcing or recording to be named. Found: only the accent backfill was. The doc now names the accent repair, the read routes' self-heal persist, and the `094-seed-avatar-manifest` migration.
- **Gap 3, wording.** Expected: no "still" used as a contrast with removed text. Found four: the `announceChange` doc, one store test title, one route test title, and the `AvatarChangedTelemetryEvent` alias doc (now "one per avatar mutation that changed the avatar"). All recast.
- **Gap 4, two redundant predicate tests.** Expected: each `isSameAvatar` branch pinned once. Found: "a legacy-derived image is not the same once the bytes change" duplicated the `imageBytesChanged` short-circuit pin, and "a previous custom accent under a derived one is not, even with an unknown source" had both branches pinned elsewhere. Both deleted, nothing else.
- **Gap 5, route test mock re-implemented `getOriginClientId`.** Expected: the real export passed through the mock, as `sync-avatar.test.ts` does. Found: a verbatim copy. Now `import * as realSyncEvents` above the mock and `getOriginClientId: realSyncEvents.getOriginClientId`; only `publishAvatarChanged` is faked. "the client id reaches the fan-out" passes.
- **Gap 6, route test duplication.** Expected: the hoisted `uploadRed()` helper used everywhere it fits, and no test that another already covers. Found: one inline upload call in "reads the accent out of the uploaded image" (now `uploadRed()`), and "no headers yields an event without client_os" (deleted; the 65-character case pins the sanitizer bound at the route and the mapper's empty-input path is unit-tested).
- **Gap 7, `avatar/remove` read the manifest twice.** Expected: one read. Found: the handler called `readManifestSelfHealing()` for `hadAvatar`, then `clearAvatar` read the state again. `clearAvatar` now returns the `AvatarState` it cleared and the handler derives `hadAvatar` from its `kind`; the handler's multi-line history comment is replaced by two present-tense lines. Response shape unchanged (OpenAPI check is up to date).
- **Gap 8, `Exclude<AvatarSource, "builder">` spelled twice.** Expected: one named type. Found: once in `IMAGE_ACTIONS`, once in `setImage`. Added `export type ImageSource` to `avatar-changed-telemetry.ts` and used it in both places; the now-unused `AvatarSource` import in the store is dropped.

## Validation
- `cd assistant && bun test src/avatar/__tests__/avatar-changed-telemetry.test.ts src/avatar/__tests__/avatar-store.test.ts src/runtime/routes/__tests__/avatar-state-routes.test.ts src/__tests__/avatar-identity-sync.test.ts src/telemetry/types.test.ts`: 108 pass, 0 fail.
- `cd assistant && bun run typecheck && bun run lint`: both exit 0.
- `cd assistant && bun run generate:openapi -- --check`: up to date.
- No em dashes on any added line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyMhFjRp3y2XhmreXRhUsP