### PR TITLE
feat(web): an app relays a prompt into an exact conversation as the user (LUM-3580)

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -333,7 +333,7 @@ To reach daemon capabilities, import from `@vellumai/plugin-api` — `publishEve
 
 ### Keep the assistant aware
 
-Wire `window.vellum.sendAction()` during the build so the app can pull the assistant in. The host handles two actions: **`relay_prompt`** (`{ prompt, conversation }`) sends a message to the assistant as if the user typed it — the way to get an explanation, summary, or follow-up from inside the app (`conversation: "new"` starts a fresh chat instead of the open one); **`set_view`** (`{ view }`) arranges the app and chat (`"split"` / `"full"` / `"chat"`). These two are the whole app→host surface — relay anything you want the assistant to act on as a self-contained prompt. Patterns in `{baseDir}/references/INTERACTION_HOOKS.md`.
+Wire `window.vellum.sendAction()` during the build so the app can pull the assistant in. The host handles two actions: **`relay_prompt`** (`{ prompt, conversation, conversationId }`) sends a message to the assistant as if the user typed it, the way to get an explanation, summary, or follow-up from inside the app (`conversation: "new"` starts a fresh chat instead of the open one; `conversationId` sends into one specific existing chat, from a click only); **`set_view`** (`{ view }`) arranges the app and chat (`"split"` / `"full"` / `"chat"`). These two are the whole app→host surface: relay anything you want the assistant to act on as a self-contained prompt. Patterns in `{baseDir}/references/INTERACTION_HOOKS.md`.
 
 ### Actionable UI
 

--- a/assistant/src/config/bundled-skills/app-builder/references/INTERACTION_HOOKS.md
+++ b/assistant/src/config/bundled-skills/app-builder/references/INTERACTION_HOOKS.md
@@ -29,11 +29,28 @@ window.vellum.sendAction("relay_prompt", {
   prompt: "Draft a follow-up email to this customer.",
   conversation: "new", // "active" (default) | "new"
 });
+
+// Send into one specific existing conversation, whichever chat is open
+window.vellum.sendAction("relay_prompt", {
+  prompt: "Review the deploy that just finished.",
+  conversationId: reviewConversationId,
+});
 ```
 
 - **`prompt`** (required) — the message text. Empty or missing → ignored.
 - **`conversation`** — `"active"` (default: the open conversation) or
   `"new"` (a fresh draft). With `"active"` and nothing open, it's a no-op.
+- **`conversationId`**: an existing conversation's id. Takes precedence over
+  `conversation`. The host posts the prompt into that conversation as the
+  user, from the user's own session, so the assistant sees it exactly as a
+  typed message (same identity, same permissions) and it lands there even if
+  the user switches chats meanwhile. It does not open the conversation; send
+  `open_conversation` with the same id when the user should watch the reply.
+  Only honored from a user gesture (a click in the app); calls on load or from
+  a timer are dropped. Never send to a conversation from a backend route with
+  `runConversationTurn` to work around this: that turn is attributed to the
+  app, not the user, and runs with nobody present, so anything that needs the
+  user's approval is denied instead of asked.
 - **The layout is left exactly as-is.** Relaying never opens, closes, or
   resizes the app — if the user has chat and app side by side, it stays that
   way. Each relay is delivered even when the same text is sent repeatedly.

--- a/clients/web/src/domains/chat/app-viewer-actions.test.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.test.ts
@@ -38,11 +38,18 @@ function makeCtx(isMobile = false) {
   return { navigate: mock((_to: string) => {}), isMobile };
 }
 
+const originalUserActivation = navigator.userActivation;
+
 function setUserActivation(isActive: boolean): void {
   Object.defineProperty(navigator, "userActivation", {
     value: { isActive, hasBeenActive: isActive },
     configurable: true,
   });
+}
+
+/** Let the relay's awaits settle; it is dispatched as fire-and-forget. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 let restoreViewport: (() => void) | undefined;
@@ -65,6 +72,10 @@ afterEach(() => {
   });
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
   useAssistantIdentityStore.setState({ version: null });
+  Object.defineProperty(navigator, "userActivation", {
+    value: originalUserActivation,
+    configurable: true,
+  });
 });
 
 describe("handleAppViewerAction — relay_prompt", () => {
@@ -133,25 +144,28 @@ describe("handleAppViewerAction: relay_prompt to an exact conversation", () => {
     setUserActivation(true);
   });
 
-  it("posts the prompt into the named conversation as the user, without navigating", () => {
+  it("posts the prompt into the named conversation as the user, without navigating", async () => {
     const ctx = makeCtx();
 
     handleAppViewerAction(ctx, "relay_prompt", {
       prompt: "review this",
       conversationId: "conv-9",
     });
+    await flush();
 
+    // Exactly three arguments: no options, so the send carries no `scripted`
+    // marker. A clicked CTA is user-initiated, matching the `?prompt=` relay.
     expect(postChatMessageMock).toHaveBeenCalledTimes(1);
-    expect(postChatMessageMock.mock.calls[0]?.slice(0, 3)).toEqual([
+    expect(postChatMessageMock).toHaveBeenCalledWith(
       "asst-1",
       "conv-9",
       "review this",
-    ]);
+    );
     expect(ctx.navigate).not.toHaveBeenCalled();
     expect(useConversationStore.getState().activeConversationId).toBe("conv-1");
   });
 
-  it("an explicit conversationId wins over conversation: 'new'", () => {
+  it("an explicit conversationId wins over conversation: 'new'", async () => {
     const ctx = makeCtx();
 
     handleAppViewerAction(ctx, "relay_prompt", {
@@ -159,13 +173,14 @@ describe("handleAppViewerAction: relay_prompt to an exact conversation", () => {
       conversation: "new",
       conversationId: "conv-9",
     });
+    await flush();
 
     expect(postChatMessageMock.mock.calls[0]?.[1]).toBe("conv-9");
     expect(ctx.navigate).not.toHaveBeenCalled();
     expect(useConversationStore.getState().activeConversationId).toBe("conv-1");
   });
 
-  it("is dropped without a transient user activation", () => {
+  it("is dropped without a transient user activation", async () => {
     setUserActivation(false);
     const ctx = makeCtx();
 
@@ -173,29 +188,50 @@ describe("handleAppViewerAction: relay_prompt to an exact conversation", () => {
       prompt: "on load",
       conversationId: "conv-9",
     });
+    await flush();
 
     expect(postChatMessageMock).not.toHaveBeenCalled();
     expect(ctx.navigate).not.toHaveBeenCalled();
   });
 
-  it("is dropped when no assistant is active", () => {
+  it("is dropped when no assistant is active", async () => {
     useResolvedAssistantsStore.setState({ activeAssistantId: null });
 
     handleAppViewerAction(makeCtx(), "relay_prompt", {
       prompt: "hi",
       conversationId: "conv-9",
     });
+    await flush();
 
     expect(postChatMessageMock).not.toHaveBeenCalled();
   });
 
-  it("is dropped and reported on an assistant without the conversationId wire field", () => {
+  it("delivers a click that lands before the assistant version hydrates", async () => {
+    useAssistantIdentityStore.setState({ version: null });
+
+    handleAppViewerAction(makeCtx(), "relay_prompt", {
+      prompt: "early",
+      conversationId: "conv-9",
+    });
+    await flush();
+    expect(postChatMessageMock).not.toHaveBeenCalled();
+
+    useAssistantIdentityStore.setState({ version: "0.9.0" });
+    await flush();
+
+    expect(postChatMessageMock).toHaveBeenCalledTimes(1);
+    expect(postChatMessageMock.mock.calls[0]?.[1]).toBe("conv-9");
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("is dropped and reported on an assistant without the conversationId wire field", async () => {
     useAssistantIdentityStore.setState({ version: "0.8.5" });
 
     handleAppViewerAction(makeCtx(), "relay_prompt", {
       prompt: "hi",
       conversationId: "conv-9",
     });
+    await flush();
 
     expect(postChatMessageMock).not.toHaveBeenCalled();
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
@@ -216,14 +252,27 @@ describe("handleAppViewerAction: relay_prompt to an exact conversation", () => {
       prompt: "hi",
       conversationId: "conv-gone",
     });
-    await Promise.resolve();
-    await Promise.resolve();
+    await flush();
 
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
     expect(captureErrorMock.mock.calls[0]?.[1]).toMatchObject({
       context: "app_viewer_relay_prompt",
       extra: { conversationId: "conv-gone" },
     });
+  });
+
+  it("reports a send that throws", async () => {
+    postChatMessageMock.mockImplementationOnce(async () => {
+      throw new Error("offline");
+    });
+
+    handleAppViewerAction(makeCtx(), "relay_prompt", {
+      prompt: "hi",
+      conversationId: "conv-9",
+    });
+    await flush();
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/clients/web/src/domains/chat/app-viewer-actions.test.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.test.ts
@@ -1,14 +1,47 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 
+import type * as MessagesApi from "@/domains/chat/api/messages";
+import type * as CaptureErrorModule from "@/lib/sentry/capture-error";
+
+const postChatMessageMock = mock<typeof MessagesApi.postChatMessage>(
+  async (assistantId, conversationId) => ({
+    ok: true,
+    assistantId,
+    conversationId: conversationId ?? "minted",
+    messageId: "msg-1",
+  }),
+);
+mock.module(
+  "@/domains/chat/api/messages",
+  (): Partial<typeof MessagesApi> => ({
+    postChatMessage: postChatMessageMock,
+  }),
+);
+const captureErrorMock = mock<typeof CaptureErrorModule.captureError>(() => {});
+mock.module(
+  "@/lib/sentry/capture-error",
+  (): Partial<typeof CaptureErrorModule> => ({
+    captureError: captureErrorMock,
+  }),
+);
+
 import { handleAppViewerAction } from "@/domains/chat/app-viewer-actions";
 import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useViewerStore } from "@/stores/viewer-store";
 
 const SAMPLE_APP = { appId: "app-1", name: "My App", html: "<h1>hi</h1>" };
 
 function makeCtx(isMobile = false) {
   return { navigate: mock((_to: string) => {}), isMobile };
+}
+
+function setUserActivation(isActive: boolean): void {
+  Object.defineProperty(navigator, "userActivation", {
+    value: { isActive, hasBeenActive: isActive },
+    configurable: true,
+  });
 }
 
 let restoreViewport: (() => void) | undefined;
@@ -18,6 +51,8 @@ beforeEach(() => {
     narrow: false,
     coarsePointer: false,
   });
+  postChatMessageMock.mockClear();
+  captureErrorMock.mockClear();
 });
 
 afterEach(() => {
@@ -27,6 +62,7 @@ afterEach(() => {
     activeConversationId: null,
     editingConversationId: null,
   });
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
 
 describe("handleAppViewerAction — relay_prompt", () => {
@@ -84,6 +120,91 @@ describe("handleAppViewerAction — relay_prompt", () => {
     handleAppViewerAction(ctx, "relay_prompt", { prompt: "nowhere" });
 
     expect(ctx.navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleAppViewerAction: relay_prompt to an exact conversation", () => {
+  beforeEach(() => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+    useConversationStore.setState({ activeConversationId: "conv-1" });
+    setUserActivation(true);
+  });
+
+  it("posts the prompt into the named conversation as the user, without navigating", () => {
+    const ctx = makeCtx();
+
+    handleAppViewerAction(ctx, "relay_prompt", {
+      prompt: "review this",
+      conversationId: "conv-9",
+    });
+
+    expect(postChatMessageMock).toHaveBeenCalledTimes(1);
+    expect(postChatMessageMock.mock.calls[0]?.slice(0, 3)).toEqual([
+      "asst-1",
+      "conv-9",
+      "review this",
+    ]);
+    expect(ctx.navigate).not.toHaveBeenCalled();
+    expect(useConversationStore.getState().activeConversationId).toBe("conv-1");
+  });
+
+  it("an explicit conversationId wins over conversation: 'new'", () => {
+    const ctx = makeCtx();
+
+    handleAppViewerAction(ctx, "relay_prompt", {
+      prompt: "hi",
+      conversation: "new",
+      conversationId: "conv-9",
+    });
+
+    expect(postChatMessageMock.mock.calls[0]?.[1]).toBe("conv-9");
+    expect(ctx.navigate).not.toHaveBeenCalled();
+    expect(useConversationStore.getState().activeConversationId).toBe("conv-1");
+  });
+
+  it("is dropped without a transient user activation", () => {
+    setUserActivation(false);
+    const ctx = makeCtx();
+
+    handleAppViewerAction(ctx, "relay_prompt", {
+      prompt: "on load",
+      conversationId: "conv-9",
+    });
+
+    expect(postChatMessageMock).not.toHaveBeenCalled();
+    expect(ctx.navigate).not.toHaveBeenCalled();
+  });
+
+  it("is dropped when no assistant is active", () => {
+    useResolvedAssistantsStore.setState({ activeAssistantId: null });
+
+    handleAppViewerAction(makeCtx(), "relay_prompt", {
+      prompt: "hi",
+      conversationId: "conv-9",
+    });
+
+    expect(postChatMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a rejected send", async () => {
+    postChatMessageMock.mockImplementationOnce(async () => ({
+      ok: false,
+      status: 404,
+      error: {},
+    }));
+
+    handleAppViewerAction(makeCtx(), "relay_prompt", {
+      prompt: "hi",
+      conversationId: "conv-gone",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock.mock.calls[0]?.[1]).toMatchObject({
+      context: "app_viewer_relay_prompt",
+      extra: { conversationId: "conv-gone" },
+    });
   });
 });
 

--- a/clients/web/src/domains/chat/app-viewer-actions.test.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.test.ts
@@ -27,6 +27,7 @@ mock.module(
 
 import { handleAppViewerAction } from "@/domains/chat/app-viewer-actions";
 import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useViewerStore } from "@/stores/viewer-store";
@@ -63,6 +64,7 @@ afterEach(() => {
     editingConversationId: null,
   });
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  useAssistantIdentityStore.setState({ version: null });
 });
 
 describe("handleAppViewerAction — relay_prompt", () => {
@@ -126,6 +128,7 @@ describe("handleAppViewerAction — relay_prompt", () => {
 describe("handleAppViewerAction: relay_prompt to an exact conversation", () => {
   beforeEach(() => {
     useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+    useAssistantIdentityStore.setState({ version: "0.9.0" });
     useConversationStore.setState({ activeConversationId: "conv-1" });
     setUserActivation(true);
   });
@@ -184,6 +187,22 @@ describe("handleAppViewerAction: relay_prompt to an exact conversation", () => {
     });
 
     expect(postChatMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("is dropped and reported on an assistant without the conversationId wire field", () => {
+    useAssistantIdentityStore.setState({ version: "0.8.5" });
+
+    handleAppViewerAction(makeCtx(), "relay_prompt", {
+      prompt: "hi",
+      conversationId: "conv-9",
+    });
+
+    expect(postChatMessageMock).not.toHaveBeenCalled();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock.mock.calls[0]?.[1]).toMatchObject({
+      context: "app_viewer_relay_prompt",
+      level: "warning",
+    });
   });
 
   it("reports a rejected send", async () => {

--- a/clients/web/src/domains/chat/app-viewer-actions.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.ts
@@ -36,7 +36,7 @@
 
 import { postChatMessage } from "@/domains/chat/api/messages";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
-import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
+import { resolveConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -63,7 +63,7 @@ function relayPrompt(
   const targetConversationId =
     typeof data?.conversationId === "string" ? data.conversationId : "";
   if (targetConversationId) {
-    relayPromptToConversation(targetConversationId, prompt);
+    void relayPromptToConversation(targetConversationId, prompt);
     return;
   }
 
@@ -101,15 +101,32 @@ function relayPrompt(
  * nothing more; see the accepted one-click path in `visual-surface.tsx`.
  *
  * Exact targeting needs the strict `conversationId` wire field. An assistant
- * that predates it is sent `conversationKey`, which is a create-or-lookup by
- * external key, so an internal id that key space does not hold would mint a
- * stray conversation and run the prompt there. On such an assistant the relay
- * is dropped and reported rather than misdelivered.
+ * that predates it is sent `conversationKey`, a create-or-lookup by external
+ * key, so an internal id that key space does not hold would mint a stray
+ * conversation and run the prompt there. On such an assistant the relay is
+ * dropped and reported rather than misdelivered.
+ *
+ * The send is deliberately NOT marked `scripted`. That marker is for text an
+ * onboarding flow auto-sends with no user action behind it; a CTA the user
+ * clicked is user-initiated, which is why the `?prompt=` relay is unmarked too
+ * (see `use-auto-send-effects.ts`) and what the analytics classifier expects.
+ * The activation gate above is what makes that true of every send from here.
  */
-function relayPromptToConversation(
+async function relayPromptToConversation(
   conversationId: string,
   prompt: string,
-): void {
+): Promise<void> {
+  const report = (error: unknown, level?: "warning"): void => {
+    captureError(error, {
+      context: "app_viewer_relay_prompt",
+      ...(level ? { level } : {}),
+      extra: { conversationId },
+    });
+  };
+
+  // Read before the first await: an activation is transient, so a gate that
+  // resolved it after waiting on version hydration would be asking whether the
+  // user has clicked recently rather than whether this call came from a click.
   if (!navigator.userActivation?.isActive) {
     return;
   }
@@ -117,35 +134,24 @@ function relayPromptToConversation(
   if (!assistantId) {
     return;
   }
-  if (pickConversationIdWireField() !== "conversationId") {
-    captureError(
-      new Error("relay_prompt to an exact conversation needs assistant 0.8.6+"),
-      {
-        context: "app_viewer_relay_prompt",
-        level: "warning",
-        extra: { conversationId },
-      },
-    );
-    return;
+
+  try {
+    if ((await resolveConversationIdWireField()) !== "conversationId") {
+      report(
+        new Error(
+          "relay_prompt to an exact conversation needs a newer assistant",
+        ),
+        "warning",
+      );
+      return;
+    }
+    const result = await postChatMessage(assistantId, conversationId, prompt);
+    if (!result.ok) {
+      report(new Error(`relay_prompt send rejected: HTTP ${result.status}`));
+    }
+  } catch (err) {
+    report(err);
   }
-  void postChatMessage(assistantId, conversationId, prompt)
-    .then((result) => {
-      if (!result.ok) {
-        captureError(
-          new Error(`relay_prompt send rejected: HTTP ${result.status}`),
-          {
-            context: "app_viewer_relay_prompt",
-            extra: { conversationId },
-          },
-        );
-      }
-    })
-    .catch((err: unknown) => {
-      captureError(err, {
-        context: "app_viewer_relay_prompt",
-        extra: { conversationId },
-      });
-    });
 }
 
 /**

--- a/clients/web/src/domains/chat/app-viewer-actions.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.ts
@@ -2,12 +2,20 @@
  * Handles actions a sandboxed app viewer dispatches through
  * `window.vellum.sendAction(actionId, data)`. Three independent actions:
  *
- * - `relay_prompt` ({ prompt, conversation }) — sends `prompt` to a conversation
- *   via the `?prompt=` auto-send pathway (see `use-auto-send-effects.ts`).
- *   `conversation` is `"active"` (default, the open conversation) or `"new"` (a
- *   fresh draft). It never touches the layout. Each relay carries a unique
- *   token so the auto-send dedupe re-fires even when the same prompt is relayed
- *   repeatedly. No-op for `"active"` when no conversation is open.
+ * - `relay_prompt` ({ prompt, conversation, conversationId }): sends `prompt`
+ *   to a conversation as the user. `conversation` is `"active"` (default, the
+ *   open conversation) or `"new"` (a fresh draft); both go through the
+ *   `?prompt=` auto-send pathway (see `use-auto-send-effects.ts`), so the
+ *   prompt lands in whichever conversation the client is showing by the time
+ *   the route mounts. `conversationId` names an existing conversation instead
+ *   and wins over `conversation`: the host posts the prompt straight into that
+ *   conversation through the user's own authenticated client, without
+ *   navigating, so the send carries the user's identity, interface, and
+ *   presence exactly like a typed message and cannot drift to another chat.
+ *   Pair it with `open_conversation` to show the reply. Relaying never touches
+ *   the layout. Each `?prompt=` relay carries a unique token so the auto-send
+ *   dedupe re-fires even when the same prompt is relayed repeatedly. No-op for
+ *   `"active"` when no conversation is open.
  *
  * - `open_conversation` ({ conversationId }) — navigates to an existing
  *   conversation by ID without sending a message. On a wide viewport the
@@ -26,8 +34,11 @@
  * navigation / viewport arrive through `ctx`, so this is unit-testable.
  */
 
+import { postChatMessage } from "@/domains/chat/api/messages";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { captureError } from "@/lib/sentry/capture-error";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { keepOpenAppBesideConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
@@ -48,6 +59,13 @@ function relayPrompt(
     return;
   }
 
+  const targetConversationId =
+    typeof data?.conversationId === "string" ? data.conversationId : "";
+  if (targetConversationId) {
+    relayPromptToConversation(targetConversationId, prompt);
+    return;
+  }
+
   let conversationId: string | null;
   if (data?.conversation === "new") {
     conversationId = createDraftConversationId();
@@ -62,6 +80,54 @@ function relayPrompt(
   ctx.navigate(
     routes.conversationWithPrompt(conversationId, prompt, crypto.randomUUID()),
   );
+}
+
+/**
+ * Post `prompt` into an existing conversation as the user, from the host.
+ *
+ * The sandboxed frame cannot reach `POST /v1/messages` itself (its fetch proxy
+ * admits only the app's own `/v1/x/` routes), and an app backend that posts on
+ * its behalf has no user to be: the daemon attributes such a turn to the app,
+ * not to the person who clicked. Sending from the host keeps the click's
+ * identity on the turn. The send is a plain post rather than the chat's
+ * optimistic pipeline because the target need not be the conversation on
+ * screen; when it is, the daemon's `user_message_echo` renders the row.
+ *
+ * Gated on a transient user activation, the same way the frame's other
+ * host-mediated egress is (`vellum_open_link`): this reaches every
+ * conversation the user owns, so a frame must not be able to fire it on load
+ * or in a loop. An activation says the user clicked somewhere in the frame,
+ * nothing more; see the accepted one-click path in `visual-surface.tsx`.
+ */
+function relayPromptToConversation(
+  conversationId: string,
+  prompt: string,
+): void {
+  if (!navigator.userActivation?.isActive) {
+    return;
+  }
+  const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+  if (!assistantId) {
+    return;
+  }
+  void postChatMessage(assistantId, conversationId, prompt)
+    .then((result) => {
+      if (!result.ok) {
+        captureError(
+          new Error(`relay_prompt send rejected: HTTP ${result.status}`),
+          {
+            context: "app_viewer_relay_prompt",
+            extra: { conversationId },
+          },
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      captureError(err, {
+        context: "app_viewer_relay_prompt",
+        extra: { conversationId },
+      });
+    });
 }
 
 /**

--- a/clients/web/src/domains/chat/app-viewer-actions.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.ts
@@ -36,6 +36,7 @@
 
 import { postChatMessage } from "@/domains/chat/api/messages";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -98,6 +99,12 @@ function relayPrompt(
  * conversation the user owns, so a frame must not be able to fire it on load
  * or in a loop. An activation says the user clicked somewhere in the frame,
  * nothing more; see the accepted one-click path in `visual-surface.tsx`.
+ *
+ * Exact targeting needs the strict `conversationId` wire field. An assistant
+ * that predates it is sent `conversationKey`, which is a create-or-lookup by
+ * external key, so an internal id that key space does not hold would mint a
+ * stray conversation and run the prompt there. On such an assistant the relay
+ * is dropped and reported rather than misdelivered.
  */
 function relayPromptToConversation(
   conversationId: string,
@@ -108,6 +115,17 @@ function relayPromptToConversation(
   }
   const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
   if (!assistantId) {
+    return;
+  }
+  if (pickConversationIdWireField() !== "conversationId") {
+    captureError(
+      new Error("relay_prompt to an exact conversation needs assistant 0.8.6+"),
+      {
+        context: "app_viewer_relay_prompt",
+        level: "warning",
+        extra: { conversationId },
+      },
+    );
     return;
   }
   void postChatMessage(assistantId, conversationId, prompt)

--- a/clients/web/src/lib/backwards-compat/conversation-id-wire-field.test.ts
+++ b/clients/web/src/lib/backwards-compat/conversation-id-wire-field.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { pickConversationIdWireField } from "@/lib/backwards-compat/conversation-id-wire-field";
+import {
+  pickConversationIdWireField,
+  resolveConversationIdWireField,
+} from "@/lib/backwards-compat/conversation-id-wire-field";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 function setVersion(version: string | null) {
@@ -57,5 +60,24 @@ describe("pickConversationIdWireField", () => {
     expect(pickConversationIdWireField()).toBe("conversationKey");
     setVersion("0.8");
     expect(pickConversationIdWireField()).toBe("conversationKey");
+  });
+});
+
+describe("resolveConversationIdWireField", () => {
+  test("waits for an unhydrated version instead of answering conversationKey", async () => {
+    setVersion(null);
+
+    const pending = resolveConversationIdWireField();
+    // The synchronous pick is what a caller must not use here: unhydrated
+    // reads as the legacy field, which a gated write would refuse on.
+    expect(pickConversationIdWireField()).toBe("conversationKey");
+
+    setVersion("0.9.0");
+    expect(await pending).toBe("conversationId");
+  });
+
+  test("answers conversationKey once a genuinely old version is known", async () => {
+    setVersion("0.8.5");
+    expect(await resolveConversationIdWireField()).toBe("conversationKey");
   });
 });

--- a/clients/web/src/lib/backwards-compat/conversation-id-wire-field.ts
+++ b/clients/web/src/lib/backwards-compat/conversation-id-wire-field.ts
@@ -24,6 +24,8 @@
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { compareParsed, parseSemver } from "@/utils/semver";
 
+import { whenAssistantVersionKnown } from "./utils";
+
 const MIN_VERSION = "0.8.6";
 
 export type ConversationIdWireField = "conversationId" | "conversationKey";
@@ -53,4 +55,20 @@ export function pickConversationIdWireField(): ConversationIdWireField {
   return compareParsed({ ...parsed, pre: null }, min) >= 0
     ? "conversationId"
     : "conversationKey";
+}
+
+/**
+ * The same pick, for a caller whose behavior changes on the answer rather
+ * than only the field name it sends.
+ *
+ * {@link pickConversationIdWireField} answers `"conversationKey"` both for an
+ * assistant that predates the strict field and for one whose version has not
+ * hydrated yet. A body builder may collapse the two, because the legacy field
+ * is understood either way. A caller that refuses to act on the legacy answer
+ * cannot: the unhydrated read would refuse against a modern assistant, which
+ * is the gated-write case `whenAssistantVersionKnown` exists for.
+ */
+export async function resolveConversationIdWireField(): Promise<ConversationIdWireField> {
+  await whenAssistantVersionKnown();
+  return pickConversationIdWireField();
 }

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -7,7 +7,7 @@
     },
     "app-builder": {
       "docsSlug": "app-builder",
-      "sha256": "250636cb682019210f87615f9412ca1278f72b1f1b50953f8f13fe07b5e33880"
+      "sha256": "87ff363eb960c83067626cbbab435b13cf72a91bde668e1775a7c5e6afb251da"
     },
     "computer-use": {
       "docsSlug": "computer-use",


### PR DESCRIPTION
## TL;DR

`relay_prompt` now accepts a `conversationId`. When an app names one, the web host posts the prompt into that exact conversation through the clicking user's own authenticated client, so the turn carries the user's identity, interface, and presence exactly like a typed message. Until now an app could relay only into the active or a new conversation (via `?prompt=` navigation), and an app that needed an exact target had to post from its backend route, where the daemon attributes the turn to the app and runs it with nobody present.

Fixes LUM-3580

## Why this is the right layer

The sandboxed frame cannot reach `POST /v1/messages` (its fetch proxy admits only `/v1/x/` routes), and nothing a backend route can do carries the click's identity:

- `runConversationTurn` (the supported route-handler path) stamps the row `automated`, runs it `isInteractive: false`, and binds no actor. Approval-gated tools are denied rather than asked, and the row is excluded from reply push and memory. That attribution gap is already tracked as ATL-1045 / ATL-1021 and stays in Atlas's lane.
- A route handler posting to `/v1/messages` with a token of its own has no user to be.

The one party that already holds the user's session is the host page, and host actions exist for exactly this. The new branch is the same `postChatMessage` the composer, the channel-setup signal, and `sendBackgroundPrompt` use, with no new daemon field: `conversationId` on `/v1/messages` has existed since 0.8.6, and the wire-field compat shim handles older assistants.

## Why it is safe

- **Opt-in by field.** The `"active"` / `"new"` paths are untouched; only an app that sends `conversationId` takes the new branch, and it wins over `conversation` (explicit target beats a mode).
- **Gated on a user gesture.** The new branch requires a transient user activation, the same gate the frame's other host-mediated egress uses (`vellum_open_link`, and `vellum_widget_prompt` in `visual-surface.tsx`). It reaches every conversation the user owns, so a frame must not be able to fire it on load or in a loop. The legacy `"active"` / `"new"` branches keep their current ungated behaviour; that gap is ATL-908 and was not widened here.
- **Version-gated, against a resolved version.** Exact targeting needs the strict `conversationId` wire field (assistant 0.8.6+); on an older assistant the send would go out as `conversationKey`, a create-or-lookup by external key that could mint a stray conversation, so the relay is dropped and reported instead. The gate awaits version hydration first (`whenAssistantVersionKnown`, the write-path rule in `docs/BACKWARDS_COMPAT.md`), because the wire-field pick answers `conversationKey` for an unhydrated version too: reading it synchronously would refuse a click that landed early against a perfectly modern assistant. The user activation is read before that wait, since an activation is transient.
- **No navigation, no layout change.** Relaying keeps the app where it is. The transcript renders the row via `user_message_echo` when the target happens to be on screen (the reducer folds echoed user rows with no optimistic twin), matching the channel-setup signal precedent.
- **Deliberately not `scripted`.** That marker is for text an onboarding flow auto-sends with no user action behind it. A CTA the user clicked is user-initiated, which is why the `?prompt=` relay is unmarked too and what the analytics classifier expects (`use-auto-send-effects.ts` states this explicitly). The activation gate is what makes it true of every send from here.
- **Failures are reported, not swallowed.** A rejected send (404 for an unknown id, for example) goes through `captureError` with the conversation id.
- **Every host that renders apps runs this renderer** (web, desktop, iOS shell), so the behaviour is the same everywhere an app can dispatch actions. The standalone Library viewer passes no action handler and still ignores all actions, as documented.

## Before / after

| Situation | Before | After |
| --- | --- | --- |
| App button relays into a specific conversation | Not possible from the frame; apps posted from a backend route | `sendAction("relay_prompt", { prompt, conversationId })` sends it as the user |
| Who the daemon sees on that turn | The app (automated, non-interactive, no actor) | The person who clicked, same as typing |
| User switches chats mid-relay | `?prompt=` could land in the newly opened chat | Lands in the named conversation regardless |
| App relays on load / in a loop to an exact conversation | n/a | Dropped (no user activation) |
| Existing `conversation: "active"` / `"new"` relays | Unchanged | Unchanged |

## Adoption

Apps that today deliver a click through their backend (Vex Ops "Review with Vex") switch to:

```js
window.vellum.sendAction("relay_prompt", { prompt, conversationId });
window.vellum.sendAction("open_conversation", { conversationId }); // optional: show the reply
```

The app-builder skill (`SKILL.md`, `references/INTERACTION_HOOKS.md`) documents the field and tells authors not to route around it with `runConversationTurn`.

## Deferred

- **Library standalone viewer** ignores app actions by design, so an app opened from the Library still cannot relay. Same as before; not the ticket's case.
- **`open_conversation`** is implemented but absent from the app-builder docs. Left as is to keep this PR to one claim.

## Test

```bash
cd clients/web && bun test src/domains/chat/app-viewer-actions.test.ts
cd assistant && bun test src/__tests__/app-builder-skill-instructions.test.ts
```

Web `tsc --noEmit` and `eslint` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
