### PR TITLE
fix(assistant): bundle @vellumai/app-icons in the published package

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -90,6 +90,7 @@
     "node": ">=20.12.0"
   },
   "bundledDependencies": [
+    "@vellumai/app-icons",
     "@vellumai/avatar-catalog",
     "@vellumai/avatar-manifest",
     "@vellumai/ces-client",


### PR DESCRIPTION
## Summary
- The last two hourly Dev Release runs ([34494476021](https://github.com/vellum-ai/vellum-assistant/actions/runs/34494476021), [34501027408](https://github.com/vellum-ai/vellum-assistant/actions/runs/34501027408)) fail in `build-npm-dev (assistant)` at "Strip bundled deps from the manifest" with `"@vellumai/app-icons" (workspace:*) is not in bundledDependencies`.
- #42508 added `@vellumai/app-icons` as a workspace dep of the assistant without listing it in `bundledDependencies`. This adds it, so it ships inside the tarball like the other workspace packages.

## Test plan
- [x] `bun scripts/strip-bundled-deps.mjs` on the patched manifest now strips all 12 workspace deps and exits 0
- [ ] Next scheduled Dev Release (or a manual re-run) gets past `build-npm-dev (assistant)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p9gF12QLoMMXP8FdgyZLS