### PR TITLE
chore(oauth): GA Link by Stripe and retire the stripe-link-oauth flag

### DIFF
--- a/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
+++ b/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
@@ -112,6 +112,12 @@ describe("PROVIDER_SEED_DATA managed mode wiring", () => {
     expect(link.identityResponsePaths).toEqual(["email", "phone"]);
   });
 
+  test("Link is GA and ships without a feature flag", () => {
+    // The seed upserts featureFlag on every startup, so a flag reintroduced
+    // here would hide Link from every install on the next boot.
+    expect(PROVIDER_SEED_DATA.stripe_link.featureFlag).toBeUndefined();
+  });
+
   test("figma ships behind the figma-oauth flag", () => {
     // The provider is hidden from the providers list and the connect routes
     // until the flag is enabled. Dropping featureFlag here would make Figma

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -1328,7 +1328,6 @@ export const PROVIDER_SEED_DATA: Record<
     // backstops a wallet that has one but no email on file.
     identityUrl: "https://api.link.com/userinfo",
     identityResponsePaths: ["email", "phone"],
-    featureFlag: "stripe-link-oauth",
   },
 };
 

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -133,6 +133,13 @@ describe("feature flag catalog", () => {
       false,
     );
   });
+
+  test("does not expose GA Link by Stripe as a feature flag", () => {
+    expect("stripeLinkOauth" in CLIENT_FLAG_DEFAULTS).toBe(false);
+    expect("stripeLinkOauth" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
+    expect("stripeLinkOauth" in CLIENT_STRING_FLAG_DEFAULTS).toBe(false);
+    expect("stripeLinkOauth" in ASSISTANT_STRING_FLAG_DEFAULTS).toBe(false);
+  });
 });
 
 describe("readEnvFlagOverrides", () => {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -447,14 +447,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "stripe-link-oauth",
-      "scope": "assistant",
-      "key": "stripe-link-oauth",
-      "label": "Link by Stripe Integration",
-      "description": "Gates the seeded Link by Stripe OAuth provider. When off, the provider is hidden from GET /v1/oauth/providers, its get-by-id route, and the connect/update routes, so it cannot be listed or connected from the CLI, gateway, or web integrations list. The row is still seeded into oauth_providers on startup; only its visibility changes. Off by default because a connected wallet lets an assistant spend real money.",
-      "defaultEnabled": false
-    },
-    {
       "id": "monday-oauth",
       "scope": "assistant",
       "key": "monday-oauth",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -447,14 +447,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "stripe-link-oauth",
-      "scope": "assistant",
-      "key": "stripe-link-oauth",
-      "label": "Link by Stripe Integration",
-      "description": "Gates the seeded Link by Stripe OAuth provider. When off, the provider is hidden from GET /v1/oauth/providers, its get-by-id route, and the connect/update routes, so it cannot be listed or connected from the CLI, gateway, or web integrations list. The row is still seeded into oauth_providers on startup; only its visibility changes. Off by default because a connected wallet lets an assistant spend real money.",
-      "defaultEnabled": false
-    },
-    {
       "id": "monday-oauth",
       "scope": "assistant",
       "key": "monday-oauth",


### PR DESCRIPTION
## Summary

- `stripe_link` no longer declares `featureFlag: "stripe-link-oauth"` in the provider seed, so the Link by Stripe provider is listed and connectable on every install. The seed re-stamps `featureFlag` on each startup, so existing installs un-gate on their next boot with no migration.
- The `stripe-link-oauth` entry is removed from `meta/feature-flags/feature-flag-registry.json`, and the bundled `clients/web` copy is regenerated with `bun run meta/sync-bundled-copies.ts`. A negative test in the web flag catalog and a positive "ships without a flag" test in the managed seed suite guard the retirement.
- No platform follow-up: the flag was never provisioned in `vellum-assistant-platform` Terraform and has no `PENDING_PLATFORM_PRS.md` row, so per the flag conventions the retirement ends here with nothing to archive.

## Original prompt

GA the Link by Stripe feature flag. With the OAuth passthrough proxy (#42466) and the wallet skill changes (#42491, #42493) merged, the `stripe-link-oauth` gate that hid the seeded provider from the providers list and the connect routes is no longer wanted. This follows the repo's flag retirement conventions: code reads and the registry entry go in the same PR with the bundled copy synced, and the never-provisioned flag needs no LaunchDarkly archival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bkYhHxbELAgnqNpgdgUeo