### PR TITLE
fix: avatar_changed final polish (doc accuracy, formatting)

### DIFF
--- a/assistant/src/avatar/__tests__/avatar-changed-telemetry.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-changed-telemetry.test.ts
@@ -204,9 +204,9 @@ describe("isSameAvatar", () => {
 
   test("none is always the same as none", () => {
     expect(isSameAvatar(NONE_AVATAR_STATE, NONE_AVATAR_STATE)).toBe(true);
-    expect(isSameAvatar(NONE_AVATAR_STATE, { ...NONE_AVATAR_STATE }, true)).toBe(
-      true,
-    );
+    expect(
+      isSameAvatar(NONE_AVATAR_STATE, { ...NONE_AVATAR_STATE }, true),
+    ).toBe(true);
   });
 
   test("none is never the same as an avatar", () => {

--- a/assistant/src/avatar/__tests__/avatar-store.test.ts
+++ b/assistant/src/avatar/__tests__/avatar-store.test.ts
@@ -5,7 +5,7 @@
  * artifacts:
  *   - setCharacter  → traits.json + PNG (+ ASCII) on disk, `character` manifest
  *   - setImage      → PNG on disk, character sidecars removed, `image` manifest
- *   - clearAvatar   → everything removed, `none` manifest
+ *   - clearAvatar   → everything removed, manifest deleted
  *
  * Every successful mutation also leaves a `## Avatar` note in IDENTITY.md,
  * hands the change to the client/platform fan-out, and records an

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -234,7 +234,11 @@ export async function setAccent(
     accent: hex ? { hex, source: "custom" } : await automaticAccent(state),
   };
   writeManifest(next);
-  announceChange({ action: "set_accent", previous: state, next }, null, options);
+  announceChange(
+    { action: "set_accent", previous: state, next },
+    null,
+    options,
+  );
   return next;
 }
 

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -76,7 +76,7 @@ function handleGetCharacterComponents() {
 /**
  * Reads the manifest, self-healing once if it is absent.
  *
- * The migration (092) seeds `avatar.json` for every workspace, so the manifest
+ * The migration (094) seeds `avatar.json` for every workspace, so the manifest
  * is normally present. If it is somehow missing (e.g. a workspace that predates
  * the manifest and skipped the migration), we derive state from the legacy
  * sidecar files. A *real* avatar (character/image) is persisted once so
@@ -274,7 +274,7 @@ async function handleSetAvatar({ body, headers }: RouteHandlerArgs) {
 }
 
 function handleRemoveAvatar({ headers }: RouteHandlerArgs) {
-  // A character-only workspace (traits, no PNG) is still an avatar, so
+  // A character-only workspace (traits, no PNG) counts as an avatar, so
   // `hadAvatar` comes from the cleared state's kind.
   const hadAvatar = clearAvatar(changeOptions(headers)).kind !== "none";
   return { ok: true, hadAvatar };


### PR DESCRIPTION
## Summary
Fixes the last round-3 review notes for avatar-changed-telemetry.md.

- The avatar routes doc cited migration 092 for the manifest seed; the seed is 094.
- The remove handler's comment used "still" as a contrast; recast.
- The store test header said clearAvatar leaves a none manifest; it deletes the manifest.
- Two lines in the store and the mapper test were Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CyMhFjRp3y2XhmreXRhUsP