### PR TITLE
fix(persistence): a Slack thread rooted at the assistant's own post continues the post's conversation

### DIFF
--- a/assistant/src/persistence/__tests__/slack-thread-root-evidence.test.ts
+++ b/assistant/src/persistence/__tests__/slack-thread-root-evidence.test.ts
@@ -5,35 +5,55 @@ import { getOrCreateConversation } from "../conversation-key-store.js";
 import { initializeDb } from "../db-init.js";
 import {
   buildScopedConversationKey,
+  recordOutboundPost,
   resolveInboundConversation,
 } from "../delivery-crud.js";
 
 // A Slack thread may continue the conversation that lives on the flat
 // channel key. The evidence for that includes the thread's root being a
-// post the assistant made from that conversation, so a reply under the
-// assistant's own top-level post lands where the post is recorded.
+// post the assistant made from that conversation, resolved through the
+// outbound-post index the post-send reconciliation writes, so a reply under
+// the assistant's own top-level post lands where the post is recorded.
 
 beforeAll(async () => {
   await initializeDb();
 });
 
+/** Record a delivered post the way the post-send reconciliation does. */
+async function recordFlatPost(
+  chatId: string,
+  providerMessageIds: readonly string[],
+): Promise<{ conversationId: string }> {
+  const flat = getOrCreateConversation(
+    buildScopedConversationKey("slack", chatId),
+  );
+  const [firstId] = providerMessageIds;
+  const row = await addMessage(flat.conversationId, "assistant", "posted", {
+    skipIndexing: true,
+    metadata: {
+      providerMeta: JSON.stringify({
+        source: "slack",
+        conversationExternalId: chatId,
+        messageId: firstId,
+        eventKind: "message",
+      }),
+    },
+  });
+  for (const providerMessageId of providerMessageIds) {
+    recordOutboundPost({
+      sourceChannel: "slack",
+      externalChatId: chatId,
+      providerMessageId,
+      messageId: row.id,
+      conversationId: flat.conversationId,
+    });
+  }
+  return flat;
+}
+
 describe("slack thread evidence", () => {
   test("a thread rooted at the assistant's own flat post continues the flat conversation", async () => {
-    const flat = getOrCreateConversation(
-      buildScopedConversationKey("slack", "C0ROOTED"),
-    );
-    await addMessage(flat.conversationId, "assistant", "posted from a run", {
-      skipIndexing: true,
-      metadata: {
-        providerMeta: JSON.stringify({
-          source: "slack",
-          conversationExternalId: "C0ROOTED",
-          messageId: "1700000000.000900",
-          eventKind: "message",
-        }),
-      },
-    });
-
+    const flat = await recordFlatPost("C0ROOTED", ["1700000000.000900"]);
     const reply = resolveInboundConversation(
       "slack",
       "C0ROOTED",
@@ -42,21 +62,24 @@ describe("slack thread evidence", () => {
     expect(reply.conversationId).toBe(flat.conversationId);
   });
 
-  test("a post recorded in another chat is not evidence for this one", async () => {
+  test("a thread rooted at a later chunk of a split post continues it too", async () => {
+    const flat = await recordFlatPost("C0SPLIT", [
+      "1700000000.000910",
+      "1700000000.000911",
+    ]);
+    const reply = resolveInboundConversation(
+      "slack",
+      "C0SPLIT",
+      "1700000000.000911",
+    );
+    expect(reply.conversationId).toBe(flat.conversationId);
+  });
+
+  test("a post recorded for another chat is not evidence for this one", async () => {
+    await recordFlatPost("C0SOMEWHEREELSE", ["1700000000.000902"]);
     const flat = getOrCreateConversation(
       buildScopedConversationKey("slack", "C0OTHERCHAT"),
     );
-    await addMessage(flat.conversationId, "assistant", "posted elsewhere", {
-      skipIndexing: true,
-      metadata: {
-        providerMeta: JSON.stringify({
-          source: "slack",
-          conversationExternalId: "C0SOMEWHEREELSE",
-          messageId: "1700000000.000902",
-          eventKind: "message",
-        }),
-      },
-    });
     const reply = resolveInboundConversation(
       "slack",
       "C0OTHERCHAT",

--- a/assistant/src/persistence/__tests__/slack-thread-root-evidence.test.ts
+++ b/assistant/src/persistence/__tests__/slack-thread-root-evidence.test.ts
@@ -1,0 +1,79 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import { addMessage } from "../conversation-crud.js";
+import { getOrCreateConversation } from "../conversation-key-store.js";
+import { initializeDb } from "../db-init.js";
+import {
+  buildScopedConversationKey,
+  resolveInboundConversation,
+} from "../delivery-crud.js";
+
+// A Slack thread may continue the conversation that lives on the flat
+// channel key. The evidence for that includes the thread's root being a
+// post the assistant made from that conversation, so a reply under the
+// assistant's own top-level post lands where the post is recorded.
+
+beforeAll(async () => {
+  await initializeDb();
+});
+
+describe("slack thread evidence", () => {
+  test("a thread rooted at the assistant's own flat post continues the flat conversation", async () => {
+    const flat = getOrCreateConversation(
+      buildScopedConversationKey("slack", "C0ROOTED"),
+    );
+    await addMessage(flat.conversationId, "assistant", "posted from a run", {
+      skipIndexing: true,
+      metadata: {
+        providerMeta: JSON.stringify({
+          source: "slack",
+          conversationExternalId: "C0ROOTED",
+          messageId: "1700000000.000900",
+          eventKind: "message",
+        }),
+      },
+    });
+
+    const reply = resolveInboundConversation(
+      "slack",
+      "C0ROOTED",
+      "1700000000.000900",
+    );
+    expect(reply.conversationId).toBe(flat.conversationId);
+  });
+
+  test("a post recorded in another chat is not evidence for this one", async () => {
+    const flat = getOrCreateConversation(
+      buildScopedConversationKey("slack", "C0OTHERCHAT"),
+    );
+    await addMessage(flat.conversationId, "assistant", "posted elsewhere", {
+      skipIndexing: true,
+      metadata: {
+        providerMeta: JSON.stringify({
+          source: "slack",
+          conversationExternalId: "C0SOMEWHEREELSE",
+          messageId: "1700000000.000902",
+          eventKind: "message",
+        }),
+      },
+    });
+    const reply = resolveInboundConversation(
+      "slack",
+      "C0OTHERCHAT",
+      "1700000000.000902",
+    );
+    expect(reply.conversationId).not.toBe(flat.conversationId);
+  });
+
+  test("a thread with no evidence in the flat conversation is its own conversation", async () => {
+    const flat = getOrCreateConversation(
+      buildScopedConversationKey("slack", "C0UNRELATED"),
+    );
+    const reply = resolveInboundConversation(
+      "slack",
+      "C0UNRELATED",
+      "1700000000.000901",
+    );
+    expect(reply.conversationId).not.toBe(flat.conversationId);
+  });
+});

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -161,9 +161,12 @@ function legacySlackConversationHasThreadEvidence(
     }
     for (const metadata of metadataRows) {
       const meta = readProviderMetadata(metadata, { allowFlatLegacy: true });
+      // A row in the thread, or the row the thread is rooted at: a thread
+      // under the assistant's own flat post continues the conversation the
+      // post was recorded in.
       if (
         meta?.conversationExternalId === externalChatId &&
-        meta.threadId === sourceThreadId
+        (meta.threadId === sourceThreadId || meta.messageId === sourceThreadId)
       ) {
         return true;
       }

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -142,6 +142,19 @@ function legacySlackConversationHasThreadEvidence(
     return true;
   }
 
+  // A thread rooted at the assistant's own post continues the conversation
+  // the post was recorded in. Every id a delivered post was acknowledged
+  // under is in the outbound index, split posts included, so this lookup
+  // is exact and not bounded by the scan below.
+  const rooted = findMessageByProviderMessageId(
+    "slack",
+    externalChatId,
+    sourceThreadId,
+  );
+  if (rooted?.conversationId === conversationId) {
+    return true;
+  }
+
   let offset = 0;
   while (offset < SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN) {
     const remaining = SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN - offset;
@@ -161,12 +174,9 @@ function legacySlackConversationHasThreadEvidence(
     }
     for (const metadata of metadataRows) {
       const meta = readProviderMetadata(metadata, { allowFlatLegacy: true });
-      // A row in the thread, or the row the thread is rooted at: a thread
-      // under the assistant's own flat post continues the conversation the
-      // post was recorded in.
       if (
         meta?.conversationExternalId === externalChatId &&
-        (meta.threadId === sourceThreadId || meta.messageId === sourceThreadId)
+        meta.threadId === sourceThreadId
       ) {
         return true;
       }


### PR DESCRIPTION
**TL;DR:** A reply in a Slack thread rooted at the assistant's own top-level post continues the conversation that post was recorded in. The flat-to-thread aliasing that lets a Slack thread continue a flat channel conversation looked for evidence of the thread in that conversation, but only as a stored thread id, so a thread whose root is the assistant's own recorded post had no evidence and every reply under it minted a fresh, empty conversation. The evidence check now asks the outbound-post index, which holds every id a delivered post was acknowledged under, so a thread rooted at any chunk of the assistant's own post resolves in one exact read. Part of JARVIS-1733.

## Why

A proactive post to a Slack channel (a notification, or a `messaging_send` from a scheduled run) is a top-level message; people reply to it in a thread. Each such reply resolved to a new thread conversation containing nothing, so the assistant answered without the post in its history. The record was right where it was; the lookup did not recognise it.

## What changes for the user

| Before | After |
| --- | --- |
| A reply under the assistant's own top-level Slack post ran in a new, empty conversation | It continues the conversation the post is recorded in |
| A reply under someone else's top-level post that the assistant had answered in-thread | Unchanged: the stored thread id was already evidence |
| A thread with no trace in the flat conversation | Unchanged: it is its own conversation |

## Why this is safe

- The root is resolved through `findMessageByProviderMessageId`, the existing reader of the `channel_outbound_posts` index: exact, keyed on channel, chat, and provider id, with no scan cap, and every chunk of a split post is indexed onto its row. The match still requires the indexed row's conversation to be the flat conversation the reply would alias to.
- The capped metadata scan keeps its original condition; nothing about the existing evidence changes.
- Tests seed the index the way the post-send reconciliation does, against the real database: a thread rooted at the assistant's flat post resolves to the flat conversation; so does one rooted at the second chunk of a split post; a post recorded for another chat is not evidence; a thread with no evidence stays its own conversation. Typecheck clean; run on CI at exact HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
