### PR TITLE
fix(web): Chat Info opens at the mock's width and tile labels keep their descenders

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.test.ts
+++ b/clients/web/src/domains/chat/components/chat-content-layout.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the side drawer's width profile.
+ *
+ * The selection is a pure function of the active view, so it is asserted
+ * without mounting the layout, which reaches for every store the chat route
+ * owns.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
+import {
+  CHAT_INFO_BODY_WIDTH_PX,
+  CHAT_INFO_DRAWER_WIDTH_PX,
+} from "@/domains/chat/components/chat-info-drawer-width";
+import type { MainView } from "@/stores/viewer-store";
+
+import { rightDrawerWidthProfile } from "./chat-content-layout";
+
+describe("rightDrawerWidthProfile", () => {
+  test("Chat Info opens at the mock's width under its own key", () => {
+    expect(rightDrawerWidthProfile("chat-info")).toEqual({
+      storageKey: "chatInfoPanelWidth",
+      defaultWidth: CHAT_INFO_DRAWER_WIDTH_PX,
+    });
+  });
+
+  test("the drawer width is the mock's body plus the shell's two insets", () => {
+    expect(CHAT_INFO_DRAWER_WIDTH_PX).toBe(
+      CHAT_INFO_BODY_WIDTH_PX + 2 * DETAIL_SHELL_BODY_INSET_PX,
+    );
+  });
+
+  test.each<MainView>([
+    "chat",
+    "document",
+    "tool-detail",
+    "activity-steps",
+    "subagent-detail",
+    "skill-detail",
+    "channel-setup",
+  ])("%s keeps the shared key and the drawer's own default", (mainView) => {
+    // No `defaultWidth`, so `AnimatedRightDrawer` applies its own.
+    expect(rightDrawerWidthProfile(mainView)).toEqual({
+      storageKey: "rightPanelWidth",
+    });
+  });
+
+  test("the two profiles never share a key", () => {
+    expect(rightDrawerWidthProfile("chat-info").storageKey).not.toBe(
+      rightDrawerWidthProfile("chat").storageKey,
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -14,6 +14,7 @@ import { lazy, useCallback, useEffect, type ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { Loader2 } from "lucide-react";
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
+import { CHAT_INFO_DRAWER_WIDTH_PX } from "@/domains/chat/components/chat-info-drawer-width";
 import { ProgressStack } from "@/domains/chat/components/progress-stack";
 import { SideControlPlacementBoundary } from "@/domains/chat/components/side-control-placement";
 import { LazyBoundary } from "@/components/lazy-boundary";
@@ -30,7 +31,11 @@ import { useConversationStore } from "@/stores/conversation-store";
 import { paneState } from "@/stores/pane-state";
 import { WorkspacePanes } from "@/domains/chat/components/workspace-panes";
 import { useDeployStore } from "@/stores/deploy-store";
-import { chatInfoTargetKey, useViewerStore } from "@/stores/viewer-store";
+import {
+  chatInfoTargetKey,
+  type MainView,
+  useViewerStore,
+} from "@/stores/viewer-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useAcpRunStore } from "@/domains/chat/acp-run-store";
@@ -105,6 +110,32 @@ const ChannelTranscriptPanel = lazy(() =>
     default: m.ChannelTranscriptPanel,
   })),
 );
+
+export interface RightDrawerWidthProfile {
+  /** `localStorage` key the drawer remembers this profile's width under. */
+  storageKey: string;
+  /** Omitted for the shared profile, which opens at the drawer's own default. */
+  defaultWidth?: number;
+}
+
+/**
+ * Which width the one shared side drawer opens at, and where it remembers it.
+ *
+ * Chat Info draws fitted rows of tiles the other panels have no equivalent of,
+ * so it opens at the width the mock draws those rows at and keeps its own
+ * remembered width; every other panel shares one.
+ */
+export function rightDrawerWidthProfile(
+  mainView: MainView,
+): RightDrawerWidthProfile {
+  if (mainView === "chat-info") {
+    return {
+      storageKey: "chatInfoPanelWidth",
+      defaultWidth: CHAT_INFO_DRAWER_WIDTH_PX,
+    };
+  }
+  return { storageKey: "rightPanelWidth" };
+}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -683,9 +714,14 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     }
   }
 
+  // One drawer instance across every panel, so switching profiles moves the
+  // width the hook reports and motion eases it rather than remounting.
+  const widthProfile = rightDrawerWidthProfile(mainView);
+
   return (
     <AnimatedRightDrawer
-      storageKey="rightPanelWidth"
+      storageKey={widthProfile.storageKey}
+      defaultWidth={widthProfile.defaultWidth}
       open={rightPanel != null}
       left={chatContent}
       right={rightPanel}

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.stories.tsx
@@ -18,7 +18,7 @@ import {
   withChatInfoStoryClient,
 } from "@/domains/chat/components/chat-info-story-fixtures";
 import {
-  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_BODY_WIDTH_PX,
   makeAppSummary,
   makeChatInfoQueryClient,
   seedChatInfoConversation,
@@ -80,7 +80,7 @@ export const Default: Story = {};
 export const Stretched: Story = {
   args: { stretch: true },
   render: (args) => (
-    <div className="flex gap-2" style={{ width: CHAT_INFO_DRAWER_WIDTH_PX }}>
+    <div className="flex gap-2" style={{ width: CHAT_INFO_BODY_WIDTH_PX }}>
       <ChatInfoAppTile {...args} app={TRIP_PLANNER} />
       <ChatInfoAppTile {...args} app={PACKING_LIST} />
       <ChatInfoAppTile {...args} app={FERRY_TIMES} />

--- a/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-app-tile.tsx
@@ -81,7 +81,7 @@ export function ChatInfoAppTile({
       <Typography
         variant="body-small-default"
         title={app.name}
-        className="truncate text-[var(--content-tertiary)]"
+        className="truncate leading-normal text-[var(--content-tertiary)]"
       >
         {app.name}
       </Typography>

--- a/clients/web/src/domains/chat/components/chat-info-drawer-width.ts
+++ b/clients/web/src/domains/chat/components/chat-info-drawer-width.ts
@@ -1,0 +1,15 @@
+/**
+ * The width the Chat Info panel opens its drawer at.
+ *
+ * Its own module so the chat layout can read the number without importing the
+ * lazily-loaded panel, which would pull that chunk back into the main bundle.
+ */
+
+import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
+
+/** The width the mock draws the rows at: four file tiles, or three app tiles. */
+export const CHAT_INFO_BODY_WIDTH_PX = 569;
+
+/** The body width plus the shell's inset on each side. */
+export const CHAT_INFO_DRAWER_WIDTH_PX =
+  CHAT_INFO_BODY_WIDTH_PX + 2 * DETAIL_SHELL_BODY_INSET_PX;

--- a/clients/web/src/domains/chat/components/chat-info-file-row.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-row.test.tsx
@@ -31,7 +31,7 @@ import {
   SAMPLE_PREVIEWS,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import {
-  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_BODY_WIDTH_PX,
   CHAT_INFO_T0,
   CHAT_INFO_TEST_LOCALE,
   installChatInfoDomStubs,
@@ -47,7 +47,7 @@ const restoreDomStubs = installChatInfoDomStubs();
 const restoreHostLanguage = stubHostLanguage(CHAT_INFO_TEST_LOCALE);
 
 mock.module("@/hooks/use-element-size", () =>
-  makeElementSizeMock(() => CHAT_INFO_DRAWER_WIDTH_PX),
+  makeElementSizeMock(() => CHAT_INFO_BODY_WIDTH_PX),
 );
 
 const { ChatInfoFileRow } =

--- a/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-file-tile.tsx
@@ -124,10 +124,12 @@ export function ChatInfoFileTile({
         </AssetActionsSlot>
       ) : null}
 
+      {/* The variant's line height is 1, which leaves `truncate` no room for a
+          descender; `leading-normal` gives the line box the 18px it needs. */}
       <Typography
         variant="body-small-default"
         title={label}
-        className="truncate text-[var(--content-tertiary)]"
+        className="truncate leading-normal text-[var(--content-tertiary)]"
       >
         {label}
       </Typography>

--- a/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.stories.tsx
@@ -18,9 +18,10 @@
  * The last three stories are the states the sources put the panel in: still
  * loading, loaded and empty, and one source down.
  *
- * The frame is the shipped drawer, so a story opens at its 400px default and
- * the rows fit what that width holds. Drag the drawer's left edge to walk the
- * fit rule out to the mock's wider column.
+ * The frame is the shipped drawer, opened at the width the app gives Chat
+ * Info: a 569px body, which is four file tiles or three app tiles. Drag the
+ * drawer's left edge to walk the fit rule down to what a narrower column
+ * holds.
  *
  * Read the phone stories at the Mobile viewports: there the rows become
  * horizontal strips that run past the panel's body inset to the screen edge.
@@ -34,6 +35,7 @@ import {
   makeMixedAttachments,
   makePreviewableImages,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { CHAT_INFO_DRAWER_WIDTH_PX } from "@/domains/chat/components/chat-info-drawer-width";
 import {
   CHAT_INFO_ASSISTANT_ID,
   CHAT_INFO_CONVERSATION_ID,
@@ -68,7 +70,7 @@ const WITH_FRAMES: Partial<ChatInfoStoryConversation> = {
 };
 
 const inDrawer: Decorator = (Story) => (
-  <DetailPanelStoryFrame>
+  <DetailPanelStoryFrame defaultWidth={CHAT_INFO_DRAWER_WIDTH_PX}>
     <Story />
   </DetailPanelStoryFrame>
 );
@@ -97,15 +99,15 @@ export default meta;
 type Story = StoryObj<typeof ChatInfoPanel>;
 
 /**
- * The panel as a working conversation leaves it: twelve apps and four files,
- * both more than one line of the default-width drawer holds, so each row is
- * truncated to what fits and offers See All.
+ * The panel as a working conversation leaves it: twelve apps and four files.
+ * One line holds three app tiles and four file tiles here, so Apps is
+ * truncated to what fits and offers See All while every file is on show.
  */
 export const Default: Story = {};
 
 /**
- * A young conversation, sized to the default drawer: one app and one document,
- * so every tile is on show and neither header carries a See All.
+ * A young conversation: one app and one document, so every tile is on show and
+ * neither header carries a See All.
  */
 export const FewAssets: Story = {
   parameters: {

--- a/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-panel.test.tsx
@@ -37,7 +37,7 @@ import {
 
 import {
   attachmentRows,
-  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_BODY_WIDTH_PX,
   CHAT_INFO_T0,
   chatInfoAppHtmlCacheMock,
   clearTranscriptMessages,
@@ -66,7 +66,7 @@ const OTHER_CONVERSATION_ID = "conv-2";
 const restoreDomStubs = installChatInfoDomStubs();
 
 mock.module("@/hooks/use-element-size", () =>
-  makeElementSizeMock(() => CHAT_INFO_DRAWER_WIDTH_PX),
+  makeElementSizeMock(() => CHAT_INFO_BODY_WIDTH_PX),
 );
 
 // The app tile's live preview would otherwise call the daemon's open endpoint.

--- a/clients/web/src/domains/chat/components/chat-info-section.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-section.test.tsx
@@ -23,13 +23,13 @@ import { DETAIL_SHELL_BODY_INSET_PX } from "@/components/detail-shell";
 import { CHAT_INFO_APP_TILE_WIDTH_PX } from "@/domains/chat/components/chat-info-app-tile";
 import { CHAT_INFO_FILE_TILE_WIDTH_PX } from "@/domains/chat/components/chat-info-file-tile";
 import {
-  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_BODY_WIDTH_PX,
   CHAT_INFO_NARROW_PHONE_PX,
   makeElementSizeMock,
 } from "@/domains/chat/components/chat-info.test-helper";
 import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
-const widthRef = { value: CHAT_INFO_DRAWER_WIDTH_PX };
+const widthRef = { value: CHAT_INFO_BODY_WIDTH_PX };
 
 mock.module("@/hooks/use-element-size", () =>
   makeElementSizeMock(() => widthRef.value),
@@ -94,7 +94,7 @@ function seeAll(): HTMLElement | null {
 }
 
 beforeEach(() => {
-  widthRef.value = CHAT_INFO_DRAWER_WIDTH_PX;
+  widthRef.value = CHAT_INFO_BODY_WIDTH_PX;
   viewport.set({ narrow: false, coarsePointer: false });
 });
 
@@ -109,8 +109,8 @@ afterAll(() => {
 
 describe("fitTileCount", () => {
   test.each([
-    [CHAT_INFO_DRAWER_WIDTH_PX, CHAT_INFO_APP_TILE_WIDTH_PX, 3],
-    [CHAT_INFO_DRAWER_WIDTH_PX, CHAT_INFO_FILE_TILE_WIDTH_PX, 4],
+    [CHAT_INFO_BODY_WIDTH_PX, CHAT_INFO_APP_TILE_WIDTH_PX, 3],
+    [CHAT_INFO_BODY_WIDTH_PX, CHAT_INFO_FILE_TILE_WIDTH_PX, 4],
     [378, CHAT_INFO_APP_TILE_WIDTH_PX, 2],
     [378, CHAT_INFO_FILE_TILE_WIDTH_PX, 2],
     [0, CHAT_INFO_FILE_TILE_WIDTH_PX, 1],

--- a/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
+++ b/clients/web/src/domains/chat/components/chat-info-story-fixtures.tsx
@@ -33,7 +33,7 @@ import {
 import { attachmentContentQueryKey } from "@/domains/chat/components/chat-attachments/use-attachment-object-url";
 import {
   attachmentRows,
-  CHAT_INFO_DRAWER_WIDTH_PX,
+  CHAT_INFO_BODY_WIDTH_PX,
   CHAT_INFO_NARROW_PHONE_PX,
   CHAT_INFO_T0,
   clearTranscriptMessages,
@@ -185,7 +185,7 @@ export const inChatInfoDrawerColumn: Decorator = (Story) => (
     className="bg-[var(--surface-lift)]"
     style={{ padding: DETAIL_SHELL_BODY_INSET_PX }}
   >
-    <div style={{ width: CHAT_INFO_DRAWER_WIDTH_PX }}>
+    <div style={{ width: CHAT_INFO_BODY_WIDTH_PX }}>
       <Story />
     </div>
   </div>

--- a/clients/web/src/domains/chat/components/chat-info.test-helper.ts
+++ b/clients/web/src/domains/chat/components/chat-info.test-helper.ts
@@ -51,8 +51,8 @@ import * as appHtmlCache from "@/utils/app-html-cache";
 /** Fixed epoch ms, so nothing built here depends on the clock. */
 export const CHAT_INFO_T0 = 1_760_000_000_000;
 
-/** The drawer body's column on the desktop mock: 3 app tiles, 4 file tiles. */
-export const CHAT_INFO_DRAWER_WIDTH_PX = 569;
+/** Re-exported so a fixture, a test, and the panel cannot drift on the width. */
+export { CHAT_INFO_BODY_WIDTH_PX } from "@/domains/chat/components/chat-info-drawer-width";
 
 /**
  * The narrowest phone the app's designs are drawn for, screen width and all.

--- a/clients/web/src/domains/chat/components/detail-panel-story-frame.tsx
+++ b/clients/web/src/domains/chat/components/detail-panel-story-frame.tsx
@@ -3,15 +3,16 @@
  *
  * Every detail panel reaches the screen as `AnimatedRightDrawer`'s `right`
  * slot, so the story mounts the real drawer around it and states no geometry
- * of its own. The width, the cap a too-narrow container applies to it, and the
- * drag handle all come from the drawer, so narrowing the Storybook viewport
- * walks a panel through the same widths the app puts it through, including the
- * capped regime below the drawer's own minimum.
+ * of its own. The opening width, the cap a too-narrow container applies to it,
+ * and the drag handle all come from the drawer, so narrowing the Storybook
+ * viewport walks a panel through the same widths the app puts it through,
+ * including the capped regime below the drawer's own minimum. A panel the app
+ * opens wider than the drawer's default names its own `defaultWidth`.
  *
  * `left` is empty. In the app it holds the chat column, which the drawer needs
  * only as the flex sibling it takes its width from; an empty box plays that
  * part exactly, and drawing a stand-in chat would be scenery the app does not
- * ship. No `storageKey` either, so a story opens at the drawer's default width
+ * ship. No `storageKey` either, so a story opens at the width it asks for
  * rather than wherever the last reviewer dragged it.
  */
 
@@ -19,10 +20,24 @@ import type { ReactNode } from "react";
 
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
 
-export function DetailPanelStoryFrame({ children }: { children: ReactNode }) {
+interface DetailPanelStoryFrameProps {
+  children: ReactNode;
+  /** Opening width, for a panel the app opens wider than the drawer's default. */
+  defaultWidth?: number;
+}
+
+export function DetailPanelStoryFrame({
+  children,
+  defaultWidth,
+}: DetailPanelStoryFrameProps) {
   return (
     <div className="h-screen w-full bg-[var(--surface-base)]">
-      <AnimatedRightDrawer open left={null} right={children} />
+      <AnimatedRightDrawer
+        open
+        left={null}
+        right={children}
+        defaultWidth={defaultWidth}
+      />
     </div>
   );
 }

--- a/packages/design-library/src/hooks/use-resizable-pane.test.ts
+++ b/packages/design-library/src/hooks/use-resizable-pane.test.ts
@@ -2,11 +2,23 @@
  * Tests for the resizable-pane sizing rules.
  *
  * The arithmetic is exported as plain functions so it can be asserted without
- * a DOM, matching the rest of this package. The separator's rendered markup is
- * covered in `pane-resize-handle.test.tsx`.
+ * a DOM, matching the rest of this package. Following a `storageKey` change is
+ * the one behaviour that only exists in the mounted hook, so that section
+ * installs a happy-dom window for its own duration and renders. The
+ * separator's rendered markup is covered in `pane-resize-handle.test.tsx`.
  */
 
-import { describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { Window } from "happy-dom";
+import { act, createElement, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
 
 import {
   boundedMaxSize,
@@ -15,6 +27,8 @@ import {
   nextSizeForKey,
   paneDelta,
   resolveMaxSize,
+  useResizablePane,
+  type UseResizablePaneOptions,
 } from "./use-resizable-pane";
 
 describe("resolveMaxSize", () => {
@@ -242,5 +256,176 @@ describe("migrateLegacySize", () => {
         ...bounds,
       }),
     ).toBe(814);
+  });
+});
+
+describe("following a storage key change", () => {
+  const DRAWER: UseResizablePaneOptions = {
+    side: "end",
+    defaultSize: 400,
+    minSize: 400,
+    label: "Resize side panel",
+    storageKey: "paneA",
+  };
+
+  let win: Window;
+  let host: HTMLElement;
+  let root: Root;
+  const restore: Array<() => void> = [];
+
+  /** Installs one global for the duration of this section, restoring after. */
+  function install(name: string, value: unknown): void {
+    const globals = globalThis as unknown as Record<string, unknown>;
+    const had = name in globals;
+    const previous = globals[name];
+    globals[name] = value;
+    restore.push(() => {
+      if (had) {
+        globals[name] = previous;
+      } else {
+        delete globals[name];
+      }
+    });
+  }
+
+  beforeAll(() => {
+    win = new Window({ url: "https://localhost" });
+    install("window", win);
+    install("document", win.document);
+    install("navigator", win.navigator);
+    install("localStorage", win.localStorage);
+    install("Element", win.Element);
+    install("HTMLElement", win.HTMLElement);
+    install("Node", win.Node);
+    install("IS_REACT_ACT_ENVIRONMENT", true);
+  });
+
+  // Cleared here rather than at the end of a test, so one that fails part-way
+  // cannot hand its entries to the next.
+  beforeEach(() => {
+    win.localStorage.clear();
+  });
+
+  afterAll(() => {
+    while (restore.length > 0) {
+      restore.pop()?.();
+    }
+    void win.close();
+  });
+
+  /**
+   * Mounts the hook with `options`, renders the separator its `handleProps`
+   * describe, and hands back the size it reports plus the two things a test
+   * changes: the options it holds, and a key press on the separator.
+   */
+  async function mountPane(options: UseResizablePaneOptions) {
+    let size = 0;
+    let setOptions: ((next: UseResizablePaneOptions) => void) | null = null;
+
+    function Pane() {
+      const [current, update] = useState(options);
+      setOptions = update;
+      const pane = useResizablePane(current);
+      size = pane.size;
+      return createElement("div", pane.handleProps);
+    }
+
+    host = win.document.createElement("div");
+    win.document.body.appendChild(host);
+    root = createRoot(host as unknown as HTMLElement);
+    await act(async () => {
+      root.render(createElement(Pane));
+    });
+
+    return {
+      size: () => size,
+      async setOptions(next: UseResizablePaneOptions) {
+        await act(async () => {
+          setOptions?.(next);
+        });
+      },
+      async pressKey(key: string) {
+        const separator = host.querySelector('[role="separator"]');
+        if (!separator) {
+          throw new Error("no separator rendered");
+        }
+        await act(async () => {
+          separator.dispatchEvent(
+            new win.KeyboardEvent("keydown", { key, bubbles: true }),
+          );
+        });
+      },
+      async unmount() {
+        await act(async () => {
+          root.unmount();
+        });
+        host.remove();
+      },
+    };
+  }
+
+  test("takes the size the new key holds", async () => {
+    win.localStorage.setItem("paneA", "420");
+    win.localStorage.setItem("paneB", "609");
+    const pane = await mountPane(DRAWER);
+    expect(pane.size()).toBe(420);
+
+    await pane.setOptions({ ...DRAWER, storageKey: "paneB" });
+    expect(pane.size()).toBe(609);
+
+    await pane.unmount();
+  });
+
+  test("falls back to the default the new key arrives with", async () => {
+    const pane = await mountPane(DRAWER);
+    expect(pane.size()).toBe(400);
+
+    // A caller switching width profiles passes the new default on the same
+    // render as the new key, which is what the hook reads it at.
+    await pane.setOptions({
+      ...DRAWER,
+      storageKey: "paneB",
+      defaultSize: 609,
+    });
+    expect(pane.size()).toBe(609);
+
+    await pane.unmount();
+  });
+
+  test("holds a stored size below the minimum at the minimum", async () => {
+    win.localStorage.setItem("paneB", "120");
+    const pane = await mountPane(DRAWER);
+
+    await pane.setOptions({ ...DRAWER, storageKey: "paneB" });
+    expect(pane.size()).toBe(400);
+
+    await pane.unmount();
+  });
+
+  test("commits under the new key and leaves the old one alone", async () => {
+    win.localStorage.setItem("paneA", "420");
+    win.localStorage.setItem("paneB", "609");
+    const pane = await mountPane(DRAWER);
+
+    await pane.setOptions({ ...DRAWER, storageKey: "paneB" });
+    // An end pane grows as the divider travels left, one 16px step.
+    await pane.pressKey("ArrowLeft");
+    expect(pane.size()).toBe(625);
+    expect(win.localStorage.getItem("paneB")).toBe("625");
+    expect(win.localStorage.getItem("paneA")).toBe("420");
+
+    await pane.unmount();
+  });
+
+  test("a stable key keeps the size a commit gave it", async () => {
+    const pane = await mountPane(DRAWER);
+
+    await pane.pressKey("ArrowLeft");
+    expect(pane.size()).toBe(416);
+    // Re-rendering with the same key is not a switch, so nothing is re-read.
+    await pane.setOptions({ ...DRAWER });
+    expect(pane.size()).toBe(416);
+
+    await pane.unmount();
   });
 });

--- a/packages/design-library/src/hooks/use-resizable-pane.ts
+++ b/packages/design-library/src/hooks/use-resizable-pane.ts
@@ -60,6 +60,21 @@ function readStoredSize(storageKey: string | undefined): number | null {
   }
 }
 
+/**
+ * The size a pane takes under `storageKey`: the value stored there, else
+ * `defaultSize`, never below `minSize`. The minimum is applied at read time so
+ * a stale or corrupt stored value never renders below it, not even for the
+ * frame before the re-clamp effect runs. The upper bound needs a measured
+ * container, so it waits.
+ */
+function storedOrDefaultSize(
+  storageKey: string | undefined,
+  defaultSize: number,
+  minSize: number,
+): number {
+  return Math.max(minSize, readStoredSize(storageKey) ?? defaultSize);
+}
+
 function writeStoredSize(storageKey: string | undefined, size: number): void {
   if (!storageKey) return;
   try {
@@ -302,17 +317,20 @@ export function useResizablePane({
   // caller passing an inline object would otherwise re-run it every render.
   const legacySizeRef = useRef(legacySize);
   legacySizeRef.current = legacySize;
+  // Same reason, for the two numbers the key-switch effect resolves a size
+  // from: it depends on the key alone.
+  const defaultSizeRef = useRef(defaultSize);
+  defaultSizeRef.current = defaultSize;
+  const minSizeRef = useRef(minSize);
+  minSizeRef.current = minSize;
 
   const generatedPaneId = useId();
   const paneId = providedPaneId ?? generatedPaneId;
   const containerRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<{ startX: number; startSize: number } | null>(null);
   const [isResizing, setIsResizing] = useState(false);
-  // `minSize` is applied at read time so a stale or corrupt stored value never
-  // renders below the minimum, not even for the frame before the re-clamp
-  // effect runs. The upper bound needs a measured container, so it waits.
   const [size, setSize] = useState(() =>
-    Math.max(minSize, readStoredSize(storageKey) ?? defaultSize),
+    storedOrDefaultSize(storageKey, defaultSize, minSize),
   );
   const [containerSize, setContainerSize] = useState(0);
 
@@ -330,6 +348,24 @@ export function useResizablePane({
     observer.observe(container);
     return () => observer.disconnect();
   }, []);
+
+  // A caller may repoint the pane at another remembered width: the pane keeps
+  // its DOM and takes the size the new key holds, so anything animating the
+  // width eases between the two rather than remounting at the new one.
+  const storageKeyRef = useRef(storageKey);
+  useIsomorphicLayoutEffect(() => {
+    if (storageKeyRef.current === storageKey) {
+      return;
+    }
+    storageKeyRef.current = storageKey;
+    setSize(
+      storedOrDefaultSize(
+        storageKey,
+        defaultSizeRef.current,
+        minSizeRef.current,
+      ),
+    );
+  }, [storageKey]);
 
   const effectiveMax = resolveMaxSize({
     minSize,


### PR DESCRIPTION
## Summary
- The Chat Info drawer opens at 609px (a 569px body, the width the mock draws its rows at: four file tiles, three app tiles) under its own persisted width key, `chatInfoPanelWidth`; every other side panel keeps `rightPanelWidth` and its 400px default.
- `useResizablePane` follows a `storageKey` change after mount, reading the new key's stored size or the default, so the single shared drawer eases between the two profiles without remounting.
- Tile labels get `leading-normal`: the `body-small-default` token's unit line height left no room for descenders under `truncate`, which cut the bottom off names like `sight-5.jpg`.
- `CHAT_INFO_BODY_WIDTH_PX` is the one source for the mock width in production code, tests, and stories; the panel stories open at the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hgD7bhzXbP7HoXUPuaB9c