### PR TITLE
test(web): cast the unknown-visibility fixture through unknown

### DIFF
--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -208,7 +208,7 @@ describe("mapRuntimeToDisplayMessage", () => {
       id: "m-unknown",
       role: "assistant",
       assistantTextVisibility: "later",
-    } as Partial<ConversationMessage>);
+    } as unknown as Partial<ConversationMessage>);
     expect(
       mapRuntimeToDisplayMessage(unknown).assistantTextVisibility,
     ).toBeUndefined();


### PR DESCRIPTION
Main fails the web Type Check since #42185 landed after #42183: the map-runtime-message test feeds `later`, a value outside the `assistantTextVisibility` enum, through a direct `as Partial<ConversationMessage>` cast. The test is checking the unknown-value path on purpose, so the conversion goes through `unknown`.

Same fix Aaron applied on qa/combined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VE1mb4E2stik5ebjfiQwNZ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42497" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->