### PR TITLE
fix(web): keep a model update that lands before its session is seeded

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -754,15 +754,50 @@ describe("setModel", () => {
     expect(stamped).toBeGreaterThanOrEqual(before);
   });
 
-  it("ignores an unknown session", () => {
+  it("buffers an update for a session it has not seeded yet", () => {
     const before = { ...getState().byId };
     getState().setModel({
       acpSessionId: "acp-missing",
       model: "opus",
-      availableModels: [],
+      availableModels: [{ value: "opus", label: "Opus" }],
     });
 
     expect(getState().byId).toEqual(before);
+    expect(getState().pendingModelUpdates.get("acp-missing")).toMatchObject({
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+  });
+
+  it("drops the buffered update once a live update lands on the entry", () => {
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+    spawn();
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+
+    expect(getState().pendingModelUpdates.has("acp-1")).toBe(false);
+  });
+
+  it("caps the buffer and drops the least recently updated session", () => {
+    for (let i = 0; i < 64; i += 1) {
+      getState().setModel({
+        acpSessionId: `acp-pending-${i}`,
+        model: "opus",
+        availableModels: [],
+      });
+    }
+
+    const pending = getState().pendingModelUpdates;
+    expect(pending.size).toBeLessThan(64);
+    expect(pending.has("acp-pending-0")).toBe(false);
+    expect(pending.has("acp-pending-63")).toBe(true);
   });
 });
 
@@ -979,6 +1014,59 @@ describe("seedFromHistory", () => {
     const entry = getState().byId["acp-1"]!;
     expect(entry.model).toBe("opus");
     expect(entry.modelUpdatedAt).toBe(200);
+  });
+
+  it("applies an update buffered before the session was seeded", () => {
+    // The update lands while /acp/sessions is in flight, so there is no entry
+    // to stamp, and the response still carries the model read before it.
+    const fetchedAt = Date.now() - 1;
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "opus",
+          availableModels: [{ value: "opus", label: "Opus" }],
+        }),
+      ],
+      { fetchedAt },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("sonnet");
+    expect(entry.availableModels).toEqual([
+      { value: "sonnet", label: "Sonnet" },
+    ]);
+    expect(getState().pendingModelUpdates.has("acp-1")).toBe(false);
+  });
+
+  it("lets a snapshot fetched after the buffered update win", () => {
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "opus",
+          availableModels: [{ value: "opus", label: "Opus" }],
+        }),
+      ],
+      { fetchedAt: Date.now() + 1000 },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("opus");
+    expect(entry.availableModels).toEqual([{ value: "opus", label: "Opus" }]);
+    expect(getState().pendingModelUpdates.has("acp-1")).toBe(false);
   });
 
   it("is idempotent — re-seeding the same entry does not duplicate ordered ids", () => {
@@ -1215,5 +1303,18 @@ describe("reset", () => {
     expect(getState().orderedIds).toEqual([]);
     expect(getState().byToolUseId.size).toBe(0);
     expect(getState().highWaterMark.size).toBe(0);
+  });
+
+  it("clears buffered model updates", () => {
+    getState().setModel({
+      acpSessionId: "acp-unseeded",
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
+    expect(getState().pendingModelUpdates.size).toBe(1);
+
+    getState().reset();
+
+    expect(getState().pendingModelUpdates.size).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -87,6 +87,36 @@ describe("spawnRun", () => {
     expect(getState().byId["acp-1"]!.startedAt).toBe(NOW);
   });
 
+  it("applies a model update buffered before the spawn event", () => {
+    // The adapter reports the opening selection before `acp_session_spawned`,
+    // so the update arrives with no entry to hold it.
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+
+    spawn();
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("sonnet");
+    expect(entry.availableModels).toEqual([
+      { value: "sonnet", label: "Sonnet" },
+    ]);
+    expect(getState().pendingModelUpdates.has("acp-1")).toBe(false);
+  });
+
+  it("applies a buffered empty-picker withdrawal to the spawned entry", () => {
+    getState().setModel({ acpSessionId: "acp-1", availableModels: [] });
+
+    spawn();
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBeUndefined();
+    expect(entry.availableModels).toEqual([]);
+    expect(getState().pendingModelUpdates.has("acp-1")).toBe(false);
+  });
+
   it("indexes byToolUseId when parentToolUseId is present", () => {
     spawn({ parentToolUseId: "tool-use-1" });
 

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -145,10 +145,12 @@ export interface AcpRunState {
    */
   highWaterMark: Map<string, number>;
   /**
-   * Model updates that landed for a session with no entry yet. The snapshot
-   * that creates the entry folds the buffered update in under the same
-   * ordering rule a live entry gets, so an update racing an in-flight
-   * `/acp/sessions` read is not lost. Bounded by
+   * Model updates that landed for a session with no entry yet: the daemon
+   * reports the opening selection (and an empty-picker withdrawal) before
+   * `acp_session_spawned`, and an `/acp/sessions` read can be answered after an
+   * update it predates. Whichever path creates the entry, a spawn or a
+   * snapshot, folds the buffered update in under the same ordering rule a live
+   * entry gets, so the selection is not lost. Bounded by
    * {@link MAX_PENDING_MODEL_UPDATES}, least recently updated id dropped first.
    */
   pendingModelUpdates: Map<string, PendingModelUpdate>;
@@ -258,7 +260,7 @@ export interface AcpRunActions {
    * update cannot roll it back.
    *
    * A session with no entry yet buffers the update in `pendingModelUpdates`
-   * instead, for the snapshot that creates the entry to apply.
+   * instead, for the spawn or snapshot that creates the entry to apply.
    */
   setModel: (params: {
     acpSessionId: string;
@@ -465,6 +467,22 @@ function applyPendingModelUpdate(
 }
 
 /**
+ * Fold a buffered model update into an entry a live event just created or
+ * resumed. The entry's own `modelUpdatedAt` stands in for the fetch time, so
+ * an entry with no selection yet takes the buffered one and a selection
+ * recorded later than the buffered update keeps its place.
+ */
+function withPendingModelUpdate(
+  entry: AcpRunEntry,
+  pending: PendingModelUpdate | undefined,
+): AcpRunEntry {
+  if (pending === undefined) {
+    return entry;
+  }
+  return applyPendingModelUpdate(entry, pending, entry.modelUpdatedAt);
+}
+
+/**
  * Merge a history entry into an existing live entry. Unions both event buffers
  * by `seq` (never dropping the newest live events) and always folds in the
  * history entry's terminal/status/usage metadata. A terminal history status
@@ -558,8 +576,13 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
   ...INITIAL_STATE,
 
   spawnRun: (params) => {
-    const { byId, orderedIds, byToolUseId } = get();
+    const { byId, orderedIds, byToolUseId, pendingModelUpdates } = get();
     const existing = byId[params.acpSessionId];
+    const pending = pendingModelUpdates.get(params.acpSessionId);
+    const nextPendingModelUpdates = dropPendingModelUpdates(
+      pendingModelUpdates,
+      [params.acpSessionId],
+    );
 
     if (existing) {
       // A respawn for an active run is a no-op. A respawn for a terminal run
@@ -569,15 +592,18 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
         return;
       }
 
-      const resumed: AcpRunEntry = {
-        ...existing,
-        status: "running",
-        stopReason: undefined,
-        error: undefined,
-        completedAt: undefined,
-        task: existing.task ?? params.task,
-        parentToolUseId: existing.parentToolUseId ?? params.parentToolUseId,
-      };
+      const resumed: AcpRunEntry = withPendingModelUpdate(
+        {
+          ...existing,
+          status: "running",
+          stopReason: undefined,
+          error: undefined,
+          completedAt: undefined,
+          task: existing.task ?? params.task,
+          parentToolUseId: existing.parentToolUseId ?? params.parentToolUseId,
+        },
+        pending,
+      );
 
       const nextByToolUseId = existing.parentToolUseId
         ? byToolUseId
@@ -590,24 +616,30 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
       set({
         byId: { ...byId, [params.acpSessionId]: resumed },
         byToolUseId: nextByToolUseId,
+        pendingModelUpdates: nextPendingModelUpdates,
       });
       return;
     }
 
-    const entry: AcpRunEntry = {
-      acpSessionId: params.acpSessionId,
-      agent: params.agent,
-      parentConversationId: params.parentConversationId,
-      task: params.task,
-      // Daemon emits `acp_session_spawned` only after the session is already
-      // running, so a spawned run starts as "running", not "initializing".
-      status: "running",
-      startedAt: params.startedAt,
-      parentToolUseId: params.parentToolUseId,
-      usedTokens: 0,
-      contextSize: 0,
-      events: [],
-    };
+    // A model update can precede `acp_session_spawned`, so the entry this
+    // event creates takes the selection the adapter already reported.
+    const entry: AcpRunEntry = withPendingModelUpdate(
+      {
+        acpSessionId: params.acpSessionId,
+        agent: params.agent,
+        parentConversationId: params.parentConversationId,
+        task: params.task,
+        // Daemon emits `acp_session_spawned` only after the session is already
+        // running, so a spawned run starts as "running", not "initializing".
+        status: "running",
+        startedAt: params.startedAt,
+        parentToolUseId: params.parentToolUseId,
+        usedTokens: 0,
+        contextSize: 0,
+        events: [],
+      },
+      pending,
+    );
 
     // Only clone the tool-use index when this spawn carries a
     // `parentToolUseId`; otherwise keep the reference stable.
@@ -621,6 +653,7 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
       byId: { ...byId, [params.acpSessionId]: entry },
       orderedIds: [...orderedIds, params.acpSessionId],
       byToolUseId: nextByToolUseId,
+      pendingModelUpdates: nextPendingModelUpdates,
     });
   },
 

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -119,6 +119,17 @@ export interface AcpRunEntry {
   events: AcpRunRawEvent[];
 }
 
+/** A model update recorded before its session had an entry in the store. */
+export interface PendingModelUpdate {
+  model?: string;
+  availableModels: AcpModelOption[];
+  /** When the update landed, in `Date.now()` ms, for the snapshot ordering rule. */
+  updatedAt: number;
+}
+
+/** How many sessions can hold a buffered model update at once. */
+const MAX_PENDING_MODEL_UPDATES = 32;
+
 export interface AcpRunState {
   byId: Record<string, AcpRunEntry>;
   orderedIds: string[];
@@ -133,6 +144,14 @@ export interface AcpRunState {
    * reconnection by ignoring anything at or below the mark.
    */
   highWaterMark: Map<string, number>;
+  /**
+   * Model updates that landed for a session with no entry yet. The snapshot
+   * that creates the entry folds the buffered update in under the same
+   * ordering rule a live entry gets, so an update racing an in-flight
+   * `/acp/sessions` read is not lost. Bounded by
+   * {@link MAX_PENDING_MODEL_UPDATES}, least recently updated id dropped first.
+   */
+  pendingModelUpdates: Map<string, PendingModelUpdate>;
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +256,9 @@ export interface AcpRunActions {
    * cleared selection or a shrunken option set must not be masked by the
    * previous one. Stamps `modelUpdatedAt` so a snapshot requested before this
    * update cannot roll it back.
+   *
+   * A session with no entry yet buffers the update in `pendingModelUpdates`
+   * instead, for the snapshot that creates the entry to apply.
    */
   setModel: (params: {
     acpSessionId: string;
@@ -254,7 +276,8 @@ export interface AcpRunActions {
    * `fetchedAt` is when the caller issued the request these entries answer.
    * A model update stamped at or after it is newer than the snapshot, so the
    * live selection is kept. Callers that cannot say omit it and get the plain
-   * snapshot rules.
+   * snapshot rules. A buffered update from `pendingModelUpdates` is folded in
+   * by the same rule and dropped either way.
    */
   seedFromHistory: (
     entries: AcpRunEntry[],
@@ -275,6 +298,7 @@ const INITIAL_STATE: AcpRunState = {
   orderedIds: [],
   byToolUseId: new Map<string, string>(),
   highWaterMark: new Map<string, number>(),
+  pendingModelUpdates: new Map<string, PendingModelUpdate>(),
 };
 
 // ---------------------------------------------------------------------------
@@ -371,6 +395,72 @@ function mergeModelSelection(
     model: incoming.model ?? existing.model,
     availableModels: existing.availableModels,
     modelUpdatedAt,
+  };
+}
+
+/**
+ * Buffer a model update for a session with no entry, replacing any earlier one
+ * for the same id. Re-inserting the key keeps the map in recency order so the
+ * cap evicts the least recently updated session.
+ */
+function rememberPendingModelUpdate(
+  pendingModelUpdates: Map<string, PendingModelUpdate>,
+  acpSessionId: string,
+  update: PendingModelUpdate,
+): Map<string, PendingModelUpdate> {
+  const next = new Map(pendingModelUpdates);
+  next.delete(acpSessionId);
+  next.set(acpSessionId, update);
+  for (const id of next.keys()) {
+    if (next.size <= MAX_PENDING_MODEL_UPDATES) {
+      break;
+    }
+    next.delete(id);
+  }
+  return next;
+}
+
+/**
+ * Forget the buffered model updates for the given sessions, keeping the map
+ * reference stable when none of them had one.
+ */
+function dropPendingModelUpdates(
+  pendingModelUpdates: Map<string, PendingModelUpdate>,
+  acpSessionIds: string[],
+): Map<string, PendingModelUpdate> {
+  const buffered = acpSessionIds.filter((id) => pendingModelUpdates.has(id));
+  if (buffered.length === 0) {
+    return pendingModelUpdates;
+  }
+  const next = new Map(pendingModelUpdates);
+  for (const id of buffered) {
+    next.delete(id);
+  }
+  return next;
+}
+
+/**
+ * Fold a buffered model update into the snapshot entry that creates its
+ * session. The buffered update stands in for the live entry the store never
+ * had, so {@link mergeModelSelection} picks the winner by the same rule.
+ */
+function applyPendingModelUpdate(
+  entry: AcpRunEntry,
+  pending: PendingModelUpdate,
+  fetchedAt?: number,
+): AcpRunEntry {
+  return {
+    ...entry,
+    ...mergeModelSelection(
+      {
+        ...entry,
+        model: pending.model,
+        availableModels: pending.availableModels,
+        modelUpdatedAt: pending.updatedAt,
+      },
+      entry,
+      fetchedAt,
+    ),
   };
 }
 
@@ -708,9 +798,20 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
   },
 
   setModel: (params) => {
-    const { byId } = get();
+    const { byId, pendingModelUpdates } = get();
     const existing = byId[params.acpSessionId];
     if (!existing) {
+      set({
+        pendingModelUpdates: rememberPendingModelUpdate(
+          pendingModelUpdates,
+          params.acpSessionId,
+          {
+            model: params.model,
+            availableModels: params.availableModels,
+            updatedAt: Date.now(),
+          },
+        ),
+      });
       return;
     }
 
@@ -724,11 +825,20 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
           modelUpdatedAt: Date.now(),
         },
       },
+      pendingModelUpdates: dropPendingModelUpdates(pendingModelUpdates, [
+        params.acpSessionId,
+      ]),
     });
   },
 
   seedFromHistory: (entries, options) => {
-    const { byId, orderedIds, byToolUseId, highWaterMark } = get();
+    const {
+      byId,
+      orderedIds,
+      byToolUseId,
+      highWaterMark,
+      pendingModelUpdates,
+    } = get();
 
     // Union live + history events by seq and always merge terminal/status/
     // usage metadata from history so a live entry can't stay stale. The shared
@@ -737,10 +847,16 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
     // A row inserted fresh carries the fetch time too, so an older overlapping
     // response cannot roll it back through the merge path afterwards.
     const fetchedAt = options?.fetchedAt;
-    const stamped =
-      fetchedAt === undefined
-        ? entries
-        : entries.map((entry) => ({ ...entry, modelUpdatedAt: fetchedAt }));
+    const stamped = entries.map((entry) => {
+      const base =
+        fetchedAt === undefined
+          ? entry
+          : { ...entry, modelUpdatedAt: fetchedAt };
+      // An update that landed while this snapshot was in flight had no entry to
+      // stamp, so it waited in `pendingModelUpdates` for the row to arrive.
+      const pending = pendingModelUpdates.get(entry.acpSessionId);
+      return pending ? applyPendingModelUpdate(base, pending, fetchedAt) : base;
+    });
     const { byId: nextById, orderedIds: nextOrderedIds } =
       seedEntriesFromHistory({
         entries: stamped,
@@ -781,6 +897,10 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
       orderedIds: nextOrderedIds,
       byToolUseId: nextByToolUseId,
       highWaterMark: nextHighWaterMark,
+      pendingModelUpdates: dropPendingModelUpdates(
+        pendingModelUpdates,
+        entries.map((entry) => entry.acpSessionId),
+      ),
     });
   },
 
@@ -790,6 +910,7 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
       orderedIds: [],
       byToolUseId: new Map<string, string>(),
       highWaterMark: new Map<string, number>(),
+      pendingModelUpdates: new Map<string, PendingModelUpdate>(),
     }),
 }));
 


### PR DESCRIPTION
## Summary
- A model update for a session the store has not seeded yet is held and applied when the snapshot creates the entry, if it is newer than the snapshot; the tile no longer sits on a stale model until the next event
- Bounded pending map, cleared on reset and removal

Part of plan: acp-model-control-lite.md (feature-branch review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D