### PR TITLE
perf(web): warm the Settings chunks on menu open, and show a pending bar

### DIFF
--- a/clients/web/src/components/route-pending-indicator.test.tsx
+++ b/clients/web/src/components/route-pending-indicator.test.tsx
@@ -74,6 +74,13 @@ describe("RoutePendingIndicator", () => {
     expect(bar).not.toBeNull();
     expect(bar.className).toContain("route-pending-indicator");
 
+    // AND the moving fill carries its animation in a class, not an inline
+    // style: an inline `animation` outranks a stylesheet rule, so the
+    // reduced-motion override could not turn it off.
+    const fill = bar.firstElementChild as HTMLElement;
+    expect(fill.className).toContain("route-pending-indicator-fill");
+    expect(fill.style.animation).toBe("");
+
     // WHEN the chunk resolves
     await act(async () => {
       release();

--- a/clients/web/src/components/route-pending-indicator.test.tsx
+++ b/clients/web/src/components/route-pending-indicator.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for `RoutePendingIndicator`.
+ *
+ * The property that matters is that it tracks the router's own pending state
+ * rather than a timer of its own, so it cannot outlive a navigation or miss
+ * one. The delay before it is visible is CSS, so it is asserted as a class
+ * rather than by waiting.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+
+import { RoutePendingIndicator } from "@/components/route-pending-indicator";
+
+afterEach(cleanup);
+
+/**
+ * A router whose second route resolves only when the returned `release` is
+ * called, so a navigation can be held open and inspected mid-flight.
+ */
+function routerWithHeldChunk(): {
+  router: ReturnType<typeof createMemoryRouter>;
+  release: () => void;
+} {
+  let release = (): void => {};
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        Component: () => (
+          <>
+            <RoutePendingIndicator />
+            <div>home</div>
+          </>
+        ),
+      },
+      {
+        path: "/slow",
+        lazy: {
+          Component: () =>
+            new Promise<() => React.JSX.Element>((resolve) => {
+              release = () => resolve(() => <div>arrived</div>);
+            }),
+        },
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+  return { router, release: () => release() };
+}
+
+describe("RoutePendingIndicator", () => {
+  test("renders nothing while the router is idle", () => {
+    const { router } = routerWithHeldChunk();
+    render(<RouterProvider router={router} />);
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  test("appears while a lazy route is still resolving and goes when it lands", async () => {
+    const { router, release } = routerWithHeldChunk();
+    render(<RouterProvider router={router} />);
+
+    // GIVEN a navigation whose chunk has not arrived
+    await act(async () => {
+      void router.navigate("/slow");
+      await Promise.resolve();
+    });
+
+    // THEN the bar is mounted, and carries the class that keeps it invisible
+    // until the wait outlasts the CSS delay
+    const bar = screen.getByRole("status");
+    expect(bar).not.toBeNull();
+    expect(bar.className).toContain("route-pending-indicator");
+
+    // WHEN the chunk resolves
+    await act(async () => {
+      release();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // THEN the bar goes with the navigation that caused it
+    expect(screen.getByText("arrived")).not.toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/clients/web/src/components/route-pending-indicator.tsx
+++ b/clients/web/src/components/route-pending-indicator.tsx
@@ -32,10 +32,7 @@ export function RoutePendingIndicator() {
       role="status"
       aria-label={t("routePendingIndicator.loadingAria")}
     >
-      <div
-        className="h-full bg-[var(--content-default)]"
-        style={{ animation: "indeterminate 1.5s ease-in-out infinite" }}
-      />
+      <div className="route-pending-indicator-fill h-full bg-[var(--content-default)]" />
     </div>
   );
 }

--- a/clients/web/src/components/route-pending-indicator.tsx
+++ b/clients/web/src/components/route-pending-indicator.tsx
@@ -13,9 +13,9 @@ import { useTranslation } from "@/i18n";
  * two chunks before it will commit.
  *
  * The reveal is delayed in CSS rather than by a timer, so a navigation that
- * resolves inside the delay never paints the bar and fast transitions look
- * exactly as they did. Nothing here drives a render: the bar mounts when the
- * router reports a pending navigation and unmounts when it stops.
+ * resolves inside the delay never paints the bar at all. Nothing here holds
+ * state: the bar mounts while the router reports a pending navigation and
+ * unmounts when it stops, so it cannot outlive one or miss one.
  */
 export function RoutePendingIndicator() {
   const { t } = useTranslation();

--- a/clients/web/src/components/route-pending-indicator.tsx
+++ b/clients/web/src/components/route-pending-indicator.tsx
@@ -1,0 +1,41 @@
+import { useNavigation } from "react-router";
+
+import { useTranslation } from "@/i18n";
+
+/**
+ * A thin bar across the top of the app shell while a route navigation is
+ * still resolving.
+ *
+ * Route components are code split, so a navigation whose chunk is not in the
+ * module cache cannot commit until the fetch finishes, and the router holds
+ * the outgoing page on screen for the whole wait. With nothing moving, the
+ * tap reads as ignored, and the slowest of these is Settings, which resolves
+ * two chunks before it will commit.
+ *
+ * The reveal is delayed in CSS rather than by a timer, so a navigation that
+ * resolves inside the delay never paints the bar and fast transitions look
+ * exactly as they did. Nothing here drives a render: the bar mounts when the
+ * router reports a pending navigation and unmounts when it stops.
+ */
+export function RoutePendingIndicator() {
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+
+  if (navigation.state === "idle") {
+    return null;
+  }
+
+  return (
+    <div
+      data-slot="route-pending-indicator"
+      className="route-pending-indicator pointer-events-none absolute inset-x-0 top-0 z-50 h-0.5 overflow-hidden bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]"
+      role="status"
+      aria-label={t("routePendingIndicator.loadingAria")}
+    >
+      <div
+        className="h-full bg-[var(--content-default)]"
+        style={{ animation: "indeterminate 1.5s ease-in-out infinite" }}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -229,6 +229,15 @@ stubModule(
   },
 );
 
+// Records the paths the menu warms. Which chunks a path pulls in is
+// `prefetch-route.test.ts`'s business; this suite owns only when the menu asks.
+const prefetchedPaths: string[] = [];
+stubModule("@/lib/prefetch-route", await import("@/lib/prefetch-route"), {
+  prefetchRoute: (href?: string) => {
+    prefetchedPaths.push(href ?? "");
+  },
+});
+
 // The panel owns its own reads (subscription, plan catalog, usage totals),
 // which this suite's partial `@tanstack/react-query` mock cannot host. Its
 // rendering is covered by `preferences-usage-panel.test.tsx`; what the menu
@@ -410,6 +419,7 @@ beforeEach(() => {
   usageRef.opts = undefined;
   panelPropsRef.conversationId = undefined;
   feedbackRef.prefetches = 0;
+  prefetchedPaths.length = 0;
 });
 
 afterEach(() => {
@@ -599,6 +609,25 @@ describe("PreferencesMenu", () => {
       await Promise.resolve();
     });
     expect(feedbackRef.prefetches).toBe(1);
+  });
+
+  test("opening the menu warms the Settings route, once", async () => {
+    expect(prefetchedPaths).toEqual([]);
+
+    // GIVEN the menu opens, which is the first moment Settings is a plausible
+    // next tap
+    await openMenu();
+
+    // THEN its route is warmed, so the two chunks it needs are usually in
+    // hand before the tap that navigates to it
+    expect(prefetchedPaths).toEqual([routes.settings.root]);
+
+    // AND closing the menu does not ask again
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Usage settings" }));
+      await Promise.resolve();
+    });
+    expect(prefetchedPaths).toEqual([routes.settings.root]);
   });
 
   test("native Android keeps the panel's add-credits action, same as iOS", async () => {

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -32,6 +32,7 @@ import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { displayedCreditsUsd } from "@/lib/billing/displayed-credits";
+import { prefetchRoute } from "@/lib/prefetch-route";
 import { isElectron } from "@/runtime/is-electron";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
 import { openUrl } from "@/runtime/browser";
@@ -117,16 +118,20 @@ export function PreferencesMenu({
      opens the checkout. */
   const [isAddCreditsOpen, setIsAddCreditsOpen] = useState(false);
 
-  /* Warm the feedback chunk as the menu opens rather than on the click that
-     needs it, so the dialog is usually already there by the time it is asked
-     for. Once per mount: the chunk is cached after the first fetch. */
-  const hasPrefetchedFeedback = useRef(false);
+  /* Warm the chunks this menu leads to as it opens rather than on the click
+     that needs them, so they are usually already there by the time they are
+     asked for. Settings is the expensive one: it is two lazy chunks, the
+     layout and its landing page, and the router resolves both before it will
+     commit, holding the previous screen with no feedback for the whole wait.
+     Once per mount: chunks are module-cached after the first fetch. */
+  const hasPrefetchedMenuTargets = useRef(false);
   useEffect(() => {
-    if (!isOpen || hasPrefetchedFeedback.current) {
+    if (!isOpen || hasPrefetchedMenuTargets.current) {
       return;
     }
-    hasPrefetchedFeedback.current = true;
+    hasPrefetchedMenuTargets.current = true;
     prefetchShareFeedbackModal();
+    prefetchRoute(routes.settings.root);
   }, [isOpen]);
 
   if (!isAuthenticated) {

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -444,6 +444,9 @@
   "rootHydrateFallback": {
     "loadingAria": "Loading"
   },
+  "routePendingIndicator": {
+    "loadingAria": "Loading"
+  },
   "rootLayout": {
     "unnamedAssistant": "the assistant"
   },

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -442,6 +442,9 @@
   "rootHydrateFallback": {
     "loadingAria": "Cargando"
   },
+  "routePendingIndicator": {
+    "loadingAria": "Cargando"
+  },
   "rootLayout": {
     "unnamedAssistant": "el asistente"
   },

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -444,6 +444,9 @@
   "rootHydrateFallback": {
     "loadingAria": "正在載入"
   },
+  "routePendingIndicator": {
+    "loadingAria": "正在載入"
+  },
   "rootLayout": {
     "unnamedAssistant": "該助理"
   },

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -444,6 +444,9 @@
   "rootHydrateFallback": {
     "loadingAria": "正在加载"
   },
+  "routePendingIndicator": {
+    "loadingAria": "正在加载"
+  },
   "rootLayout": {
     "unnamedAssistant": "该助手"
   },

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -71,14 +71,42 @@ body {
  * collapsible-slide-*) live in the library's tokens.css. */
 
 @keyframes indeterminate {
-  0% { width: 0%; margin-left: 0%; }
-  50% { width: 60%; margin-left: 20%; }
-  100% { width: 0%; margin-left: 100%; }
+  0% {
+    width: 0%;
+    margin-left: 0%;
+  }
+  50% {
+    width: 60%;
+    margin-left: 20%;
+  }
+  100% {
+    width: 0%;
+    margin-left: 100%;
+  }
+}
+
+/* Route pending bar. Held transparent through the delay, so a navigation that
+   resolves inside it never paints anything and only a wait long enough to read
+   as unresponsive shows the bar. */
+.route-pending-indicator {
+  animation: fadeIn 0.2s ease-out 250ms both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .route-pending-indicator > * {
+    animation: none;
+  }
 }
 
 @keyframes fadeInUp {
-  0% { transform: translateY(16px); opacity: 0; }
-  100% { transform: none; opacity: 1; }
+  0% {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+  100% {
+    transform: none;
+    opacity: 1;
+  }
 }
 
 /* View Plans takeover entrance — the route swaps straight onto a full-dark
@@ -86,8 +114,12 @@ body {
    The canvas fade is opacity-only: translating it would drag the page
    background along and expose whatever sits behind the route. */
 @keyframes fadeIn {
-  0% { opacity: 0; }
-  100% { opacity: 1; }
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 .plans-takeover-canvas-enter {
@@ -112,16 +144,28 @@ body {
 /* Onboarding edge characters popping into place — a quick scale-up with a soft
    overshoot (paired with a spring-ish cubic-bezier at the call site). */
 @keyframes character-pop-in {
-  0% { transform: scale(0); opacity: 0; }
-  100% { transform: scale(1); opacity: 1; }
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 /* Home Activity detail drawer (schedule / heartbeat / notification) sliding
    in from the right. The panel hosts fixed Select/tooltip layers, so the
    fill mode below matters: see the note on the rule. */
 @keyframes drawer-slide-in {
-  0% { transform: translateX(16px); opacity: 0; }
-  100% { transform: none; opacity: 1; }
+  0% {
+    transform: translateX(16px);
+    opacity: 0;
+  }
+  100% {
+    transform: none;
+    opacity: 1;
+  }
 }
 
 /* `backwards`, not `both`. Forwards-fill would hold the final keyframe after
@@ -143,12 +187,19 @@ body {
    for the same reason as `.home-detail-drawer` above: nothing here should be
    left holding a transform once the entrance ends. */
 @keyframes notifications-panel-detail-in {
-  0% { transform: translateX(8px); opacity: 0; }
-  100% { transform: none; opacity: 1; }
+  0% {
+    transform: translateX(8px);
+    opacity: 0;
+  }
+  100% {
+    transform: none;
+    opacity: 1;
+  }
 }
 
 .notifications-panel-detail-enter {
-  animation: notifications-panel-detail-in var(--anim-fast) var(--anim-ease-out) backwards;
+  animation: notifications-panel-detail-in var(--anim-fast) var(--anim-ease-out)
+    backwards;
 }
 
 .notifications-panel-list-enter {
@@ -205,10 +256,26 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   animation: page-arrive-leading var(--page-transition-duration) ease-out both;
 }
 
-@keyframes page-arrive-trailing { from { transform: translateX(100%); } }
-@keyframes page-depart-leading { to { transform: translateX(-25%); } }
-@keyframes page-arrive-leading { from { transform: translateX(-25%); } }
-@keyframes page-depart-trailing { to { transform: translateX(100%); } }
+@keyframes page-arrive-trailing {
+  from {
+    transform: translateX(100%);
+  }
+}
+@keyframes page-depart-leading {
+  to {
+    transform: translateX(-25%);
+  }
+}
+@keyframes page-arrive-leading {
+  from {
+    transform: translateX(-25%);
+  }
+}
+@keyframes page-depart-trailing {
+  to {
+    transform: translateX(100%);
+  }
+}
 
 /* Snap to the destination. The transition still runs, so React Router's
    snapshot still covers the router's own latency; only the travel is dropped. */
@@ -221,29 +288,59 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes typing-dot-pulse {
-  0%, 100% { opacity: 0.45; transform: scale(0.6); }
-  50% { opacity: 1; transform: scale(1); }
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: scale(0.6);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 /* Avatar breathing — gentle scale pulse matching macOS
    AnimatedAvatarView.swift startBreathing() (2s in, 2s out). */
 @keyframes avatar-breathe-kf {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.03); }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.03);
+  }
 }
 
 @keyframes avatar-morph-scale {
-  0%, 100% { transform: scale(1, 1); }
-  25% { transform: scale(1.02, 0.99); }
-  50% { transform: scale(0.99, 1.02); }
-  75% { transform: scale(1.01, 0.99); }
+  0%,
+  100% {
+    transform: scale(1, 1);
+  }
+  25% {
+    transform: scale(1.02, 0.99);
+  }
+  50% {
+    transform: scale(0.99, 1.02);
+  }
+  75% {
+    transform: scale(1.01, 0.99);
+  }
 }
 
 @keyframes avatar-morph-rotate {
-  0%, 100% { transform: rotate(0deg); }
-  25% { transform: rotate(0.86deg); }
-  50% { transform: rotate(0deg); }
-  75% { transform: rotate(-0.86deg); }
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(0.86deg);
+  }
+  50% {
+    transform: rotate(0deg);
+  }
+  75% {
+    transform: rotate(-0.86deg);
+  }
 }
 
 /* Companion avatar bob: the creature lifting off its baseline and settling
@@ -259,8 +356,13 @@ html[data-page-transition="pop"]::view-transition-new(root) {
    short of the top, so the raised creature is still somewhere the host's
    hit-test finds the pointer. */
 @keyframes companion-avatar-bob {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-3px); }
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
 }
 
 .companion-avatar-bob {
@@ -280,8 +382,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * opacity (1→0.3) and scale (1→0.85) over 1s easeInOut. Used in
  * ActivityRunCard for active/thinking phases. */
 @keyframes busy-pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.3; transform: scale(0.85); }
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.3;
+    transform: scale(0.85);
+  }
 }
 
 .busy-indicator {
@@ -307,7 +416,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes companion-orbit {
-  to { --companion-orbit: 360deg; }
+  to {
+    --companion-orbit: 360deg;
+  }
 }
 
 .companion-working-ring {
@@ -329,7 +440,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
    * A 2px line over an arbitrary desktop needs it: the surface has no backdrop
    * of its own to hold the edge against. */
   filter: drop-shadow(
-    0 0 3px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 55%, transparent)
+    0 0 3px
+      color-mix(in srgb, var(--companion-ring-accent, #5eead4) 55%, transparent)
   );
   -webkit-mask:
     linear-gradient(#000 0 0) content-box,
@@ -356,13 +468,20 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * screen displaced, so there is no reduced-motion fallback: holding it still
  * would delete the only signal that the surface was read at that moment. */
 @keyframes companion-watch-frame-flash {
-  0% { opacity: 0; }
-  15% { opacity: 1; }
-  100% { opacity: 0; }
+  0% {
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 .companion-watch-frame-flash {
-  box-shadow: inset 0 0 0 4px color-mix(in srgb, white 70%, var(--companion-ring-accent, #5eead4));
+  box-shadow: inset 0 0 0 4px
+    color-mix(in srgb, white 70%, var(--companion-ring-accent, #5eead4));
   opacity: 0;
   animation: companion-watch-frame-flash 700ms ease-out 1;
 }
@@ -381,17 +500,25 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * hairline holds it off a dark background and the rim holds it off a light
  * one, so the edge stays found on every background the surface can have. */
 @keyframes companion-watch-frame-in {
-  from { opacity: 0; }
+  from {
+    opacity: 0;
+  }
 }
 
 @keyframes companion-call-breathe {
-  0%, 100% { opacity: 0.72; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.72;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 .companion-watch-frame {
   box-shadow:
-    inset 0 0 0 4px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 92%, transparent),
+    inset 0 0 0 4px
+      color-mix(in srgb, var(--companion-ring-accent, #5eead4) 92%, transparent),
     inset 0 0 0 5px color-mix(in srgb, white 75%, transparent),
     inset 0 0 0 7px color-mix(in srgb, black 35%, transparent);
   animation:
@@ -435,7 +562,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   color: #fff;
   background: color-mix(in srgb, black 78%, transparent);
   box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent),
+    inset 0 0 0 1px
+      color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent),
     0 1px 6px color-mix(in srgb, black 35%, transparent);
   animation: companion-watch-frame-in 300ms ease-out 1;
 }
@@ -447,7 +575,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   height: 8px;
   border-radius: 50%;
   background: var(--companion-ring-accent, #5eead4);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 30%, transparent);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--companion-ring-accent, #5eead4) 30%, transparent);
   animation: companion-call-breathe 3s ease-in-out infinite;
 }
 
@@ -507,7 +636,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * `COMPANION_INK_FADE_MS` in `companion-share-annotation.tsx`), which drops
  * the element on the same numbers. */
 @keyframes companion-share-ink-out {
-  to { opacity: 0; }
+  to {
+    opacity: 0;
+  }
 }
 
 .companion-share-ink-spent {
@@ -574,7 +705,11 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 .companion-coachmark-ink,
 .companion-coachmark-pointer-ink {
-  stroke: color-mix(in srgb, var(--companion-ring-accent, #5eead4) 90%, transparent);
+  stroke: color-mix(
+    in srgb,
+    var(--companion-ring-accent, #5eead4) 90%,
+    transparent
+  );
   stroke-width: 5;
 }
 
@@ -608,7 +743,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   line-height: 1.35;
   color: #fff;
   background: color-mix(in srgb, black 78%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent);
   animation: companion-coachmark-in 260ms ease-out 1;
 }
 
@@ -627,8 +763,14 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * component also holds it static via useReducedMotion; the media query is
  * defense-in-depth for callers that don't. */
 @keyframes voice-caret-blink {
-  0%, 50% { opacity: 1; }
-  50.01%, 100% { opacity: 0; }
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
 }
 
 .voice-caret-blink {
@@ -650,9 +792,16 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * media query is defense-in-depth for callers that don't, and pins the dot lit
  * rather than mid-dip. */
 @keyframes camera-status-blink {
-  0%, 55% { opacity: 1; }
-  75% { opacity: 0.25; }
-  100% { opacity: 1; }
+  0%,
+  55% {
+    opacity: 1;
+  }
+  75% {
+    opacity: 0.25;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 .camera-status-blink {
@@ -795,14 +944,20 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 @keyframes camera-shutter-pulse {
   0% {
     box-shadow: 0 0 0 0 rgba(207, 67, 112, 0.75);
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--camera-accent) 75%, transparent);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--camera-accent) 75%, transparent);
   }
-  70% { box-shadow: 0 0 0 12px transparent; }
-  100% { box-shadow: 0 0 0 0 transparent; }
+  70% {
+    box-shadow: 0 0 0 12px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
 }
 
 .camera-shutter-pulse {
-  animation: camera-shutter-pulse var(--camera-shutter-pulse-duration) ease-out 1;
+  animation: camera-shutter-pulse var(--camera-shutter-pulse-duration) ease-out
+    1;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -821,10 +976,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 @keyframes sight-frame-kept {
   0% {
     box-shadow: 0 0 0 0 rgba(207, 67, 112, 0.75);
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--camera-accent) 75%, transparent);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--camera-accent) 75%, transparent);
   }
-  70% { box-shadow: 0 0 0 8px transparent; }
-  100% { box-shadow: 0 0 0 0 transparent; }
+  70% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
 }
 
 .sight-frame-kept {
@@ -832,15 +992,21 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .sight-frame-kept { animation: none; }
+  .sight-frame-kept {
+    animation: none;
+  }
 }
 
 /* Deep-link message highlight — a one-shot background flash applied when the
  * transcript scrolls to a message (e.g. opening a saved bookmark). Fades from
  * the active-surface tint back to transparent over 2s. */
 @keyframes message-highlight-flash {
-  0% { background-color: var(--surface-active); }
-  100% { background-color: transparent; }
+  0% {
+    background-color: var(--surface-active);
+  }
+  100% {
+    background-color: transparent;
+  }
 }
 
 .message-highlighted {
@@ -884,8 +1050,13 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * useReducedMotion; the media query is defense-in-depth for callers that
  * don't. */
 @keyframes unseen-dot-pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.35); }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.35);
+  }
 }
 
 .unseen-dot-pulse {
@@ -919,8 +1090,12 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * creature reads as "asleep" during hatching. When the assistant becomes
  * active, swap the class for `.onboarding-avatar-awake`. */
 @keyframes morphPulse {
-  0% { transform: scale(0.9); }
-  100% { transform: scale(1.0); }
+  0% {
+    transform: scale(0.9);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .onboarding-avatar-pulse {
@@ -948,8 +1123,14 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* Billing onboarding modal — step content entrance */
 @keyframes onboarding-step-in {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Provisioning takeover — the assistant grows into a larger form when the
@@ -994,8 +1175,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes provision-placeholder-breathe {
-  0%, 100% { transform: scale(0.94); opacity: 0.65; }
-  50% { transform: scale(1.05); opacity: 1; }
+  0%,
+  100% {
+    transform: scale(0.94);
+    opacity: 0.65;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
 }
 
 /* Fades out on the same beat the creature reveals on, then costs nothing. */
@@ -1033,20 +1221,44 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* The crouch is what makes this read as the creature pushing itself up rather
  * than as something being scaled. */
 @keyframes provision-grow {
-  0% { transform: scale(1); }
-  11% { transform: scale(1.03) scaleY(0.9); }
-  38% { transform: scale(1.3); }
-  50% { transform: scale(1.24); }
-  82% { transform: scale(1.49); }
-  100% { transform: scale(var(--provision-avatar-growth)); }
+  0% {
+    transform: scale(1);
+  }
+  11% {
+    transform: scale(1.03) scaleY(0.9);
+  }
+  38% {
+    transform: scale(1.3);
+  }
+  50% {
+    transform: scale(1.24);
+  }
+  82% {
+    transform: scale(1.49);
+  }
+  100% {
+    transform: scale(var(--provision-avatar-growth));
+  }
 }
 
 /* The shadow tightens as it leaves the ground and spreads as it lands. */
 @keyframes provision-grow-shadow {
-  0% { transform: scaleX(1); opacity: 0.85; }
-  18% { transform: scaleX(1.08); opacity: 1; }
-  45% { transform: scaleX(0.95); opacity: 0.6; }
-  100% { transform: scaleX(1.16); opacity: 1; }
+  0% {
+    transform: scaleX(1);
+    opacity: 0.85;
+  }
+  18% {
+    transform: scaleX(1.08);
+    opacity: 1;
+  }
+  45% {
+    transform: scaleX(0.95);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scaleX(1.16);
+    opacity: 1;
+  }
 }
 
 .provision-avatar-evolve.is-evolved .provision-avatar-current {
@@ -1089,7 +1301,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
     animation-timing-function: cubic-bezier(0.5, 0, 0.75, 0);
   }
   28% {
-    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.62)) scaleY(0.985);
+    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.62))
+      scaleY(0.985);
     animation-timing-function: cubic-bezier(0.2, 1.5, 0.4, 1);
   }
   40% {
@@ -1097,7 +1310,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
     animation-timing-function: cubic-bezier(0.5, 0, 0.75, 0);
   }
   58% {
-    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.28)) scaleY(0.985);
+    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.28))
+      scaleY(0.985);
     animation-timing-function: cubic-bezier(0.2, 1.5, 0.4, 1);
   }
   70% {
@@ -1108,18 +1322,41 @@ html[data-page-transition="pop"]::view-transition-new(root) {
     transform: scale(0.975) scaleY(0.955);
     animation-timing-function: cubic-bezier(0.2, 1.6, 0.4, 1);
   }
-  100% { transform: scale(1); }
+  100% {
+    transform: scale(1);
+  }
 }
 
 /* The shadow tightens a notch behind each drop and spreads as it is caught. */
 @keyframes provision-shrink-shadow {
-  0% { transform: scaleX(1.16); opacity: 1; }
-  28% { transform: scaleX(1.12); opacity: 0.9; }
-  40% { transform: scaleX(1.13); opacity: 0.92; }
-  58% { transform: scaleX(1.06); opacity: 0.82; }
-  70% { transform: scaleX(1.07); opacity: 0.84; }
-  86% { transform: scaleX(0.98); opacity: 0.94; }
-  100% { transform: scaleX(1); opacity: 0.85; }
+  0% {
+    transform: scaleX(1.16);
+    opacity: 1;
+  }
+  28% {
+    transform: scaleX(1.12);
+    opacity: 0.9;
+  }
+  40% {
+    transform: scaleX(1.13);
+    opacity: 0.92;
+  }
+  58% {
+    transform: scaleX(1.06);
+    opacity: 0.82;
+  }
+  70% {
+    transform: scaleX(1.07);
+    opacity: 0.84;
+  }
+  86% {
+    transform: scaleX(0.98);
+    opacity: 0.94;
+  }
+  100% {
+    transform: scaleX(1);
+    opacity: 0.85;
+  }
 }
 
 .provision-avatar-evolve.is-downsizing.is-evolved .provision-avatar-current {
@@ -1135,8 +1372,12 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * stage has already reserved its height, so this fades in place with nothing
  * moving around it. */
 @keyframes provision-avatar-reveal {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* The takeover's arrival beat: the avatar, the surface color, and the blurred
@@ -1184,13 +1425,20 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes provision-strain {
-  0% { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
   18% {
     transform: scaleX(calc(1 + var(--provision-strain) * 0.35))
       scaleY(calc(1 - var(--provision-strain) * 0.75));
   }
-  44% { transform: scale(calc(1 + var(--provision-strain))); }
-  66%, 100% { transform: scale(1); }
+  44% {
+    transform: scale(calc(1 + var(--provision-strain)));
+  }
+  66%,
+  100% {
+    transform: scale(1);
+  }
 }
 
 /* A third of every cycle is rest — that pause is what keeps it reading as
@@ -1454,16 +1702,29 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* Idle — gentle 4.5s breathing scale, mirroring macOS startBreathing(). */
 @keyframes voice-avatar-idle-breathe {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.03); }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.03);
+  }
 }
 
 /* Idle — faint invitation ring that swells and fades, inviting the user to
  * speak without the urgency of the listening sonar. */
 @keyframes voice-avatar-invite-ring {
-  0% { opacity: 0; transform: scale(0.96); }
-  50% { opacity: 0.35; }
-  100% { opacity: 0; transform: scale(1.12); }
+  0% {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  50% {
+    opacity: 0.35;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.12);
+  }
 }
 
 .voice-avatar--idle {
@@ -1480,8 +1741,13 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * carried by the top-edge waves coming in (see voice-listening-waves.tsx), not by
  * the avatar reacting to mic amplitude. */
 @keyframes voice-avatar-soft-pulse {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.02); }
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.02);
+  }
 }
 
 .voice-avatar--listening {
@@ -1491,8 +1757,13 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* Thinking — "stillness with intent": a slow brightness/saturation cycle on
  * the avatar itself. Deliberately NOT a spinner. */
 @keyframes voice-avatar-think-glow {
-  0%, 100% { filter: brightness(1) saturate(1); }
-  50% { filter: brightness(1.12) saturate(1.35); }
+  0%,
+  100% {
+    filter: brightness(1) saturate(1);
+  }
+  50% {
+    filter: brightness(1.12) saturate(1.35);
+  }
 }
 
 .voice-avatar--thinking {
@@ -1505,8 +1776,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* Reconnecting — dimmed, slow pulse, distinct from idle-breathe (full opacity)
  * and think-glow (brightens rather than dims). */
 @keyframes voice-avatar-reconnect-pulse {
-  0%, 100% { opacity: 0.45; transform: scale(0.98); }
-  50% { opacity: 0.7; transform: scale(1.01); }
+  0%,
+  100% {
+    opacity: 0.45;
+    transform: scale(0.98);
+  }
+  50% {
+    opacity: 0.7;
+    transform: scale(1.01);
+  }
 }
 
 .voice-avatar--reconnecting {
@@ -1740,22 +2018,34 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 /* Palette: aurora = fixed cyan→indigo (matches the listening sonar). */
-.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--back path {
+.voice-listening-waves--aurora.voice-listening-waves--fill
+  .voice-wave--back
+  path {
   fill: rgba(99, 102, 241, 0.16);
 }
-.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--mid path {
+.voice-listening-waves--aurora.voice-listening-waves--fill
+  .voice-wave--mid
+  path {
   fill: rgba(79, 140, 255, 0.2);
 }
-.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--front path {
+.voice-listening-waves--aurora.voice-listening-waves--fill
+  .voice-wave--front
+  path {
   fill: rgba(34, 211, 238, 0.26);
 }
-.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--back path {
+.voice-listening-waves--aurora.voice-listening-waves--line
+  .voice-wave--back
+  path {
   stroke: rgba(99, 102, 241, 0.5);
 }
-.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--mid path {
+.voice-listening-waves--aurora.voice-listening-waves--line
+  .voice-wave--mid
+  path {
   stroke: rgba(79, 140, 255, 0.62);
 }
-.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--front path {
+.voice-listening-waves--aurora.voice-listening-waves--line
+  .voice-wave--front
+  path {
   stroke: rgba(34, 211, 238, 0.78);
 }
 
@@ -1770,27 +2060,39 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 .voice-listening-waves--accent {
   --wave-accent: var(--avatar-accent, #6366f1);
 }
-.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--back path {
+.voice-listening-waves--accent.voice-listening-waves--fill
+  .voice-wave--back
+  path {
   fill: rgba(99, 102, 241, 0.16);
   fill: color-mix(in srgb, var(--wave-accent) 16%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--mid path {
+.voice-listening-waves--accent.voice-listening-waves--fill
+  .voice-wave--mid
+  path {
   fill: rgba(79, 140, 255, 0.2);
   fill: color-mix(in srgb, var(--wave-accent) 24%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--front path {
+.voice-listening-waves--accent.voice-listening-waves--fill
+  .voice-wave--front
+  path {
   fill: rgba(34, 211, 238, 0.26);
   fill: color-mix(in srgb, var(--wave-accent) 34%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--back path {
+.voice-listening-waves--accent.voice-listening-waves--line
+  .voice-wave--back
+  path {
   stroke: rgba(99, 102, 241, 0.5);
   stroke: color-mix(in srgb, var(--wave-accent) 50%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--mid path {
+.voice-listening-waves--accent.voice-listening-waves--line
+  .voice-wave--mid
+  path {
   stroke: rgba(79, 140, 255, 0.62);
   stroke: color-mix(in srgb, var(--wave-accent) 66%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--front path {
+.voice-listening-waves--accent.voice-listening-waves--line
+  .voice-wave--front
+  path {
   stroke: rgba(34, 211, 238, 0.78);
   stroke: color-mix(in srgb, var(--wave-accent) 82%, transparent);
 }
@@ -1801,7 +2103,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 .voice-listening-waves--tone {
   --wave-tone: var(--room-fg, #ffffff);
 }
-.voice-listening-waves--tone.voice-listening-waves--fill .voice-wave--back path {
+.voice-listening-waves--tone.voice-listening-waves--fill
+  .voice-wave--back
+  path {
   fill: rgba(255, 255, 255, 0.1);
   fill: color-mix(in srgb, var(--wave-tone) 12%, transparent);
 }
@@ -1809,11 +2113,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   fill: rgba(255, 255, 255, 0.14);
   fill: color-mix(in srgb, var(--wave-tone) 17%, transparent);
 }
-.voice-listening-waves--tone.voice-listening-waves--fill .voice-wave--front path {
+.voice-listening-waves--tone.voice-listening-waves--fill
+  .voice-wave--front
+  path {
   fill: rgba(255, 255, 255, 0.2);
   fill: color-mix(in srgb, var(--wave-tone) 24%, transparent);
 }
-.voice-listening-waves--tone.voice-listening-waves--line .voice-wave--back path {
+.voice-listening-waves--tone.voice-listening-waves--line
+  .voice-wave--back
+  path {
   stroke: rgba(255, 255, 255, 0.42);
   stroke: color-mix(in srgb, var(--wave-tone) 45%, transparent);
 }
@@ -1821,7 +2129,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   stroke: rgba(255, 255, 255, 0.55);
   stroke: color-mix(in srgb, var(--wave-tone) 58%, transparent);
 }
-.voice-listening-waves--tone.voice-listening-waves--line .voice-wave--front path {
+.voice-listening-waves--tone.voice-listening-waves--line
+  .voice-wave--front
+  path {
   stroke: rgba(255, 255, 255, 0.72);
   stroke: color-mix(in srgb, var(--wave-tone) 75%, transparent);
 }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -83,8 +83,19 @@ body {
   animation: fadeIn 0.2s ease-out 250ms both;
 }
 
+.route-pending-indicator-fill {
+  animation: indeterminate 1.5s ease-in-out infinite;
+}
+
+/* Reduced motion keeps the bar but stops it travelling, so it reads as a
+   static rule. The fill carries its animation in a class rather than an inline
+   style so this can turn it off: an inline `animation` outranks a stylesheet
+   rule. The wrapper's fade is left alone because the delay in it is what keeps
+   a fast navigation from flashing a bar, which is function rather than
+   decoration, and an opacity fade is not the kind of movement this preference
+   is asking to remove. */
 @media (prefers-reduced-motion: reduce) {
-  .route-pending-indicator > * {
+  .route-pending-indicator-fill {
     animation: none;
   }
 }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -76,6 +76,19 @@ body {
   100% { width: 0%; margin-left: 100%; }
 }
 
+/* Route pending bar. Held transparent through the delay, so a navigation that
+   resolves inside it never paints anything and only a wait long enough to read
+   as unresponsive shows the bar. */
+.route-pending-indicator {
+  animation: fadeIn 0.2s ease-out 250ms both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .route-pending-indicator > * {
+    animation: none;
+  }
+}
+
 @keyframes fadeInUp {
   0% { transform: translateY(16px); opacity: 0; }
   100% { transform: none; opacity: 1; }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -71,42 +71,14 @@ body {
  * collapsible-slide-*) live in the library's tokens.css. */
 
 @keyframes indeterminate {
-  0% {
-    width: 0%;
-    margin-left: 0%;
-  }
-  50% {
-    width: 60%;
-    margin-left: 20%;
-  }
-  100% {
-    width: 0%;
-    margin-left: 100%;
-  }
-}
-
-/* Route pending bar. Held transparent through the delay, so a navigation that
-   resolves inside it never paints anything and only a wait long enough to read
-   as unresponsive shows the bar. */
-.route-pending-indicator {
-  animation: fadeIn 0.2s ease-out 250ms both;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .route-pending-indicator > * {
-    animation: none;
-  }
+  0% { width: 0%; margin-left: 0%; }
+  50% { width: 60%; margin-left: 20%; }
+  100% { width: 0%; margin-left: 100%; }
 }
 
 @keyframes fadeInUp {
-  0% {
-    transform: translateY(16px);
-    opacity: 0;
-  }
-  100% {
-    transform: none;
-    opacity: 1;
-  }
+  0% { transform: translateY(16px); opacity: 0; }
+  100% { transform: none; opacity: 1; }
 }
 
 /* View Plans takeover entrance — the route swaps straight onto a full-dark
@@ -114,12 +86,8 @@ body {
    The canvas fade is opacity-only: translating it would drag the page
    background along and expose whatever sits behind the route. */
 @keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
+  0% { opacity: 0; }
+  100% { opacity: 1; }
 }
 
 .plans-takeover-canvas-enter {
@@ -144,28 +112,16 @@ body {
 /* Onboarding edge characters popping into place — a quick scale-up with a soft
    overshoot (paired with a spring-ish cubic-bezier at the call site). */
 @keyframes character-pop-in {
-  0% {
-    transform: scale(0);
-    opacity: 0;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
+  0% { transform: scale(0); opacity: 0; }
+  100% { transform: scale(1); opacity: 1; }
 }
 
 /* Home Activity detail drawer (schedule / heartbeat / notification) sliding
    in from the right. The panel hosts fixed Select/tooltip layers, so the
    fill mode below matters: see the note on the rule. */
 @keyframes drawer-slide-in {
-  0% {
-    transform: translateX(16px);
-    opacity: 0;
-  }
-  100% {
-    transform: none;
-    opacity: 1;
-  }
+  0% { transform: translateX(16px); opacity: 0; }
+  100% { transform: none; opacity: 1; }
 }
 
 /* `backwards`, not `both`. Forwards-fill would hold the final keyframe after
@@ -187,19 +143,12 @@ body {
    for the same reason as `.home-detail-drawer` above: nothing here should be
    left holding a transform once the entrance ends. */
 @keyframes notifications-panel-detail-in {
-  0% {
-    transform: translateX(8px);
-    opacity: 0;
-  }
-  100% {
-    transform: none;
-    opacity: 1;
-  }
+  0% { transform: translateX(8px); opacity: 0; }
+  100% { transform: none; opacity: 1; }
 }
 
 .notifications-panel-detail-enter {
-  animation: notifications-panel-detail-in var(--anim-fast) var(--anim-ease-out)
-    backwards;
+  animation: notifications-panel-detail-in var(--anim-fast) var(--anim-ease-out) backwards;
 }
 
 .notifications-panel-list-enter {
@@ -256,26 +205,10 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   animation: page-arrive-leading var(--page-transition-duration) ease-out both;
 }
 
-@keyframes page-arrive-trailing {
-  from {
-    transform: translateX(100%);
-  }
-}
-@keyframes page-depart-leading {
-  to {
-    transform: translateX(-25%);
-  }
-}
-@keyframes page-arrive-leading {
-  from {
-    transform: translateX(-25%);
-  }
-}
-@keyframes page-depart-trailing {
-  to {
-    transform: translateX(100%);
-  }
-}
+@keyframes page-arrive-trailing { from { transform: translateX(100%); } }
+@keyframes page-depart-leading { to { transform: translateX(-25%); } }
+@keyframes page-arrive-leading { from { transform: translateX(-25%); } }
+@keyframes page-depart-trailing { to { transform: translateX(100%); } }
 
 /* Snap to the destination. The transition still runs, so React Router's
    snapshot still covers the router's own latency; only the travel is dropped. */
@@ -288,59 +221,29 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes typing-dot-pulse {
-  0%,
-  100% {
-    opacity: 0.45;
-    transform: scale(0.6);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1);
-  }
+  0%, 100% { opacity: 0.45; transform: scale(0.6); }
+  50% { opacity: 1; transform: scale(1); }
 }
 
 /* Avatar breathing — gentle scale pulse matching macOS
    AnimatedAvatarView.swift startBreathing() (2s in, 2s out). */
 @keyframes avatar-breathe-kf {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.03);
-  }
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
 }
 
 @keyframes avatar-morph-scale {
-  0%,
-  100% {
-    transform: scale(1, 1);
-  }
-  25% {
-    transform: scale(1.02, 0.99);
-  }
-  50% {
-    transform: scale(0.99, 1.02);
-  }
-  75% {
-    transform: scale(1.01, 0.99);
-  }
+  0%, 100% { transform: scale(1, 1); }
+  25% { transform: scale(1.02, 0.99); }
+  50% { transform: scale(0.99, 1.02); }
+  75% { transform: scale(1.01, 0.99); }
 }
 
 @keyframes avatar-morph-rotate {
-  0%,
-  100% {
-    transform: rotate(0deg);
-  }
-  25% {
-    transform: rotate(0.86deg);
-  }
-  50% {
-    transform: rotate(0deg);
-  }
-  75% {
-    transform: rotate(-0.86deg);
-  }
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(0.86deg); }
+  50% { transform: rotate(0deg); }
+  75% { transform: rotate(-0.86deg); }
 }
 
 /* Companion avatar bob: the creature lifting off its baseline and settling
@@ -356,13 +259,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
    short of the top, so the raised creature is still somewhere the host's
    hit-test finds the pointer. */
 @keyframes companion-avatar-bob {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-3px);
-  }
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
 }
 
 .companion-avatar-bob {
@@ -382,15 +280,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * opacity (1→0.3) and scale (1→0.85) over 1s easeInOut. Used in
  * ActivityRunCard for active/thinking phases. */
 @keyframes busy-pulse {
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  50% {
-    opacity: 0.3;
-    transform: scale(0.85);
-  }
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.3; transform: scale(0.85); }
 }
 
 .busy-indicator {
@@ -416,9 +307,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes companion-orbit {
-  to {
-    --companion-orbit: 360deg;
-  }
+  to { --companion-orbit: 360deg; }
 }
 
 .companion-working-ring {
@@ -440,8 +329,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
    * A 2px line over an arbitrary desktop needs it: the surface has no backdrop
    * of its own to hold the edge against. */
   filter: drop-shadow(
-    0 0 3px
-      color-mix(in srgb, var(--companion-ring-accent, #5eead4) 55%, transparent)
+    0 0 3px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 55%, transparent)
   );
   -webkit-mask:
     linear-gradient(#000 0 0) content-box,
@@ -468,20 +356,13 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * screen displaced, so there is no reduced-motion fallback: holding it still
  * would delete the only signal that the surface was read at that moment. */
 @keyframes companion-watch-frame-flash {
-  0% {
-    opacity: 0;
-  }
-  15% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
+  0% { opacity: 0; }
+  15% { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 .companion-watch-frame-flash {
-  box-shadow: inset 0 0 0 4px
-    color-mix(in srgb, white 70%, var(--companion-ring-accent, #5eead4));
+  box-shadow: inset 0 0 0 4px color-mix(in srgb, white 70%, var(--companion-ring-accent, #5eead4));
   opacity: 0;
   animation: companion-watch-frame-flash 700ms ease-out 1;
 }
@@ -500,25 +381,17 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * hairline holds it off a dark background and the rim holds it off a light
  * one, so the edge stays found on every background the surface can have. */
 @keyframes companion-watch-frame-in {
-  from {
-    opacity: 0;
-  }
+  from { opacity: 0; }
 }
 
 @keyframes companion-call-breathe {
-  0%,
-  100% {
-    opacity: 0.72;
-  }
-  50% {
-    opacity: 1;
-  }
+  0%, 100% { opacity: 0.72; }
+  50% { opacity: 1; }
 }
 
 .companion-watch-frame {
   box-shadow:
-    inset 0 0 0 4px
-      color-mix(in srgb, var(--companion-ring-accent, #5eead4) 92%, transparent),
+    inset 0 0 0 4px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 92%, transparent),
     inset 0 0 0 5px color-mix(in srgb, white 75%, transparent),
     inset 0 0 0 7px color-mix(in srgb, black 35%, transparent);
   animation:
@@ -562,8 +435,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   color: #fff;
   background: color-mix(in srgb, black 78%, transparent);
   box-shadow:
-    inset 0 0 0 1px
-      color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent),
     0 1px 6px color-mix(in srgb, black 35%, transparent);
   animation: companion-watch-frame-in 300ms ease-out 1;
 }
@@ -575,8 +447,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   height: 8px;
   border-radius: 50%;
   background: var(--companion-ring-accent, #5eead4);
-  box-shadow: 0 0 0 2px
-    color-mix(in srgb, var(--companion-ring-accent, #5eead4) 30%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 30%, transparent);
   animation: companion-call-breathe 3s ease-in-out infinite;
 }
 
@@ -636,9 +507,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * `COMPANION_INK_FADE_MS` in `companion-share-annotation.tsx`), which drops
  * the element on the same numbers. */
 @keyframes companion-share-ink-out {
-  to {
-    opacity: 0;
-  }
+  to { opacity: 0; }
 }
 
 .companion-share-ink-spent {
@@ -705,11 +574,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 .companion-coachmark-ink,
 .companion-coachmark-pointer-ink {
-  stroke: color-mix(
-    in srgb,
-    var(--companion-ring-accent, #5eead4) 90%,
-    transparent
-  );
+  stroke: color-mix(in srgb, var(--companion-ring-accent, #5eead4) 90%, transparent);
   stroke-width: 5;
 }
 
@@ -743,8 +608,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   line-height: 1.35;
   color: #fff;
   background: color-mix(in srgb, black 78%, transparent);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--companion-ring-accent, #5eead4) 70%, transparent);
   animation: companion-coachmark-in 260ms ease-out 1;
 }
 
@@ -763,14 +627,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * component also holds it static via useReducedMotion; the media query is
  * defense-in-depth for callers that don't. */
 @keyframes voice-caret-blink {
-  0%,
-  50% {
-    opacity: 1;
-  }
-  50.01%,
-  100% {
-    opacity: 0;
-  }
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
 }
 
 .voice-caret-blink {
@@ -792,16 +650,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * media query is defense-in-depth for callers that don't, and pins the dot lit
  * rather than mid-dip. */
 @keyframes camera-status-blink {
-  0%,
-  55% {
-    opacity: 1;
-  }
-  75% {
-    opacity: 0.25;
-  }
-  100% {
-    opacity: 1;
-  }
+  0%, 55% { opacity: 1; }
+  75% { opacity: 0.25; }
+  100% { opacity: 1; }
 }
 
 .camera-status-blink {
@@ -944,20 +795,14 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 @keyframes camera-shutter-pulse {
   0% {
     box-shadow: 0 0 0 0 rgba(207, 67, 112, 0.75);
-    box-shadow: 0 0 0 0
-      color-mix(in srgb, var(--camera-accent) 75%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--camera-accent) 75%, transparent);
   }
-  70% {
-    box-shadow: 0 0 0 12px transparent;
-  }
-  100% {
-    box-shadow: 0 0 0 0 transparent;
-  }
+  70% { box-shadow: 0 0 0 12px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
 }
 
 .camera-shutter-pulse {
-  animation: camera-shutter-pulse var(--camera-shutter-pulse-duration) ease-out
-    1;
+  animation: camera-shutter-pulse var(--camera-shutter-pulse-duration) ease-out 1;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -976,15 +821,10 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 @keyframes sight-frame-kept {
   0% {
     box-shadow: 0 0 0 0 rgba(207, 67, 112, 0.75);
-    box-shadow: 0 0 0 0
-      color-mix(in srgb, var(--camera-accent) 75%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--camera-accent) 75%, transparent);
   }
-  70% {
-    box-shadow: 0 0 0 8px transparent;
-  }
-  100% {
-    box-shadow: 0 0 0 0 transparent;
-  }
+  70% { box-shadow: 0 0 0 8px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
 }
 
 .sight-frame-kept {
@@ -992,21 +832,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .sight-frame-kept {
-    animation: none;
-  }
+  .sight-frame-kept { animation: none; }
 }
 
 /* Deep-link message highlight — a one-shot background flash applied when the
  * transcript scrolls to a message (e.g. opening a saved bookmark). Fades from
  * the active-surface tint back to transparent over 2s. */
 @keyframes message-highlight-flash {
-  0% {
-    background-color: var(--surface-active);
-  }
-  100% {
-    background-color: transparent;
-  }
+  0% { background-color: var(--surface-active); }
+  100% { background-color: transparent; }
 }
 
 .message-highlighted {
@@ -1050,13 +884,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * useReducedMotion; the media query is defense-in-depth for callers that
  * don't. */
 @keyframes unseen-dot-pulse {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.35);
-  }
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.35); }
 }
 
 .unseen-dot-pulse {
@@ -1090,12 +919,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * creature reads as "asleep" during hatching. When the assistant becomes
  * active, swap the class for `.onboarding-avatar-awake`. */
 @keyframes morphPulse {
-  0% {
-    transform: scale(0.9);
-  }
-  100% {
-    transform: scale(1);
-  }
+  0% { transform: scale(0.9); }
+  100% { transform: scale(1.0); }
 }
 
 .onboarding-avatar-pulse {
@@ -1123,14 +948,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* Billing onboarding modal — step content entrance */
 @keyframes onboarding-step-in {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 /* Provisioning takeover — the assistant grows into a larger form when the
@@ -1175,15 +994,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes provision-placeholder-breathe {
-  0%,
-  100% {
-    transform: scale(0.94);
-    opacity: 0.65;
-  }
-  50% {
-    transform: scale(1.05);
-    opacity: 1;
-  }
+  0%, 100% { transform: scale(0.94); opacity: 0.65; }
+  50% { transform: scale(1.05); opacity: 1; }
 }
 
 /* Fades out on the same beat the creature reveals on, then costs nothing. */
@@ -1221,44 +1033,20 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* The crouch is what makes this read as the creature pushing itself up rather
  * than as something being scaled. */
 @keyframes provision-grow {
-  0% {
-    transform: scale(1);
-  }
-  11% {
-    transform: scale(1.03) scaleY(0.9);
-  }
-  38% {
-    transform: scale(1.3);
-  }
-  50% {
-    transform: scale(1.24);
-  }
-  82% {
-    transform: scale(1.49);
-  }
-  100% {
-    transform: scale(var(--provision-avatar-growth));
-  }
+  0% { transform: scale(1); }
+  11% { transform: scale(1.03) scaleY(0.9); }
+  38% { transform: scale(1.3); }
+  50% { transform: scale(1.24); }
+  82% { transform: scale(1.49); }
+  100% { transform: scale(var(--provision-avatar-growth)); }
 }
 
 /* The shadow tightens as it leaves the ground and spreads as it lands. */
 @keyframes provision-grow-shadow {
-  0% {
-    transform: scaleX(1);
-    opacity: 0.85;
-  }
-  18% {
-    transform: scaleX(1.08);
-    opacity: 1;
-  }
-  45% {
-    transform: scaleX(0.95);
-    opacity: 0.6;
-  }
-  100% {
-    transform: scaleX(1.16);
-    opacity: 1;
-  }
+  0% { transform: scaleX(1); opacity: 0.85; }
+  18% { transform: scaleX(1.08); opacity: 1; }
+  45% { transform: scaleX(0.95); opacity: 0.6; }
+  100% { transform: scaleX(1.16); opacity: 1; }
 }
 
 .provision-avatar-evolve.is-evolved .provision-avatar-current {
@@ -1301,8 +1089,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
     animation-timing-function: cubic-bezier(0.5, 0, 0.75, 0);
   }
   28% {
-    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.62))
-      scaleY(0.985);
+    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.62)) scaleY(0.985);
     animation-timing-function: cubic-bezier(0.2, 1.5, 0.4, 1);
   }
   40% {
@@ -1310,8 +1097,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
     animation-timing-function: cubic-bezier(0.5, 0, 0.75, 0);
   }
   58% {
-    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.28))
-      scaleY(0.985);
+    transform: scale(calc(1 + (var(--provision-avatar-growth) - 1) * 0.28)) scaleY(0.985);
     animation-timing-function: cubic-bezier(0.2, 1.5, 0.4, 1);
   }
   70% {
@@ -1322,41 +1108,18 @@ html[data-page-transition="pop"]::view-transition-new(root) {
     transform: scale(0.975) scaleY(0.955);
     animation-timing-function: cubic-bezier(0.2, 1.6, 0.4, 1);
   }
-  100% {
-    transform: scale(1);
-  }
+  100% { transform: scale(1); }
 }
 
 /* The shadow tightens a notch behind each drop and spreads as it is caught. */
 @keyframes provision-shrink-shadow {
-  0% {
-    transform: scaleX(1.16);
-    opacity: 1;
-  }
-  28% {
-    transform: scaleX(1.12);
-    opacity: 0.9;
-  }
-  40% {
-    transform: scaleX(1.13);
-    opacity: 0.92;
-  }
-  58% {
-    transform: scaleX(1.06);
-    opacity: 0.82;
-  }
-  70% {
-    transform: scaleX(1.07);
-    opacity: 0.84;
-  }
-  86% {
-    transform: scaleX(0.98);
-    opacity: 0.94;
-  }
-  100% {
-    transform: scaleX(1);
-    opacity: 0.85;
-  }
+  0% { transform: scaleX(1.16); opacity: 1; }
+  28% { transform: scaleX(1.12); opacity: 0.9; }
+  40% { transform: scaleX(1.13); opacity: 0.92; }
+  58% { transform: scaleX(1.06); opacity: 0.82; }
+  70% { transform: scaleX(1.07); opacity: 0.84; }
+  86% { transform: scaleX(0.98); opacity: 0.94; }
+  100% { transform: scaleX(1); opacity: 0.85; }
 }
 
 .provision-avatar-evolve.is-downsizing.is-evolved .provision-avatar-current {
@@ -1372,12 +1135,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * stage has already reserved its height, so this fades in place with nothing
  * moving around it. */
 @keyframes provision-avatar-reveal {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 /* The takeover's arrival beat: the avatar, the surface color, and the blurred
@@ -1425,20 +1184,13 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 @keyframes provision-strain {
-  0% {
-    transform: scale(1);
-  }
+  0% { transform: scale(1); }
   18% {
     transform: scaleX(calc(1 + var(--provision-strain) * 0.35))
       scaleY(calc(1 - var(--provision-strain) * 0.75));
   }
-  44% {
-    transform: scale(calc(1 + var(--provision-strain)));
-  }
-  66%,
-  100% {
-    transform: scale(1);
-  }
+  44% { transform: scale(calc(1 + var(--provision-strain))); }
+  66%, 100% { transform: scale(1); }
 }
 
 /* A third of every cycle is rest — that pause is what keeps it reading as
@@ -1702,29 +1454,16 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* Idle — gentle 4.5s breathing scale, mirroring macOS startBreathing(). */
 @keyframes voice-avatar-idle-breathe {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.03);
-  }
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
 }
 
 /* Idle — faint invitation ring that swells and fades, inviting the user to
  * speak without the urgency of the listening sonar. */
 @keyframes voice-avatar-invite-ring {
-  0% {
-    opacity: 0;
-    transform: scale(0.96);
-  }
-  50% {
-    opacity: 0.35;
-  }
-  100% {
-    opacity: 0;
-    transform: scale(1.12);
-  }
+  0% { opacity: 0; transform: scale(0.96); }
+  50% { opacity: 0.35; }
+  100% { opacity: 0; transform: scale(1.12); }
 }
 
 .voice-avatar--idle {
@@ -1741,13 +1480,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * carried by the top-edge waves coming in (see voice-listening-waves.tsx), not by
  * the avatar reacting to mic amplitude. */
 @keyframes voice-avatar-soft-pulse {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.02);
-  }
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.02); }
 }
 
 .voice-avatar--listening {
@@ -1757,13 +1491,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* Thinking — "stillness with intent": a slow brightness/saturation cycle on
  * the avatar itself. Deliberately NOT a spinner. */
 @keyframes voice-avatar-think-glow {
-  0%,
-  100% {
-    filter: brightness(1) saturate(1);
-  }
-  50% {
-    filter: brightness(1.12) saturate(1.35);
-  }
+  0%, 100% { filter: brightness(1) saturate(1); }
+  50% { filter: brightness(1.12) saturate(1.35); }
 }
 
 .voice-avatar--thinking {
@@ -1776,15 +1505,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* Reconnecting — dimmed, slow pulse, distinct from idle-breathe (full opacity)
  * and think-glow (brightens rather than dims). */
 @keyframes voice-avatar-reconnect-pulse {
-  0%,
-  100% {
-    opacity: 0.45;
-    transform: scale(0.98);
-  }
-  50% {
-    opacity: 0.7;
-    transform: scale(1.01);
-  }
+  0%, 100% { opacity: 0.45; transform: scale(0.98); }
+  50% { opacity: 0.7; transform: scale(1.01); }
 }
 
 .voice-avatar--reconnecting {
@@ -2018,34 +1740,22 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 /* Palette: aurora = fixed cyan→indigo (matches the listening sonar). */
-.voice-listening-waves--aurora.voice-listening-waves--fill
-  .voice-wave--back
-  path {
+.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--back path {
   fill: rgba(99, 102, 241, 0.16);
 }
-.voice-listening-waves--aurora.voice-listening-waves--fill
-  .voice-wave--mid
-  path {
+.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--mid path {
   fill: rgba(79, 140, 255, 0.2);
 }
-.voice-listening-waves--aurora.voice-listening-waves--fill
-  .voice-wave--front
-  path {
+.voice-listening-waves--aurora.voice-listening-waves--fill .voice-wave--front path {
   fill: rgba(34, 211, 238, 0.26);
 }
-.voice-listening-waves--aurora.voice-listening-waves--line
-  .voice-wave--back
-  path {
+.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--back path {
   stroke: rgba(99, 102, 241, 0.5);
 }
-.voice-listening-waves--aurora.voice-listening-waves--line
-  .voice-wave--mid
-  path {
+.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--mid path {
   stroke: rgba(79, 140, 255, 0.62);
 }
-.voice-listening-waves--aurora.voice-listening-waves--line
-  .voice-wave--front
-  path {
+.voice-listening-waves--aurora.voice-listening-waves--line .voice-wave--front path {
   stroke: rgba(34, 211, 238, 0.78);
 }
 
@@ -2060,39 +1770,27 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 .voice-listening-waves--accent {
   --wave-accent: var(--avatar-accent, #6366f1);
 }
-.voice-listening-waves--accent.voice-listening-waves--fill
-  .voice-wave--back
-  path {
+.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--back path {
   fill: rgba(99, 102, 241, 0.16);
   fill: color-mix(in srgb, var(--wave-accent) 16%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--fill
-  .voice-wave--mid
-  path {
+.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--mid path {
   fill: rgba(79, 140, 255, 0.2);
   fill: color-mix(in srgb, var(--wave-accent) 24%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--fill
-  .voice-wave--front
-  path {
+.voice-listening-waves--accent.voice-listening-waves--fill .voice-wave--front path {
   fill: rgba(34, 211, 238, 0.26);
   fill: color-mix(in srgb, var(--wave-accent) 34%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--line
-  .voice-wave--back
-  path {
+.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--back path {
   stroke: rgba(99, 102, 241, 0.5);
   stroke: color-mix(in srgb, var(--wave-accent) 50%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--line
-  .voice-wave--mid
-  path {
+.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--mid path {
   stroke: rgba(79, 140, 255, 0.62);
   stroke: color-mix(in srgb, var(--wave-accent) 66%, transparent);
 }
-.voice-listening-waves--accent.voice-listening-waves--line
-  .voice-wave--front
-  path {
+.voice-listening-waves--accent.voice-listening-waves--line .voice-wave--front path {
   stroke: rgba(34, 211, 238, 0.78);
   stroke: color-mix(in srgb, var(--wave-accent) 82%, transparent);
 }
@@ -2103,9 +1801,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 .voice-listening-waves--tone {
   --wave-tone: var(--room-fg, #ffffff);
 }
-.voice-listening-waves--tone.voice-listening-waves--fill
-  .voice-wave--back
-  path {
+.voice-listening-waves--tone.voice-listening-waves--fill .voice-wave--back path {
   fill: rgba(255, 255, 255, 0.1);
   fill: color-mix(in srgb, var(--wave-tone) 12%, transparent);
 }
@@ -2113,15 +1809,11 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   fill: rgba(255, 255, 255, 0.14);
   fill: color-mix(in srgb, var(--wave-tone) 17%, transparent);
 }
-.voice-listening-waves--tone.voice-listening-waves--fill
-  .voice-wave--front
-  path {
+.voice-listening-waves--tone.voice-listening-waves--fill .voice-wave--front path {
   fill: rgba(255, 255, 255, 0.2);
   fill: color-mix(in srgb, var(--wave-tone) 24%, transparent);
 }
-.voice-listening-waves--tone.voice-listening-waves--line
-  .voice-wave--back
-  path {
+.voice-listening-waves--tone.voice-listening-waves--line .voice-wave--back path {
   stroke: rgba(255, 255, 255, 0.42);
   stroke: color-mix(in srgb, var(--wave-tone) 45%, transparent);
 }
@@ -2129,9 +1821,7 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   stroke: rgba(255, 255, 255, 0.55);
   stroke: color-mix(in srgb, var(--wave-tone) 58%, transparent);
 }
-.voice-listening-waves--tone.voice-listening-waves--line
-  .voice-wave--front
-  path {
+.voice-listening-waves--tone.voice-listening-waves--line .voice-wave--front path {
   stroke: rgba(255, 255, 255, 0.72);
   stroke: color-mix(in srgb, var(--wave-tone) 75%, transparent);
 }

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -93,6 +93,7 @@ import {
 import { isPopoutWindow } from "@/runtime/popout-window";
 import { GlobalPushToTalkBridge } from "@/domains/chat/voice/global-push-to-talk-bridge";
 import { TimezoneSync } from "@/components/timezone-sync";
+import { RoutePendingIndicator } from "@/components/route-pending-indicator";
 import { StatusBanner } from "@/components/status-banner";
 import { UpdateToast } from "@/components/update-toast";
 import { retireAssistant } from "@/assistant/retire-service";
@@ -585,9 +586,13 @@ export function RootLayout() {
       <UpdateToast />
       {appShellOwnsTopInset ? <StatusBanner placement="web" /> : null}
       <div
-        className="flex min-w-0 flex-col overflow-hidden w-full"
+        className="relative flex min-w-0 flex-col overflow-hidden w-full"
         style={{ flex: "1 1 0%", minHeight: 0 }}
       >
+        {/* Inside the shell rather than fixed to the viewport, so it sits
+            below the safe-area inset and the status banner instead of under
+            the notch. */}
+        <RoutePendingIndicator />
         <Outlet />
       </div>
 

--- a/clients/web/src/routes.test.ts
+++ b/clients/web/src/routes.test.ts
@@ -309,3 +309,34 @@ describe("Activity route compatibility", () => {
     );
   });
 });
+
+describe("Settings route prefetching", () => {
+  // What `prefetchRoute` warms is every `lazy` on the matched branch, so the
+  // number of lazy properties on this branch is the number of round trips a
+  // cold tap on Settings pays before the router will commit. The layout and
+  // its index page are separate chunks, and warming the root has to cover
+  // both: warming only the layout would still leave the page to fetch on tap.
+  test("the Settings root carries the layout chunk and its index page chunk", async () => {
+    const matches =
+      matchRoutes(routeTree as never, "/assistant/settings") ?? [];
+    const lazyRoutes = matches.filter(
+      (m) => (m.route as { lazy?: unknown }).lazy !== undefined,
+    );
+
+    expect(lazyRoutes).toHaveLength(2);
+
+    const loaded = await Promise.all(
+      lazyRoutes.map(async (m) =>
+        (
+          m.route as { lazy: { Component: () => Promise<unknown> } }
+        ).lazy.Component(),
+      ),
+    );
+    expect(loaded).toContain(
+      (await import("@/domains/settings/settings-layout")).SettingsLayout,
+    );
+    expect(loaded).toContain(
+      (await import("@/domains/settings/pages/general-page")).GeneralPage,
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

Tapping Settings resolves two lazy chunks, the layout and its landing page, before the router will commit. Nothing warmed them and nothing reported the wait, so the previous screen sat frozen with no feedback for a round trip. This warms them when the menu that leads to Settings opens, and adds a pending bar for the waits that warming does not catch.

## What changes for the user

| Moment | Before | After |
| --- | --- | --- |
| Opening the preferences menu | Warms the feedback dialog's chunk | Also warms the Settings route, both of its chunks |
| Tapping Settings after the menu was open | Frozen screen for a chunk round trip | Chunks usually already in hand, so it commits immediately |
| Tapping Settings cold, or on a slow network | Frozen screen, no signal | A thin bar appears once the wait is long enough to notice |
| Any navigation that resolves quickly | Nothing | Nothing, the bar never paints |

## Why it is safe

- `prefetchRoute` is best effort by contract. It never throws, never awaits, dedupes by path, and a failure leaves the real navigation to fetch and own the error. This adds a second caller to a helper that already existed.
- The prefetch fires from the effect that already warms the feedback chunk on menu open, guarded by the same once-per-mount ref, so it costs one extra request at most and only when the menu is opened.
- `RoutePendingIndicator` derives entirely from `useNavigation()`. It holds no state and runs no timer, so it cannot outlive a navigation, get stuck on, or miss one.
- The delay before the bar is visible is a CSS `animation-delay` with `both`, so the element is transparent through the delay. Fast navigations are pixel-identical to today. This also keeps it clear of the convention that decorative timing must not drive React renders.
- It renders inside the app shell rather than fixed to the viewport, so the existing safe-area inset and status banner sit above it instead of it landing under the notch.
- It reuses the `indeterminate` keyframe and the track-plus-fill markup the setup and cleanup screens already use, so it is not a new visual idiom. Under reduced motion the sweep is stopped and the bar reads as a static rule.

## A choice worth flagging

The indicator is not restricted to Settings. The mechanism is identical for every lazy route, and a path allowlist would be arbitrary special-casing of the one route that happens to have been measured. With the CSS delay, routes that resolve quickly never show it, so nothing else visibly changes. The design library has a `ProgressBar`, but it is determinate and takes a `value`; a route transition has no progress to report, hence the indeterminate treatment already in the codebase.

## Tests

- `routes.test.ts`: the Settings root branch carries exactly two lazy chunks, and they resolve to `SettingsLayout` and `GeneralPage`. This is the claim that warming the root covers the landing page and not just the layout.
- `preferences-menu.test.tsx`: opening the menu warms the Settings route exactly once, and closing it does not ask again.
- `route-pending-indicator.test.tsx`: nothing renders while the router is idle; the bar appears while a lazy route is held unresolved and goes when it lands. The held-chunk router makes the pending window deterministic rather than timing-dependent.

Verified against the real route tree rather than a fixture, and confirmed separately that React Router does report a pending navigation while a lazy `Component` resolves, since the indicator depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->