### PR TITLE
fix(web): main typecheck, cast the unknown visibility fixture through unknown

### DIFF
--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -208,7 +208,7 @@ describe("mapRuntimeToDisplayMessage", () => {
       id: "m-unknown",
       role: "assistant",
       assistantTextVisibility: "later",
-    } as Partial<ConversationMessage>);
+    } as unknown as Partial<ConversationMessage>);
     expect(
       mapRuntimeToDisplayMessage(unknown).assistantTextVisibility,
     ).toBeUndefined();


### PR DESCRIPTION
Main's `CI Main Web` type check fails since #42185 landed after #42183: the `map-runtime-message` test casts a row with an out-of-union `assistantTextVisibility` directly to `Partial<ConversationMessage>`, which TypeScript rejects now that the daemon's union type is on main. Cast through `unknown`; the test's intent (the mapper drops an unknown marker) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oPSTYuVjkzuXHZskHfpTm
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->