### PR TITLE
fix(providers): round-trip Gemini thought signatures on openai-compatible

### DIFF
--- a/assistant/src/providers/gemini-thought-signature.test.ts
+++ b/assistant/src/providers/gemini-thought-signature.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { isGemini3Model } from "./gemini-thought-signature.js";
+
+describe("isGemini3Model", () => {
+  test("matches native Gemini 3 ids", () => {
+    expect(isGemini3Model("gemini-3.7-flash")).toBe(true);
+    expect(isGemini3Model("models/gemini-3.1-pro-preview")).toBe(true);
+  });
+
+  test("matches OpenAI-compatible catalog prefixes", () => {
+    expect(isGemini3Model("google/gemini-3.7-flash")).toBe(true);
+  });
+
+  test("does not match Gemini 2.5 or unrelated ids", () => {
+    expect(isGemini3Model("gemini-2.5-flash")).toBe(false);
+    expect(isGemini3Model("gpt-5.2")).toBe(false);
+  });
+});

--- a/assistant/src/providers/gemini-thought-signature.test.ts
+++ b/assistant/src/providers/gemini-thought-signature.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { isGemini3Model } from "./gemini-thought-signature.js";
+import {
+  GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+  isGemini3Model,
+  unsignedThoughtSignatureFallback,
+} from "./gemini-thought-signature.js";
 
 describe("isGemini3Model", () => {
   test("matches native Gemini 3 ids", () => {
@@ -15,5 +19,45 @@ describe("isGemini3Model", () => {
   test("does not match Gemini 2.5 or unrelated ids", () => {
     expect(isGemini3Model("gemini-2.5-flash")).toBe(false);
     expect(isGemini3Model("gpt-5.2")).toBe(false);
+  });
+});
+
+describe("unsignedThoughtSignatureFallback", () => {
+  test("stamps the dummy on the first unsigned Gemini 3 call", () => {
+    expect(
+      unsignedThoughtSignatureFallback([undefined, undefined], {
+        model: "gemini-3.7-flash",
+      }),
+    ).toEqual({
+      index: 0,
+      signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+    });
+  });
+
+  test("does not stamp when any call already has a signature", () => {
+    expect(
+      unsignedThoughtSignatureFallback(["signed-thought-1", undefined], {
+        model: "gemini-3.7-flash",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("does not stamp for non-Gemini-3 models when a model id is provided", () => {
+    expect(
+      unsignedThoughtSignatureFallback([undefined], { model: "gpt-5.2" }),
+    ).toBeUndefined();
+  });
+
+  test("stamps unsigned calls when no model gate is supplied", () => {
+    expect(unsignedThoughtSignatureFallback([undefined])).toEqual({
+      index: 0,
+      signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+    });
+  });
+
+  test("does not stamp an empty function-call list", () => {
+    expect(
+      unsignedThoughtSignatureFallback([], { model: "gemini-3.7-flash" }),
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/providers/gemini-thought-signature.ts
+++ b/assistant/src/providers/gemini-thought-signature.ts
@@ -1,0 +1,19 @@
+/**
+ * Gemini 3.x requires a thought signature on the first function-call part of
+ * each step. When history has no captured signature (unsigned tool_use from an
+ * earlier provider, or a client-injected call), Google documents these dummy
+ * values to skip validation.
+ */
+export const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
+  "context_engineering_is_the_way_to_go";
+
+/**
+ * True for Gemini 3.x model ids, including the native `models/` prefix and
+ * OpenAI-compatible catalog prefixes such as `google/gemini-3.7-flash`.
+ */
+export function isGemini3Model(model: string): boolean {
+  if (model.startsWith("gemini-3") || model.startsWith("models/gemini-3")) {
+    return true;
+  }
+  return /\/gemini-3/.test(model);
+}

--- a/assistant/src/providers/gemini-thought-signature.ts
+++ b/assistant/src/providers/gemini-thought-signature.ts
@@ -17,3 +17,28 @@ export function isGemini3Model(model: string): boolean {
   }
   return /\/gemini-3/.test(model);
 }
+
+/**
+ * Decide whether unsigned function-call history should receive Google's
+ * documented dummy thought signature. Returns the first call's index when
+ * every call is unsigned. Pass `model` to restrict this to Gemini 3.x;
+ * omit it for retry backfills that already observed a thought-signature 4xx.
+ */
+export function unsignedThoughtSignatureFallback(
+  signatures: ReadonlyArray<string | undefined | null>,
+  options?: { model?: string },
+): { index: 0; signature: string } | undefined {
+  if (options?.model !== undefined && !isGemini3Model(options.model)) {
+    return undefined;
+  }
+  if (signatures.length === 0) {
+    return undefined;
+  }
+  if (signatures.some((signature) => Boolean(signature))) {
+    return undefined;
+  }
+  return {
+    index: 0,
+    signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+  };
+}

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -15,6 +15,10 @@ import {
   keepFileAsWorkspaceRef,
 } from "../content-block-size.js";
 import { fileBlockToProviderText } from "../file-block-text.js";
+import {
+  GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+  isGemini3Model,
+} from "../gemini-thought-signature.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { recordProviderRequestDiagnostics } from "../request-diagnostics.js";
@@ -44,13 +48,6 @@ import {
  */
 const GEMINI_CONTEXT_OVERFLOW_TOKEN_PATTERNS =
   /token.?count.*exceeds|exceeds.*maximum.*tokens|prompt.?is.?too.?long|too.?many.?(?:input.?)?tokens|input.?too.?long|context.?length.?exceeded/i;
-
-const GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE =
-  "context_engineering_is_the_way_to_go";
-
-function isGemini3Model(model: string): boolean {
-  return model.startsWith("gemini-3") || model.startsWith("models/gemini-3");
-}
 
 const THINKING_LEVEL_BY_NAME: Record<ThinkingLevelName, ThinkingLevel> = {
   minimal: ThinkingLevel.MINIMAL,
@@ -435,7 +432,8 @@ export class GeminiProvider implements Provider {
     const maxTokens = configObj?.max_tokens as number | undefined;
     const modelOverride = configObj?.model as string | undefined;
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
-      Record<string, string> | undefined;
+      | Record<string, string>
+      | undefined;
     const activeModel = modelOverride ?? this.model;
     const thinkingConfig = geminiModelSupportsThinking(activeModel)
       ? buildThinkingConfig(

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -15,10 +15,7 @@ import {
   keepFileAsWorkspaceRef,
 } from "../content-block-size.js";
 import { fileBlockToProviderText } from "../file-block-text.js";
-import {
-  GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
-  isGemini3Model,
-} from "../gemini-thought-signature.js";
+import { unsignedThoughtSignatureFallback } from "../gemini-thought-signature.js";
 import { base64Source, resolveMediaReferences } from "../media-resolve.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { recordProviderRequestDiagnostics } from "../request-diagnostics.js";
@@ -900,28 +897,19 @@ export class GeminiProvider implements Provider {
     parts: genai.Part[],
     model: string,
   ): void {
-    if (!isGemini3Model(model)) {
-      return;
-    }
-
     const functionCallParts = parts.filter((part) => part.functionCall);
-    if (functionCallParts.length === 0) {
-      return;
-    }
-
-    const hasRealThoughtSignature = functionCallParts.some((part) =>
-      Boolean(part.thoughtSignature),
+    const fallback = unsignedThoughtSignatureFallback(
+      functionCallParts.map((part) => part.thoughtSignature),
+      { model },
     );
-    if (hasRealThoughtSignature) {
+    if (!fallback) {
       return;
     }
-
-    const firstFunctionCallPart = functionCallParts[0];
+    const firstFunctionCallPart = functionCallParts[fallback.index];
     if (!firstFunctionCallPart) {
       return;
     }
-    firstFunctionCallPart.thoughtSignature =
-      GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE;
+    firstFunctionCallPart.thoughtSignature = fallback.signature;
   }
 
   private supportsGeminiInlineFile(mimeType: string): boolean {

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-thought-signature.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-thought-signature.test.ts
@@ -120,6 +120,23 @@ const unsignedToolHistory = [
   },
 ];
 
+const signedToolHistory = [
+  {
+    role: "assistant" as const,
+    content: [
+      {
+        type: "tool_use" as const,
+        id: "call_1",
+        name: "search",
+        input: { q: "x" },
+        providerMetadata: {
+          gemini: { thoughtSignature: "signed-thought-1" },
+        },
+      },
+    ],
+  },
+];
+
 describe("OpenAIChatCompletionsProvider Gemini thought signature capture", () => {
   test("captures extra_content.google.thought_signature onto tool_use providerMetadata", async () => {
     const { provider } = stubProvider([
@@ -266,8 +283,10 @@ describe("OpenAIChatCompletionsProvider Gemini thought signature capture", () =>
 });
 
 describe("OpenAIChatCompletionsProvider Gemini thought signature replay", () => {
-  test("replays captured thought signatures as extra_content on tool_calls", async () => {
-    const { provider, requests } = stubProvider(OK_CHUNKS);
+  test("replays captured thought signatures as extra_content on Gemini 3 models", async () => {
+    const { provider, requests } = stubProvider(OK_CHUNKS, {
+      model: "gemini-3.7-flash",
+    });
 
     await provider.sendMessage([
       { role: "user", content: [{ type: "text", text: "Read /tmp/test" }] },
@@ -360,6 +379,21 @@ describe("OpenAIChatCompletionsProvider Gemini thought signature replay", () => 
     };
     expect(params.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
   });
+
+  test("does not replay captured thought signatures onto non-Gemini OpenAI requests", async () => {
+    const { provider, requests } = stubProvider(OK_CHUNKS, {
+      model: "gpt-5.2",
+    });
+
+    await provider.sendMessage(signedToolHistory);
+
+    const params = requests[0] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    expect(params.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
+  });
 });
 
 describe("missing thought signature rejection fallback", () => {
@@ -430,30 +464,42 @@ describe("missing thought signature rejection fallback", () => {
     ).toBe(GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE);
   });
 
-  test("does not retry when tool_calls already carry a thought signature", async () => {
+  test("retries a remapped model with the captured signature, not the dummy", async () => {
     const { provider, requests } = stubProviderWithErrors(
       [rejection("Invalid thought signature")],
       OK_CHUNKS,
+      { model: "vertex-flash" },
     );
 
-    await expect(
-      provider.sendMessage([
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_use",
-              id: "call_1",
-              name: "search",
-              input: { q: "x" },
-              providerMetadata: {
-                gemini: { thoughtSignature: "signed-thought-1" },
-              },
-            },
-          ],
-        },
-      ]),
-    ).rejects.toThrow();
+    await provider.sendMessage(signedToolHistory);
+
+    expect(requests).toHaveLength(2);
+    const first = requests[0] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    const second = requests[1] as {
+      messages: Array<{
+        tool_calls?: Array<{
+          extra_content?: { google?: { thought_signature?: string } };
+        }>;
+      }>;
+    };
+    expect(first.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
+    expect(second.messages[0].tool_calls?.[0].extra_content).toEqual({
+      google: { thought_signature: "signed-thought-1" },
+    });
+  });
+
+  test("does not retry when Gemini 3 tool_calls already carry a thought signature", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("Invalid thought signature")],
+      OK_CHUNKS,
+      { model: "gemini-3.7-flash" },
+    );
+
+    await expect(provider.sendMessage(signedToolHistory)).rejects.toThrow();
     expect(requests).toHaveLength(1);
   });
 
@@ -477,24 +523,10 @@ describe("unknown extra_content rejection fallback", () => {
         ),
       ],
       OK_CHUNKS,
+      { model: "gemini-3.7-flash" },
     );
 
-    await provider.sendMessage([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call_1",
-            name: "search",
-            input: { q: "x" },
-            providerMetadata: {
-              gemini: { thoughtSignature: "signed-thought-1" },
-            },
-          },
-        ],
-      },
-    ]);
+    await provider.sendMessage(signedToolHistory);
 
     expect(requests).toHaveLength(2);
     const first = requests[0] as {
@@ -517,26 +549,10 @@ describe("unknown extra_content rejection fallback", () => {
     const { provider, requests } = stubProviderWithErrors(
       [rejection("Invalid thought signature")],
       OK_CHUNKS,
+      { model: "gemini-3.7-flash" },
     );
 
-    await expect(
-      provider.sendMessage([
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_use",
-              id: "call_1",
-              name: "search",
-              input: { q: "x" },
-              providerMetadata: {
-                gemini: { thoughtSignature: "signed-thought-1" },
-              },
-            },
-          ],
-        },
-      ]),
-    ).rejects.toThrow();
+    await expect(provider.sendMessage(signedToolHistory)).rejects.toThrow();
     expect(requests).toHaveLength(1);
     expect(
       (

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-thought-signature.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-thought-signature.test.ts
@@ -551,3 +551,47 @@ describe("unknown extra_content rejection fallback", () => {
     });
   });
 });
+
+describe("stacked openai-compatible fallback retries", () => {
+  test("applies thought-signature backfill then extra_content strip when both 4xx", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [
+        rejection("Invalid thought signature"),
+        rejection(
+          "Additional properties are not allowed ('extra_content' was unexpected)",
+        ),
+      ],
+      OK_CHUNKS,
+    );
+
+    const response = await provider.sendMessage(unsignedToolHistory);
+
+    expect(requests).toHaveLength(3);
+    const first = requests[0] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    const second = requests[1] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    const third = requests[2] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    expect(first.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
+    expect(second.messages[0].tool_calls?.[0].extra_content).toEqual({
+      google: {
+        thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+      },
+    });
+    expect(third.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
+    expect(response.content.find((b) => b.type === "text")).toEqual({
+      type: "text",
+      text: "ok",
+    });
+  });
+});

--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-thought-signature.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-thought-signature.test.ts
@@ -1,0 +1,553 @@
+import { describe, expect, test } from "bun:test";
+
+import OpenAI from "openai";
+
+import { GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE } from "../../gemini-thought-signature.js";
+import {
+  OpenAIChatCompletionsProvider,
+  type OpenAIChatCompletionsProviderOptions,
+} from "../chat-completions-provider.js";
+
+type MockToolCallDelta = {
+  index: number;
+  id?: string;
+  type?: "function";
+  function?: { name?: string; arguments?: string };
+  extra_content?: {
+    google?: { thought_signature?: string; thoughtSignature?: string };
+  };
+};
+
+type MockChunk = {
+  choices: Array<{
+    delta: {
+      content?: string | null;
+      tool_calls?: MockToolCallDelta[];
+    };
+    finish_reason?: string | null;
+  }>;
+  model?: string;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+function makeStream(chunks: MockChunk[]): AsyncIterable<MockChunk> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) {
+        yield c;
+      }
+    },
+  };
+}
+
+function stubProvider(
+  chunks: MockChunk[],
+  options?: OpenAIChatCompletionsProviderOptions & { model?: string },
+): {
+  provider: OpenAIChatCompletionsProvider;
+  requests: unknown[];
+} {
+  const provider = new OpenAIChatCompletionsProvider(
+    "test-key",
+    options?.model ?? "test-model",
+    options,
+  );
+  const requests: unknown[] = [];
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async (params: unknown) => {
+          requests.push(params);
+          return makeStream(chunks);
+        },
+      },
+    },
+  };
+  return { provider, requests };
+}
+
+function stubProviderWithErrors(
+  errors: unknown[],
+  chunks: MockChunk[],
+  options?: OpenAIChatCompletionsProviderOptions & { model?: string },
+): { provider: OpenAIChatCompletionsProvider; requests: unknown[] } {
+  const provider = new OpenAIChatCompletionsProvider(
+    "test-key",
+    options?.model ?? "test-model",
+    options,
+  );
+  const requests: unknown[] = [];
+  const pending = [...errors];
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async (params: unknown) => {
+          requests.push(JSON.parse(JSON.stringify(params)));
+          const error = pending.shift();
+          if (error !== undefined) {
+            throw error;
+          }
+          return makeStream(chunks);
+        },
+      },
+    },
+  };
+  return { provider, requests };
+}
+
+const OK_CHUNKS: MockChunk[] = [
+  {
+    choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 1, completion_tokens: 1 },
+  },
+];
+
+function rejection(message: string, status = 400): Error {
+  return Object.assign(new Error(message), { status });
+}
+
+const unsignedToolHistory = [
+  {
+    role: "assistant" as const,
+    content: [
+      {
+        type: "tool_use" as const,
+        id: "call_1",
+        name: "search",
+        input: { q: "x" },
+      },
+    ],
+  },
+];
+
+describe("OpenAIChatCompletionsProvider Gemini thought signature capture", () => {
+  test("captures extra_content.google.thought_signature onto tool_use providerMetadata", async () => {
+    const { provider } = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_signed",
+                  type: "function",
+                  function: { name: "file_read" },
+                  extra_content: {
+                    google: { thought_signature: "signed-thought-1" },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  function: { arguments: '{"path":"/tmp/test"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 4, completion_tokens: 8 },
+      },
+    ]);
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Read /tmp/test" }] },
+    ]);
+
+    expect(result.content).toEqual([
+      {
+        type: "tool_use",
+        id: "call_signed",
+        name: "file_read",
+        input: { path: "/tmp/test" },
+        providerMetadata: {
+          gemini: { thoughtSignature: "signed-thought-1" },
+        },
+      },
+    ]);
+  });
+
+  test("captures a thought signature that arrives after the tool call id", async () => {
+    const { provider } = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_signed",
+                  type: "function",
+                  function: { name: "file_read", arguments: '{"path":"/a"}' },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  extra_content: {
+                    google: { thought_signature: "signed-thought-1" },
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 2, completion_tokens: 3 },
+      },
+    ]);
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Read /a" }] },
+    ]);
+
+    expect(result.content[0]).toEqual({
+      type: "tool_use",
+      id: "call_signed",
+      name: "file_read",
+      input: { path: "/a" },
+      providerMetadata: {
+        gemini: { thoughtSignature: "signed-thought-1" },
+      },
+    });
+  });
+
+  test("does not attach providerMetadata when extra_content is absent", async () => {
+    const { provider } = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  type: "function",
+                  function: { name: "search", arguments: '{"q":"x"}' },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+
+    const result = await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "search" }] },
+    ]);
+
+    expect(result.content[0]).toEqual({
+      type: "tool_use",
+      id: "call_1",
+      name: "search",
+      input: { q: "x" },
+    });
+  });
+});
+
+describe("OpenAIChatCompletionsProvider Gemini thought signature replay", () => {
+  test("replays captured thought signatures as extra_content on tool_calls", async () => {
+    const { provider, requests } = stubProvider(OK_CHUNKS);
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "Read /tmp/test" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_signed",
+            name: "file_read",
+            input: { path: "/tmp/test" },
+            providerMetadata: {
+              gemini: { thoughtSignature: "signed-thought-1" },
+            },
+          },
+          {
+            type: "tool_use",
+            id: "call_unsigned",
+            name: "file_read",
+            input: { path: "/tmp/other" },
+          },
+        ],
+      },
+    ]);
+
+    const params = requests[0] as {
+      messages: Array<{
+        role: string;
+        tool_calls?: Array<{
+          id: string;
+          type?: string;
+          function?: { name: string; arguments: string };
+          extra_content?: { google?: { thought_signature?: string } };
+        }>;
+      }>;
+    };
+    expect(params.messages[1].tool_calls).toEqual([
+      {
+        id: "call_signed",
+        type: "function",
+        function: {
+          name: "file_read",
+          arguments: JSON.stringify({ path: "/tmp/test" }),
+        },
+        extra_content: {
+          google: { thought_signature: "signed-thought-1" },
+        },
+      },
+      {
+        id: "call_unsigned",
+        type: "function",
+        function: {
+          name: "file_read",
+          arguments: JSON.stringify({ path: "/tmp/other" }),
+        },
+      },
+    ]);
+  });
+
+  test("adds Gemini 3 fallback thought signature to unsigned tool_use history", async () => {
+    const { provider, requests } = stubProvider(OK_CHUNKS, {
+      model: "gemini-3.7-flash",
+    });
+
+    await provider.sendMessage(unsignedToolHistory);
+
+    const params = requests[0] as {
+      messages: Array<{
+        tool_calls?: Array<{
+          extra_content?: { google?: { thought_signature?: string } };
+        }>;
+      }>;
+    };
+    expect(params.messages[0].tool_calls?.[0].extra_content).toEqual({
+      google: {
+        thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+      },
+    });
+  });
+
+  test("does not add extra_content for unsigned history on non-Gemini-3 models", async () => {
+    const { provider, requests } = stubProvider(OK_CHUNKS);
+
+    await provider.sendMessage(unsignedToolHistory);
+
+    const params = requests[0] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    expect(params.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
+  });
+});
+
+describe("missing thought signature rejection fallback", () => {
+  test("retries once with a dummy thought signature on unsigned tool_calls", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("Invalid thought signature")],
+      OK_CHUNKS,
+    );
+
+    const response = await provider.sendMessage(unsignedToolHistory);
+
+    expect(requests).toHaveLength(2);
+    const first = requests[0] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    const second = requests[1] as {
+      messages: Array<{
+        tool_calls?: Array<{
+          extra_content?: { google?: { thought_signature?: string } };
+        }>;
+      }>;
+    };
+    expect(first.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
+    expect(second.messages[0].tool_calls?.[0].extra_content).toEqual({
+      google: {
+        thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+      },
+    });
+    expect(response.content.find((b) => b.type === "text")).toEqual({
+      type: "text",
+      text: "ok",
+    });
+  });
+
+  test("retries once for an OpenRouter-wrapped missing thought signature rejection", async () => {
+    const wrapped = new OpenAI.APIError(
+      400,
+      {
+        code: 400,
+        message: "Provider returned error",
+        metadata: {
+          raw: "[invalid_request_error] Function call search in the 1. content block is missing a thought_signature",
+          provider_name: "google",
+        },
+      },
+      undefined,
+      new Headers(),
+    );
+    expect(/thought_signature/i.test(wrapped.message)).toBe(false);
+
+    const { provider, requests } = stubProviderWithErrors([wrapped], OK_CHUNKS);
+
+    await provider.sendMessage(unsignedToolHistory);
+
+    expect(requests).toHaveLength(2);
+    expect(
+      (
+        requests[1] as {
+          messages: Array<{
+            tool_calls?: Array<{
+              extra_content?: { google?: { thought_signature?: string } };
+            }>;
+          }>;
+        }
+      ).messages[0].tool_calls?.[0].extra_content?.google?.thought_signature,
+    ).toBe(GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE);
+  });
+
+  test("does not retry when tool_calls already carry a thought signature", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("Invalid thought signature")],
+      OK_CHUNKS,
+    );
+
+    await expect(
+      provider.sendMessage([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "call_1",
+              name: "search",
+              input: { q: "x" },
+              providerMetadata: {
+                gemini: { thoughtSignature: "signed-thought-1" },
+              },
+            },
+          ],
+        },
+      ]),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+
+  test("does not retry thought-signature 500s", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("Invalid thought signature", 500)],
+      OK_CHUNKS,
+    );
+
+    await expect(provider.sendMessage(unsignedToolHistory)).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+  });
+});
+
+describe("unknown extra_content rejection fallback", () => {
+  test("retries once without extra_content when a strict schema rejects it", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [
+        rejection(
+          "Additional properties are not allowed ('extra_content' was unexpected)",
+        ),
+      ],
+      OK_CHUNKS,
+    );
+
+    await provider.sendMessage([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call_1",
+            name: "search",
+            input: { q: "x" },
+            providerMetadata: {
+              gemini: { thoughtSignature: "signed-thought-1" },
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(requests).toHaveLength(2);
+    const first = requests[0] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    const second = requests[1] as {
+      messages: Array<{
+        tool_calls?: Array<{ extra_content?: unknown }>;
+      }>;
+    };
+    expect(first.messages[0].tool_calls?.[0].extra_content).toEqual({
+      google: { thought_signature: "signed-thought-1" },
+    });
+    expect(second.messages[0].tool_calls?.[0].extra_content).toBeUndefined();
+  });
+
+  test("does not strip extra_content on a missing thought signature error", async () => {
+    const { provider, requests } = stubProviderWithErrors(
+      [rejection("Invalid thought signature")],
+      OK_CHUNKS,
+    );
+
+    await expect(
+      provider.sendMessage([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "call_1",
+              name: "search",
+              input: { q: "x" },
+              providerMetadata: {
+                gemini: { thoughtSignature: "signed-thought-1" },
+              },
+            },
+          ],
+        },
+      ]),
+    ).rejects.toThrow();
+    expect(requests).toHaveLength(1);
+    expect(
+      (
+        requests[0] as {
+          messages: Array<{
+            tool_calls?: Array<{ extra_content?: unknown }>;
+          }>;
+        }
+      ).messages[0].tool_calls?.[0].extra_content,
+    ).toEqual({
+      google: { thought_signature: "signed-thought-1" },
+    });
+  });
+});

--- a/assistant/src/providers/openai/__tests__/google-thought-signature.test.ts
+++ b/assistant/src/providers/openai/__tests__/google-thought-signature.test.ts
@@ -5,11 +5,15 @@ import {
   applyGemini3UnsignedToolCallFallback,
   assistantToolCallsNeedThoughtSignatureBackfill,
   attachGoogleThoughtSignature,
+  attachGoogleThoughtSignatureIfNeeded,
+  backfillGoogleThoughtSignatures,
   backfillUnsignedGoogleThoughtSignatures,
+  geminiThoughtSignaturesByToolCallId,
   googleThoughtSignatureFromUnknown,
   type GoogleToolCallExtraContent,
   messagesCarryGoogleThoughtSignature,
   stripGoogleThoughtSignatures,
+  toolUseMetadataFromChatCompletionsDelta,
 } from "../google-thought-signature.js";
 
 describe("googleThoughtSignatureFromUnknown", () => {
@@ -54,6 +58,45 @@ describe("attachGoogleThoughtSignature", () => {
     expect(attachGoogleThoughtSignature({ id: "call_1" }, undefined)).toEqual({
       id: "call_1",
     });
+  });
+});
+
+describe("attachGoogleThoughtSignatureIfNeeded", () => {
+  test("attaches extra_content for Gemini 3 models", () => {
+    expect(
+      attachGoogleThoughtSignatureIfNeeded(
+        { id: "call_1" },
+        "signed-thought-1",
+        "google/gemini-3.7-flash",
+      ),
+    ).toEqual({
+      id: "call_1",
+      extra_content: { google: { thought_signature: "signed-thought-1" } },
+    });
+  });
+
+  test("does not attach extra_content for non-Gemini models", () => {
+    expect(
+      attachGoogleThoughtSignatureIfNeeded(
+        { id: "call_1" },
+        "signed-thought-1",
+        "gpt-5.2",
+      ),
+    ).toEqual({ id: "call_1" });
+  });
+});
+
+describe("toolUseMetadataFromChatCompletionsDelta", () => {
+  test("maps extra_content onto gemini providerMetadata", () => {
+    expect(
+      toolUseMetadataFromChatCompletionsDelta({
+        extra_content: { google: { thought_signature: "signed-thought-1" } },
+      }),
+    ).toEqual({ gemini: { thoughtSignature: "signed-thought-1" } });
+  });
+
+  test("returns undefined when extra_content is absent", () => {
+    expect(toolUseMetadataFromChatCompletionsDelta({ id: "call_1" })).toBeUndefined();
   });
 });
 
@@ -146,5 +189,47 @@ describe("thought signature params helpers", () => {
     expect(stripGoogleThoughtSignatures(params)).toBe(true);
     expect(messagesCarryGoogleThoughtSignature(params)).toBe(false);
     expect(params.messages[0].tool_calls[0].extra_content).toBeUndefined();
+  });
+
+  test("replays captured signatures by tool_call id on unsigned params", () => {
+    const params = structuredClone(unsignedParams);
+    expect(
+      backfillGoogleThoughtSignatures(
+        params,
+        new Map([["call_1", "signed-thought-1"]]),
+      ),
+    ).toBe(true);
+    expect(
+      params.messages[0].tool_calls[0].extra_content?.google?.thought_signature,
+    ).toBe("signed-thought-1");
+  });
+});
+
+describe("geminiThoughtSignaturesByToolCallId", () => {
+  test("indexes captured signatures from assistant tool_use blocks", () => {
+    expect(
+      geminiThoughtSignaturesByToolCallId([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "call_1",
+              name: "search",
+              input: { q: "x" },
+              providerMetadata: {
+                gemini: { thoughtSignature: "signed-thought-1" },
+              },
+            },
+            {
+              type: "tool_use",
+              id: "call_2",
+              name: "search",
+              input: { q: "y" },
+            },
+          ],
+        },
+      ]),
+    ).toEqual(new Map([["call_1", "signed-thought-1"]]));
   });
 });

--- a/assistant/src/providers/openai/__tests__/google-thought-signature.test.ts
+++ b/assistant/src/providers/openai/__tests__/google-thought-signature.test.ts
@@ -7,9 +7,9 @@ import {
   attachGoogleThoughtSignature,
   backfillUnsignedGoogleThoughtSignatures,
   googleThoughtSignatureFromUnknown,
+  type GoogleToolCallExtraContent,
   messagesCarryGoogleThoughtSignature,
   stripGoogleThoughtSignatures,
-  type GoogleToolCallExtraContent,
 } from "../google-thought-signature.js";
 
 describe("googleThoughtSignatureFromUnknown", () => {

--- a/assistant/src/providers/openai/__tests__/google-thought-signature.test.ts
+++ b/assistant/src/providers/openai/__tests__/google-thought-signature.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+import { GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE } from "../../gemini-thought-signature.js";
+import {
+  applyGemini3UnsignedToolCallFallback,
+  assistantToolCallsNeedThoughtSignatureBackfill,
+  attachGoogleThoughtSignature,
+  backfillUnsignedGoogleThoughtSignatures,
+  googleThoughtSignatureFromUnknown,
+  messagesCarryGoogleThoughtSignature,
+  stripGoogleThoughtSignatures,
+  type GoogleToolCallExtraContent,
+} from "../google-thought-signature.js";
+
+describe("googleThoughtSignatureFromUnknown", () => {
+  test("reads extra_content.google.thought_signature", () => {
+    expect(
+      googleThoughtSignatureFromUnknown({
+        extra_content: { google: { thought_signature: "signed-thought-1" } },
+      }),
+    ).toBe("signed-thought-1");
+  });
+
+  test("reads camelCase thoughtSignature under google", () => {
+    expect(
+      googleThoughtSignatureFromUnknown({
+        extra_content: { google: { thoughtSignature: "signed-thought-1" } },
+      }),
+    ).toBe("signed-thought-1");
+  });
+
+  test("ignores empty, missing, and non-object extra_content", () => {
+    expect(googleThoughtSignatureFromUnknown(undefined)).toBeUndefined();
+    expect(googleThoughtSignatureFromUnknown({})).toBeUndefined();
+    expect(
+      googleThoughtSignatureFromUnknown({ extra_content: "nope" }),
+    ).toBeUndefined();
+    expect(
+      googleThoughtSignatureFromUnknown({
+        extra_content: { google: { thought_signature: "" } },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("attachGoogleThoughtSignature", () => {
+  test("adds extra_content only when a signature is present", () => {
+    expect(
+      attachGoogleThoughtSignature({ id: "call_1" }, "signed-thought-1"),
+    ).toEqual({
+      id: "call_1",
+      extra_content: { google: { thought_signature: "signed-thought-1" } },
+    });
+    expect(attachGoogleThoughtSignature({ id: "call_1" }, undefined)).toEqual({
+      id: "call_1",
+    });
+  });
+});
+
+describe("applyGemini3UnsignedToolCallFallback", () => {
+  test("adds the dummy signature to the first unsigned Gemini 3 tool_call", () => {
+    const toolCalls: GoogleToolCallExtraContent[] = [{}, {}];
+    applyGemini3UnsignedToolCallFallback(toolCalls, "google/gemini-3.7-flash");
+    expect(toolCalls[0].extra_content).toEqual({
+      google: {
+        thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+      },
+    });
+    expect(toolCalls[1].extra_content).toBeUndefined();
+  });
+
+  test("does not overwrite a captured signature", () => {
+    const toolCalls: GoogleToolCallExtraContent[] = [
+      attachGoogleThoughtSignature({}, "signed-thought-1"),
+      {},
+    ];
+    applyGemini3UnsignedToolCallFallback(toolCalls, "gemini-3.7-flash");
+    expect(toolCalls[0].extra_content?.google?.thought_signature).toBe(
+      "signed-thought-1",
+    );
+    expect(toolCalls[1].extra_content).toBeUndefined();
+  });
+
+  test("does not add extra_content for non-Gemini-3 models", () => {
+    const toolCalls: GoogleToolCallExtraContent[] = [{}];
+    applyGemini3UnsignedToolCallFallback(toolCalls, "gpt-5.2");
+    expect(toolCalls[0].extra_content).toBeUndefined();
+  });
+});
+
+describe("thought signature params helpers", () => {
+  type ToolCallParams = {
+    messages: Array<{
+      role: string;
+      tool_calls: Array<
+        GoogleToolCallExtraContent & { id: string; type: string }
+      >;
+    }>;
+  };
+
+  const unsignedParams: ToolCallParams = {
+    messages: [
+      {
+        role: "assistant",
+        tool_calls: [{ id: "call_1", type: "function" }],
+      },
+    ],
+  };
+
+  const signedParams = {
+    messages: [
+      {
+        role: "assistant",
+        tool_calls: [
+          attachGoogleThoughtSignature(
+            { id: "call_1", type: "function" },
+            "signed-thought-1",
+          ),
+        ],
+      },
+    ],
+  };
+
+  test("detects unsigned assistant tool_calls that need a backfill", () => {
+    expect(assistantToolCallsNeedThoughtSignatureBackfill(unsignedParams)).toBe(
+      true,
+    );
+    expect(assistantToolCallsNeedThoughtSignatureBackfill(signedParams)).toBe(
+      false,
+    );
+    expect(messagesCarryGoogleThoughtSignature(unsignedParams)).toBe(false);
+    expect(messagesCarryGoogleThoughtSignature(signedParams)).toBe(true);
+  });
+
+  test("backfills the dummy signature onto unsigned tool_calls", () => {
+    const params = structuredClone(unsignedParams);
+    expect(backfillUnsignedGoogleThoughtSignatures(params)).toBe(true);
+    expect(messagesCarryGoogleThoughtSignature(params)).toBe(true);
+    expect(
+      params.messages[0].tool_calls[0].extra_content?.google?.thought_signature,
+    ).toBe(GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE);
+  });
+
+  test("strips extra_content from assistant tool_calls", () => {
+    const params = structuredClone(signedParams);
+    expect(stripGoogleThoughtSignatures(params)).toBe(true);
+    expect(messagesCarryGoogleThoughtSignature(params)).toBe(false);
+    expect(params.messages[0].tool_calls[0].extra_content).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -52,6 +52,16 @@ import {
   decodeCoercedObjectArgs,
 } from "./coerce-object-args.js";
 import {
+  applyGemini3UnsignedToolCallFallback,
+  assistantToolCallsNeedThoughtSignatureBackfill,
+  attachGoogleThoughtSignature,
+  backfillUnsignedGoogleThoughtSignatures,
+  googleThoughtSignatureFromUnknown,
+  type GoogleToolCallExtraContent,
+  messagesCarryGoogleThoughtSignature,
+  stripGoogleThoughtSignatures,
+} from "./google-thought-signature.js";
+import {
   isOpenAICompatInlineAudio,
   OPENAI_COMPAT_MAX_INLINE_AUDIO_BYTES,
   openAIInputAudioFormat,
@@ -204,7 +214,13 @@ const log = getLogger("chat-completions");
 /** Wire-level reasoning_effort values. The OpenAI SDK type doesn't include
  *  `"max"`, but Fireworks accepts it for DeepSeek V4; the assignment to
  *  `params.reasoning_effort` casts through this union. */
-export type ReasoningEffortWire = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+export type ReasoningEffortWire =
+  | "none"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max";
 
 const REASONING_EFFORT_RANK: Record<ReasoningEffortWire, number> = {
   none: 0,
@@ -566,6 +582,50 @@ function isUnknownAssistantReasoningFieldRejection(
   );
 }
 
+/**
+ * True when thinking-enabled Gemini (via an OpenAI-compatible gateway)
+ * rejected the follow-up because assistant tool_calls omitted
+ * extra_content.google.thought_signature. One retry attaches the documented
+ * dummy signature to unsigned tool_calls so unsigned history can proceed.
+ */
+function isMissingThoughtSignatureRejection(
+  error: unknown,
+  params: unknown,
+): boolean {
+  if (!isClientErrorStatus(error)) {
+    return false;
+  }
+  if (!assistantToolCallsNeedThoughtSignatureBackfill(params)) {
+    return false;
+  }
+  const haystack = openaiCompatErrorHaystack(error);
+  return /thought[_\s-]?signature/i.test(haystack);
+}
+
+/**
+ * True when the request included tool_call extra_content and the provider
+ * rejected it as an unknown property. One retry without those extras lets a
+ * strict Chat Completions schema succeed.
+ */
+function isUnknownExtraContentRejection(
+  error: unknown,
+  params: unknown,
+): boolean {
+  if (!isClientErrorStatus(error)) {
+    return false;
+  }
+  if (!messagesCarryGoogleThoughtSignature(params)) {
+    return false;
+  }
+  const haystack = openaiCompatErrorHaystack(error);
+  if (!/extra_content/i.test(haystack)) {
+    return false;
+  }
+  return /unknown|unexpected|unrecognized|additional propert|extra (?:field|property)|not (?:a )?valid|invalid (?:argument|parameter|field|property)/i.test(
+    haystack,
+  );
+}
+
 function isTextualContentPart(part: { type: string }): boolean {
   return part.type === "text" || part.type === "refusal";
 }
@@ -778,6 +838,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         messages,
         systemPrompt,
         requestSupportsInlineAudio(modelOverride ?? this.model),
+        modelOverride ?? this.model,
       );
 
       recordProviderRequestDiagnostics({
@@ -973,7 +1034,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       const toolCallMap = new Map<
         number,
-        { id: string; name: string; args: string }
+        { id: string; name: string; args: string; thoughtSignature?: string }
       >();
       const toolProgress = createToolProgressEmitter(onEvent);
       let finishReason = "unknown";
@@ -1049,6 +1110,28 @@ export class OpenAIChatCompletionsProvider implements Provider {
               "Upstream rejected assistant reasoning field; retrying without it",
             );
             stripAssistantReasoningFields(params);
+            stream = await createStream();
+          } else if (isMissingThoughtSignatureRejection(error, params)) {
+            log.warn(
+              {
+                provider: this.name,
+                model: modelOverride ?? this.model,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Upstream requires thought signature round-trip; retrying with dummy signature on unsigned tool_calls",
+            );
+            backfillUnsignedGoogleThoughtSignatures(params);
+            stream = await createStream();
+          } else if (isUnknownExtraContentRejection(error, params)) {
+            log.warn(
+              {
+                provider: this.name,
+                model: modelOverride ?? this.model,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Upstream rejected tool_call extra_content; retrying without it",
+            );
+            stripGoogleThoughtSignatures(params);
             stream = await createStream();
           } else if (isChatTemplateRejection(error, params)) {
             log.warn(
@@ -1149,6 +1232,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
                     entry.name,
                     entry.args,
                   );
+                }
+                const thoughtSignature = googleThoughtSignatureFromUnknown(tc);
+                if (thoughtSignature && !entry.thoughtSignature) {
+                  entry.thoughtSignature = thoughtSignature;
                 }
               }
             }
@@ -1271,6 +1358,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
           id: tc.id,
           name: tc.name,
           input,
+          ...(tc.thoughtSignature
+            ? {
+                providerMetadata: {
+                  gemini: { thoughtSignature: tc.thoughtSignature },
+                },
+              }
+            : {}),
         });
       }
 
@@ -1284,11 +1378,16 @@ export class OpenAIChatCompletionsProvider implements Provider {
               content: contentText || null,
               tool_calls:
                 toolCallMap.size > 0
-                  ? Array.from(toolCallMap.values()).map((tc) => ({
-                      id: tc.id,
-                      type: "function",
-                      function: { name: tc.name, arguments: tc.args },
-                    }))
+                  ? Array.from(toolCallMap.values()).map((tc) =>
+                      attachGoogleThoughtSignature(
+                        {
+                          id: tc.id,
+                          type: "function",
+                          function: { name: tc.name, arguments: tc.args },
+                        },
+                        tc.thoughtSignature,
+                      ),
+                    )
                   : undefined,
             },
             finish_reason: finishReason,
@@ -1492,6 +1591,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     messages: Message[],
     systemPrompt?: string,
     audioInputEnabled = false,
+    model = this.model,
   ): Promise<OpenAI.Chat.Completions.ChatCompletionMessageParam[]> {
     // Swap any persisted attachment references back to inline base64 before
     // serializing, so the block transforms below can read `source.data`.
@@ -1513,7 +1613,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const emittedToolCallIds = new Set<string>();
     for (const msg of messages) {
       if (msg.role === "assistant") {
-        const assistantMessage = this.toOpenAIAssistantMessage(msg);
+        const assistantMessage = this.toOpenAIAssistantMessage(msg, model);
         for (const toolCall of assistantMessage.tool_calls ?? []) {
           emittedToolCallIds.add(toolCall.id);
         }
@@ -1591,11 +1691,14 @@ export class OpenAIChatCompletionsProvider implements Provider {
   /** Convert an assistant message with text + tool_use blocks to OpenAI format. */
   private toOpenAIAssistantMessage(
     msg: Message,
+    model: string,
   ): OpenAI.Chat.Completions.ChatCompletionAssistantMessageParam {
     const textParts: string[] = [];
     const reasoningParts: string[] = [];
-    const toolCalls: OpenAI.Chat.Completions.ChatCompletionMessageToolCall[] =
-      [];
+    const toolCalls: Array<
+      OpenAI.Chat.Completions.ChatCompletionMessageToolCall &
+        GoogleToolCallExtraContent
+    > = [];
 
     for (const block of msg.content) {
       switch (block.type) {
@@ -1609,14 +1712,19 @@ export class OpenAIChatCompletionsProvider implements Provider {
           }
           break;
         case "tool_use":
-          toolCalls.push({
-            id: block.id,
-            type: "function",
-            function: {
-              name: block.name,
-              arguments: JSON.stringify(block.input),
-            },
-          });
+          toolCalls.push(
+            attachGoogleThoughtSignature(
+              {
+                id: block.id,
+                type: "function",
+                function: {
+                  name: block.name,
+                  arguments: JSON.stringify(block.input),
+                },
+              },
+              block.providerMetadata?.gemini?.thoughtSignature,
+            ),
+          );
           break;
         case "server_tool_use":
           textParts.push(`[Web search: ${block.name}]`);
@@ -1635,6 +1743,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
       };
 
     if (toolCalls.length > 0) {
+      applyGemini3UnsignedToolCallFallback(toolCalls, model);
       result.tool_calls = toolCalls;
     }
 

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -694,6 +694,92 @@ function flattenContentPartsToStrings(params: unknown): boolean {
   return flattened;
 }
 
+type OpenAICompatRetryKind =
+  | "reasoning-opt-out"
+  | "thinking-tool-choice"
+  | "missing-reasoning-content"
+  | "unknown-reasoning-field"
+  | "missing-thought-signature"
+  | "unknown-extra-content"
+  | "chat-template";
+
+function classifyOpenAICompatRetry(
+  error: unknown,
+  params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+): { kind: OpenAICompatRetryKind; message: string; apply: () => void } | null {
+  if (isReasoningOptOutRejection(error, params)) {
+    return {
+      kind: "reasoning-opt-out",
+      message:
+        "Model rejected the explicit reasoning opt-out; retrying without reasoning params",
+      apply: () => {
+        delete params.reasoning_effort;
+        delete (params as unknown as Record<string, unknown>).reasoning;
+      },
+    };
+  }
+  if (isThinkingModeToolChoiceRejection(error, params)) {
+    return {
+      kind: "thinking-tool-choice",
+      message:
+        "Upstream rejected tool_choice in thinking mode; retrying without tool_choice",
+      apply: () => {
+        delete params.tool_choice;
+      },
+    };
+  }
+  if (isMissingReasoningContentRejection(error, params)) {
+    return {
+      kind: "missing-reasoning-content",
+      message:
+        "Upstream requires reasoning_content round-trip; retrying with empty field on assistant messages",
+      apply: () => {
+        backfillEmptyReasoningContent(params);
+      },
+    };
+  }
+  if (isUnknownAssistantReasoningFieldRejection(error, params)) {
+    return {
+      kind: "unknown-reasoning-field",
+      message:
+        "Upstream rejected assistant reasoning field; retrying without it",
+      apply: () => {
+        stripAssistantReasoningFields(params);
+      },
+    };
+  }
+  if (isMissingThoughtSignatureRejection(error, params)) {
+    return {
+      kind: "missing-thought-signature",
+      message:
+        "Upstream requires thought signature round-trip; retrying with dummy signature on unsigned tool_calls",
+      apply: () => {
+        backfillUnsignedGoogleThoughtSignatures(params);
+      },
+    };
+  }
+  if (isUnknownExtraContentRejection(error, params)) {
+    return {
+      kind: "unknown-extra-content",
+      message: "Upstream rejected tool_call extra_content; retrying without it",
+      apply: () => {
+        stripGoogleThoughtSignatures(params);
+      },
+    };
+  }
+  if (isChatTemplateRejection(error, params)) {
+    return {
+      kind: "chat-template",
+      message:
+        "Upstream chat template rejected structured message content; retrying with flattened plain-text content",
+      apply: () => {
+        flattenContentPartsToStrings(params);
+      },
+    };
+  }
+  return null;
+}
+
 /**
  * Translate the neutral (Anthropic-shaped) `tool_choice` carried on the call
  * config into the OpenAI chat-completions wire format. Callers express
@@ -1062,90 +1148,27 @@ export class OpenAIChatCompletionsProvider implements Provider {
               ? { headers: requestHeaders }
               : {}),
           });
+        const attemptedCompatRetries = new Set<OpenAICompatRetryKind>();
         let stream: Awaited<ReturnType<typeof createStream>>;
-        try {
-          stream = await createStream();
-        } catch (error) {
-          if (isReasoningOptOutRejection(error, params)) {
+        for (;;) {
+          try {
+            stream = await createStream();
+            break;
+          } catch (error) {
+            const retry = classifyOpenAICompatRetry(error, params);
+            if (!retry || attemptedCompatRetries.has(retry.kind)) {
+              throw error;
+            }
+            attemptedCompatRetries.add(retry.kind);
             log.warn(
               {
                 provider: this.name,
                 model: modelOverride ?? this.model,
                 error: error instanceof Error ? error.message : String(error),
               },
-              "Model rejected the explicit reasoning opt-out; retrying without reasoning params",
+              retry.message,
             );
-            delete params.reasoning_effort;
-            delete (params as unknown as Record<string, unknown>).reasoning;
-            stream = await createStream();
-          } else if (isThinkingModeToolChoiceRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Upstream rejected tool_choice in thinking mode; retrying without tool_choice",
-            );
-            delete params.tool_choice;
-            stream = await createStream();
-          } else if (isMissingReasoningContentRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Upstream requires reasoning_content round-trip; retrying with empty field on assistant messages",
-            );
-            backfillEmptyReasoningContent(params);
-            stream = await createStream();
-          } else if (isUnknownAssistantReasoningFieldRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Upstream rejected assistant reasoning field; retrying without it",
-            );
-            stripAssistantReasoningFields(params);
-            stream = await createStream();
-          } else if (isMissingThoughtSignatureRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Upstream requires thought signature round-trip; retrying with dummy signature on unsigned tool_calls",
-            );
-            backfillUnsignedGoogleThoughtSignatures(params);
-            stream = await createStream();
-          } else if (isUnknownExtraContentRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Upstream rejected tool_call extra_content; retrying without it",
-            );
-            stripGoogleThoughtSignatures(params);
-            stream = await createStream();
-          } else if (isChatTemplateRejection(error, params)) {
-            log.warn(
-              {
-                provider: this.name,
-                model: modelOverride ?? this.model,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Upstream chat template rejected structured message content; retrying with flattened plain-text content",
-            );
-            flattenContentPartsToStrings(params);
-            stream = await createStream();
-          } else {
-            throw error;
+            retry.apply();
           }
         }
 

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -27,6 +27,7 @@ import type {
   Provider,
   ProviderResponse,
   SendMessageOptions,
+  ToolUseContent,
 } from "../types.js";
 import {
   ContextOverflowError,
@@ -53,13 +54,12 @@ import {
 } from "./coerce-object-args.js";
 import {
   applyGemini3UnsignedToolCallFallback,
-  assistantToolCallsNeedThoughtSignatureBackfill,
-  attachGoogleThoughtSignature,
-  backfillUnsignedGoogleThoughtSignatures,
-  googleThoughtSignatureFromUnknown,
+  attachGoogleThoughtSignatureIfNeeded,
+  classifyGoogleThoughtSignatureRetry,
+  geminiThoughtSignaturesByToolCallId,
   type GoogleToolCallExtraContent,
-  messagesCarryGoogleThoughtSignature,
-  stripGoogleThoughtSignatures,
+  thoughtSignatureFromToolUseMetadata,
+  toolUseMetadataFromChatCompletionsDelta,
 } from "./google-thought-signature.js";
 import {
   isOpenAICompatInlineAudio,
@@ -582,50 +582,6 @@ function isUnknownAssistantReasoningFieldRejection(
   );
 }
 
-/**
- * True when thinking-enabled Gemini (via an OpenAI-compatible gateway)
- * rejected the follow-up because assistant tool_calls omitted
- * extra_content.google.thought_signature. One retry attaches the documented
- * dummy signature to unsigned tool_calls so unsigned history can proceed.
- */
-function isMissingThoughtSignatureRejection(
-  error: unknown,
-  params: unknown,
-): boolean {
-  if (!isClientErrorStatus(error)) {
-    return false;
-  }
-  if (!assistantToolCallsNeedThoughtSignatureBackfill(params)) {
-    return false;
-  }
-  const haystack = openaiCompatErrorHaystack(error);
-  return /thought[_\s-]?signature/i.test(haystack);
-}
-
-/**
- * True when the request included tool_call extra_content and the provider
- * rejected it as an unknown property. One retry without those extras lets a
- * strict Chat Completions schema succeed.
- */
-function isUnknownExtraContentRejection(
-  error: unknown,
-  params: unknown,
-): boolean {
-  if (!isClientErrorStatus(error)) {
-    return false;
-  }
-  if (!messagesCarryGoogleThoughtSignature(params)) {
-    return false;
-  }
-  const haystack = openaiCompatErrorHaystack(error);
-  if (!/extra_content/i.test(haystack)) {
-    return false;
-  }
-  return /unknown|unexpected|unrecognized|additional propert|extra (?:field|property)|not (?:a )?valid|invalid (?:argument|parameter|field|property)/i.test(
-    haystack,
-  );
-}
-
 function isTextualContentPart(part: { type: string }): boolean {
   return part.type === "text" || part.type === "refusal";
 }
@@ -706,6 +662,7 @@ type OpenAICompatRetryKind =
 function classifyOpenAICompatRetry(
   error: unknown,
   params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
+  thoughtSignaturesByCallId: ReadonlyMap<string, string>,
 ): { kind: OpenAICompatRetryKind; message: string; apply: () => void } | null {
   if (isReasoningOptOutRejection(error, params)) {
     return {
@@ -748,24 +705,13 @@ function classifyOpenAICompatRetry(
       },
     };
   }
-  if (isMissingThoughtSignatureRejection(error, params)) {
-    return {
-      kind: "missing-thought-signature",
-      message:
-        "Upstream requires thought signature round-trip; retrying with dummy signature on unsigned tool_calls",
-      apply: () => {
-        backfillUnsignedGoogleThoughtSignatures(params);
-      },
-    };
-  }
-  if (isUnknownExtraContentRejection(error, params)) {
-    return {
-      kind: "unknown-extra-content",
-      message: "Upstream rejected tool_call extra_content; retrying without it",
-      apply: () => {
-        stripGoogleThoughtSignatures(params);
-      },
-    };
+  const thoughtSignatureRetry = classifyGoogleThoughtSignatureRetry(params, {
+    isClientError: isClientErrorStatus(error),
+    haystack: openaiCompatErrorHaystack(error),
+    capturedByCallId: thoughtSignaturesByCallId,
+  });
+  if (thoughtSignatureRetry) {
+    return thoughtSignatureRetry;
   }
   if (isChatTemplateRejection(error, params)) {
     return {
@@ -920,6 +866,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const coercedObjectKeys = new Map<string, string[]>();
 
     try {
+      const thoughtSignaturesByCallId =
+        geminiThoughtSignaturesByToolCallId(messages);
       const openaiMessages = await this.toOpenAIMessages(
         messages,
         systemPrompt,
@@ -1120,7 +1068,12 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       const toolCallMap = new Map<
         number,
-        { id: string; name: string; args: string; thoughtSignature?: string }
+        {
+          id: string;
+          name: string;
+          args: string;
+          providerMetadata?: ToolUseContent["providerMetadata"];
+        }
       >();
       const toolProgress = createToolProgressEmitter(onEvent);
       let finishReason = "unknown";
@@ -1155,7 +1108,11 @@ export class OpenAIChatCompletionsProvider implements Provider {
             stream = await createStream();
             break;
           } catch (error) {
-            const retry = classifyOpenAICompatRetry(error, params);
+            const retry = classifyOpenAICompatRetry(
+              error,
+              params,
+              thoughtSignaturesByCallId,
+            );
             if (!retry || attemptedCompatRetries.has(retry.kind)) {
               throw error;
             }
@@ -1256,9 +1213,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
                     entry.args,
                   );
                 }
-                const thoughtSignature = googleThoughtSignatureFromUnknown(tc);
-                if (thoughtSignature && !entry.thoughtSignature) {
-                  entry.thoughtSignature = thoughtSignature;
+                const providerMetadata =
+                  toolUseMetadataFromChatCompletionsDelta(tc);
+                if (
+                  providerMetadata &&
+                  !thoughtSignatureFromToolUseMetadata(entry.providerMetadata)
+                ) {
+                  entry.providerMetadata = providerMetadata;
                 }
               }
             }
@@ -1381,12 +1342,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
           id: tc.id,
           name: tc.name,
           input,
-          ...(tc.thoughtSignature
-            ? {
-                providerMetadata: {
-                  gemini: { thoughtSignature: tc.thoughtSignature },
-                },
-              }
+          ...(tc.providerMetadata
+            ? { providerMetadata: tc.providerMetadata }
             : {}),
         });
       }
@@ -1402,13 +1359,16 @@ export class OpenAIChatCompletionsProvider implements Provider {
               tool_calls:
                 toolCallMap.size > 0
                   ? Array.from(toolCallMap.values()).map((tc) =>
-                      attachGoogleThoughtSignature(
+                      attachGoogleThoughtSignatureIfNeeded(
                         {
                           id: tc.id,
                           type: "function",
                           function: { name: tc.name, arguments: tc.args },
                         },
-                        tc.thoughtSignature,
+                        thoughtSignatureFromToolUseMetadata(
+                          tc.providerMetadata,
+                        ),
+                        modelOverride ?? this.model,
                       ),
                     )
                   : undefined,
@@ -1736,7 +1696,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
           break;
         case "tool_use":
           toolCalls.push(
-            attachGoogleThoughtSignature(
+            attachGoogleThoughtSignatureIfNeeded(
               {
                 id: block.id,
                 type: "function",
@@ -1745,7 +1705,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
                   arguments: JSON.stringify(block.input),
                 },
               },
-              block.providerMetadata?.gemini?.thoughtSignature,
+              thoughtSignatureFromToolUseMetadata(block.providerMetadata),
+              model,
             ),
           );
           break;

--- a/assistant/src/providers/openai/google-thought-signature.ts
+++ b/assistant/src/providers/openai/google-thought-signature.ts
@@ -1,4 +1,8 @@
-import { unsignedThoughtSignatureFallback } from "../gemini-thought-signature.js";
+import {
+  isGemini3Model,
+  unsignedThoughtSignatureFallback,
+} from "../gemini-thought-signature.js";
+import type { Message, ToolUseContent } from "../types.js";
 
 export type GoogleToolCallExtraContent = {
   extra_content?: {
@@ -7,6 +11,10 @@ export type GoogleToolCallExtraContent = {
     };
   };
 };
+
+export type GoogleThoughtSignatureRetryKind =
+  | "missing-thought-signature"
+  | "unknown-extra-content";
 
 function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
@@ -40,6 +48,22 @@ export function googleThoughtSignatureFromUnknown(
   return googleObjectThoughtSignature((extra as { google?: unknown }).google);
 }
 
+export function toolUseMetadataFromChatCompletionsDelta(
+  delta: unknown,
+): ToolUseContent["providerMetadata"] | undefined {
+  const thoughtSignature = googleThoughtSignatureFromUnknown(delta);
+  if (!thoughtSignature) {
+    return undefined;
+  }
+  return { gemini: { thoughtSignature } };
+}
+
+export function thoughtSignatureFromToolUseMetadata(
+  metadata: ToolUseContent["providerMetadata"] | undefined,
+): string | undefined {
+  return metadata?.gemini?.thoughtSignature;
+}
+
 export function attachGoogleThoughtSignature<T extends object>(
   toolCall: T,
   thoughtSignature: string | undefined,
@@ -53,6 +77,23 @@ export function attachGoogleThoughtSignature<T extends object>(
       google: { thought_signature: thoughtSignature },
     },
   };
+}
+
+/**
+ * Attach Gemini extra_content only when the destination model is Gemini 3.x.
+ * Non-Gemini Chat Completions endpoints never see the vendor field on the
+ * first request. Remapped model ids that still require a signature recover
+ * via {@link backfillGoogleThoughtSignatures} after a 4xx.
+ */
+export function attachGoogleThoughtSignatureIfNeeded<T extends object>(
+  toolCall: T,
+  thoughtSignature: string | undefined,
+  model: string,
+): T & GoogleToolCallExtraContent {
+  if (!isGemini3Model(model)) {
+    return toolCall;
+  }
+  return attachGoogleThoughtSignature(toolCall, thoughtSignature);
 }
 
 function stampUnsignedGoogleThoughtSignature(
@@ -76,6 +117,27 @@ function stampUnsignedGoogleThoughtSignature(
   return true;
 }
 
+function stampCapturedGoogleThoughtSignatures(
+  toolCalls: Array<GoogleToolCallExtraContent & { id?: unknown }>,
+  capturedByCallId: ReadonlyMap<string, string>,
+): boolean {
+  let added = false;
+  for (const tc of toolCalls) {
+    if (typeof tc.id !== "string") {
+      continue;
+    }
+    const captured = capturedByCallId.get(tc.id);
+    if (!captured || googleThoughtSignatureFromUnknown(tc)) {
+      continue;
+    }
+    tc.extra_content = {
+      google: { thought_signature: captured },
+    };
+    added = true;
+  }
+  return added;
+}
+
 /**
  * Gemini 3.x validates the first function call of each step. When none of the
  * serialized tool_calls carry a captured signature, attach the documented dummy
@@ -95,7 +157,7 @@ function paramsMessages(params: unknown): unknown[] | undefined {
 
 function assistantToolCalls(
   msg: unknown,
-): GoogleToolCallExtraContent[] | undefined {
+): Array<GoogleToolCallExtraContent & { id?: unknown }> | undefined {
   if (msg === null || typeof msg !== "object") {
     return undefined;
   }
@@ -103,7 +165,9 @@ function assistantToolCalls(
   if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
     return undefined;
   }
-  return record.tool_calls as GoogleToolCallExtraContent[];
+  return record.tool_calls as Array<
+    GoogleToolCallExtraContent & { id?: unknown }
+  >;
 }
 
 export function messagesCarryGoogleThoughtSignature(params: unknown): boolean {
@@ -154,8 +218,30 @@ export function stripGoogleThoughtSignatures(params: unknown): boolean {
   return stripped;
 }
 
-export function backfillUnsignedGoogleThoughtSignatures(
+export function geminiThoughtSignaturesByToolCallId(
+  messages: ReadonlyArray<Message>,
+): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const msg of messages) {
+    if (msg.role !== "assistant") {
+      continue;
+    }
+    for (const block of msg.content) {
+      if (block.type !== "tool_use") {
+        continue;
+      }
+      const signature = block.providerMetadata?.gemini?.thoughtSignature;
+      if (signature) {
+        out.set(block.id, signature);
+      }
+    }
+  }
+  return out;
+}
+
+export function backfillGoogleThoughtSignatures(
   params: unknown,
+  capturedByCallId?: ReadonlyMap<string, string>,
 ): boolean {
   const messages = paramsMessages(params);
   if (!messages) {
@@ -167,9 +253,68 @@ export function backfillUnsignedGoogleThoughtSignatures(
     if (!toolCalls || toolCalls.length === 0) {
       continue;
     }
+    if (
+      capturedByCallId &&
+      stampCapturedGoogleThoughtSignatures(toolCalls, capturedByCallId)
+    ) {
+      added = true;
+    }
     if (stampUnsignedGoogleThoughtSignature(toolCalls)) {
       added = true;
     }
   }
   return added;
+}
+
+export function backfillUnsignedGoogleThoughtSignatures(
+  params: unknown,
+): boolean {
+  return backfillGoogleThoughtSignatures(params);
+}
+
+const UNKNOWN_EXTRA_CONTENT_REJECTION =
+  /unknown|unexpected|unrecognized|additional propert|extra (?:field|property)|not (?:a )?valid|invalid (?:argument|parameter|field|property)/i;
+
+export function classifyGoogleThoughtSignatureRetry(
+  params: unknown,
+  options: {
+    isClientError: boolean;
+    haystack: string;
+    capturedByCallId?: ReadonlyMap<string, string>;
+  },
+): {
+  kind: GoogleThoughtSignatureRetryKind;
+  message: string;
+  apply: () => void;
+} | null {
+  if (!options.isClientError) {
+    return null;
+  }
+  if (
+    assistantToolCallsNeedThoughtSignatureBackfill(params) &&
+    /thought[_\s-]?signature/i.test(options.haystack)
+  ) {
+    return {
+      kind: "missing-thought-signature",
+      message:
+        "Upstream requires thought signature round-trip; retrying with signatures on unsigned tool_calls",
+      apply: () => {
+        backfillGoogleThoughtSignatures(params, options.capturedByCallId);
+      },
+    };
+  }
+  if (
+    messagesCarryGoogleThoughtSignature(params) &&
+    /extra_content/i.test(options.haystack) &&
+    UNKNOWN_EXTRA_CONTENT_REJECTION.test(options.haystack)
+  ) {
+    return {
+      kind: "unknown-extra-content",
+      message: "Upstream rejected tool_call extra_content; retrying without it",
+      apply: () => {
+        stripGoogleThoughtSignatures(params);
+      },
+    };
+  }
+  return null;
 }

--- a/assistant/src/providers/openai/google-thought-signature.ts
+++ b/assistant/src/providers/openai/google-thought-signature.ts
@@ -1,0 +1,181 @@
+import {
+  GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+  isGemini3Model,
+} from "../gemini-thought-signature.js";
+
+export type GoogleToolCallExtraContent = {
+  extra_content?: {
+    google?: {
+      thought_signature?: string;
+    };
+  };
+};
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function googleObjectThoughtSignature(google: unknown): string | undefined {
+  if (google === null || typeof google !== "object") {
+    return undefined;
+  }
+  const record = google as Record<string, unknown>;
+  return (
+    asNonEmptyString(record.thought_signature) ??
+    asNonEmptyString(record.thoughtSignature)
+  );
+}
+
+/**
+ * Gemini's OpenAI-compatible wire format puts the thought signature on
+ * `tool_calls[].extra_content.google.thought_signature`.
+ */
+export function googleThoughtSignatureFromUnknown(
+  value: unknown,
+): string | undefined {
+  if (value === null || typeof value !== "object") {
+    return undefined;
+  }
+  const extra = (value as { extra_content?: unknown }).extra_content;
+  if (extra === null || typeof extra !== "object") {
+    return undefined;
+  }
+  return googleObjectThoughtSignature((extra as { google?: unknown }).google);
+}
+
+export function attachGoogleThoughtSignature<T extends object>(
+  toolCall: T,
+  thoughtSignature: string | undefined,
+): T & GoogleToolCallExtraContent {
+  if (!thoughtSignature) {
+    return toolCall;
+  }
+  return {
+    ...toolCall,
+    extra_content: {
+      google: { thought_signature: thoughtSignature },
+    },
+  };
+}
+
+/**
+ * Gemini 3.x validates the first function call of each step. When none of the
+ * serialized tool_calls carry a captured signature, attach the documented dummy
+ * so unsigned history (or a non-capturing earlier turn) does not 400.
+ */
+export function applyGemini3UnsignedToolCallFallback(
+  toolCalls: GoogleToolCallExtraContent[],
+  model: string,
+): void {
+  if (!isGemini3Model(model) || toolCalls.length === 0) {
+    return;
+  }
+  if (toolCalls.some((tc) => googleThoughtSignatureFromUnknown(tc))) {
+    return;
+  }
+  const first = toolCalls[0];
+  if (!first) {
+    return;
+  }
+  first.extra_content = {
+    google: {
+      thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+    },
+  };
+}
+
+function paramsMessages(params: unknown): unknown[] | undefined {
+  const messages = (params as { messages?: unknown }).messages;
+  return Array.isArray(messages) ? messages : undefined;
+}
+
+function assistantToolCalls(
+  msg: unknown,
+): GoogleToolCallExtraContent[] | undefined {
+  if (msg === null || typeof msg !== "object") {
+    return undefined;
+  }
+  const record = msg as { role?: unknown; tool_calls?: unknown };
+  if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
+    return undefined;
+  }
+  return record.tool_calls as GoogleToolCallExtraContent[];
+}
+
+export function messagesCarryGoogleThoughtSignature(params: unknown): boolean {
+  const messages = paramsMessages(params);
+  if (!messages) {
+    return false;
+  }
+  return messages.some((msg) => {
+    const toolCalls = assistantToolCalls(msg);
+    return toolCalls?.some((tc) => googleThoughtSignatureFromUnknown(tc));
+  });
+}
+
+export function assistantToolCallsNeedThoughtSignatureBackfill(
+  params: unknown,
+): boolean {
+  const messages = paramsMessages(params);
+  if (!messages) {
+    return false;
+  }
+  return messages.some((msg) => {
+    const toolCalls = assistantToolCalls(msg);
+    if (!toolCalls || toolCalls.length === 0) {
+      return false;
+    }
+    return !toolCalls.some((tc) => googleThoughtSignatureFromUnknown(tc));
+  });
+}
+
+export function stripGoogleThoughtSignatures(params: unknown): boolean {
+  const messages = paramsMessages(params);
+  if (!messages) {
+    return false;
+  }
+  let stripped = false;
+  for (const msg of messages) {
+    const toolCalls = assistantToolCalls(msg);
+    if (!toolCalls) {
+      continue;
+    }
+    for (const tc of toolCalls) {
+      if (tc.extra_content !== undefined) {
+        delete tc.extra_content;
+        stripped = true;
+      }
+    }
+  }
+  return stripped;
+}
+
+export function backfillUnsignedGoogleThoughtSignatures(
+  params: unknown,
+): boolean {
+  const messages = paramsMessages(params);
+  if (!messages) {
+    return false;
+  }
+  let added = false;
+  for (const msg of messages) {
+    const toolCalls = assistantToolCalls(msg);
+    if (!toolCalls || toolCalls.length === 0) {
+      continue;
+    }
+    if (toolCalls.some((tc) => googleThoughtSignatureFromUnknown(tc))) {
+      continue;
+    }
+    const first = toolCalls[0];
+    if (!first) {
+      continue;
+    }
+    first.extra_content = {
+      google: {
+        thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
+      },
+    };
+    added = true;
+  }
+  return added;
+}

--- a/assistant/src/providers/openai/google-thought-signature.ts
+++ b/assistant/src/providers/openai/google-thought-signature.ts
@@ -1,7 +1,4 @@
-import {
-  GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
-  isGemini3Model,
-} from "../gemini-thought-signature.js";
+import { unsignedThoughtSignatureFallback } from "../gemini-thought-signature.js";
 
 export type GoogleToolCallExtraContent = {
   extra_content?: {
@@ -58,6 +55,27 @@ export function attachGoogleThoughtSignature<T extends object>(
   };
 }
 
+function stampUnsignedGoogleThoughtSignature(
+  toolCalls: GoogleToolCallExtraContent[],
+  options?: { model?: string },
+): boolean {
+  const fallback = unsignedThoughtSignatureFallback(
+    toolCalls.map((tc) => googleThoughtSignatureFromUnknown(tc)),
+    options,
+  );
+  if (!fallback) {
+    return false;
+  }
+  const target = toolCalls[fallback.index];
+  if (!target) {
+    return false;
+  }
+  target.extra_content = {
+    google: { thought_signature: fallback.signature },
+  };
+  return true;
+}
+
 /**
  * Gemini 3.x validates the first function call of each step. When none of the
  * serialized tool_calls carry a captured signature, attach the documented dummy
@@ -67,21 +85,7 @@ export function applyGemini3UnsignedToolCallFallback(
   toolCalls: GoogleToolCallExtraContent[],
   model: string,
 ): void {
-  if (!isGemini3Model(model) || toolCalls.length === 0) {
-    return;
-  }
-  if (toolCalls.some((tc) => googleThoughtSignatureFromUnknown(tc))) {
-    return;
-  }
-  const first = toolCalls[0];
-  if (!first) {
-    return;
-  }
-  first.extra_content = {
-    google: {
-      thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
-    },
-  };
+  stampUnsignedGoogleThoughtSignature(toolCalls, { model });
 }
 
 function paramsMessages(params: unknown): unknown[] | undefined {
@@ -163,19 +167,9 @@ export function backfillUnsignedGoogleThoughtSignatures(
     if (!toolCalls || toolCalls.length === 0) {
       continue;
     }
-    if (toolCalls.some((tc) => googleThoughtSignatureFromUnknown(tc))) {
-      continue;
+    if (stampUnsignedGoogleThoughtSignature(toolCalls)) {
+      added = true;
     }
-    const first = toolCalls[0];
-    if (!first) {
-      continue;
-    }
-    first.extra_content = {
-      google: {
-        thought_signature: GEMINI_3_UNSIGNED_TOOL_CALL_THOUGHT_SIGNATURE,
-      },
-    };
-    added = true;
   }
   return added;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Fix https://github.com/vellum-ai/vellum-assistant/issues/42421 (Linear [EPD-2929](https://linear.app/vellum/issue/EPD-2929)): Gemini thought signatures dropped on the openai-compatible path, so the second turn of a thinking + tool-call conversation 400s with `Invalid thought signature`.

The native Gemini provider already captures `thoughtSignature` onto `tool_use.providerMetadata` and replays it. This change reuses that slot on the OpenAI-compatible adapter, mapping to Gemini's documented wire field `tool_calls[].extra_content.google.thought_signature`.

## Summary
- Capture `extra_content.google.thought_signature` from streamed tool_calls onto `providerMetadata.gemini.thoughtSignature`.
- Replay that value as `extra_content.google.thought_signature` on outbound assistant `tool_calls` only when the destination model is Gemini 3.x (including catalog prefixes like `google/gemini-3.7-flash`). Non-Gemini OpenAI requests never get `extra_content` on the first try, even if history still has Gemini metadata.
- Unsigned Gemini 3 history still gets Google's documented dummy via shared `unsignedThoughtSignatureFallback`.
- Remapped model ids that still 400 for a missing thought signature recover captured signatures by `tool_call` id on retry, then fall back to the dummy for remaining unsigned calls.
- Thought-signature 4xx classification lives in `google-thought-signature.ts`. The Chat Completions send path does not inline Google wire-format matching.
- OpenAI-compatible 4xx compatibility fallbacks re-enter the classifier after each mutation, so stacked rejections (missing thought signature, then unexpected `extra_content`) can each fire once.

## Test Plan
- `cd assistant && bun test src/providers/openai/__tests__/google-thought-signature.test.ts src/providers/openai/__tests__/chat-completions-provider-thought-signature.test.ts src/providers/gemini-thought-signature.test.ts src/__tests__/gemini-provider.test.ts src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts`
- `cd assistant && bun run typecheck:fast`
- `cd assistant && bunx eslint` on the changed files

## Risk
- `extra_content` is attached only when the model looks like Gemini 3, or a 4xx retry requested it. Strict OpenAI-compatible endpoints that reject the extra field get a one-shot strip retry.
- No persistence migration: `providerMetadata` already passthroughs on `tool_use` blocks.

Closes #42421
Closes EPD-2929
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d72de1b9-fd76-4250-b20b-327a49f9ec48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d72de1b9-fd76-4250-b20b-327a49f9ec48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

