### PR TITLE
fix(acp): a pin whose reply drops the model selector is reported as not applied

### DIFF
--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -17,6 +17,7 @@ import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import {
   MODEL_OPTION_MODELS,
   modelOption,
+  nonModelOption,
 } from "./helpers/acp-model-option.js";
 
 // ---------------------------------------------------------------------------
@@ -48,6 +49,8 @@ let resumeConfigOptions: SessionConfigOption[] = [];
 let replayConfigOptionUpdates: SessionConfigOption[][] = [];
 /** When set, setConfigOption rejects with it (the adapter refusing a pin). */
 let setConfigOptionError: Error | null = null;
+/** When set, setConfigOption answers with this instead of the moved selector. */
+let setConfigOptionResult: SessionConfigOption[] | null = null;
 /** Every `setConfigOption` the manager dispatched during a resume. */
 const setConfigOptionCalls: Array<{
   sessionId: string;
@@ -132,6 +135,9 @@ class FakeAcpAgentProcess {
     setConfigOptionCalls.push({ sessionId, configId, value });
     if (setConfigOptionError) {
       throw setConfigOptionError;
+    }
+    if (setConfigOptionResult) {
+      return setConfigOptionResult;
     }
     return typeof value === "string"
       ? [modelOption(value)]
@@ -326,6 +332,7 @@ beforeEach(() => {
   resumeConfigOptions = [];
   replayConfigOptionUpdates = [];
   setConfigOptionError = null;
+  setConfigOptionResult = null;
   setConfigOptionCalls.length = 0;
   resolveImpl = () => ({
     ok: true,
@@ -853,6 +860,50 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       acpSessionId: "resume-replay-only",
       availableModels: MODEL_OPTION_MODELS,
     });
+  });
+
+  test("a re-pin answered without the selector withdraws the picker the replay announced", async () => {
+    fakeCaps.loadSession = true;
+    // The replay puts the selector in front of clients before the re-pin
+    // runs, so the answer that drops it has something to correct.
+    replayConfigOptionUpdates = [[modelOption("default")]];
+    resumeConfigOptions = [];
+    setConfigOptionResult = [nonModelOption()];
+    insertHistoryRow({
+      id: "resume-selector-gone",
+      eventLogJson: JSON.stringify([PERSISTED_EVENT]),
+      model: "opus",
+    });
+
+    const manager = new AcpSessionManager(4);
+    const sent: AssistantEvent[] = [];
+    await manager.resumeFromHistory("resume-selector-gone", (msg) =>
+      sent.push(msg),
+    );
+
+    const state = manager.getStatus("resume-selector-gone") as AcpSessionState;
+    expect(state.model).toBeUndefined();
+    expect(state.availableModels).toEqual([]);
+    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId: "resume-selector-gone",
+        model: "default",
+        availableModels: MODEL_OPTION_MODELS,
+      },
+      {
+        type: "acp_session_model_update",
+        acpSessionId: "resume-selector-gone",
+        availableModels: [],
+      },
+    ]);
+
+    await manager.steer("resume-selector-gone", "keep going");
+    fakeInstances[0]!.resolvePrompt!({ stopReason: "end_turn" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readHistoryRow("resume-selector-gone")!.model).toBeNull();
   });
 
   test("a resume the adapter refuses to re-pin runs on the adapter's model and records that on the row", async () => {

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -466,12 +466,69 @@ describe("AcpSessionManager: model selection at spawn", () => {
     const state = manager.getStatus(result.acpSessionId) as AcpSessionState;
     expect(state.model).toBeUndefined();
     expect(state.availableModels).toEqual([]);
-    // Nothing was announced before the pin ran, so the empty picker is the
-    // silence a selector-less adapter already gets.
-    expect(sent.map((e) => e.type)).toEqual(["acp_session_spawned"]);
+    // The withdrawal goes out before the session is announced, which no
+    // client holds an entry for yet, and the spawn's own model event stays
+    // silent for an adapter with nothing to select.
+    expect(sent.map((e) => e.type)).toEqual([
+      "acp_session_model_update",
+      "acp_session_spawned",
+    ]);
+    expect(sent[0]).toEqual({
+      type: "acp_session_model_update",
+      acpSessionId: result.acpSessionId,
+      availableModels: [],
+    });
 
     manager.close(result.acpSessionId);
     expect(readHistoryRow(result.acpSessionId)?.model).toBeNull();
+  });
+
+  test("a selector announced while the pin was open is withdrawn from clients", async () => {
+    scriptedConfigOptions = [[modelOption("sonnet")]];
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    setConfigOptionResponder = async () => {
+      await held;
+      return [nonModelOption()];
+    };
+
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const spawned = manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-pin-announced",
+      (msg) => sent.push(msg),
+      { model: "opus" },
+    );
+    await waitForConfigOptionCalls(1);
+    const acpSessionId = manager.getActiveAndPendingIds()[0]!;
+    // The adapter reports a selector of its own while the pin is still open,
+    // which reaches clients right away.
+    await emitConfigOptions(manager, acpSessionId, [modelOption("opus")]);
+    release();
+    await spawned;
+
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.model).toBeUndefined();
+    expect(state.availableModels).toEqual([]);
+    expect(sent.filter((e) => e.type === "acp_session_model_update")).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId,
+        model: "opus",
+        availableModels: MODEL_OPTION_MODELS,
+      },
+      {
+        type: "acp_session_model_update",
+        acpSessionId,
+        availableModels: [],
+      },
+    ]);
   });
 
   test("an inherited model whose pin loses the selector warns nobody", async () => {

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -16,6 +16,7 @@ import { initializeDb } from "../../persistence/db-init.js";
 import type { VellumAcpClientHandler } from "../client-handler.js";
 import type { AcpSessionState } from "../types.js";
 import { installAcpConfigStub } from "./helpers/acp-config-stub.js";
+import { readHistoryRow } from "./helpers/acp-history-db.js";
 import {
   MODEL_OPTION_MODELS,
   modelOption,
@@ -438,6 +439,52 @@ describe("AcpSessionManager: model selection at spawn", () => {
       "acp_session_spawned",
       "acp_session_model_update",
     ]);
+  });
+
+  test("a pin answered without the selector warns and leaves no model", async () => {
+    scriptedConfigOptions = [[modelOption("sonnet")]];
+    // The adapter takes the call, then answers with a set that advertises no
+    // model selection at all.
+    setConfigOptionResult = [nonModelOption()];
+
+    const manager = new AcpSessionManager(5);
+    const sent: AssistantEvent[] = [];
+    const result = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-pin-dropped",
+      (msg) => sent.push(msg),
+      { model: "opus" },
+    );
+
+    expect(result.modelWarning).toBe(
+      'Agent "agent-model" does not support model selection, so the ' +
+        "session is running on the agent's own model.",
+    );
+    const state = manager.getStatus(result.acpSessionId) as AcpSessionState;
+    expect(state.model).toBeUndefined();
+    expect(state.availableModels).toEqual([]);
+    // Nothing was announced before the pin ran, so the empty picker is the
+    // silence a selector-less adapter already gets.
+    expect(sent.map((e) => e.type)).toEqual(["acp_session_spawned"]);
+
+    manager.close(result.acpSessionId);
+    expect(readHistoryRow(result.acpSessionId)?.model).toBeNull();
+  });
+
+  test("an inherited model whose pin loses the selector warns nobody", async () => {
+    config.setConfig({ defaultModel: "opus" });
+    scriptedConfigOptions = [[modelOption("sonnet")]];
+    setConfigOptionResult = [nonModelOption()];
+
+    const { modelWarning, state } = await spawnWithModel({
+      conversationId: "conv-pin-dropped-inherited",
+    });
+
+    expect(modelWarning).toBeUndefined();
+    expect(state.model).toBeUndefined();
   });
 });
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -501,7 +501,8 @@ export class AcpSessionManager {
    *
    * An answer that carries no model selector is not a pin that landed: the
    * session is left with no model rather than one only the superseded
-   * response ever named.
+   * response ever named, and the empty picker goes out so no client is left
+   * holding a selector the answer retired.
    */
   private async applyModelPin(
     entry: SessionEntry,
@@ -536,7 +537,10 @@ export class AcpSessionManager {
       );
       this.applyModelInfo(entry, refreshed);
       if (!entry.modelConfigId) {
-        this.clearModelSnapshot(entry);
+        // Published, not just recorded: a `config_option_update` that arrived
+        // while the round trip was open has already put its selector in front
+        // of clients, and a session no client holds yet drops the frame.
+        this.clearVanishedModelSelector(state.id, entry);
         log.warn(
           { acpSessionId: state.id, agentId: state.agentId, resolvedModel },
           "ACP agent dropped its model selector while applying the model; running on its own model",
@@ -803,24 +807,14 @@ export class AcpSessionManager {
     if (entry.modelConfigId || entry.state.availableModels === undefined) {
       return false;
     }
-    this.clearModelSnapshot(entry);
+    entry.state.model = undefined;
+    entry.state.availableModels = [];
     entry.sendToVellum({
       type: "acp_session_model_update",
       acpSessionId,
       availableModels: [],
     });
     return true;
-  }
-
-  /**
-   * Drops the live model snapshot without publishing anything. The pin's
-   * caller uses it directly: a spawn or resume clears before the session is
-   * announced, where the silence `sendModelEvent` keeps for a selector-less
-   * adapter is already the whole story.
-   */
-  private clearModelSnapshot(entry: SessionEntry): void {
-    entry.state.model = undefined;
-    entry.state.availableModels = [];
   }
 
   /**

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -184,6 +184,15 @@ interface ModelPinResult {
 }
 
 /**
+ * The sentence a caller who named a model gets when the session has no model
+ * selector to put it through, whether the adapter never advertised one or its
+ * answer to the pin dropped the one it had.
+ */
+function noModelSelectionWarning(agentId: string): string {
+  return `Agent "${agentId}" does not support model selection, so the session is running on the agent's own model.`;
+}
+
+/**
  * An `acp_session_history` row that passed resumeFromHistory's validation
  * guards: `cwd` (nullable in the schema for pre-resume-support rows) is
  * guaranteed present.
@@ -489,6 +498,10 @@ export class AcpSessionManager {
   /**
    * The pin itself: record what the opening response says about the model,
    * then put the session on `resolvedModel` if that is somewhere else.
+   *
+   * An answer that carries no model selector is not a pin that landed: the
+   * session is left with no model rather than one only the superseded
+   * response ever named.
    */
   private async applyModelPin(
     entry: SessionEntry,
@@ -510,9 +523,7 @@ export class AcpSessionManager {
       return {
         applied: false,
         ...(requestedModel
-          ? {
-              warning: `Agent "${state.agentId}" does not support model selection, so the session is running on the agent's own model.`,
-            }
+          ? { warning: noModelSelectionWarning(state.agentId) }
           : {}),
       };
     }
@@ -524,6 +535,19 @@ export class AcpSessionManager {
         resolvedModel,
       );
       this.applyModelInfo(entry, refreshed);
+      if (!entry.modelConfigId) {
+        this.clearModelSnapshot(entry);
+        log.warn(
+          { acpSessionId: state.id, agentId: state.agentId, resolvedModel },
+          "ACP agent dropped its model selector while applying the model; running on its own model",
+        );
+        return {
+          applied: false,
+          ...(requestedModel
+            ? { warning: noModelSelectionWarning(state.agentId) }
+            : {}),
+        };
+      }
       return { applied: true };
     } catch (err) {
       log.warn(
@@ -779,14 +803,24 @@ export class AcpSessionManager {
     if (entry.modelConfigId || entry.state.availableModels === undefined) {
       return false;
     }
-    entry.state.model = undefined;
-    entry.state.availableModels = [];
+    this.clearModelSnapshot(entry);
     entry.sendToVellum({
       type: "acp_session_model_update",
       acpSessionId,
       availableModels: [],
     });
     return true;
+  }
+
+  /**
+   * Drops the live model snapshot without publishing anything. The pin's
+   * caller uses it directly: a spawn or resume clears before the session is
+   * announced, where the silence `sendModelEvent` keeps for a selector-less
+   * adapter is already the whole story.
+   */
+  private clearModelSnapshot(entry: SessionEntry): void {
+    entry.state.model = undefined;
+    entry.state.availableModels = [];
   }
 
   /**

--- a/assistant/src/tools/acp/set-model.test.ts
+++ b/assistant/src/tools/acp/set-model.test.ts
@@ -20,7 +20,11 @@ let setModelImpl: (
 ) => Promise<unknown> = async (acpSessionId, model) =>
   sessionState(acpSessionId, model);
 
-function sessionState(acpSessionId: string, model?: string): AcpSessionState {
+function sessionState(
+  acpSessionId: string,
+  model?: string,
+  availableModels?: AcpSessionState["availableModels"],
+): AcpSessionState {
   return {
     id: "sess-1",
     agentId: "claude",
@@ -29,6 +33,7 @@ function sessionState(acpSessionId: string, model?: string): AcpSessionState {
     status: "running",
     startedAt: 0,
     ...(model ? { model } : {}),
+    ...(availableModels ? { availableModels } : {}),
   } as AcpSessionState;
 }
 
@@ -93,6 +98,24 @@ describe("executeAcpSetModel", () => {
 
     expect(result.isError).toBe(false);
     expect(JSON.parse(result.content as string).model).toBe("sonnet");
+  });
+
+  test("a switch the adapter answered without a selector is not claimed", async () => {
+    // What the manager leaves behind when the reply drops the model selector.
+    setModelImpl = async (acpSessionId) =>
+      sessionState(acpSessionId, undefined, []);
+
+    const result = await executeAcpSetModel(
+      { acp_session_id: "acp-123", model: "opus" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(
+      'Could not switch the model on ACP session "acp-123": the agent ' +
+        "dropped its model selector. Check the session with acp_status " +
+        "before relying on it.",
+    );
   });
 
   test("trims the requested model before handing it to the manager", async () => {

--- a/assistant/src/tools/acp/set-model.ts
+++ b/assistant/src/tools/acp/set-model.ts
@@ -42,6 +42,18 @@ export async function executeAcpSetModel(
 
   try {
     const state = await getAcpSessionManager().setModel(acpSessionId, model);
+    // An empty picker with nothing selected is the session saying the
+    // adapter's answer advertised no model at all, so the value asked for is
+    // exactly what cannot be claimed.
+    if (!state.model && state.availableModels?.length === 0) {
+      return {
+        content: unconfirmedSwitchMessage(
+          acpSessionId,
+          "the agent dropped its model selector",
+        ),
+        isError: true,
+      };
+    }
     return {
       content: JSON.stringify({
         acpSessionId,
@@ -83,5 +95,17 @@ function describeSetModelFailure(acpSessionId: string, err: unknown): string {
     return err.message;
   }
   const msg = err instanceof Error ? err.message : String(err);
-  return `Could not switch the model on ACP session "${acpSessionId}": ${msg}. Check the session with acp_status before relying on it.`;
+  return unconfirmedSwitchMessage(acpSessionId, msg);
+}
+
+/**
+ * The neutral answer for a switch nothing confirmed: it names what went wrong
+ * without ruling on which model the session is on, and points at the tool that
+ * can say.
+ */
+function unconfirmedSwitchMessage(
+  acpSessionId: string,
+  reason: string,
+): string {
+  return `Could not switch the model on ACP session "${acpSessionId}": ${reason}. Check the session with acp_status before relying on it.`;
 }


### PR DESCRIPTION
## Summary
- When the adapter's reply to the opening model pin carries no model selector, the session clears its model state and the pin reports unapplied (a warning when the model was explicitly requested), instead of reporting success while status and history keep the pre-switch model
- Red-green test on the spawn path

Part of plan: acp-model-control-lite.md (feature-branch review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D