### PR TITLE
fix(acp): a stop that lands during the model pin tears the spawn down

### DIFF
--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -1057,3 +1057,93 @@ describe("AcpSessionManager: unsolicited model updates", () => {
     });
   });
 });
+
+describe("AcpSessionManager: a resumed id and the process it replaced", () => {
+  /**
+   * A cancel frees the id, so a resume can register a fresh entry under it
+   * while the stopped spawn's pin is still open. Everything the old process
+   * says after that reaches the manager through the old entry's own closures,
+   * and those closures own nothing the replacement holds: not its state, not
+   * its ring buffer, not its clients.
+   */
+  test("late frames from the replaced process touch nothing the replacement owns", async () => {
+    scriptedConfigOptions = [[modelOption("sonnet")]];
+    let release = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    setConfigOptionResponder = async () => {
+      await held;
+      // The withdrawal a vanished selector publishes, which is the frame that
+      // would otherwise go out over the replacement's id.
+      return [];
+    };
+
+    const manager = new AcpSessionManager(5);
+    const controller = new AbortController();
+    const sent: AssistantEvent[] = [];
+    const spawned = manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-replaced",
+      (msg) => sent.push(msg),
+      { model: "opus" },
+      { signal: controller.signal },
+    );
+    await waitForConfigOptionCalls(1);
+    const acpSessionId = manager.getActiveAndPendingIds()[0]!;
+    const oldHandler = clientHandlerFor(manager, acpSessionId);
+
+    // The user stops the turn and a resume takes the id over, both while the
+    // pin's round trip is still open.
+    controller.abort();
+    const internals = manager as unknown as {
+      registerSession: (opts: Record<string, unknown>) => {
+        state: AcpSessionState;
+      };
+      eventBuffers: Map<string, unknown[]>;
+    };
+    const replacement = internals.registerSession({
+      acpSessionId,
+      agentId: "agent-model",
+      agentConfig: { command: "echo", args: ["hi"] },
+      parentConversationId: "conv-resumed",
+      cwd: "/tmp",
+      startedAt: Date.now(),
+      sendToVellum: () => {},
+    });
+    replacement.state.status = "running";
+    sent.length = 0;
+
+    release();
+    await expect(spawned).rejects.toThrow();
+
+    // The old adapter goes on talking: a model change typed into its
+    // transcript, then a message chunk.
+    await oldHandler.sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: [modelOption("haiku")],
+      },
+    });
+    await oldHandler.sessionUpdate({
+      sessionId: "proto-agent-model",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: "from the old process" },
+      },
+    });
+
+    // The replacement is on nothing the old process said, and its buffer and
+    // its clients heard none of it.
+    const state = manager.getStatus(acpSessionId) as AcpSessionState;
+    expect(state.parentConversationId).toBe("conv-resumed");
+    expect(state.model).toBeUndefined();
+    expect(state.availableModels).toBeUndefined();
+    expect(internals.eventBuffers.get(acpSessionId)).toEqual([]);
+    expect(sent).toEqual([]);
+  });
+});

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -39,6 +39,7 @@ mock.module("./prepare-agent-env.js", () => ({
 }));
 
 import { createAbortReason } from "../util/abort-reasons.js";
+import { modelOption } from "./__tests__/helpers/acp-model-option.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
 import { AcpSessionManager } from "./session-manager.js";
 
@@ -128,6 +129,7 @@ function injectSession(
     parentConversationId,
     cwd: "/tmp",
     command: "noop",
+    modelSwitchQueue: Promise.resolve(),
   };
   (manager as any).sessions.set(acpSessionId, entry);
   return entry;
@@ -712,6 +714,68 @@ describe("AcpSessionManager.spawn: a stopped turn leaves no agent running", () =
       ),
     ).rejects.toThrow();
 
+    expect(prompt).not.toHaveBeenCalled();
+    expect(proc.kill).toHaveBeenCalled();
+    expect(internals.sessions.size).toBe(0);
+  });
+
+  /**
+   * The model pin is an await of its own, and it sits after the setup
+   * recheck. A stop landing inside it gets the same treatment: no spawned
+   * event, no model event, no prompt, and no session left behind.
+   */
+  test("a cancel during the model pin tears the process down and fires nothing", async () => {
+    const manager = new AcpSessionManager(1);
+    const controller = new AbortController();
+    const prompt = mock(() => Promise.resolve({}));
+    const setConfigOption = mock(async () => {
+      // The user stops the turn while the pin's round trip is open.
+      controller.abort(REASON);
+      return [modelOption("opus")];
+    });
+    const proc = {
+      ...fakeProcess(prompt),
+      spawn: () => {},
+      initialize: async () => {},
+      createSession: async () => ({
+        sessionId: "proto-1",
+        configOptions: [modelOption("sonnet")],
+      }),
+      setConfigOption,
+    };
+    let injected: ReturnType<typeof injectSession> | undefined;
+    const internals = manager as unknown as {
+      registerSession: (opts: {
+        acpSessionId: string;
+        parentConversationId: string;
+      }) => unknown;
+      sessions: Map<string, unknown>;
+    };
+    internals.registerSession = (opts) => {
+      injected = injectSession(
+        manager,
+        opts.acpSessionId,
+        opts.parentConversationId,
+        proc as unknown as ReturnType<typeof fakeProcess>,
+      );
+      return injected;
+    };
+
+    await expect(
+      manager.spawn(
+        "claude",
+        { command: "noop", args: [] } as never,
+        "do the task",
+        "/tmp",
+        "conv-1",
+        () => {},
+        { model: "opus" },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow();
+
+    expect(setConfigOption).toHaveBeenCalled();
+    expect(injected?.sendToVellum).not.toHaveBeenCalled();
     expect(prompt).not.toHaveBeenCalled();
     expect(proc.kill).toHaveBeenCalled();
     expect(internals.sessions.size).toBe(0);

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -780,4 +780,74 @@ describe("AcpSessionManager.spawn: a stopped turn leaves no agent running", () =
     expect(proc.kill).toHaveBeenCalled();
     expect(internals.sessions.size).toBe(0);
   });
+
+  /**
+   * A cancel that persists a resumable row frees the id, so a resume can
+   * register a fresh entry under it before the stopped spawn's pin settles.
+   * The teardown owes that spawn its own process, and owes the replacement
+   * its map slot.
+   */
+  test("a cancel during the model pin leaves a replacement session for the same id alone", async () => {
+    const manager = new AcpSessionManager(2);
+    const controller = new AbortController();
+    const prompt = mock(() => Promise.resolve({}));
+    let replacement: ReturnType<typeof injectSession> | undefined;
+    let spawnedId: string | undefined;
+    const setConfigOption = mock(async () => {
+      // The turn is stopped and the id is resumed by another request while
+      // the pin's round trip is still open.
+      controller.abort(REASON);
+      replacement = injectSession(
+        manager,
+        spawnedId!,
+        "conv-2",
+        fakeProcess(mock(() => Promise.resolve({}))),
+      );
+      return [modelOption("opus")];
+    });
+    const proc = {
+      ...fakeProcess(prompt),
+      spawn: () => {},
+      initialize: async () => {},
+      createSession: async () => ({
+        sessionId: "proto-1",
+        configOptions: [modelOption("sonnet")],
+      }),
+      setConfigOption,
+    };
+    const internals = manager as unknown as {
+      registerSession: (opts: {
+        acpSessionId: string;
+        parentConversationId: string;
+      }) => unknown;
+      sessions: Map<string, unknown>;
+    };
+    internals.registerSession = (opts) => {
+      spawnedId = opts.acpSessionId;
+      return injectSession(
+        manager,
+        opts.acpSessionId,
+        opts.parentConversationId,
+        proc as unknown as ReturnType<typeof fakeProcess>,
+      );
+    };
+
+    await expect(
+      manager.spawn(
+        "claude",
+        { command: "noop", args: [] } as never,
+        "do the task",
+        "/tmp",
+        "conv-1",
+        () => {},
+        { model: "opus" },
+        { signal: controller.signal },
+      ),
+    ).rejects.toThrow();
+
+    expect(prompt).not.toHaveBeenCalled();
+    expect(proc.kill).toHaveBeenCalled();
+    expect(replacement?.process.kill).not.toHaveBeenCalled();
+    expect(internals.sessions.get(spawnedId!)).toBe(replacement);
+  });
 });

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -1415,6 +1415,13 @@ export class AcpSessionManager {
 
   /**
    * Denies pending ACP permissions, kills the process, and removes the session.
+   *
+   * The permissions and the process belong to `entry`, so they are always
+   * torn down; the map slot and its buffer belong to whichever entry holds
+   * the id, so they are only cleared while that is still this one. A caller
+   * whose entry the map has since replaced (a cancel that persisted a
+   * resumable row, then a resume of the same id, while an await was pending)
+   * would otherwise evict the live session that took its place.
    */
   private teardownSession(acpSessionId: string, entry: SessionEntry): void {
     for (const requestId of entry.clientHandler.pendingRequestIds) {
@@ -1424,6 +1431,9 @@ export class AcpSessionManager {
       }
     }
     entry.process.kill();
+    if (this.sessions.get(acpSessionId) !== entry) {
+      return;
+    }
     this.sessions.delete(acpSessionId);
     // Free the buffer in case persistTerminal hasn't already (e.g. close()
     // before terminal transition).

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -419,6 +419,17 @@ export class AcpSessionManager {
       resolvedModel,
     );
 
+    // Recheck: the model pin is an await too, and everything below it either
+    // announces the session or hands the agent the task.
+    if (cancellation?.signal?.aborted) {
+      log.info(
+        { acpSessionId, agentId },
+        "ACP spawn cancelled during the model pin; tearing the session down",
+      );
+      this.teardownSession(acpSessionId, entry);
+      cancellation.signal.throwIfAborted();
+    }
+
     this.sendSpawnedEvent(acpSessionId, entry);
     this.sendModelEvent(acpSessionId, entry);
 

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -628,10 +628,20 @@ export class AcpSessionManager {
     // Initialize the per-session ring buffer before any update can fire.
     this.eventBuffers.set(acpSessionId, []);
 
+    // The map is the evidence, as everywhere else in this class: an id whose
+    // entry is no longer this one was cancelled and resumed, so this
+    // process's late frames must not reach the buffer, the state, or the
+    // clients the replacement now owns. `entry` is declared below and read
+    // only from inside closures the process cannot fire until it exists.
+    const ownsSession = () => this.sessions.get(acpSessionId) === entry;
+
     // Wrap the sender so every emitted message is mirrored into the buffer
     // when it's an `acp_session_update`. The wrapper preserves the original
     // call semantics: it forwards every message unchanged.
     const wrappedSend = (msg: AssistantEvent) => {
+      if (!ownsSession()) {
+        return;
+      }
       if (msg.type === "acp_session_update") {
         this.appendToBuffer(acpSessionId, msg);
       } else if (msg.type === "acp_session_usage") {
@@ -659,7 +669,7 @@ export class AcpSessionManager {
       wrappedSend,
       opts.parentConversationId,
       (configOptions) => {
-        this.applyUnsolicitedConfigOptions(acpSessionId, configOptions);
+        this.applyUnsolicitedConfigOptions(acpSessionId, entry, configOptions);
       },
     );
 
@@ -868,10 +878,10 @@ export class AcpSessionManager {
    */
   private applyUnsolicitedConfigOptions(
     acpSessionId: string,
+    entry: SessionEntry,
     configOptions: SessionConfigOption[],
   ): void {
-    const entry = this.sessions.get(acpSessionId);
-    if (!entry || !this.isEntryLive(acpSessionId, entry)) {
+    if (!this.isEntryLive(acpSessionId, entry)) {
       return;
     }
     this.applyModelInfo(entry, configOptions);


### PR DESCRIPTION
## Summary
- The spawn path rechecks the cancellation signal after the model pin, so a turn stopped in that window tears the session down instead of announcing it and handing the agent the task

Part of plan: acp-model-control-lite.md (feature-branch review fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D