### PR TITLE
Make Teleport respect plan storage and safely transfer large bundles

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,17 @@
 
 This file is the cross-system architecture index. Detailed designs live in domain docs close to code ownership.
 
+## Teleport storage
+
+The platform owns plan allowances and returns the managed destination's byte
+budget with the signed upload URL. The CLI passes that budget to the exporter
+and reconciles purchased storage after hatch. The platform checks the uploaded
+archive and passes the current allowance to the importer, which independently
+checks extracted bytes against free space before staging. Preflight validates
+archives as streams using the same byte and entry limits. Local transfers receive
+a signed download receipt at upload authorization; managed exports retain their
+platform job record and runtime compatibility checks.
+
 ## Architecture Docs
 
 | Domain                                      | Architecture Doc                                                                                   |

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22948,6 +22948,11 @@ paths:
             schema:
               type: object
               properties:
+                max_bundle_bytes:
+                  description: Maximum extracted bundle bytes allowed by the destination plan; free disk space can impose a lower limit.
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
                 upload_url:
                   type: string
                   format: uri
@@ -22996,6 +23001,11 @@ paths:
             schema:
               type: object
               properties:
+                max_bundle_bytes:
+                  description: Maximum extracted bundle bytes allowed by the destination plan; free disk space can impose a lower limit.
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
                 url:
                   description: A signed GCS URL pointing to the .vbundle archive (JSON body path only).
                   type: string
@@ -23054,6 +23064,11 @@ paths:
             schema:
               type: object
               properties:
+                max_bundle_bytes:
+                  description: Maximum extracted bundle bytes allowed by the destination plan; free disk space can impose a lower limit.
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
                 bundle_url:
                   type: string
                   format: uri
@@ -23088,8 +23103,8 @@ paths:
       summary: Dry-run import analysis
       description:
         Validate a .vbundle archive and return a report of what would change on import without modifying data.
-        Accepts raw bytes, multipart form data, or JSON `{ path }` pointing at a file staged under the workspace
-        `.restore-staging` directory.
+        Accepts raw bytes, multipart form data, or JSON `{ url, max_bundle_bytes? }` for a signed download URL, or `{
+        path }` pointing at a file staged under the workspace `.restore-staging` directory.
       tags:
         - migrations
       requestBody:
@@ -23099,6 +23114,14 @@ paths:
             schema:
               type: object
               properties:
+                url:
+                  type: string
+                  format: uri
+                max_bundle_bytes:
+                  description: Maximum extracted bundle bytes allowed by the destination plan; free disk space can impose a lower limit.
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
                 path:
                   description: Workspace-relative or absolute path to a staged .vbundle under .restore-staging (JSON body path only).
                   type: string
@@ -23240,6 +23263,11 @@ paths:
             schema:
               type: object
               properties:
+                max_bundle_bytes:
+                  description: Maximum extracted bundle bytes allowed by the destination plan; free disk space can impose a lower limit.
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
                 bundle_url:
                   type: string
                   format: uri

--- a/assistant/src/__tests__/migration-export-to-gcs.test.ts
+++ b/assistant/src/__tests__/migration-export-to-gcs.test.ts
@@ -570,3 +570,33 @@ describe("handleMigrationExportToGcs — URL validation", () => {
     expect(body.error.message).toContain("path_traversal");
   });
 });
+
+test("plan limit rejects export before uploading any data", async () => {
+  let uploads = 0;
+  const fixture = await startFixtureServer((_req, res) => {
+    uploads += 1;
+    res.end();
+  });
+  try {
+    const response = await callHandler(
+      handleMigrationExportToGcs,
+      new Request("http://localhost/v1/migrations/export-to-gcs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          upload_url: makeFakeSignedUploadUrl(fixture.port),
+          max_bundle_bytes: 1,
+        }),
+      }),
+      undefined,
+      202,
+    );
+    const accepted = (await response.json()) as AcceptedResponse;
+    const job = await waitForJobTerminal(accepted.job_id);
+    expect(job.status).toBe("failed");
+    expect(job.error?.code).toBe("bundle_too_large");
+    expect(uploads).toBe(0);
+  } finally {
+    await fixture.close();
+  }
+});

--- a/assistant/src/__tests__/migration-import-from-url.test.ts
+++ b/assistant/src/__tests__/migration-import-from-url.test.ts
@@ -104,6 +104,7 @@ import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
 import {
   _setUrlImportValidatorOptionsForTests,
   handleMigrationImport,
+  handleMigrationImportPreflight,
 } from "../runtime/routes/migration-routes.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { callHandler } from "./helpers/call-route-handler.js";
@@ -606,4 +607,37 @@ describe("handleMigrationImport — raw-bytes regression", () => {
     expect(body.success).toBe(true);
     expect(body.files.length).toBeGreaterThan(0);
   });
+});
+
+test("URL import and preflight enforce extracted plan bytes", async () => {
+  const bundlePath = makeSmallValidBundlePath(testParent);
+  const fixture = await startFixtureServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/octet-stream" });
+    createReadStream(bundlePath).pipe(res);
+  });
+  try {
+    for (const handler of [
+      handleMigrationImport,
+      handleMigrationImportPreflight,
+    ]) {
+      const response = await callHandler(
+        handler,
+        new Request("http://localhost/v1/migrations/import", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            url: makeFakeSignedUrl(fixture.port),
+            max_bundle_bytes: 1,
+          }),
+        }),
+      );
+      const body = await response.json();
+      expect(JSON.stringify(body)).toContain("bundle_too_large");
+      expect(
+        existsSync(join(testWorkspaceRoot, "data", "db", "assistant.db")),
+      ).toBe(false);
+    }
+  } finally {
+    await fixture.close();
+  }
 });

--- a/assistant/src/archive/ustar-size.test.ts
+++ b/assistant/src/archive/ustar-size.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { MALFORMED_USTAR_SIZE, parseUstarSizeField } from "./ustar-size.js";
+import { extract } from "tar-stream";
+
+import {
+  MALFORMED_USTAR_SIZE,
+  parseUstarSizeField,
+  writeUstarSizeField,
+} from "./ustar-size.js";
 
 function headerWithSize(field: string): Uint8Array {
   const header = new Uint8Array(512);
@@ -29,4 +35,55 @@ describe("parseUstarSizeField", () => {
       MALFORMED_USTAR_SIZE,
     );
   });
+
+  test("rejects negative and unsafe base-256 sizes", () => {
+    const header = new Uint8Array(512);
+    header.fill(0xff, 124, 136);
+    expect(() => parseUstarSizeField(header)).toThrow(MALFORMED_USTAR_SIZE);
+    header[124] = 0x80;
+    expect(() => parseUstarSizeField(header)).toThrow(MALFORMED_USTAR_SIZE);
+  });
+});
+
+describe("writeUstarSizeField", () => {
+  test.each([
+    0,
+    1024,
+    8 * 1024 ** 3 - 1,
+    8 * 1024 ** 3,
+    32 * 1024 ** 3,
+    500 * 1024 ** 3,
+  ])(
+    "tar-stream and the buffered reader both decode a %d-byte file",
+    async (size) => {
+      const header = new Uint8Array(512);
+      header.set(Buffer.from("assistant.db"));
+      header[156] = "0".charCodeAt(0);
+      header.set(Buffer.from("ustar\0"), 257);
+      writeUstarSizeField(header, size);
+      header.fill(32, 148, 156);
+      const checksum = header.reduce((sum, byte) => sum + byte, 0);
+      header.set(
+        Buffer.from(`${checksum.toString(8).padStart(6, "0")}\0 `),
+        148,
+      );
+      expect(parseUstarSizeField(header)).toBe(size);
+
+      // Decode only the header so this covers large files without allocating their bodies.
+      const reader = extract();
+      try {
+        const decoded = new Promise<number>((resolve, reject) => {
+          reader.on("error", reject);
+          reader.on("entry", (entry, body) => {
+            body.on("error", () => {});
+            resolve(entry.size);
+          });
+        });
+        reader.write(header);
+        expect(await decoded).toBe(size);
+      } finally {
+        reader.destroy();
+      }
+    },
+  );
 });

--- a/assistant/src/archive/ustar-size.ts
+++ b/assistant/src/archive/ustar-size.ts
@@ -1,8 +1,27 @@
 export const MALFORMED_USTAR_SIZE = "malformed tar size field";
 
+/** Encode large files using the GNU base-256 extension beyond ustar's 8 GiB limit. */
+export function writeUstarSizeField(header: Uint8Array, size: number): void {
+  if (header.length < 136 || !Number.isSafeInteger(size) || size < 0) {
+    throw new Error(MALFORMED_USTAR_SIZE);
+  }
+  const raw = header.subarray(124, 136);
+  raw.fill(0);
+  if (size <= 0o77777777777) {
+    raw.set(new TextEncoder().encode(size.toString(8).padStart(11, "0")));
+    return;
+  }
+  let remaining = BigInt(size);
+  for (let i = raw.length - 1; i > 0; i--) {
+    raw[i] = Number(remaining & 255n);
+    remaining >>= 8n;
+  }
+  raw[0] = 0x80;
+}
+
 /**
- * Parse the ustar `size` field (bytes 124-135, octal, NUL or space
- * terminated). Rejects non-finite and negative values so a crafted header
+ * Parse the ustar `size` field (bytes 124-135), including GNU base-256.
+ * Rejects unsafe and negative values so a crafted header
  * cannot walk the archive cursor backwards.
  */
 export function parseUstarSizeField(header: Uint8Array): number {
@@ -10,13 +29,26 @@ export function parseUstarSizeField(header: Uint8Array): number {
     throw new Error(MALFORMED_USTAR_SIZE);
   }
   const raw = header.subarray(124, 136);
+  if (raw[0] & 0x80) {
+    if (raw[0] !== 0x80) {
+      throw new Error(MALFORMED_USTAR_SIZE);
+    }
+    let size = 0;
+    for (const byte of raw.subarray(1)) {
+      size = size * 256 + byte;
+    }
+    if (!Number.isSafeInteger(size)) {
+      throw new Error(MALFORMED_USTAR_SIZE);
+    }
+    return size;
+  }
   let end = 0;
   while (end < raw.length && raw[end] !== 0) {
     end++;
   }
   const sizeStr = new TextDecoder().decode(raw.subarray(0, end)).trim();
   const size = sizeStr ? Number.parseInt(sizeStr, 8) : 0;
-  if (!Number.isFinite(size) || size < 0) {
+  if (!Number.isSafeInteger(size) || size < 0) {
     throw new Error(MALFORMED_USTAR_SIZE);
   }
   return size;

--- a/assistant/src/runtime/migrations/__tests__/bundle-capacity.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/bundle-capacity.test.ts
@@ -1,0 +1,126 @@
+import * as fs from "node:fs";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { createGzip } from "node:zlib";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import { pack } from "tar-stream";
+
+import { buildVBundle, streamExportVBundle } from "../vbundle-builder.js";
+import { DefaultPathResolver } from "../vbundle-import-analyzer.js";
+import { streamCommitImport } from "../vbundle-streaming-importer.js";
+import { preflightBundleStream } from "../vbundle-streaming-preflight.js";
+import { buildTestManifest, defaultV1Options } from "./v1-test-helpers.js";
+
+const workspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
+const originalStatfs = fs.statfsSync(workspaceDir);
+let diskSpy: ReturnType<typeof spyOn> | undefined;
+afterEach(() => {
+  diskSpy?.mockRestore();
+});
+
+function reportFreeBytes(bytes: number): void {
+  diskSpy = spyOn(fs, "statfsSync").mockReturnValue({
+    ...originalStatfs,
+    bavail: bytes,
+    bsize: 1,
+  });
+}
+
+function declaredOnlyBundle(size: number): Readable {
+  const manifest = buildTestManifest({
+    contents: [
+      {
+        path: "workspace/data/db/assistant.db",
+        size_bytes: size,
+        sha256: "a".repeat(64),
+      },
+    ],
+  });
+  const tar = pack() as ReturnType<typeof pack> & {
+    entry(header: { name: string }, data: string): void;
+    finalize(): void;
+  };
+  tar.entry({ name: "manifest.json" }, JSON.stringify(manifest));
+  tar.finalize();
+  return tar.pipe(createGzip());
+}
+
+describe("Teleport capacity", () => {
+  test("an import above 16 GiB reaches content validation when space permits", async () => {
+    reportFreeBytes(100 * 1024 ** 3);
+    const result = await streamCommitImport({
+      source: declaredOnlyBundle(32 * 1024 ** 3),
+      workspaceDir,
+      pathResolver: new DefaultPathResolver(
+        workspaceDir,
+        join(workspaceDir, "hooks"),
+      ),
+      maxBundleBytes: 58 * 1024 ** 3,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === "validation_failed") {
+      expect(
+        result.errors.some((error) => error.code === "missing_entry"),
+      ).toBe(true);
+      expect(
+        result.errors.some((error) => error.code === "bundle_too_large"),
+      ).toBe(false);
+    } else {
+      throw new Error("Expected missing-entry validation");
+    }
+  });
+
+  test("an extracted bundle over the plan limit is rejected before staging", async () => {
+    reportFreeBytes(100 * 1024 ** 3);
+    const before = fs.readdirSync(workspaceDir);
+    const result = await streamCommitImport({
+      source: declaredOnlyBundle(32 * 1024 ** 3),
+      workspaceDir,
+      pathResolver: new DefaultPathResolver(
+        workspaceDir,
+        join(workspaceDir, "hooks"),
+      ),
+      maxBundleBytes: 28 * 1024 ** 3,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === "validation_failed") {
+      expect(result.errors[0]?.code).toBe("bundle_too_large");
+    } else {
+      throw new Error("Expected size validation");
+    }
+    expect(fs.readdirSync(workspaceDir)).toEqual(before);
+  });
+
+  test("preflight checks extracted bytes against remaining space without writing", async () => {
+    reportFreeBytes(2 * 1024 ** 3 + 100);
+    const bundle = buildVBundle({
+      ...defaultV1Options(),
+      files: [
+        { path: "workspace/data/db/assistant.db", data: new Uint8Array(1024) },
+      ],
+    });
+    const before = fs.readdirSync(workspaceDir);
+    const result = await preflightBundleStream(
+      Readable.from([bundle.archive]),
+      new DefaultPathResolver(workspaceDir, join(workspaceDir, "hooks")),
+      workspaceDir,
+    );
+    expect(result.can_import).toBe(false);
+    expect("validation" in result && result.validation.errors[0]?.code).toBe(
+      "bundle_too_large",
+    );
+    expect(fs.readdirSync(workspaceDir)).toEqual(before);
+  });
+
+  test("export rejects oversized data before hashing or writing an archive", async () => {
+    await expect(
+      streamExportVBundle({
+        ...defaultV1Options(),
+        workspaceDir,
+        credentials: [{ account: "test-key", value: "large value" }],
+        maxBundleBytes: 1,
+      }),
+    ).rejects.toThrow("destination allows 1 bytes");
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/bundle-capacity.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/bundle-capacity.test.ts
@@ -123,4 +123,60 @@ describe("Teleport capacity", () => {
       }),
     ).rejects.toThrow("destination allows 1 bytes");
   });
+
+  test("preflight hashes existing destination files without reading them into a buffer", async () => {
+    reportFreeBytes(100 * 1024 ** 3);
+    const data = new Uint8Array(128 * 1024).fill(1);
+    fs.writeFileSync(join(workspaceDir, "capacity-existing.bin"), data);
+    const bundle = buildVBundle({
+      ...defaultV1Options(),
+      files: [
+        { path: "workspace/data/db/assistant.db", data: new Uint8Array() },
+        { path: "workspace/capacity-existing.bin", data },
+      ],
+    });
+    const bufferedRead = spyOn(fs, "readFileSync").mockImplementation(() => {
+      throw new Error("Preflight must stream existing files");
+    });
+    try {
+      const result = await preflightBundleStream(
+        Readable.from([bundle.archive]),
+        new DefaultPathResolver(workspaceDir, join(workspaceDir, "hooks")),
+        workspaceDir,
+      );
+      expect(result.can_import).toBe(true);
+      expect(
+        "files" in result &&
+          result.files.find((file) =>
+            file.path.endsWith("capacity-existing.bin"),
+          )?.action,
+      ).toBe("unchanged");
+      expect(bufferedRead).not.toHaveBeenCalled();
+    } finally {
+      bufferedRead.mockRestore();
+    }
+  });
+
+  test("preflight blocks incompatible transfer receipts before import", async () => {
+    reportFreeBytes(100 * 1024 ** 3);
+    const bundle = buildVBundle({
+      ...defaultV1Options(),
+      compatibility: {
+        min_runtime_version: "999.0.0",
+        max_runtime_version: null,
+      },
+      files: [
+        { path: "workspace/data/db/assistant.db", data: new Uint8Array() },
+      ],
+    });
+    const result = await preflightBundleStream(
+      Readable.from([bundle.archive]),
+      new DefaultPathResolver(workspaceDir, join(workspaceDir, "hooks")),
+      workspaceDir,
+    );
+    expect(result.can_import).toBe(false);
+    expect("validation" in result && result.validation.errors[0]?.code).toBe(
+      "version_incompatible",
+    );
+  });
 });

--- a/assistant/src/runtime/migrations/bundle-capacity.ts
+++ b/assistant/src/runtime/migrations/bundle-capacity.ts
@@ -1,0 +1,26 @@
+import { existsSync, statfsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { StreamingValidationError } from "./vbundle-streaming-validator.js";
+
+const IMPORT_HEADROOM_BYTES = 2 * 1024 ** 3;
+export const MAX_BUNDLE_ENTRIES = 100_000;
+
+/** Staging must coexist with the live workspace until the atomic swap. */
+export function getImportByteBudget(workspaceDir: string): number {
+  let path = resolve(workspaceDir);
+  while (!existsSync(path) && dirname(path) !== path) {
+    path = dirname(path);
+  }
+  const stats = statfsSync(path);
+  return Math.max(0, stats.bavail * stats.bsize - IMPORT_HEADROOM_BYTES);
+}
+
+export function assertBundleFits(sizeBytes: number, maxBytes: number): void {
+  if (!Number.isSafeInteger(sizeBytes) || sizeBytes > maxBytes) {
+    throw new StreamingValidationError(
+      "bundle_too_large",
+      `Bundle requires ${sizeBytes} bytes. The destination allows ${maxBytes} bytes. Reduce the data or increase destination storage before retrying.`,
+    );
+  }
+}

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -27,8 +27,10 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGzip, gzipSync } from "node:zlib";
 
+import { writeUstarSizeField } from "../../archive/ustar-size.js";
 import { sanitizeConfigForTransfer } from "../../config/sanitize-for-transfer.js";
 import { getLogger } from "../../util/logger.js";
+import { assertBundleFits } from "./bundle-capacity.js";
 import type { VBundleOriginMode } from "./origin-mode.js";
 import type {
   ManifestFileEntryType,
@@ -228,7 +230,7 @@ function createPaxPathEntry(name: string): Uint8Array {
   writeOctal(header, 100, 8, 0o644);
   writeOctal(header, 108, 8, 0);
   writeOctal(header, 116, 8, 0);
-  writeOctal(header, 124, 12, paxData.length);
+  writeUstarSizeField(header, paxData.length);
   writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
 
   // Type flag 'x' = PAX extended header for the next entry
@@ -286,7 +288,7 @@ function createTarEntry(
   writeOctal(header, 116, 8, 0);
 
   // File size (124-135) — symlink entries always carry size 0
-  writeOctal(header, 124, 12, isSymlink ? 0 : data.length);
+  writeUstarSizeField(header, isSymlink ? 0 : data.length);
 
   // Modification time (136-147)
   writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
@@ -662,6 +664,8 @@ export function walkDirectory(
 // ---------------------------------------------------------------------------
 
 export interface BuildExportVBundleOptions {
+  /** Destination allowance, checked before hashing and building the archive. */
+  maxBundleBytes?: number;
   /** Identity of the assistant that produced this bundle. */
   assistant: VBundleAssistantInfo;
   /** Where this bundle was produced. */
@@ -971,7 +975,7 @@ function createTarHeaderBlock(
   writeOctal(header, 116, 8, 0);
 
   // File size (124-135) — symlink entries always declare size=0
-  writeOctal(header, 124, 12, linkTarget !== undefined ? 0 : size);
+  writeUstarSizeField(header, linkTarget !== undefined ? 0 : size);
 
   // Modification time (136-147)
   writeOctal(header, 136, 12, Math.floor(Date.now() / 1000));
@@ -1252,6 +1256,15 @@ export async function streamExportVBundle(
   // ------------------------------------------------------------------
   // Pass 1: Compute SHA-256 checksums to build the manifest
   // ------------------------------------------------------------------
+
+  if (options.maxBundleBytes !== undefined) {
+    const sizeBytes = [
+      ...allFileMetadata,
+      ...sanitizedConfigEntries,
+      ...inMemoryEntries,
+    ].reduce((total, file) => total + file.size, 0);
+    assertBundleFits(sizeBytes, options.maxBundleBytes);
+  }
 
   const fileEntries: ManifestFileEntryType[] = [];
   for (const file of allFileMetadata) {

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -14,7 +14,14 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import {
+  closeSync,
+  createReadStream,
+  existsSync,
+  openSync,
+  readSync,
+  statSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 
 import { resolveGuardianPersonaPath } from "../../prompts/persona-resolver.js";
@@ -229,8 +236,21 @@ export class DefaultPathResolver implements PathResolver {
 // Hash helper
 // ---------------------------------------------------------------------------
 
-function sha256Hex(data: Uint8Array): string {
-  return createHash("sha256").update(data).digest("hex");
+function hashExistingFile(path: string): string {
+  const fd = openSync(path, "r");
+  try {
+    const hash = createHash("sha256");
+    const chunk = Buffer.allocUnsafe(64 * 1024);
+    for (;;) {
+      const size = readSync(fd, chunk, 0, chunk.length, null);
+      if (size === 0) {
+        return hash.digest("hex");
+      }
+      hash.update(chunk.subarray(0, size));
+    }
+  } finally {
+    closeSync(fd);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -251,6 +271,41 @@ interface AnalyzeImportOptions {
 export function analyzeImport(
   options: AnalyzeImportOptions,
 ): ImportDryRunReport {
+  const steps = analyzeImportSteps(options);
+  let step = steps.next();
+  while (!step.done) {
+    try {
+      step = steps.next(hashExistingFile(step.value));
+    } catch (err) {
+      step = steps.throw(err);
+    }
+  }
+  return step.value;
+}
+
+/** Compare destination files incrementally without blocking runtime request handling. */
+export async function analyzeImportAsync(
+  options: AnalyzeImportOptions,
+): Promise<ImportDryRunReport> {
+  const steps = analyzeImportSteps(options);
+  let step = steps.next();
+  while (!step.done) {
+    try {
+      const hash = createHash("sha256");
+      for await (const chunk of createReadStream(step.value)) {
+        hash.update(chunk);
+      }
+      step = steps.next(hash.digest("hex"));
+    } catch (err) {
+      step = steps.throw(err);
+    }
+  }
+  return step.value;
+}
+
+function* analyzeImportSteps(
+  options: AnalyzeImportOptions,
+): Generator<string, ImportDryRunReport, string> {
   const { manifest, pathResolver } = options;
   const files: ImportFileReport[] = [];
   const conflicts: ImportConflict[] = [];
@@ -338,8 +393,7 @@ export function analyzeImport(
       try {
         const stat = statSync(diskPath);
         currentSize = stat.size;
-        const diskData = new Uint8Array(readFileSync(diskPath));
-        currentSha256 = sha256Hex(diskData);
+        currentSha256 = yield diskPath;
       } catch {
         // If we cannot read the file, treat it as a conflict
         conflicts.push({

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -53,6 +53,11 @@ import { resetDb } from "../../persistence/db-connection.js";
 import { isGuardianPersonaCustomized } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
 import { APP_VERSION } from "../../version.js";
+import {
+  assertBundleFits,
+  getImportByteBudget,
+  MAX_BUNDLE_ENTRIES,
+} from "./bundle-capacity.js";
 import type { PathResolver } from "./vbundle-import-analyzer.js";
 import * as policy from "./vbundle-import-policy.js";
 import type {
@@ -79,23 +84,8 @@ const log = getLogger("vbundle-streaming-importer");
 // These cap the streaming importer's exposure to attacker-controlled bundle
 // inputs (e.g. a signed-URL migration from an untrusted source). Both caps
 // are exposed as optional `opts.maxBundleBytes` / `opts.maxBundleEntries`
-// parameters so tests can exercise the abort path with small fixtures —
-// production callers should omit the opts and rely on the defaults.
+// parameters. Managed imports also receive the platform's plan allowance.
 // ---------------------------------------------------------------------------
-
-/**
- * Byte ceiling for the cumulative size of all file data streamed from the
- * bundle. 16 GiB gives comfortable headroom over the 8 GB product limit
- * while still bounding worst-case disk use for the temp workspace.
- */
-const DEFAULT_MAX_BUNDLE_BYTES = 16 * 1024 * 1024 * 1024;
-
-/**
- * Entry-count ceiling for the bundle. 100k is well above the largest
- * workspace we ship; anything past that is almost certainly an attack or
- * a corrupted archive.
- */
-const DEFAULT_MAX_BUNDLE_ENTRIES = 100_000;
 
 /**
  * Prefixes used for scratch dirs the streaming importer creates INSIDE the
@@ -147,8 +137,7 @@ export interface StreamCommitArgs {
     credentials: Array<{ account: string; value: string }>,
   ) => Promise<void>;
   /**
-   * Test-only override for the bundle-size ceiling (bytes). Production
-   * callers should omit this and rely on the 16 GiB default.
+   * Plan allowance in bytes. Free space further bounds staging capacity.
    */
   maxBundleBytes?: number;
   /**
@@ -178,8 +167,8 @@ export async function streamCommitImport(
     maxBundleEntries,
   } = args;
 
-  const bundleByteCap = maxBundleBytes ?? DEFAULT_MAX_BUNDLE_BYTES;
-  const bundleEntryCap = maxBundleEntries ?? DEFAULT_MAX_BUNDLE_ENTRIES;
+  let bundleByteCap = maxBundleBytes ?? Number.MAX_SAFE_INTEGER;
+  const bundleEntryCap = maxBundleEntries ?? MAX_BUNDLE_ENTRIES;
 
   const realWorkspaceDir = resolve(workspaceDir);
 
@@ -303,6 +292,10 @@ export async function streamCommitImport(
   // the generator and lands in the catch block below.
   let entryIndex = 0;
   try {
+    bundleByteCap = Math.min(
+      bundleByteCap,
+      getImportByteBudget(realWorkspaceDir),
+    );
     const entries = parseVBundleStream(source);
     let expected: Map<
       string,
@@ -316,6 +309,10 @@ export async function streamCommitImport(
         const manifestResult = await readAndValidateManifest(entry);
         manifest = manifestResult.manifest;
         expected = manifestResult.expected;
+        assertBundleFits(
+          manifest.contents.reduce((total, file) => total + file.size_bytes, 0),
+          bundleByteCap,
+        );
 
         // Defense-in-depth: refuse to populate the temp tree when the
         // bundle's compat range excludes APP_VERSION. The version gate

--- a/assistant/src/runtime/migrations/vbundle-streaming-preflight.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-preflight.ts
@@ -1,12 +1,20 @@
 import { type Readable, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
+import { APP_VERSION } from "../../version.js";
 import {
   assertBundleFits,
   getImportByteBudget,
   MAX_BUNDLE_ENTRIES,
 } from "./bundle-capacity.js";
-import { analyzeImport, type PathResolver } from "./vbundle-import-analyzer.js";
+import {
+  analyzeImportAsync,
+  type PathResolver,
+} from "./vbundle-import-analyzer.js";
+import {
+  evaluateRuntimeCompatibility,
+  formatRuntimeCompatibilityMessage,
+} from "./vbundle-import-policy.js";
 import {
   createHashVerifier,
   readAndValidateManifest,
@@ -35,6 +43,19 @@ export async function preflightBundleStream(
       );
     }
     const { manifest, expected } = await readAndValidateManifest(first.value);
+    const compatibility = evaluateRuntimeCompatibility(
+      manifest.compatibility,
+      APP_VERSION,
+    );
+    if (!compatibility.ok) {
+      throw new StreamingValidationError(
+        "version_incompatible",
+        formatRuntimeCompatibilityMessage(
+          compatibility.bundle_compat,
+          compatibility.runtime_version,
+        ),
+      );
+    }
     assertBundleFits(
       manifest.contents.reduce((n, file) => n + file.size_bytes, 0),
       budget,
@@ -92,7 +113,7 @@ export async function preflightBundleStream(
         "Bundle is missing declared files",
       );
     }
-    return analyzeImport({ manifest, pathResolver });
+    return await analyzeImportAsync({ manifest, pathResolver });
   } catch (err) {
     if (err instanceof StreamingValidationError) {
       return {

--- a/assistant/src/runtime/migrations/vbundle-streaming-preflight.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-preflight.ts
@@ -1,0 +1,117 @@
+import { type Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import {
+  assertBundleFits,
+  getImportByteBudget,
+  MAX_BUNDLE_ENTRIES,
+} from "./bundle-capacity.js";
+import { analyzeImport, type PathResolver } from "./vbundle-import-analyzer.js";
+import {
+  createHashVerifier,
+  readAndValidateManifest,
+  StreamingValidationError,
+  verifySymlinkEntry,
+} from "./vbundle-streaming-validator.js";
+import { parseVBundleStream } from "./vbundle-tar-stream.js";
+
+export async function preflightBundleStream(
+  source: Readable,
+  pathResolver: PathResolver,
+  workspaceDir: string,
+  maxBundleBytes?: number,
+) {
+  const entries = parseVBundleStream(source);
+  try {
+    const budget = Math.min(
+      maxBundleBytes ?? Number.MAX_SAFE_INTEGER,
+      getImportByteBudget(workspaceDir),
+    );
+    const first = await entries.next();
+    if (first.done) {
+      throw new StreamingValidationError(
+        "empty_archive",
+        "Bundle archive is empty",
+      );
+    }
+    const { manifest, expected } = await readAndValidateManifest(first.value);
+    assertBundleFits(
+      manifest.contents.reduce((n, file) => n + file.size_bytes, 0),
+      budget,
+    );
+    if (manifest.contents.length > MAX_BUNDLE_ENTRIES) {
+      throw new StreamingValidationError(
+        "bundle_too_many_entries",
+        "Bundle contains more than 100000 entries",
+      );
+    }
+    const seen = new Set<string>();
+    let entryCount = 0;
+    let totalBytes = 0;
+    for await (const entry of entries) {
+      entryCount += 1;
+      if (entryCount > MAX_BUNDLE_ENTRIES) {
+        throw new StreamingValidationError(
+          "bundle_too_many_entries",
+          "Bundle contains more than 100000 entries",
+        );
+      }
+      totalBytes += entry.header.size ?? 0;
+      assertBundleFits(totalBytes, budget);
+      if (entry.header.type !== "file" && entry.header.type !== "symlink") {
+        entry.body.resume();
+        continue;
+      }
+      const path = entry.header.name;
+      const declared = expected.get(path);
+      if (!declared || seen.has(path)) {
+        throw new StreamingValidationError(
+          "manifest_mismatch",
+          `Unexpected or duplicate archive entry: ${path}`,
+          path,
+        );
+      }
+      seen.add(path);
+      if (entry.header.type === "symlink" || declared.linkTarget !== null) {
+        verifySymlinkEntry({ entry, expectedEntry: declared });
+      } else {
+        await pipeline(
+          entry.body,
+          createHashVerifier({ ...declared, archivePath: path }),
+          new Writable({
+            write(_chunk, _encoding, done) {
+              done();
+            },
+          }),
+        );
+      }
+    }
+    if (seen.size !== expected.size) {
+      throw new StreamingValidationError(
+        "manifest_mismatch",
+        "Bundle is missing declared files",
+      );
+    }
+    return analyzeImport({ manifest, pathResolver });
+  } catch (err) {
+    if (err instanceof StreamingValidationError) {
+      return {
+        can_import: false,
+        validation: {
+          is_valid: false as const,
+          errors: [
+            {
+              code: err.code,
+              message: err.message,
+              ...(err.archivePath && { path: err.archivePath }),
+            },
+          ],
+        },
+      };
+    }
+    throw err;
+  } finally {
+    await entries.return();
+    source.destroy();
+  }
+}

--- a/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-validator.ts
@@ -382,6 +382,16 @@ export function createHashVerifier(expected: {
           typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk;
         hash.update(buf);
         bytes += buf.length;
+        if (bytes > expected.size) {
+          callback(
+            new StreamingValidationError(
+              "entry_size",
+              `Entry exceeds its declared size of ${expected.size} bytes`,
+              expected.archivePath,
+            ),
+          );
+          return;
+        }
         callback(null, buf);
       } catch (err) {
         callback(err instanceof Error ? err : new Error(String(err)));

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -51,6 +51,7 @@ import { getWorkspaceDir, getWorkspaceHooksDir } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { assertBundleFits } from "../migrations/bundle-capacity.js";
 import {
   validateGcsSignedUrl,
   type ValidateGcsSignedUrlOptions,
@@ -87,11 +88,7 @@ import {
   type ImportCommitResult,
 } from "../migrations/vbundle-importer.js";
 import { streamCommitImport } from "../migrations/vbundle-streaming-importer.js";
-import {
-  readAndValidateManifest,
-  StreamingValidationError,
-} from "../migrations/vbundle-streaming-validator.js";
-import { parseVBundleStream } from "../migrations/vbundle-tar-stream.js";
+import { preflightBundleStream } from "../migrations/vbundle-streaming-preflight.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 import {
   BadGatewayError,
@@ -481,9 +478,20 @@ export async function handleMigrationExport(
 /** 60 minutes — matches the URL-body import fetch deadline. */
 const EXPORT_TO_GCS_PUT_TIMEOUT_MS = 60 * 60 * 1000;
 
+const MigrationByteLimit = z
+  .number()
+  .int()
+  .nonnegative()
+  .safe()
+  .optional()
+  .describe(
+    "Maximum extracted bundle bytes allowed by the destination plan; free disk space can impose a lower limit.",
+  );
+
 const MigrationExportToGcsBody = z.object({
   upload_url: z.string().url(),
   description: z.string().optional(),
+  max_bundle_bytes: MigrationByteLimit,
 });
 
 /**
@@ -658,10 +666,14 @@ export async function handleMigrationExportToGcs({ body }: RouteHandlerArgs) {
           secretsRedacted,
           credentials: collected.credentials,
           checkpoint: checkpointDbsForExport,
+          maxBundleBytes: parsed.data.max_bundle_bytes,
         });
 
         cleanup = result.cleanup;
         const { tempPath, size, manifest } = result;
+        if (parsed.data.max_bundle_bytes !== undefined) {
+          assertBundleFits(size, parsed.data.max_bundle_bytes);
+        }
 
         // Stream the temp file to GCS via PUT. Using Node's ReadableStream
         // bridge keeps peak memory bounded — we do NOT load the archive
@@ -842,6 +854,11 @@ export async function handleMigrationImportPreflight({
 }: RouteHandlerArgs) {
   const contentType = headers?.["content-type"] ?? "";
   if (contentType.includes("application/json")) {
+    if (typeof body?.url === "string") {
+      return handleMigrationPreflightFromGcs({
+        body: { bundle_url: body.url, max_bundle_bytes: body.max_bundle_bytes },
+      });
+    }
     return handleMigrationPreflightFromPath(body);
   }
 
@@ -1034,11 +1051,20 @@ export async function handleMigrationImport(
 /** 60 minutes — matches the gateway's upstream fetch deadline. */
 const URL_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
 
-const MigrationImportUrlBody = z.object({ url: z.string().min(1) });
+const MigrationImportUrlBody = z.object({
+  url: z.string().min(1),
+  max_bundle_bytes: MigrationByteLimit,
+});
 
-const MigrationImportPathBody = z.object({ path: z.string().min(1) });
+const MigrationImportPathBody = z.object({
+  path: z.string().min(1),
+  max_bundle_bytes: MigrationByteLimit,
+});
 
-const MigrationImportFromGcsBody = z.object({ bundle_url: z.string().url() });
+const MigrationImportFromGcsBody = z.object({
+  bundle_url: z.string().url(),
+  max_bundle_bytes: MigrationByteLimit,
+});
 
 /**
  * Marker attached to errors that originate from the upstream HTTP body
@@ -1280,6 +1306,7 @@ class GcsImportError extends Error {
 async function runGcsImport(
   url: string,
   _correlationId?: string,
+  maxBundleBytes?: number,
 ): Promise<ImportSummary> {
   // ── 1. Validate the URL (defense-in-depth; never log the raw URL).
   const validated = validateGcsSignedUrl(url, importValidatorOptions());
@@ -1471,6 +1498,7 @@ async function runGcsImport(
       source: taggedSource,
       pathResolver,
       workspaceDir: getWorkspaceDir(),
+      maxBundleBytes,
       importCredentials: async (bundleCredentials) => {
         // We can't mutate `result.report.warnings` in place here — the
         // streaming importer hasn't returned its report yet. Accumulate
@@ -1667,6 +1695,7 @@ async function handleMigrationImportFromPath(
       source,
       pathResolver,
       workspaceDir: getWorkspaceDir(),
+      maxBundleBytes: parsed.data.max_bundle_bytes,
       importCredentials: async (bundleCredentials) => {
         credentialsImported = await importBundleCredentialsIntoCes(
           bundleCredentials,
@@ -1719,67 +1748,12 @@ async function handleMigrationPreflightFromPath(
     throw err;
   }
 
-  const source = createReadStream(resolvedPath);
-  try {
-    const entries = parseVBundleStream(source);
-    const first = await entries.next();
-    if (first.done) {
-      return {
-        can_import: false,
-        validation: {
-          is_valid: false as const,
-          errors: [
-            {
-              code: "empty_archive",
-              message: "Bundle archive is empty",
-            },
-          ],
-        },
-      };
-    }
-
-    let manifest;
-    try {
-      ({ manifest } = await readAndValidateManifest(first.value));
-    } catch (err) {
-      if (err instanceof StreamingValidationError) {
-        return {
-          can_import: false,
-          validation: {
-            is_valid: false as const,
-            errors: [
-              {
-                code: err.code,
-                message: err.message,
-                ...(err.archivePath !== undefined && { path: err.archivePath }),
-              },
-            ],
-          },
-        };
-      }
-      throw err;
-    }
-
-    for await (const entry of entries) {
-      entry.body.resume();
-    }
-
-    const pathResolver = new DefaultPathResolver(
-      getWorkspaceDir(),
-      getWorkspaceHooksDir(),
-    );
-    return analyzeImport({ manifest, pathResolver });
-  } catch (err) {
-    if (err instanceof RouteError) {
-      throw err;
-    }
-    log.error({ err }, "Unexpected error during staged-path preflight");
-    throw new InternalError(
-      err instanceof Error ? err.message : "Unexpected import preflight error",
-    );
-  } finally {
-    source.destroy();
-  }
+  return preflightBundleStream(
+    createReadStream(resolvedPath),
+    new DefaultPathResolver(getWorkspaceDir(), getWorkspaceHooksDir()),
+    getWorkspaceDir(),
+    parsed.data.max_bundle_bytes,
+  );
 }
 
 /**
@@ -1800,7 +1774,11 @@ async function handleMigrationImportFromUrl(
   }
 
   try {
-    const summary = await runGcsImport(parsed.data.url);
+    const summary = await runGcsImport(
+      parsed.data.url,
+      undefined,
+      parsed.data.max_bundle_bytes,
+    );
     const { credentialsImported, ...report } = summary;
     return importCommitSuccessResult(report, credentialsImported);
   } catch (err) {
@@ -1899,7 +1877,7 @@ export async function handleMigrationImportFromGcs({ body }: RouteHandlerArgs) {
 
   try {
     const job = migrationJobs.startJob("import", async (jobRecord) =>
-      runGcsImport(bundle_url, jobRecord.id),
+      runGcsImport(bundle_url, jobRecord.id, parsed.data.max_bundle_bytes),
     );
     return {
       job_id: job.id,
@@ -1944,7 +1922,12 @@ export async function handleMigrationImportFromGcs({ body }: RouteHandlerArgs) {
 export async function handleMigrationPreflightFromGcs({
   body,
 }: RouteHandlerArgs) {
-  const parsed = z.object({ bundle_url: z.string().url() }).safeParse(body);
+  const parsed = z
+    .object({
+      bundle_url: z.string().url(),
+      max_bundle_bytes: MigrationByteLimit,
+    })
+    .safeParse(body);
   if (!parsed.success) {
     throw new BadRequestError(
       "Request body must be { bundle_url: string } with a valid URL",
@@ -2001,34 +1984,17 @@ export async function handleMigrationPreflightFromGcs({
     );
   }
 
-  const bytes = new Uint8Array(await upstream.arrayBuffer());
-  const validationResult = validateVBundle(bytes);
-
-  if (!validationResult.is_valid || !validationResult.manifest) {
-    return {
-      can_import: false,
-      validation: {
-        is_valid: false as const,
-        errors: validationResult.errors,
-      },
-    };
+  if (!upstream.body) {
+    throw new InternalError("Bundle response has no body");
   }
-
-  const pathResolver = new DefaultPathResolver(
+  return preflightBundleStream(
+    Readable.fromWeb(
+      upstream.body as unknown as import("node:stream/web").ReadableStream<Uint8Array>,
+    ),
+    new DefaultPathResolver(getWorkspaceDir(), getWorkspaceHooksDir()),
     getWorkspaceDir(),
-    getWorkspaceHooksDir(),
+    parsed.data.max_bundle_bytes,
   );
-
-  try {
-    return analyzeImport({ manifest: validationResult.manifest, pathResolver });
-  } catch (err) {
-    log.error({ err }, "Unexpected error during preflight-from-gcs analysis");
-    throw new InternalError(
-      err instanceof Error
-        ? err.message
-        : "Unexpected preflight-from-gcs error",
-    );
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2333,9 +2299,11 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Dry-run import analysis",
     description:
-      "Validate a .vbundle archive and return a report of what would change on import without modifying data. Accepts raw bytes, multipart form data, or JSON `{ path }` pointing at a file staged under the workspace `.restore-staging` directory.",
+      "Validate a .vbundle archive and return a report of what would change on import without modifying data. Accepts raw bytes, multipart form data, or JSON `{ url, max_bundle_bytes? }` for a signed download URL, or `{ path }` pointing at a file staged under the workspace `.restore-staging` directory.",
     tags: ["migrations"],
     requestBody: z.object({
+      url: z.string().url().optional(),
+      max_bundle_bytes: MigrationByteLimit,
       path: z
         .string()
         .min(1)
@@ -2366,6 +2334,7 @@ export const ROUTES: RouteDefinition[] = [
       "Commit a .vbundle archive import to disk — destructive. Accepts the bundle as raw bytes (application/octet-stream), multipart/form-data, a JSON body with `{ url }` carrying a signed URL the daemon fetches, or a JSON body with `{ path }` pointing at a file staged under the workspace `.restore-staging` directory.",
     tags: ["migrations"],
     requestBody: z.object({
+      max_bundle_bytes: MigrationByteLimit,
       url: z
         .string()
         .url()
@@ -2408,6 +2377,7 @@ export const ROUTES: RouteDefinition[] = [
       "Kick off a background export job that PUTs a freshly-built .vbundle archive to the supplied GCS signed URL. Returns 202 with a job_id the caller can poll via the job-status endpoint. Fails fast with 409 if another export job is already pending or running.",
     tags: ["migrations"],
     requestBody: z.object({
+      max_bundle_bytes: MigrationByteLimit,
       upload_url: z
         .string()
         .url()
@@ -2438,6 +2408,7 @@ export const ROUTES: RouteDefinition[] = [
       "Schedule a background import job that fetches the bundle at `bundle_url` and streams it through the importer. Returns 202 with a `job_id`; poll `GET /v1/migrations/jobs/{job_id}` for status. 409 if another import is already in flight.",
     tags: ["migrations"],
     requestBody: z.object({
+      max_bundle_bytes: MigrationByteLimit,
       bundle_url: z.string().url(),
     }),
     responseStatus: "202",
@@ -2466,6 +2437,7 @@ export const ROUTES: RouteDefinition[] = [
       "Fetch a .vbundle archive from a signed GCS download URL and return a preflight report — what would change if the bundle were imported — without writing anything to disk. Enables `vellum teleport --dry-run` against local and docker targets.",
     tags: ["migrations"],
     requestBody: z.object({
+      max_bundle_bytes: MigrationByteLimit,
       bundle_url: z
         .string()
         .url()

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,6 +14,25 @@ bun run ./src/index.ts <command> [options]
 
 ## Commands
 
+### `teleport`
+
+Move assistant data between local, Docker, and platform environments:
+
+```bash
+vellum teleport --from my-local --platform
+vellum teleport --from my-platform --local my-local
+```
+
+For a platform destination, Teleport uses the account's current storage tier,
+reserving space for runtime data. It checks both the archive and extracted data
+before upload, then waits for purchased storage to finish provisioning before
+importing. Import also checks free disk space because the existing workspace
+remains on disk until the replacement is verified. If the bundle is too large,
+reduce the exported data or increase the destination storage and retry.
+
+Local and Docker destinations use their available disk space. Bundles pass
+through object storage; the CLI does not buffer the data.
+
 ### Lifecycle: `ps`, `sleep`, `wake`
 
 Day-to-day process management for the assistant and gateway.

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -137,6 +137,9 @@ const platformRequestSignedUrlMock = mock<
   expiresAt: new Date(Date.now() + 3600_000).toISOString(),
 }));
 
+const platformEnsureProvisionedMock =
+  mock<typeof platformClient.platformEnsureProvisioned>();
+
 const platformImportBundleFromGcsMock = mock<
   typeof platformClient.platformImportBundleFromGcs
 >(async () => ({
@@ -216,6 +219,7 @@ mock.module("../lib/platform-client.js", () => ({
   hatchAssistant: hatchAssistantMock,
   platformPollJobStatus: platformPollJobStatusMock,
   platformRequestSignedUrl: platformRequestSignedUrlMock,
+  platformEnsureProvisioned: platformEnsureProvisionedMock,
   platformImportBundleFromGcs: platformImportBundleFromGcsMock,
   platformImportPreflightFromGcs: platformImportPreflightFromGcsMock,
   checkExistingPlatformAssistant: checkExistingPlatformAssistantMock,
@@ -454,6 +458,12 @@ beforeEach(() => {
     bundleKey: params.bundleKey ?? "bundle-key-123",
     expiresAt: new Date(Date.now() + 3600_000).toISOString(),
   }));
+  platformEnsureProvisionedMock.mockReset();
+  platformEnsureProvisionedMock.mockResolvedValue({
+    jobId: "storage",
+    type: "import",
+    status: "complete",
+  });
   platformImportBundleFromGcsMock.mockReset();
   platformImportBundleFromGcsMock.mockResolvedValue({
     statusCode: 200,
@@ -917,6 +927,68 @@ describe("resolveOrHatchTarget", () => {
 // ---------------------------------------------------------------------------
 
 describe("unified GCS flow — four directions", () => {
+  test("local to Docker uses the upload receipt without requiring a managed import job", async () => {
+    setArgv("--from", "my-local", "--docker", "my-docker", "--keep-source");
+    const source = makeEntry("my-local", { cloud: "local" });
+    const target = makeEntry("my-docker", { cloud: "docker" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? source : name === "my-docker" ? target : null,
+    );
+    platformRequestSignedUrlMock.mockResolvedValue({
+      url: "https://storage.googleapis.com/bucket/upload",
+      downloadUrl: "https://storage.googleapis.com/bucket/receipt",
+      bundleKey: "transfer-key",
+      expiresAt: "2030-01-01T00:00:00Z",
+    });
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+      expect(platformRequestSignedUrlMock).toHaveBeenCalledTimes(1);
+      expect(platformRequestSignedUrlMock.mock.calls[0]?.[0]).toMatchObject({
+        purpose: "transfer",
+        downloadConsumer: "runtime",
+      });
+      expect(localRuntimeImportFromGcsMock).toHaveBeenCalledWith(
+        target,
+        expect.any(String),
+        { bundleUrl: "https://storage.googleapis.com/bucket/receipt" },
+      );
+      expect(platformEnsureProvisionedMock).not.toHaveBeenCalled();
+    } finally {
+      restoreFetch();
+    }
+  });
+
+  test("plan allowance is forwarded before upload and provisioning finishes before import", async () => {
+    setArgv("--from", "my-local", "--platform");
+    const localEntry = makeEntry("my-local", { cloud: "local" });
+    findAssistantByNameMock.mockImplementation((name: string) =>
+      name === "my-local" ? localEntry : null,
+    );
+    platformRequestSignedUrlMock.mockResolvedValue({
+      url: "https://storage.googleapis.com/bucket/upload",
+      bundleKey: "bundle-key",
+      expiresAt: "2030-01-01T00:00:00Z",
+      maxContentLength: 58 * 1024 ** 3,
+    });
+    platformEnsureProvisionedMock.mockImplementation(async () => {
+      expect(hatchAssistantMock).toHaveBeenCalled();
+      expect(platformImportBundleFromGcsMock).not.toHaveBeenCalled();
+      return { jobId: "storage", type: "import", status: "complete" };
+    });
+    const restoreFetch = installTrackingFetch();
+    try {
+      await teleport();
+      expect(
+        localRuntimeExportToGcsMock.mock.calls[0]?.[2].maxBundleBytes,
+      ).toBe(58 * 1024 ** 3);
+      expect(platformEnsureProvisionedMock).toHaveBeenCalledTimes(1);
+      expect(platformImportBundleFromGcsMock).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreFetch();
+    }
+  });
+
   test("local → platform: requests upload URL, drives local runtime export, imports from GCS", async () => {
     setArgv("--from", "my-local", "--platform");
 

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -707,6 +707,7 @@ async function importToAssistant(
       let importPlatformToken = platformToken;
       const terminal = await pollJobUntilDone({
         label: "platform import",
+        timeoutMs: 2 * 60 * 60 * 1000,
         poll: () =>
           platformPollJobStatus(jobId, importPlatformToken, entry.runtimeUrl),
         refreshOn401: async () => {

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -22,6 +22,7 @@ import {
   platformImportBundleFromGcs,
   platformImportPreflightFromGcs,
   platformRequestSignedUrl,
+  platformEnsureProvisioned,
   VersionMismatchError,
   ensureSelfHostedLocalRegistration,
   injectCredentialsIntoAssistant,
@@ -374,7 +375,8 @@ async function exportFromAssistant(
   entry: AssistantEntry,
   cloud: string,
   bundlePlatformUrl?: string,
-): Promise<{ bundleKey: string }> {
+  targetEnv: "platform" | "local" | "docker" = "platform",
+): Promise<{ bundleKey: string; downloadUrl?: string }> {
   const platformToken = readPlatformToken();
   if (!platformToken) {
     console.error(
@@ -416,9 +418,16 @@ async function exportFromAssistant(
     // is reachable; a docker daemon runs inside a container and reaches the
     // host the same way managed pods do, so its URL must be signed for the
     // runtime-reachable storage endpoint.
-    const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
+    const {
+      url: uploadUrl,
+      bundleKey,
+      maxContentLength,
+      downloadUrl,
+    } = await platformRequestSignedUrl(
       {
         operation: "upload",
+        purpose: targetEnv === "platform" ? "import" : "transfer",
+        downloadConsumer: targetEnv === "docker" ? "runtime" : "client",
         minRuntimeVersion: sourceRuntimeVersion,
         maxRuntimeVersion: null,
         ...(cloud === "docker" ? { consumer: "runtime" as const } : {}),
@@ -439,6 +448,8 @@ async function exportFromAssistant(
         const r = await localRuntimeExportToGcs(entry, token, {
           uploadUrl,
           description: "teleport export",
+          maxBundleBytes:
+            targetEnv === "platform" ? maxContentLength : undefined,
         });
         return { jobId: r.jobId, token };
       });
@@ -484,7 +495,7 @@ async function exportFromAssistant(
       process.exit(1);
     }
 
-    return { bundleKey };
+    return { bundleKey, downloadUrl };
   }
 
   if (cloud === "vellum") {
@@ -517,6 +528,7 @@ async function exportFromAssistant(
     const { url: uploadUrl, bundleKey } = await platformRequestSignedUrl(
       {
         operation: "upload",
+        purpose: "export",
         minRuntimeVersion: sourceRuntimeVersion,
         maxRuntimeVersion: null,
         // The managed pod PUTs the bundle, not this CLI — the URL must be
@@ -592,6 +604,7 @@ async function importToAssistant(
   bundleKey: string,
   dryRun: boolean,
   bundlePlatformUrl?: string,
+  transferDownloadUrl?: string,
 ): Promise<void> {
   const platformToken = readPlatformToken();
   if (!platformToken) {
@@ -676,7 +689,9 @@ async function importToAssistant(
     }
 
     if (importResult.statusCode !== 202 && importResult.statusCode !== 200) {
-      console.error(`Error: Import failed (${importResult.statusCode})`);
+      console.error(
+        `Error: Import failed (${importResult.statusCode}): ${JSON.stringify(importResult.body)}`,
+      );
       process.exit(1);
     }
 
@@ -719,62 +734,7 @@ async function importToAssistant(
   }
 
   if (cloud === "local" || cloud === "docker") {
-    if (dryRun) {
-      console.log("Running preflight analysis...\n");
-
-      // Query the target runtime's version before requesting a signed
-      // download URL — the platform uses it for the bundle compatibility check.
-      let targetRuntimeVersion: string;
-      try {
-        const identity = await callRuntimeWithAuthRetry(entry, (token) =>
-          localRuntimeIdentity(entry, token),
-        );
-        targetRuntimeVersion = identity.version;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(
-          `Error: Could not read target runtime version from '${entry.assistantId}': ${msg}`,
-        );
-        console.error(`Try: vellum wake ${entry.assistantId}`);
-        process.exit(1);
-      }
-
-      let bundleUrl: string;
-      try {
-        const result = await platformRequestSignedUrl(
-          { operation: "download", bundleKey, targetRuntimeVersion },
-          platformToken,
-          bundlePlatformUrl,
-        );
-        bundleUrl = result.url;
-      } catch (err) {
-        if (err instanceof VersionMismatchError) {
-          console.error(`Error: ${err.message}`);
-          process.exit(1);
-        }
-        throw err;
-      }
-
-      const preflightData = await callRuntimeWithAuthRetry(entry, (token) =>
-        localRuntimePreflightFromGcs(entry, token, { bundleUrl }),
-      );
-      printPreflightSummary(preflightData as unknown as PreflightResponse);
-      return;
-    }
-
-    // Ask the platform for a signed download URL and hand it to the local
-    // runtime. The runtime streams the bundle straight out of GCS — the CLI
-    // never touches the bytes. The URL must target the same platform the
-    // bundle was uploaded to; otherwise the object won't exist on this
-    // platform's GCS bucket.
-    //
-    // The platform's vbundle version gate compares the **target runtime's**
-    // version against the bundle's compatibility range. The CLI and the
-    // target assistant's daemon can diverge (assistants upgrade
-    // independently), so we MUST query the target runtime's `/v1/identity`
-    // for its version rather than sending `cliPkg.version`. Sending the CLI
-    // version here would falsely 422 a valid import (or pass a bundle the
-    // target can't actually load) whenever the two drift apart.
+    // Compatibility is checked against the target runtime's own version.
     let targetRuntimeVersion: string;
     try {
       const identity = await callRuntimeWithAuthRetry(entry, (token) =>
@@ -795,15 +755,18 @@ async function importToAssistant(
 
     let bundleUrl: string;
     try {
-      const result = await platformRequestSignedUrl(
-        {
-          operation: "download",
-          bundleKey,
-          targetRuntimeVersion,
-        },
-        platformToken,
-        bundlePlatformUrl,
-      );
+      const result = transferDownloadUrl
+        ? { url: transferDownloadUrl }
+        : await platformRequestSignedUrl(
+            {
+              operation: "download",
+              consumer: cloud === "docker" ? "runtime" : "client",
+              bundleKey,
+              targetRuntimeVersion,
+            },
+            platformToken,
+            bundlePlatformUrl,
+          );
       bundleUrl = result.url;
     } catch (err) {
       if (err instanceof VersionMismatchError) {
@@ -814,6 +777,15 @@ async function importToAssistant(
         process.exit(1);
       }
       throw err;
+    }
+
+    if (dryRun) {
+      console.log("Running preflight analysis...\n");
+      const preflightData = await callRuntimeWithAuthRetry(entry, (token) =>
+        localRuntimePreflightFromGcs(entry, token, { bundleUrl }),
+      );
+      printPreflightSummary(preflightData as unknown as PreflightResponse);
+      return;
     }
 
     console.log("Importing data...");
@@ -1312,10 +1284,11 @@ export async function teleport(): Promise<void> {
             : undefined;
 
       console.log(`Exporting from ${from} (${fromCloud})...`);
-      const { bundleKey } = await exportFromAssistant(
+      const { bundleKey, downloadUrl } = await exportFromAssistant(
         fromEntry,
         fromCloud,
         bundlePlatformUrl,
+        targetEnv,
       );
       console.log(`Importing to ${existingTarget.assistantId} (${toCloud})...`);
       await importToAssistant(
@@ -1324,6 +1297,7 @@ export async function teleport(): Promise<void> {
         bundleKey,
         true,
         bundlePlatformUrl,
+        downloadUrl,
       );
     } else {
       // No existing target — just describe what would happen
@@ -1401,15 +1375,23 @@ export async function teleport(): Promise<void> {
     // resolveOrHatchTarget writes to the new entry).
     console.log(`Exporting from ${from} (${fromCloud})...`);
     const bundlePlatformUrl = targetPlatformUrl ?? getPlatformUrl();
-    const { bundleKey } = await exportFromAssistant(
+    const { bundleKey, downloadUrl } = await exportFromAssistant(
       fromEntry,
       fromCloud,
       bundlePlatformUrl,
+      targetEnv,
     );
 
     // Hatch (export succeeded — safe to create the target)
     const toEntry = await resolveOrHatchTarget(targetEnv, targetName);
     const toCloud = toEntry.cloud;
+
+    console.log("Preparing your plan storage...");
+    await pollJobUntilDone({
+      label: "plan storage provisioning",
+      timeoutMs: 15 * 60 * 1000,
+      poll: () => platformEnsureProvisioned(token, bundlePlatformUrl),
+    });
 
     // Import from GCS
     console.log(`Importing to ${toEntry.assistantId} (${toCloud})...`);
@@ -1419,6 +1401,7 @@ export async function teleport(): Promise<void> {
       bundleKey,
       false,
       bundlePlatformUrl,
+      downloadUrl,
     );
 
     console.log(`Teleport complete: ${from} → ${toEntry.assistantId}`);
@@ -1471,10 +1454,11 @@ export async function teleport(): Promise<void> {
 
   // Export from source (bundle lives in GCS after this returns).
   console.log(`Exporting from ${from} (${fromCloud})...`);
-  const { bundleKey } = await exportFromAssistant(
+  const { bundleKey, downloadUrl } = await exportFromAssistant(
     fromEntry,
     fromCloud,
     bundlePlatformUrl,
+    targetEnv,
   );
 
   if (sourceIsLocalOrDocker && targetIsLocalOrDocker && !keepSource) {
@@ -1554,6 +1538,7 @@ export async function teleport(): Promise<void> {
     bundleKey,
     false,
     bundlePlatformUrl,
+    downloadUrl,
   );
 
   // After successful import, inject fresh platform credentials if the

--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { pollJobUntilDone } from "../job-polling.js";
 import {
   platformPollJobStatus,
   platformEnsureProvisioned,
@@ -653,11 +654,46 @@ describe("plan provisioning", () => {
           : "processing",
       );
       expect(calls[0]?.url).toBe(
-        `${PLATFORM_URL}/v1/billing/subscription/onboarding/ensure-provisioned/`,
+        `${PLATFORM_URL}/v1/organizations/billing/subscription/onboarding/ensure-provisioned/`,
       );
       expect(calls[0]?.method).toBe("POST");
     },
   );
+
+  test.each([
+    ["no_provisionable_assistants", "processing"],
+    ["no_active_pro", "complete"],
+    ["no_targets", "complete"],
+  ] as const)("handles not_applicable reason %s", async (reason, expected) => {
+    const { fetchMock } = captureFetch(() =>
+      Response.json({ state: "not_applicable", reason }),
+    );
+    globalThis.fetch = fetchMock;
+    expect(
+      (await platformEnsureProvisioned(VAK_TOKEN, PLATFORM_URL)).status,
+    ).toBe(expected);
+  });
+
+  test("waits for a post-hatch race and resize to settle before completing", async () => {
+    const responses = [
+      { state: "not_applicable", reason: "no_provisionable_assistants" },
+      { state: "started" },
+      { state: "in_progress" },
+      { state: "already_done" },
+    ];
+    const { calls, fetchMock } = captureFetch(() =>
+      Response.json(responses.shift()),
+    );
+    globalThis.fetch = fetchMock;
+    const result = await pollJobUntilDone({
+      label: "plan storage provisioning",
+      intervalMs: 1,
+      timeoutMs: 1_000,
+      poll: () => platformEnsureProvisioned(VAK_TOKEN, PLATFORM_URL),
+    });
+    expect(result.status).toBe("complete");
+    expect(calls).toHaveLength(4);
+  });
 
   test("unknown state cannot silently permit an import", async () => {
     const { fetchMock } = captureFetch(() =>

--- a/cli/src/lib/__tests__/platform-client-signed-url.test.ts
+++ b/cli/src/lib/__tests__/platform-client-signed-url.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   platformPollJobStatus,
+  platformEnsureProvisioned,
   platformRequestSignedUrl,
   VersionMismatchError,
   type UnifiedJobStatus,
@@ -636,5 +637,35 @@ describe("platformPollJobStatus", () => {
     await expect(
       platformPollJobStatus("missing", VAK_TOKEN, PLATFORM_URL),
     ).rejects.toThrow(/Migration job not found/);
+  });
+});
+
+describe("plan provisioning", () => {
+  test.each(["already_done", "not_applicable", "started", "in_progress"])(
+    "maps %s to a poll status",
+    async (state) => {
+      const { calls, fetchMock } = captureFetch(() => Response.json({ state }));
+      globalThis.fetch = fetchMock;
+      const result = await platformEnsureProvisioned(VAK_TOKEN, PLATFORM_URL);
+      expect(result.status).toBe(
+        state === "already_done" || state === "not_applicable"
+          ? "complete"
+          : "processing",
+      );
+      expect(calls[0]?.url).toBe(
+        `${PLATFORM_URL}/v1/billing/subscription/onboarding/ensure-provisioned/`,
+      );
+      expect(calls[0]?.method).toBe("POST");
+    },
+  );
+
+  test("unknown state cannot silently permit an import", async () => {
+    const { fetchMock } = captureFetch(() =>
+      Response.json({ state: "unexpected" }),
+    );
+    globalThis.fetch = fetchMock;
+    await expect(
+      platformEnsureProvisioned(VAK_TOKEN, PLATFORM_URL),
+    ).rejects.toThrow("unknown state");
   });
 });

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -116,11 +116,14 @@ async function throwIfInProgress(
 export async function localRuntimeExportToGcs(
   entry: Pick<AssistantEntry, "cloud" | "runtimeUrl" | "assistantId">,
   token: string,
-  params: { uploadUrl: string; description?: string },
+  params: { uploadUrl: string; description?: string; maxBundleBytes?: number },
 ): Promise<{ jobId: string }> {
   const body: Record<string, unknown> = { upload_url: params.uploadUrl };
   if (params.description !== undefined) {
     body.description = params.description;
+  }
+  if (params.maxBundleBytes !== undefined) {
+    body.max_bundle_bytes = params.maxBundleBytes;
   }
 
   const response = await loopbackSafeFetch(

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -594,6 +594,34 @@ export async function hatchAssistant(
 
 const PLATFORM_FETCH_TIMEOUT_MS = 10_000;
 
+/** Reconcile purchased resources and expose progress to the shared poller. */
+export async function platformEnsureProvisioned(
+  token: string,
+  platformUrl?: string,
+): Promise<UnifiedJobStatus> {
+  const response = await loopbackSafeFetch(
+    `${platformUrl || getPlatformUrl()}/v1/billing/subscription/onboarding/ensure-provisioned/`,
+    {
+      method: "POST",
+      headers: await authHeaders(token, platformUrl),
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(30_000),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Plan storage provisioning failed: ${response.status}`);
+  }
+  const body = (await response.json()) as { state?: string };
+  const job = { jobId: "plan-storage", type: "import" as const };
+  if (body.state === "already_done" || body.state === "not_applicable") {
+    return { ...job, status: "complete", result: {} };
+  }
+  if (body.state === "started" || body.state === "in_progress") {
+    return { ...job, status: "processing" };
+  }
+  throw new Error("Plan storage provisioning returned an unknown state");
+}
+
 /**
  * Lightweight pre-check: returns the first active managed assistant for the
  * authenticated user, or `null` if none exists. Calls `GET /v1/assistants/`
@@ -1089,6 +1117,8 @@ export async function platformRequestSignedUrl(
     // "client" server-side. No effect in production, where both endpoints
     // are the same.
     consumer?: "client" | "runtime";
+    purpose?: "import" | "export" | "transfer";
+    downloadConsumer?: "client" | "runtime";
   },
   token: string,
   platformUrl?: string,
@@ -1097,6 +1127,7 @@ export async function platformRequestSignedUrl(
   bundleKey: string;
   expiresAt: string;
   maxContentLength?: number;
+  downloadUrl?: string;
 }> {
   const resolvedUrl = platformUrl || getPlatformUrl();
   const body: Record<string, unknown> = { operation: params.operation };
@@ -1118,6 +1149,12 @@ export async function platformRequestSignedUrl(
   }
   if (params.consumer !== undefined) {
     body.consumer = params.consumer;
+  }
+  if (params.purpose !== undefined) {
+    body.purpose = params.purpose;
+  }
+  if (params.downloadConsumer !== undefined) {
+    body.download_consumer = params.downloadConsumer;
   }
 
   const doRequest = async (): Promise<Response> =>
@@ -1144,12 +1181,16 @@ export async function platformRequestSignedUrl(
       bundle_key: string;
       expires_at: string;
       max_content_length?: number;
+      download_url?: string;
     };
     return {
       url: json.url,
       bundleKey: json.bundle_key,
       expiresAt: json.expires_at,
       maxContentLength: json.max_content_length,
+      ...(json.download_url !== undefined && {
+        downloadUrl: json.download_url,
+      }),
     };
   }
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -600,7 +600,7 @@ export async function platformEnsureProvisioned(
   platformUrl?: string,
 ): Promise<UnifiedJobStatus> {
   const response = await loopbackSafeFetch(
-    `${platformUrl || getPlatformUrl()}/v1/billing/subscription/onboarding/ensure-provisioned/`,
+    `${platformUrl || getPlatformUrl()}/v1/organizations/billing/subscription/onboarding/ensure-provisioned/`,
     {
       method: "POST",
       headers: await authHeaders(token, platformUrl),
@@ -611,8 +611,15 @@ export async function platformEnsureProvisioned(
   if (!response.ok) {
     throw new Error(`Plan storage provisioning failed: ${response.status}`);
   }
-  const body = (await response.json()) as { state?: string };
+  const body = (await response.json()) as { state?: string; reason?: string };
   const job = { jobId: "plan-storage", type: "import" as const };
+  if (
+    body.state === "not_applicable" &&
+    body.reason === "no_provisionable_assistants"
+  ) {
+    return { ...job, status: "processing" };
+  }
+  // Base plans legitimately return no_active_pro and need no paid resize.
   if (body.state === "already_done" || body.state === "not_applicable") {
     return { ...job, status: "complete", result: {} };
   }


### PR DESCRIPTION
## Summary
- Teleport reads the destination plan's upload allowance, rejects oversized exports before upload, and waits for purchased PVC storage to finish provisioning before managed import. Local and Docker transfers use explicit transfer receipts and the correct storage endpoint.
- Replace the fixed 16 GiB import limit with the supplied plan allowance and available disk space, retaining 2 GiB for headroom and checking extracted bytes before staging. Stream preflight validation and existing-file comparison, verify sizes and hashes without buffering whole files, and reject incompatible runtime versions during dry runs.
- Encode individual files above 8 GiB correctly in tar archives, and preserve existing requests by making all new runtime fields optional. Refresh runtime OpenAPI and document the flow.

## Validation
- 221 focused tests pass across CLI, platform-client, migration routes, streaming import/validation, bundle capacity, archive encoding, and export round trips.
- Assistant and CLI type checks and focused ESLint pass; runtime OpenAPI regenerated.
- Large-size boundary tests use declared sizes and archive headers rather than transferring hundreds of GiB.

## Rollout
Companion platform PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/10484

Deploy or release this runtime before the companion platform change enables larger imports. The updated CLI then consumes the plan allowance and storage provisioning endpoint. Existing callers retain their request shapes; legacy raw/multipart requests keep their buffer-size limits. Teleport uses the streaming URL paths, and the runtime also enforces destination free space. No database migration or infrastructure change is needed.

## Original prompt
Extend Teleport to respect the user's current plan so uploaded data fits the maximum PVC size, and audit the full flow for related fixes.
