### PR TITLE
fix(credentials): hide the platform-provisioned API key from the credentials API

### DIFF
--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -594,16 +594,19 @@ describe("credentials routes", () => {
 
     test("non-secret vellum platform fields are stored but never scrubbed", async () => {
       /**
-       * Platform identity ids and the base URL are benign UUIDs/URLs that
-       * legitimately appear in transcripts; scrubbing them would redact
-       * ordinary conversation content. Shares the exemption with the
-       * /v1/secrets credential branch via isNonSecretPlatformField.
+       * Platform identity ids are benign UUIDs that legitimately appear in
+       * transcripts; scrubbing them would redact ordinary conversation
+       * content. Shares the exemption with the /v1/secrets credential branch
+       * via isNonSecretPlatformField.
+       *
+       * `platform_base_url` carries the same exemption but is not settable
+       * here: it decides which host receives the platform API key, so the
+       * credentials API refuses it (see the platform-managed suite).
        */
       for (const field of [
         "platform_assistant_id",
         "platform_organization_id",
         "platform_user_id",
-        "platform_base_url",
       ]) {
         const result = (await setRoute!.handler({
           body: {
@@ -883,6 +886,73 @@ describe("credentials routes", () => {
           }),
         ).rejects.toThrow(ForbiddenError);
       }
+    });
+
+    test("set refuses platform credentials", async () => {
+      /**
+       * A write is a read by another name: repointing `platform_base_url`
+       * sends the next platform call, bearing the API key, to a host the
+       * writer chose. The platform's own provisioning does not come through
+       * this route; it writes over `POST /v1/secrets`.
+       */
+      for (const field of ["assistant_api_key", "platform_base_url"]) {
+        await expect(
+          setRoute!.handler({
+            body: { service: "vellum", field, value: "https://attacker.test" },
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      }
+
+      expect(secureStore.has("vellum:assistant_api_key")).toBe(false);
+      expect(secureStore.has("vellum:platform_base_url")).toBe(false);
+    });
+
+    test("set does not overwrite an already-provisioned platform credential", async () => {
+      seedPlatformCredential("platform_base_url", PLATFORM_BASE_URL);
+
+      await expect(
+        setRoute!.handler({
+          body: {
+            service: "vellum",
+            field: "platform_base_url",
+            value: "https://attacker.test",
+          },
+        }),
+      ).rejects.toThrow(/owned by the Vellum platform/);
+
+      expect(secureStore.get("vellum:platform_base_url")).toBe(
+        PLATFORM_BASE_URL,
+      );
+    });
+
+    test("delete refuses platform credentials", async () => {
+      seedPlatformCredential("assistant_api_key", PLATFORM_KEY);
+      seedPlatformCredential("platform_base_url", PLATFORM_BASE_URL);
+
+      for (const field of ["assistant_api_key", "platform_base_url"]) {
+        await expect(
+          deleteRoute!.handler({ body: { service: "vellum", field } }),
+        ).rejects.toThrow(ForbiddenError);
+      }
+
+      expect(secureStore.get("vellum:assistant_api_key")).toBe(PLATFORM_KEY);
+      expect(secureStore.get("vellum:platform_base_url")).toBe(
+        PLATFORM_BASE_URL,
+      );
+    });
+
+    test("a user credential is still writable and deletable", async () => {
+      const stored = (await setRoute!.handler({
+        body: { service: "vercel", field: "api_token", value: SECRET_VALUE },
+      })) as SetResponse;
+      expect(stored.service).toBe("vercel");
+      expect(secureStore.get("vercel:api_token")).toBe(SECRET_VALUE);
+
+      const deleted = (await deleteRoute!.handler({
+        body: { service: "vercel", field: "api_token" },
+      })) as DeleteResponse;
+      expect(deleted.field).toBe("api_token");
+      expect(secureStore.has("vercel:api_token")).toBe(false);
     });
 
     test("a user credential still inspects and reveals", async () => {

--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { BadRequestError } from "../runtime/routes/errors.js";
+import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
 import type { CredentialMetadata } from "../tools/credentials/metadata-store.js";
 
 // ---------------------------------------------------------------------------
@@ -169,6 +169,9 @@ const setRoute = ROUTES.find((r) => r.operationId === "credentials_set");
 const listRoute = ROUTES.find((r) => r.operationId === "credentials_list");
 const deleteRoute = ROUTES.find((r) => r.operationId === "credentials_delete");
 const revealRoute = ROUTES.find((r) => r.operationId === "credentials_reveal");
+const inspectRoute = ROUTES.find(
+  (r) => r.operationId === "credentials_inspect",
+);
 
 type SetResponse = { credentialId: string; service: string; field: string };
 type ListResponse = {
@@ -792,6 +795,112 @@ describe("credentials routes", () => {
       // THEN only the matching credential is returned
       expect(result.credentials).toHaveLength(1);
       expect(result.credentials[0].service).toBe("github");
+    });
+  });
+
+  describe("platform-managed credentials", () => {
+    const PLATFORM_KEY = "vk-platform-provisioned-key";
+    const PLATFORM_BASE_URL = "https://platform.example";
+
+    /**
+     * The platform provisions the pod's own credentials by POSTing them to
+     * `/v1/secrets` as `credential` entries, which land in the same secure
+     * store and metadata table as a user's own credentials.
+     */
+    function seedPlatformCredential(field: string, value: string): string {
+      const key = `vellum:${field}`;
+      secureStore.set(key, value);
+      const now = Date.now();
+      metadataStore.set(key, {
+        credentialId: `cred-${++credentialIdCounter}`,
+        service: "vellum",
+        field,
+        allowedTools: [],
+        allowedDomains: [],
+        createdAt: now,
+        updatedAt: now,
+      });
+      return metadataStore.get(key)!.credentialId;
+    }
+
+    test("the listing omits platform credentials and keeps the user's own", async () => {
+      // GIVEN the platform's provisioned credentials alongside a user's
+      seedPlatformCredential("assistant_api_key", PLATFORM_KEY);
+      seedPlatformCredential("platform_base_url", PLATFORM_BASE_URL);
+      await setRoute!.handler({
+        body: { service: "vercel", field: "api_token", value: SECRET_VALUE },
+      });
+
+      // WHEN the credentials are listed
+      const result = (await listRoute!.handler({ body: {} })) as ListResponse;
+
+      // THEN only the user's credential is a row, and no platform value leaks
+      expect(result.credentials.map((c) => `${c.service}:${c.field}`)).toEqual([
+        "vercel:api_token",
+      ]);
+      expect(JSON.stringify(result)).not.toContain(PLATFORM_KEY);
+    });
+
+    test("reveal refuses the platform API key for every principal", async () => {
+      /**
+       * Both farming paths land on this handler: the assistant's own tool
+       * shell arrives as `local`, a Settings click as `user`.
+       */
+      seedPlatformCredential("assistant_api_key", PLATFORM_KEY);
+
+      for (const principal of ["local", "user", "svc_gateway"]) {
+        await expect(
+          revealRoute!.handler({
+            body: { service: "vellum", field: "assistant_api_key" },
+            headers: { "x-vellum-principal-type": principal },
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      }
+    });
+
+    test("reveal refuses a platform credential looked up by UUID", async () => {
+      const credentialId = seedPlatformCredential(
+        "assistant_api_key",
+        PLATFORM_KEY,
+      );
+
+      await expect(
+        revealRoute!.handler({
+          body: { id: credentialId },
+          headers: { "x-vellum-principal-type": "local" },
+        }),
+      ).rejects.toThrow(/owned by the Vellum platform/);
+    });
+
+    test("inspect refuses platform credentials", async () => {
+      seedPlatformCredential("assistant_api_key", PLATFORM_KEY);
+      seedPlatformCredential("platform_base_url", PLATFORM_BASE_URL);
+
+      for (const field of ["assistant_api_key", "platform_base_url"]) {
+        await expect(
+          inspectRoute!.handler({
+            body: { service: "vellum", field },
+          }),
+        ).rejects.toThrow(ForbiddenError);
+      }
+    });
+
+    test("a user credential still inspects and reveals", async () => {
+      seedPlatformCredential("assistant_api_key", PLATFORM_KEY);
+      await setRoute!.handler({
+        body: { service: "vercel", field: "api_token", value: SECRET_VALUE },
+      });
+
+      const inspected = (await inspectRoute!.handler({
+        body: { service: "vercel", field: "api_token" },
+      })) as { scrubbedValue: string };
+      expect(inspected.scrubbedValue).toBe("supe****");
+
+      const revealed = (await revealRoute!.handler({
+        body: { service: "vercel", field: "api_token" },
+        headers: { "x-vellum-principal-type": "user" },
+      })) as { value: string };
+      expect(revealed.value).toBe(SECRET_VALUE);
     });
   });
 

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -59,7 +59,11 @@ import {
   invalidateConnectionsAfterCredentialDelete,
 } from "./credential-in-use.js";
 import { InjectionTemplateSchema } from "./credential-prompt-routes.js";
-import { BadRequestError, InternalError } from "./errors.js";
+import { BadRequestError, ForbiddenError, InternalError } from "./errors.js";
+import {
+  isPlatformManagedCredential,
+  platformManagedCredentialRefusal,
+} from "./platform-managed-credentials.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -157,7 +161,12 @@ interface CredentialLookup {
 
 /**
  * Resolve a credential lookup from service+field or UUID.
- * Throws BadRequestError when neither is provided or the UUID is not found.
+ * Throws BadRequestError when neither is provided or the UUID is not found,
+ * and ForbiddenError for a credential the platform owns.
+ *
+ * Every read handler that returns credential material (inspect, reveal)
+ * resolves through here, so the platform-managed refusal sits at the single
+ * point they share and cannot drift apart from the list filter.
  */
 function resolveCredentialLookup(
   body: Record<string, unknown>,
@@ -169,6 +178,7 @@ function resolveCredentialLookup(
   };
 
   if (service && field) {
+    assertNotPlatformManaged(service, field);
     return {
       storageKey: credentialKey(service, field),
       metadata: getCredentialMetadata(service, field),
@@ -182,6 +192,7 @@ function resolveCredentialLookup(
     if (!metadata) {
       throw new BadRequestError("Credential not found");
     }
+    assertNotPlatformManaged(metadata.service, metadata.field);
     return {
       storageKey: credentialKey(metadata.service, metadata.field),
       metadata,
@@ -193,6 +204,18 @@ function resolveCredentialLookup(
   throw new BadRequestError("Either service+field or id is required");
 }
 
+/**
+ * Refuse reads of a credential the platform provisions for itself, whatever
+ * the calling principal. The assistant's own tool shell arrives as `local`
+ * and Settings arrives as `user`, and neither has any business reading the
+ * key the daemon bills inference with.
+ */
+function assertNotPlatformManaged(service: string, field: string): void {
+  if (isPlatformManagedCredential(service, field)) {
+    throw new ForbiddenError(platformManagedCredentialRefusal(service, field));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -200,7 +223,11 @@ function resolveCredentialLookup(
 async function handleCredentialsList({ body }: RouteHandlerArgs) {
   const search = (body as { search?: string } | undefined)?.search;
 
-  let allMetadata = listCredentialMetadata();
+  // Platform-provisioned credentials are not the user's to act on, so they
+  // never become a Settings row (and never a click-to-reveal).
+  let allMetadata = listCredentialMetadata().filter(
+    (m) => !isPlatformManagedCredential(m.service, m.field),
+  );
 
   if (search) {
     const query = search.toLowerCase();

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -62,6 +62,7 @@ import { InjectionTemplateSchema } from "./credential-prompt-routes.js";
 import { BadRequestError, ForbiddenError, InternalError } from "./errors.js";
 import {
   isPlatformManagedCredential,
+  type PlatformManagedCredentialAction,
   platformManagedCredentialRefusal,
 } from "./platform-managed-credentials.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -178,7 +179,7 @@ function resolveCredentialLookup(
   };
 
   if (service && field) {
-    assertNotPlatformManaged(service, field);
+    assertNotPlatformManaged(service, field, "read");
     return {
       storageKey: credentialKey(service, field),
       metadata: getCredentialMetadata(service, field),
@@ -192,7 +193,7 @@ function resolveCredentialLookup(
     if (!metadata) {
       throw new BadRequestError("Credential not found");
     }
-    assertNotPlatformManaged(metadata.service, metadata.field);
+    assertNotPlatformManaged(metadata.service, metadata.field, "read");
     return {
       storageKey: credentialKey(metadata.service, metadata.field),
       metadata,
@@ -205,14 +206,25 @@ function resolveCredentialLookup(
 }
 
 /**
- * Refuse reads of a credential the platform provisions for itself, whatever
- * the calling principal. The assistant's own tool shell arrives as `local`
- * and Settings arrives as `user`, and neither has any business reading the
- * key the daemon bills inference with.
+ * Refuse any use of a credential the platform provisions for itself, whatever
+ * the calling principal. Reads are refused because the API key spends
+ * inference on Vellum's account. Writes are refused because they are a read
+ * by another name: repointing `vellum:platform_base_url` sends the next
+ * platform call, bearing that same key, to a host of the writer's choosing.
+ *
+ * The platform's own provisioning does not come through here. It writes over
+ * `POST /v1/secrets` (Django to vembda to the pod), as does the CLI and the
+ * local-mode connect flow in the web client.
  */
-function assertNotPlatformManaged(service: string, field: string): void {
+function assertNotPlatformManaged(
+  service: string,
+  field: string,
+  action: PlatformManagedCredentialAction,
+): void {
   if (isPlatformManagedCredential(service, field)) {
-    throw new ForbiddenError(platformManagedCredentialRefusal(service, field));
+    throw new ForbiddenError(
+      platformManagedCredentialRefusal(service, field, action),
+    );
   }
 }
 
@@ -480,6 +492,8 @@ async function handleCredentialsSet({ body }: RouteHandlerArgs) {
     throw new BadRequestError("value is required");
   }
 
+  assertNotPlatformManaged(service, field, "change");
+
   try {
     return await storeCredentialValue({
       service,
@@ -522,6 +536,8 @@ async function handleCredentialsDelete({ body }: RouteHandlerArgs) {
   if (!field || typeof field !== "string") {
     throw new BadRequestError("field is required");
   }
+
+  assertNotPlatformManaged(service, field, "change");
 
   assertMetadataWritable();
 

--- a/assistant/src/runtime/routes/platform-managed-credentials.ts
+++ b/assistant/src/runtime/routes/platform-managed-credentials.ts
@@ -5,10 +5,18 @@
  *
  * The platform writes them over `POST /v1/secrets`, and the daemon, the
  * gateway, and CES read them straight out of the vault. The user never sets
- * them and can do nothing useful with them, while the API key spends inference
- * on Vellum's account. So the credentials API treats them as invisible: they
- * are omitted from listings and refused by inspect and reveal, whatever the
+ * them through the credentials API and can do nothing useful with them there,
+ * so that API treats the pair as neither readable nor writable: omitted from
+ * listings, and refused by inspect, reveal, set, and delete, whatever the
  * calling principal.
+ *
+ * The two fields travel together because they are one capability. The API key
+ * spends inference on Vellum's account, and the base URL decides which host
+ * receives it: the gateway resolves the platform host from
+ * `vellum:platform_base_url` (see `gateway/src/platform-url.ts`) and then
+ * sends `vellum:assistant_api_key` to it as the bearer. Leaving the URL
+ * writable while hiding the key would hand back the same key by another
+ * route, pointed at a host of the writer's choosing.
  */
 const MANAGED_PROXY_CREDENTIALS = [
   { service: "vellum", field: "assistant_api_key" },
@@ -24,11 +32,17 @@ export function isPlatformManagedCredential(
   );
 }
 
+/** What a caller was trying to do with a platform-managed credential. */
+export type PlatformManagedCredentialAction = "read" | "change";
+
 /** Message the credentials API refuses one of these with. */
 export function platformManagedCredentialRefusal(
   service: string | undefined,
   field: string | undefined,
+  action: PlatformManagedCredentialAction,
 ): string {
   const name = service && field ? `${service}:${field}` : "This credential";
-  return `${name} is provisioned and owned by the Vellum platform. It cannot be inspected or revealed through the credentials API.`;
+  const verb =
+    action === "read" ? "inspected or revealed" : "changed or deleted";
+  return `${name} is provisioned and owned by the Vellum platform. It cannot be ${verb} through the credentials API.`;
 }

--- a/assistant/src/runtime/routes/platform-managed-credentials.ts
+++ b/assistant/src/runtime/routes/platform-managed-credentials.ts
@@ -1,0 +1,34 @@
+/**
+ * Credentials the Vellum platform provisions onto a managed assistant pod for
+ * its own use: the API key the daemon authenticates to the managed LLM proxy
+ * with, and the base URL that proxy lives at.
+ *
+ * The platform writes them over `POST /v1/secrets`, and the daemon, the
+ * gateway, and CES read them straight out of the vault. The user never sets
+ * them and can do nothing useful with them, while the API key spends inference
+ * on Vellum's account. So the credentials API treats them as invisible: they
+ * are omitted from listings and refused by inspect and reveal, whatever the
+ * calling principal.
+ */
+const MANAGED_PROXY_CREDENTIALS = [
+  { service: "vellum", field: "assistant_api_key" },
+  { service: "vellum", field: "platform_base_url" },
+] as const;
+
+export function isPlatformManagedCredential(
+  service: string,
+  field: string,
+): boolean {
+  return MANAGED_PROXY_CREDENTIALS.some(
+    (c) => c.service === service && c.field === field,
+  );
+}
+
+/** Message the credentials API refuses one of these with. */
+export function platformManagedCredentialRefusal(
+  service: string | undefined,
+  field: string | undefined,
+): string {
+  const name = service && field ? `${service}:${field}` : "This credential";
+  return `${name} is provisioned and owned by the Vellum platform. It cannot be inspected or revealed through the credentials API.`;
+}

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -71,19 +71,10 @@ import {
   NotFoundError,
   RouteError,
 } from "./errors.js";
+import { isPlatformManagedCredential } from "./platform-managed-credentials.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("runtime-http");
-const MANAGED_PROXY_CREDENTIALS = [
-  { service: "vellum", field: "assistant_api_key" },
-  { service: "vellum", field: "platform_base_url" },
-] as const;
-
-function isManagedProxyCredential(service: string, field: string): boolean {
-  return MANAGED_PROXY_CREDENTIALS.some(
-    (c) => c.service === service && c.field === field,
-  );
-}
 
 const CES_READY_POLL_INTERVAL_MS = 500;
 const CES_READY_POLL_TIMEOUT_MS = 30_000;
@@ -401,7 +392,7 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
           setPlatformUserId(effectiveValue || undefined);
         }
       }
-      if (isManagedProxyCredential(service, field)) {
+      if (isPlatformManagedCredential(service, field)) {
         await refreshProvidersAfterSecretChange();
         // Close the first-boot race where the startup capability seed ran before
         // the managed embedding credential was provisioned, leaving skill/CLI
@@ -645,7 +636,7 @@ async function handleDeleteSecret({ body }: RouteHandlerArgs) {
       if (service === "vellum" && field === "platform_user_id") {
         setPlatformUserId(undefined);
       }
-      if (isManagedProxyCredential(service, field)) {
+      if (isPlatformManagedCredential(service, field)) {
         await refreshProvidersAfterSecretChange();
       }
       invalidateConnectionsAfterCredentialDelete(affectedConnections);


### PR DESCRIPTION
## Problem

Django provisions a managed pod's platform API key by POSTing it to the daemon as a `type: "credential"` secret named `vellum:assistant_api_key` (platform repo, `django/app/auth/vellum_api_keys/service.py`). The daemon's secret handler calls `upsertCredentialMetadata()` unconditionally, so the platform's own key lands in the same credential metadata store as a user's GitHub token, and the credentials API had no idea it was different.

That opened three farming paths, two of which have been used:

1. **Through the assistant.** In August, rings prompted the assistant to `curl localhost:8000/v1/credentials/reveal` from its own tool shell.
2. **Through Settings.** On 2026-09-08, roughly 133 fresh accounts went straight to `/assistant/settings/credentials` and clicked reveal within a minute of signup. The key rendered as an ordinary row with a click-to-reveal. The developer-mode gate added in #39898 only hides the `managedCredentials` catalog descriptors, not this stored row.
3. **By repointing the platform host** (raised by Devin on this PR, and correct). The gateway resolves the platform host from `vellum:platform_base_url` and then sends `vellum:assistant_api_key` to that host as the bearer. In `gateway/src/platform-url.ts` the credential *outranks* `VELLUM_PLATFORM_URL`, so `credentials/set` on the URL made the next platform call (velay, push proxy, feature-flag sync, email register-callback) hand the key to a host of the writer's choosing. Hiding the key from reads while leaving the URL writable gives it back by another route.

## Change

One predicate, applied in both directions.

`assistant/src/runtime/routes/platform-managed-credentials.ts` holds the enumeration that `secret-routes.ts` already had (`vellum:assistant_api_key`, `vellum:platform_base_url`) plus `isPlatformManagedCredential()`. `secret-routes.ts` imports it instead of keeping its own copy, so there is exactly one list of these strings. The two fields travel together because they are one capability: the key is the credential, the URL is where it gets sent.

In `credential-routes.ts`, the pair is now inert through `/v1/credentials/*`:

- **List** filters them out, so neither is a Settings row and neither has a click-to-reveal.
- **Inspect and reveal** refuse via `resolveCredentialLookup()`, the lookup resolver both read handlers already share. Covers the service+field form and the UUID form.
- **Set and delete** refuse through the same predicate.

Every refusal is a 403 naming the credential, and fires regardless of principal.

Storage and daemon use are untouched. The platform still writes the key, and the daemon, gateway, and CES still read it from the vault.

## What breaks

`assistant credentials reveal|inspect|set|delete` for these two fields, and the row in `credentials list`. That is the intended loss of a debugging affordance. The values are still readable from the vault by the processes that need them, and still writable by every real provisioning path, all of which use `/v1/secrets`:

- **Django to vembda to the pod** (`proxy_runtime_request` to `POST v1/secrets`).
- **CLI login and teleport** (`injectCredentialsIntoAssistant` in `cli/src/lib/platform-client.ts`, which POSTs each credential to the gateway's `/v1/secrets`).
- **Web local-mode connect** (`clients/web/src/lib/local-platform-identity.ts`), which writes both fields. That flow early-returns unless `isLocalClient()` and not `isRemoteGatewayMode()`, so it is self-hosted/local only and never runs on a managed pod.

I also grepped `clients/` (web, macos, ios, windows, linux, chrome-extension), `cli/`, `gateway/`, and `assistant/src` for `credentials/reveal`, `credentialsRevealPost`, `assistant_api_key`, and `vellum:`. Nothing reads or writes these fields through `/v1/credentials/*`. The gateway reads them straight from the credential store.

One existing test changed: the `isNonSecretPlatformField` scrub-exemption case was using `credentials_set` as a driver and included `platform_base_url` in its loop. It keeps the other three platform identity fields, which exercise the same exemption; the URL's behaviour is now covered by the refusal tests.

## Not fixed here, and why

### `POST /v1/secrets` writes cannot be gated on principal

I was asked to refuse `/v1/secrets` writes to these fields from any principal other than the platform's. **That is not implementable, and attempting it would break provisioning.** On a managed pod the vembda template sets `DISABLE_HTTP_AUTH=true` and `IS_PLATFORM=1` (`vembda/src/vembda_assistant_server/core/assistant_machine/stateful_template.yaml`). `authenticateRequest()` then short-circuits to `buildDevBypassContext()`, which hardcodes `principalType: "actor"`, and `enforcePolicy()` returns `null` before it looks at anything. So Django's provisioning push, a Settings click, and a `curl` from the assistant's own tool shell all arrive as the same synthetic `actor`. There is no principal, scope, or token that separates them.

Nor is there a forgeable-proof header to key on. Vembda attaches no `Authorization` when forwarding to the pod, and anything it did attach would be settable by a shell that can already reach `localhost:8000`.

`POST /v1/secrets` and `POST /v1/secrets/read` therefore remain open on both fields. Options for a follow-up, in my order of preference:

1. **Invert the gateway's precedence** so `VELLUM_PLATFORM_URL` wins over `vellum:platform_base_url` when the env var is set, matching what the daemon's `getPlatformBaseUrl()` already does. That kills the redirect on managed pods without touching auth, and local mode (no env var) keeps working off the credential. Risk to check first: whether the platform ever repoints a live pod by pushing a new credential without a restart.
2. **Give provisioning its own transport** the tool shell cannot reach, so a principal distinction exists to enforce.

I did not do (1) in this PR because it changes gateway behaviour on every managed pod and deserves its own review rather than riding along on a credentials-API change.

### Out of scope by design

- The Django `self-hosted-local/ensure-registration` and `reprovision-api-key` endpoints still return the raw key. Handled separately by the rate cap on the runtime proxy, in the platform repo.
- `platform_assistant_id` stays out of the managed set. It is an identity component, not a host, so it does not change where the key is sent. `platform_organization_id`, `platform_user_id`, and `webhook_secret` likewise stay listed: they are per-instance values the pod's single owner conceptually already holds, and none buys inference on Vellum's account.

## Verified

- `bun test src/__tests__/credential-routes.test.ts` — 41 pass. New cases: list omits both fields but keeps the user's own; reveal refuses for `local` / `user` / `svc_gateway`; reveal refuses the UUID lookup form; inspect refuses both fields; set refuses both and leaves an already-provisioned value intact; delete refuses both; a normal user credential still lists, inspects, reveals, writes, and deletes.
- `bun run typecheck:fast` — clean.
- `bun run lint` — clean.
- `bun run generate:openapi` — no spec drift.
- Neighbouring suites (`credential-security-invariants`, `secret-routes-acp-guard`, `secret-routes-platform-proxy`, `secret-routes-scrub`, `credential-delete-in-use`) pass file-by-file, which is how CI runs them (`--isolate`). Running them in one un-isolated batch shows 8 failures from `mock.module` bleeding across files; that is pre-existing on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGHYJ12FeZoTExA41Lf7NK
