### PR TITLE
fix(web): restore the web type check on main

### DIFF
--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -208,7 +208,7 @@ describe("mapRuntimeToDisplayMessage", () => {
       id: "m-unknown",
       role: "assistant",
       assistantTextVisibility: "later",
-    } as Partial<ConversationMessage>);
+    } as unknown as Partial<ConversationMessage>);
     expect(
       mapRuntimeToDisplayMessage(unknown).assistantTextVisibility,
     ).toBeUndefined();


### PR DESCRIPTION
One-line test-only cast that restores the web Type Check job.

## The break

`clients/web` fails `bunx tsc --noEmit`:

```
src/domains/chat/utils/map-runtime-message.test.ts(207,33): error TS2352:
Conversion of type '{ id: string; role: "assistant"; assistantTextVisibility: "later"; }'
to type 'Partial<ConversationMessage>' may be a mistake because neither type
sufficiently overlaps with the other.
```

The test deliberately feeds an unrecognized marker to assert that `mapRuntimeToDisplayMessage` drops it rather than guessing at it. `"later"` is not in the `AssistantTextVisibility` union (`'private' | 'visible'`), so TypeScript rejects the direct cast. Widening through `unknown` lets the test keep exercising a value the union does not contain, which is the whole point of that case.

## Why it matters now

`pr-web.yaml` and `ci-main-web.yaml` both run `bun run typecheck`, which is exactly `bunx tsc --noEmit`. So this is not a local-only problem:

- `ci-main-web` is **failing on main** at `c4c1b078` (run 34457006331) with this error.
- Every open PR inherits the failure the moment it merges main. It surfaced on #42282 as a `Type Check` failure in a PR that touches no web runtime code.

The same fix already exists on the local `qa/combined` QA branch (`9051619ddf chore(qa): test-only cast after merge`), so it has been hit before; it just never landed on `main`.

## Testing

- `bunx tsc --noEmit` in `clients/web`: clean (exit 0).
- `bun test src/domains/chat/utils/map-runtime-message.test.ts`: 22 pass.

Test-only change, no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBmHacmyMsBG9aQB7sHrES

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->