### PR TITLE
fix(oauth): strip the gateway's x-trace-id before the managed proxy allowlist

### DIFF
--- a/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/oauth-proxy-routes.test.ts
@@ -471,6 +471,7 @@ describe("header handling", () => {
         "accept-encoding": "gzip",
         cookie: "session=abc",
         "x-forwarded-for": "203.0.113.9",
+        "x-trace-id": "trace-123",
         "x-vellum-subject": "local:self:spoofed",
         "user-agent": "link-cli/1.0",
         accept: "application/json",
@@ -486,6 +487,7 @@ describe("header handling", () => {
       "accept-encoding",
       "cookie",
       "x-forwarded-for",
+      "x-trace-id",
       "x-vellum-subject",
       "x-vellum-principal-type",
     ]) {
@@ -526,7 +528,7 @@ describe("header handling", () => {
   }
 
   for (const method of ["GET", "POST"]) {
-    test(`forwards managed ${method} with Node CLI defaults`, async () => {
+    test(`forwards managed ${method} with Node CLI defaults and the gateway trace stamp`, async () => {
       let attempts = 0;
       const forwardedHeaders = {
         "content-type": "application/json",
@@ -550,6 +552,7 @@ describe("header handling", () => {
           "sec-fetch-mode": "cors",
           "accept-encoding": "gzip, deflate",
           connection: "keep-alive",
+          "x-trace-id": "trace-123",
         },
       });
 

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.test.ts
@@ -343,6 +343,7 @@ describe("sanitizeInboundHeaders", () => {
       "cookie",
       "forwarded",
       "x-real-ip",
+      "x-trace-id",
       "x-forwarded-for",
       "x-forwarded-proto",
       "x-vellum-subject",

--- a/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
+++ b/assistant/src/runtime/routes/oauth-proxy-passthrough.ts
@@ -59,6 +59,9 @@ const STRIPPED_REQUEST_HEADERS = new Set([
   "cookie",
   "forwarded",
   "x-real-ip",
+  // The gateway stamps this on every request it forwards. It names this
+  // hop's trace, not the caller's request, and the daemon never reads it.
+  "x-trace-id",
 ]);
 
 const TEXT_ENCODER = new TextEncoder();


### PR DESCRIPTION
## Summary

- `sanitizeInboundHeaders` now strips `x-trace-id`. The gateway stamps that header on every request before route dispatch and the runtime proxy forwards it to the daemon, where the managed-connection allowlist rejected it as a caller header. Every proxied request through a managed connection (for example `@stripe/link-cli` against `stripe_link`) returned `400 Managed OAuth connections cannot forward these request headers: x-trace-id` before reaching the provider.
- The daemon never reads the header and it identifies the gateway hop, not the caller's request, so stripping it is right on both connection modes: managed requests forward again, and BYO requests stop passing the gateway's correlation id to the provider.
- Tests: the sanitizer unit test and the route-level BYO strip test both cover the header, and the managed forwarding test now sends it alongside the Node fetch defaults and asserts the platform receives only the four allowlisted headers. All four fail without the fix.

## Original prompt

A bug report showed every request through the OAuth passthrough proxy for a managed `stripe_link` connection failing with the 400 above, with a local capture proving `link-cli` never sends `x-trace-id`. Investigation traced the header to the gateway's per-request trace stamp and a gap in the daemon's inbound sanitizer, whose doc comment says it removes anything the edge injected but which only matched the `x-forwarded-*` and `x-vellum-*` prefixes. The fix was requested via `/do` with the constraint that the header be stripped daemon-side rather than allowlisted, which would forward an internal correlation id to providers, or removed from the gateway, which would drop correlation for every other route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyNKbXfkVnQ1FGofZDuAV4