### PR TITLE
fix(web): the Settings health read is cached and no longer waits on the record

### DIFF
--- a/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Tests for `useAssistantWithHealthz`.
+ *
+ * The properties that matter are that the health read is cached per assistant
+ * rather than re-issued on every mount of the Settings landing page, and that
+ * it does not queue behind the assistant record. Both are asserted by counting
+ * requests, because both were previously true only by accident of ordering.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type { getAssistant } from "@/assistant/api";
+import type { healthzGet } from "@/generated/daemon/sdk.gen";
+import type { HealthzGetResponse } from "@/generated/daemon/types.gen";
+import {
+  restoreStubbedModules,
+  stubModule,
+} from "@/utils/module-mock.test-helper";
+import type { toast } from "@vellumai/design-library";
+
+const HEALTHZ: HealthzGetResponse = {
+  version: "1.2.3",
+  disk: { usedMb: 10, totalMb: 100 },
+  cpu: { currentPercent: 5, maxCores: 2 },
+  memory: { currentMb: 200, maxMb: 1024 },
+} as HealthzGetResponse;
+
+let healthzCalls = 0;
+let healthzFails = false;
+
+const healthzGetMock = mock(async () => {
+  healthzCalls += 1;
+  if (healthzFails) {
+    throw new Error("healthz unreachable");
+  }
+  return { data: HEALTHZ, error: undefined, response: new Response(null) };
+});
+
+let assistantCalls = 0;
+/** Held open by default, so "healthz did not wait for it" is observable. */
+let releaseAssistant: (() => void) | null = null;
+
+const captureErrorMock = mock((_error: unknown, _tags: unknown) => {});
+const toastErrorMock = mock((_message: string) => {});
+
+// Every module below goes through `stubModule`, which spreads the real one and
+// registers the undo: `mock.module` is process-global in bun, so a partial
+// shape erases a module's other exports for whatever file loads it next.
+afterAll(restoreStubbedModules);
+
+stubModule(
+  "@/generated/daemon/sdk.gen",
+  await import("@/generated/daemon/sdk.gen"),
+  { healthzGet: healthzGetMock as unknown as typeof healthzGet },
+);
+
+stubModule("@/assistant/api", await import("@/assistant/api"), {
+  getAssistant: (async () => {
+    assistantCalls += 1;
+    if (releaseAssistant !== null) {
+      await new Promise<void>((resolve) => {
+        releaseAssistant = () => resolve();
+      });
+    }
+    return { ok: true, status: 200, data: { id: "a-1", name: "Assistant" } };
+  }) as unknown as typeof getAssistant,
+});
+
+stubModule(
+  "@/assistant/use-active-assistant-id",
+  await import("@/assistant/use-active-assistant-id"),
+  { useActiveAssistantId: () => "a-1" },
+);
+
+stubModule(
+  "@/hooks/use-is-org-ready",
+  await import("@/hooks/use-is-org-ready"),
+  {
+    useIsOrgReady: () => true,
+  },
+);
+
+stubModule(
+  "@/lib/sentry/capture-error",
+  await import("@/lib/sentry/capture-error"),
+  { captureError: captureErrorMock },
+);
+
+stubModule(
+  "@vellumai/design-library",
+  await import("@vellumai/design-library"),
+  {
+    toast: { error: toastErrorMock } as unknown as typeof toast,
+  },
+);
+
+const { useAssistantWithHealthz } =
+  await import("@/domains/settings/components/assistant-status-panel");
+
+/**
+ * One client across every render in a test, so a remount reads the cache the
+ * first mount populated. This is what the app does: the provider outlives any
+ * one Settings visit.
+ */
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+beforeEach(() => {
+  healthzCalls = 0;
+  assistantCalls = 0;
+  healthzFails = false;
+  releaseAssistant = null;
+  captureErrorMock.mockClear();
+  toastErrorMock.mockClear();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { staleTime: 10_000, retry: false } },
+  });
+});
+
+afterEach(cleanup);
+
+describe("useAssistantWithHealthz", () => {
+  test("a second visit reads the cached health instead of asking again", async () => {
+    // GIVEN one visit to Settings that loaded the health card
+    const first = renderHook(() => useAssistantWithHealthz(), { wrapper });
+    await waitFor(() => expect(first.result.current.healthz).not.toBeNull());
+    expect(healthzCalls).toBe(1);
+
+    // WHEN the user leaves Settings and comes back inside the stale window
+    first.unmount();
+    const second = renderHook(() => useAssistantWithHealthz(), { wrapper });
+
+    // THEN the card has its values with no request and no loading state, so it
+    // paints immediately rather than showing spinners again
+    expect(second.result.current.healthz).toEqual(HEALTHZ);
+    expect(second.result.current.healthzLoading).toBe(false);
+    expect(healthzCalls).toBe(1);
+  });
+
+  test("the health read does not queue behind the assistant record", async () => {
+    // GIVEN an assistant record that never resolves, standing in for a slow
+    // round trip over the tunnel
+    releaseAssistant = () => {};
+
+    // WHEN the hook mounts
+    renderHook(() => useAssistantWithHealthz(), { wrapper });
+
+    // THEN health is fetched anyway: the two reads go out together rather than
+    // nose to tail, which over a tunnel was a whole extra round trip
+    await waitFor(() => expect(healthzCalls).toBe(1));
+    expect(assistantCalls).toBe(1);
+  });
+
+  test("reports a failure the user is looking at", async () => {
+    healthzFails = true;
+
+    const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
+
+    await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    expect(result.current.healthz).toBeNull();
+  });
+
+  test("stays silent about a failure while polling through a resize", async () => {
+    // GIVEN a loaded card
+    const { result, unmount } = renderHook(() => useAssistantWithHealthz(), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.healthz).not.toBeNull());
+
+    // WHEN a resize poll is running and the endpoint goes unreachable, which
+    // is what a rolling pod looks like from here
+    healthzFails = true;
+    const polling = result.current.refetchUntilResized(HEALTHZ);
+    await waitFor(() => expect(result.current.healthzPolling).toBe(true));
+    // The poll sleeps a whole interval before its first read, so this outwaits
+    // `HEALTHZ_POLL_INTERVAL_MS` rather than the default second.
+    await waitFor(() => expect(healthzCalls).toBeGreaterThan(1), {
+      timeout: 10_000,
+    });
+
+    // THEN the expected unreachability is not reported to the user, and the
+    // last good reading stays on the cards rather than blanking
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(result.current.healthz).toEqual(HEALTHZ);
+
+    // Stand the poll down rather than leaving it running behind the suite.
+    unmount();
+    await polling;
+  }, 30_000);
+});

--- a/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Tests for `useAssistantWithHealthz`.
  *
- * The properties that matter are that the health read is cached per assistant
- * rather than re-issued on every mount of the Settings landing page, and that
- * it does not queue behind the assistant record. Both are asserted by counting
- * requests, because both were previously true only by accident of ordering.
+ * Two properties carry this hook. A revisit to Settings paints the last
+ * readings straight away instead of blanking the cards back to spinners, and
+ * the health read does not queue behind the assistant record. The resize watch
+ * is the third: the query owns its cadence, so the rule that decides it is
+ * tested as a pure function and the hook test only covers the watch opening
+ * and closing.
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -36,6 +38,15 @@ const HEALTHZ: HealthzGetResponse = {
   memory: { currentMb: 200, maxMb: 1024 },
 } as HealthzGetResponse;
 
+/** The same pod after a resize landed: more cores, more memory. */
+const RESIZED: HealthzGetResponse = {
+  ...HEALTHZ,
+  cpu: { currentPercent: 5, maxCores: 4 },
+  memory: { currentMb: 200, maxMb: 4096 },
+} as HealthzGetResponse;
+
+let healthzResponse: HealthzGetResponse = HEALTHZ;
+
 let healthzCalls = 0;
 let healthzFails = false;
 /** Set to hold the next response open, so an in-flight window is observable. */
@@ -49,7 +60,11 @@ const healthzGetMock = mock(async () => {
   if (healthzFails) {
     throw new Error("healthz unreachable");
   }
-  return { data: HEALTHZ, error: undefined, response: new Response(null) };
+  return {
+    data: healthzResponse,
+    error: undefined,
+    response: new Response(null),
+  };
 });
 
 let orgReadiness: "ready" | "resolving" | "unavailable" = "ready";
@@ -111,7 +126,7 @@ stubModule(
   },
 );
 
-const { useAssistantWithHealthz } =
+const { useAssistantWithHealthz, resizePollInterval } =
   await import("@/domains/settings/components/assistant-status-panel");
 
 /**
@@ -129,34 +144,70 @@ beforeEach(() => {
   healthzCalls = 0;
   assistantCalls = 0;
   healthzFails = false;
+  healthzResponse = HEALTHZ;
   holdHealthz = null;
   orgReadiness = "ready";
   releaseAssistant = null;
   captureErrorMock.mockClear();
   toastErrorMock.mockClear();
   queryClient = new QueryClient({
-    defaultOptions: { queries: { staleTime: 10_000, retry: false } },
+    defaultOptions: { queries: { retry: false } },
   });
 });
 
 afterEach(cleanup);
 
+describe("resizePollInterval", () => {
+  const watch = { baseline: HEALTHZ, until: 1_000 };
+
+  test("does not poll when no resize is being watched", () => {
+    expect(resizePollInterval(HEALTHZ, null, 0)).toBe(false);
+  });
+
+  test("stops at the deadline even if the allocation never moved", () => {
+    expect(resizePollInterval(HEALTHZ, watch, 1_000)).toBe(false);
+    expect(resizePollInterval(HEALTHZ, watch, 2_000)).toBe(false);
+  });
+
+  test("keeps polling while the allocation still matches the baseline", () => {
+    expect(resizePollInterval(HEALTHZ, watch, 0)).toBeGreaterThan(0);
+  });
+
+  test("stops as soon as the allocation differs", () => {
+    expect(resizePollInterval(RESIZED, watch, 0)).toBe(false);
+  });
+
+  test("keeps polling until a baseline exists to compare against", () => {
+    // A resize started before any reading arrived: the first one back could
+    // still be the pre-resize values, so it cannot end the watch.
+    const unknown = { baseline: null, until: 1_000 };
+    expect(resizePollInterval(undefined, unknown, 0)).toBeGreaterThan(0);
+    expect(resizePollInterval(HEALTHZ, unknown, 0)).toBeGreaterThan(0);
+  });
+
+  test("keeps polling while the endpoint is still unreachable", () => {
+    // Mid-restart there is no reading at all, which is not a reason to stop.
+    expect(resizePollInterval(undefined, watch, 0)).toBeGreaterThan(0);
+  });
+});
+
 describe("useAssistantWithHealthz", () => {
-  test("a second visit reads the cached health instead of asking again", async () => {
+  test("a second visit paints the last readings instead of spinners", async () => {
     // GIVEN one visit to Settings that loaded the health card
     const first = renderHook(() => useAssistantWithHealthz(), { wrapper });
     await waitFor(() => expect(first.result.current.healthz).not.toBeNull());
-    expect(healthzCalls).toBe(1);
 
-    // WHEN the user leaves Settings and comes back inside the stale window
+    // WHEN the user leaves Settings and comes back
     first.unmount();
     const second = renderHook(() => useAssistantWithHealthz(), { wrapper });
 
-    // THEN the card has its values with no request and no loading state, so it
-    // paints immediately rather than showing spinners again
+    // THEN the values are on screen in the first render, with no loading state
+    // to blank the cards. These are live readings, so a fresh one is still
+    // fetched behind them: the cache is here to avoid the blank, not to stand
+    // in for a current number.
     expect(second.result.current.healthz).toEqual(HEALTHZ);
     expect(second.result.current.healthzLoading).toBe(false);
-    expect(healthzCalls).toBe(1);
+    await waitFor(() => expect(healthzCalls).toBe(2));
   });
 
   test("the health read does not queue behind the assistant record", async () => {
@@ -173,7 +224,7 @@ describe("useAssistantWithHealthz", () => {
     expect(assistantCalls).toBe(1);
   });
 
-  test("reports a failure the user is looking at", async () => {
+  test("reports a failure when there is nothing to show", async () => {
     healthzFails = true;
 
     const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
@@ -183,7 +234,26 @@ describe("useAssistantWithHealthz", () => {
     expect(result.current.healthz).toBeNull();
   });
 
-  test("waits for the organization header rather than reporting no metrics", async () => {
+  test("stays silent when a reading is already on the cards", async () => {
+    // GIVEN a loaded card
+    const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
+    await waitFor(() => expect(result.current.healthz).not.toBeNull());
+
+    // WHEN a later read fails, which is what a rolling pod looks like from here
+    healthzFails = true;
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    // THEN nothing interrupts the user, and the last reading stands. This is
+    // what keeps a resize quiet, without a flag that can surface the failure
+    // once the resize is over.
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(result.current.healthz).toEqual(HEALTHZ);
+  });
+
+  test("waits for the organization header rather than reporting no metrics", () => {
     // GIVEN a platform session whose organization header has not resolved yet
     orgReadiness = "resolving";
 
@@ -195,7 +265,7 @@ describe("useAssistantWithHealthz", () => {
     expect(result.current.healthzLoading).toBe(true);
   });
 
-  test("stops waiting once organization resolution has given up", async () => {
+  test("stops waiting once organization resolution has given up", () => {
     // GIVEN organization resolution that concluded with no usable id
     orgReadiness = "unavailable";
 
@@ -208,49 +278,36 @@ describe("useAssistantWithHealthz", () => {
     expect(result.current.healthz).toBeNull();
   });
 
-  test("stays silent about a failure while polling through a resize", async () => {
+  test("opens a resize watch and closes it when the allocation moves", async () => {
     // GIVEN a loaded card
-    const { result, unmount } = renderHook(() => useAssistantWithHealthz(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
     await waitFor(() => expect(result.current.healthz).not.toBeNull());
+    expect(result.current.healthzPolling).toBe(false);
 
-    // WHEN a resize poll is running and the endpoint goes unreachable, which
-    // is what a rolling pod looks like from here
-    healthzFails = true;
-    const polling = result.current.refetchUntilResized(HEALTHZ);
-    await waitFor(() => expect(result.current.healthzPolling).toBe(true));
-    // The poll sleeps a whole interval before its first read, so this outwaits
-    // `HEALTHZ_POLL_INTERVAL_MS` rather than the default second.
-    await waitFor(() => expect(healthzCalls).toBeGreaterThan(1), {
-      timeout: 10_000,
+    // WHEN a resize starts
+    act(() => {
+      result.current.refetchUntilResized(HEALTHZ);
     });
 
-    // THEN the expected unreachability is not reported to the user, and the
-    // last good reading stays on the cards rather than blanking
-    expect(captureErrorMock).not.toHaveBeenCalled();
-    expect(toastErrorMock).not.toHaveBeenCalled();
-    expect(result.current.healthz).toEqual(HEALTHZ);
+    // THEN the watch is open, which is what disables the resize controls
+    expect(result.current.healthzPolling).toBe(true);
 
-    // Stand the poll down rather than leaving it running behind the suite.
-    unmount();
-    await polling;
+    // WHEN the rolled pod comes back with the new allocation
+    healthzResponse = RESIZED;
+    await act(async () => {
+      await result.current.refetch();
+    });
 
-    // AND the swallowed failure does not outlive the poll. A later visit reads
-    // the same cache entry, so a poll failure left on it as the query's error
-    // would surface as a toast for a failure nobody was meant to see.
-    healthzFails = false;
-    renderHook(() => useAssistantWithHealthz(), { wrapper });
-    await waitFor(() => expect(healthzCalls).toBeGreaterThan(0));
-    expect(captureErrorMock).not.toHaveBeenCalled();
-    expect(toastErrorMock).not.toHaveBeenCalled();
-  }, 30_000);
+    // THEN the watch closes itself off the data, with no timer to cancel
+    await waitFor(() => expect(result.current.healthzPolling).toBe(false));
+    expect(result.current.healthz).toEqual(RESIZED);
+  });
 
   test("the refresh affordance reflects a refresh over existing values", async () => {
     // GIVEN a card that already has its values
     const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
     await waitFor(() => expect(result.current.healthz).not.toBeNull());
-    expect(result.current.healthzFetching).toBe(false);
+    await waitFor(() => expect(result.current.healthzFetching).toBe(false));
 
     // WHEN the user asks for a refresh, held open so the window is observable
     let releaseRefresh = (): void => {};

--- a/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
@@ -17,7 +17,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
 import type { getAssistant } from "@/assistant/api";
@@ -38,9 +38,14 @@ const HEALTHZ: HealthzGetResponse = {
 
 let healthzCalls = 0;
 let healthzFails = false;
+/** Set to hold the next response open, so an in-flight window is observable. */
+let holdHealthz: Promise<void> | null = null;
 
 const healthzGetMock = mock(async () => {
   healthzCalls += 1;
+  if (holdHealthz !== null) {
+    await holdHealthz;
+  }
   if (healthzFails) {
     throw new Error("healthz unreachable");
   }
@@ -124,6 +129,7 @@ beforeEach(() => {
   healthzCalls = 0;
   assistantCalls = 0;
   healthzFails = false;
+  holdHealthz = null;
   orgReadiness = "ready";
   releaseAssistant = null;
   captureErrorMock.mockClear();
@@ -229,5 +235,44 @@ describe("useAssistantWithHealthz", () => {
     // Stand the poll down rather than leaving it running behind the suite.
     unmount();
     await polling;
+
+    // AND the swallowed failure does not outlive the poll. A later visit reads
+    // the same cache entry, so a poll failure left on it as the query's error
+    // would surface as a toast for a failure nobody was meant to see.
+    healthzFails = false;
+    renderHook(() => useAssistantWithHealthz(), { wrapper });
+    await waitFor(() => expect(healthzCalls).toBeGreaterThan(0));
+    expect(captureErrorMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
   }, 30_000);
+
+  test("the refresh affordance reflects a refresh over existing values", async () => {
+    // GIVEN a card that already has its values
+    const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
+    await waitFor(() => expect(result.current.healthz).not.toBeNull());
+    expect(result.current.healthzFetching).toBe(false);
+
+    // WHEN the user asks for a refresh, held open so the window is observable
+    let releaseRefresh = (): void => {};
+    holdHealthz = new Promise<void>((resolve) => {
+      releaseRefresh = () => resolve();
+    });
+    let refreshing: Promise<void> = Promise.resolve();
+    act(() => {
+      refreshing = result.current.refetch();
+    });
+
+    // THEN the in-flight signal is raised even though there is nothing to
+    // load: `healthzLoading` stays false because the values are still on
+    // screen, so the button needs its own signal to spin on
+    await waitFor(() => expect(result.current.healthzFetching).toBe(true));
+    expect(result.current.healthzLoading).toBe(false);
+    expect(result.current.healthz).toEqual(HEALTHZ);
+
+    await act(async () => {
+      releaseRefresh();
+      await refreshing;
+    });
+    await waitFor(() => expect(result.current.healthzFetching).toBe(false));
+  });
 });

--- a/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.test.tsx
@@ -47,6 +47,7 @@ const healthzGetMock = mock(async () => {
   return { data: HEALTHZ, error: undefined, response: new Response(null) };
 });
 
+let orgReadiness: "ready" | "resolving" | "unavailable" = "ready";
 let assistantCalls = 0;
 /** Held open by default, so "healthz did not wait for it" is observable. */
 let releaseAssistant: (() => void) | null = null;
@@ -87,7 +88,7 @@ stubModule(
   "@/hooks/use-is-org-ready",
   await import("@/hooks/use-is-org-ready"),
   {
-    useIsOrgReady: () => true,
+    useOrgHeaderReadiness: () => orgReadiness,
   },
 );
 
@@ -123,6 +124,7 @@ beforeEach(() => {
   healthzCalls = 0;
   assistantCalls = 0;
   healthzFails = false;
+  orgReadiness = "ready";
   releaseAssistant = null;
   captureErrorMock.mockClear();
   toastErrorMock.mockClear();
@@ -172,6 +174,31 @@ describe("useAssistantWithHealthz", () => {
 
     await waitFor(() => expect(captureErrorMock).toHaveBeenCalledTimes(1));
     expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    expect(result.current.healthz).toBeNull();
+  });
+
+  test("waits for the organization header rather than reporting no metrics", async () => {
+    // GIVEN a platform session whose organization header has not resolved yet
+    orgReadiness = "resolving";
+
+    const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
+
+    // THEN nothing is requested headerless, and the cards read as loading
+    // rather than falling through to their empty dashes
+    expect(healthzCalls).toBe(0);
+    expect(result.current.healthzLoading).toBe(true);
+  });
+
+  test("stops waiting once organization resolution has given up", async () => {
+    // GIVEN organization resolution that concluded with no usable id
+    orgReadiness = "unavailable";
+
+    const { result } = renderHook(() => useAssistantWithHealthz(), { wrapper });
+
+    // THEN the surface falls through to its empty state instead of holding a
+    // spinner for as long as the page is open
+    expect(healthzCalls).toBe(0);
+    expect(result.current.healthzLoading).toBe(false);
     expect(result.current.healthz).toBeNull();
   });
 

--- a/clients/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -4,17 +4,12 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
-import {
-  type Assistant,
-  getAssistant,
-  getAssistantHealthz,
-} from "@/assistant/api";
+import { type Assistant, getAssistant } from "@/assistant/api";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { CapacityBar } from "@/domains/settings/components/capacity-bar";
 import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-version-unlock";
@@ -51,6 +46,42 @@ function allocationChanged(
   );
 }
 
+/** What a post-resize watch is waiting for. */
+export interface ResizeWatch {
+  /**
+   * The allocation to watch for a change from. Null when nothing had loaded
+   * when the resize started: the first reading after that could still be the
+   * pre-resize values, so it is adopted as the baseline rather than read as
+   * the resized allocation.
+   */
+  baseline: HealthzGetResponse | null;
+  /** Wall clock. The watch ends here whether or not the allocation moved. */
+  until: number;
+}
+
+/**
+ * The health query's `refetchInterval` decision: the cadence to poll at, or
+ * `false` to stop.
+ *
+ * At module scope so the tests exercise the same code path the runtime does.
+ * A copy of this rule in a test helper would let the two drift.
+ */
+export function resizePollInterval(
+  data: HealthzGetResponse | undefined,
+  watch: ResizeWatch | null,
+  now: number,
+): number | false {
+  if (watch === null || now >= watch.until) {
+    return false;
+  }
+  if (data === undefined || watch.baseline === null) {
+    return HEALTHZ_POLL_INTERVAL_MS;
+  }
+  return allocationChanged(data, watch.baseline)
+    ? false
+    : HEALTHZ_POLL_INTERVAL_MS;
+}
+
 export interface AssistantWithHealthz {
   assistant: Assistant | null;
   assistantLoading: boolean;
@@ -62,11 +93,12 @@ export interface AssistantWithHealthz {
   healthzPolling: boolean;
   refetch: () => Promise<void>;
   /**
-   * Refetch repeatedly until the reported CPU/memory allocation differs from
-   * `baseline` (the resize has landed) or a timeout elapses. Tolerates the
-   * pod-restart window where /v1/health is briefly unreachable.
+   * Watch for the reported CPU/memory allocation to differ from `baseline`,
+   * meaning the resize has landed. The health query polls while the watch is
+   * open and stops on its own once the allocation moves or the window
+   * elapses, tolerating the pod restart where /v1/health is unreachable.
    */
-  refetchUntilResized: (baseline: HealthzGetResponse | null) => Promise<void>;
+  refetchUntilResized: (baseline: HealthzGetResponse | null) => void;
 }
 
 export function useAssistantWithHealthz(): AssistantWithHealthz {
@@ -83,7 +115,6 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     },
     retry: false,
   });
-  const queryClient = useQueryClient();
   /* A platform-mode read needs `Vellum-Organization-Id`, which the org store
      hydrates after auth. Without this gate the request can go out headerless
      and be rejected. Ready immediately when there is no platform session, so
@@ -97,6 +128,7 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     () => healthzGetOptions({ path: { assistant_id: activeAssistantId } }),
     [activeAssistantId],
   );
+  const [resizeWatch, setResizeWatch] = useState<ResizeWatch | null>(null);
   const {
     data: healthz = null,
     isLoading: healthzQueryLoading,
@@ -107,6 +139,16 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     ...healthzQueryOptions,
     enabled: orgReadiness === "ready",
     retry: false,
+    /* Live readings, so a revisit revalidates rather than serving a frozen
+       number. The cache is here to paint the last values immediately, not to
+       stand in for a fresh one. */
+    staleTime: 0,
+    /* A resize rolls the pod, so the new allocation only appears once it comes
+       back. The query owns that cadence: it already retries nothing, keeps the
+       last good data across a failed attempt, and stops on its own when the
+       allocation moves. */
+    refetchInterval: (query) =>
+      resizePollInterval(query.state.data, resizeWatch, Date.now()),
   });
   /* A disabled query reports `isLoading: false`, so the wait for the org
      header would otherwise read as a settled "no metrics" and the cards would
@@ -115,112 +157,70 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
      a spinner on it would spin for as long as the page is open. */
   const healthzLoading = healthzQueryLoading || orgReadiness === "resolving";
 
-  const [healthzPolling, setHealthzPolling] = useState(false);
-  // Bumped to supersede any in-flight resize poll (a new poll, or unmount).
-  const pollIdRef = useRef(0);
+  const healthzPolling = resizeWatch !== null;
 
-  /* Transient unreachability is not worth a report: it is what a connection
-     blip looks like from here, and the query retries on its own terms.
-     Anything else is a real failure of a card the user is looking at. Only
-     failures the query publishes reach this, which is why the resize poll
-     reads outside it. */
+  /* Reported only when there is nothing to show. A failure with values still
+     on the cards is not worth interrupting for: the last reading stands as the
+     truth of when it was taken, and a resize deliberately spends part of its
+     window unreachable. Keyed on the error and the data rather than on whether
+     a poll is running, so there is no flag whose flip can surface a failure
+     after the fact. */
   useEffect(() => {
-    if (!healthzError || isTransientNetworkError(healthzError)) {
+    if (healthzError === null || healthz !== null) {
+      return;
+    }
+    if (isTransientNetworkError(healthzError)) {
       return;
     }
     captureError(healthzError, { context: "fetch_assistant_healthz" });
     toast.error(t("settings:assistantStatusPanel.loadHealthzFailed"));
-  }, [healthzError]);
+  }, [healthzError, healthz]);
 
-  // Cancel any in-flight resize poll when the active assistant changes or the
-  // hook unmounts. Without it a poll for the previous assistant keeps running
-  // and holds its resize controls disabled. The reported health needs no
-  // cleanup: it is cached per assistant id, so a switch reads the new
-  // assistant's entry rather than the old one's values.
+  /* Ends the watch, and adopts a baseline for a resize that started before any
+     reading arrived. The cadence is the query's; this owns only when the watch
+     is over, which is the allocation moving or the deadline passing. */
   useEffect(() => {
-    return () => {
-      pollIdRef.current += 1;
-      setHealthzPolling(false);
-    };
+    if (resizeWatch === null) {
+      return;
+    }
+    if (resizeWatch.baseline === null && healthz !== null) {
+      setResizeWatch({ ...resizeWatch, baseline: healthz });
+      return;
+    }
+    if (
+      resizePollInterval(healthz ?? undefined, resizeWatch, Date.now()) ===
+      false
+    ) {
+      setResizeWatch(null);
+      return;
+    }
+    const timer = setTimeout(
+      () => setResizeWatch(null),
+      Math.max(0, resizeWatch.until - Date.now()),
+    );
+    return () => clearTimeout(timer);
+  }, [resizeWatch, healthz]);
+
+  /* A watch belongs to the assistant that was resized. The reported health
+     needs no cleanup of its own, being cached per assistant id, but a watch
+     left running would hold the next assistant's resize controls disabled. */
+  useEffect(() => {
+    setResizeWatch(null);
   }, [activeAssistantId]);
 
-  /**
-   * One reading for the resize poll, taken outside the query on purpose.
-   *
-   * A resize rolls the pod, so the endpoint is expected to fail for part of
-   * the window. Routing those failures through the query would publish them
-   * as its error, where they outlive the poll: the error stays on the cache
-   * entry, and the next mount of this hook reports a failure the poll had
-   * deliberately swallowed. Reading directly keeps a poll failure local to the
-   * poll, and a success is written into the cache so the cards follow the
-   * resize live.
-   */
-  const readHealthzOutsideQuery =
-    useCallback(async (): Promise<HealthzGetResponse | null> => {
-      try {
-        const result = await getAssistantHealthz(activeAssistantId);
-        if (!result.ok) {
-          return null;
-        }
-        queryClient.setQueryData(healthzQueryOptions.queryKey, result.data);
-        return result.data;
-      } catch {
-        // Unreachable mid-restart. The last good reading stays in the cache,
-        // so the cards keep their values instead of blanking.
-        return null;
-      }
-    }, [activeAssistantId, queryClient, healthzQueryOptions]);
-
-  /* The user asked for this one, so it goes through the query: a failure here
-     is theirs to see, and the reporting effect above surfaces it. Both reads
-     go out together for the same reason the mount path does. */
   const refetch = useCallback(async () => {
     await Promise.all([refetchAssistant(), refetchHealthz()]);
   }, [refetchAssistant, refetchHealthz]);
 
+  /* Opens the watch; the query polls from there. The machine-size tag comes
+     from the assistant record, which the platform updates synchronously during
+     a resize, so that one is refreshed up front. */
   const refetchUntilResized = useCallback(
-    async (baseline: HealthzGetResponse | null) => {
-      const pollId = ++pollIdRef.current;
-      const deadline = Date.now() + HEALTHZ_POLL_TIMEOUT_MS;
-      setHealthzPolling(true);
-      // `baseline` is null when metrics weren't loaded yet at resize time. In
-      // that case the first reading could still be pre-resize values, so we
-      // can't treat it as the resized allocation — adopt it as the baseline and
-      // keep polling until it changes instead.
-      let reference = baseline;
-      try {
-        // The machine-size tag comes from the assistant record, which the
-        // platform updates synchronously during resize — refresh it up front.
-        void refetchAssistant();
-        while (Date.now() < deadline && pollId === pollIdRef.current) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, HEALTHZ_POLL_INTERVAL_MS),
-          );
-          if (pollId !== pollIdRef.current) {
-            return;
-          }
-          const data = await readHealthzOutsideQuery();
-          if (pollId !== pollIdRef.current) {
-            return;
-          }
-          if (!data) {
-            continue;
-          }
-          if (reference == null) {
-            reference = data;
-            continue;
-          }
-          if (allocationChanged(data, reference)) {
-            return;
-          }
-        }
-      } finally {
-        if (pollId === pollIdRef.current) {
-          setHealthzPolling(false);
-        }
-      }
+    (baseline: HealthzGetResponse | null) => {
+      void refetchAssistant();
+      setResizeWatch({ baseline, until: Date.now() + HEALTHZ_POLL_TIMEOUT_MS });
     },
-    [readHealthzOutsideQuery, refetchAssistant],
+    [refetchAssistant],
   );
 
   return {

--- a/clients/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -3,21 +3,20 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import {
-  type Assistant,
-  getAssistant,
-  getAssistantHealthz,
-} from "@/assistant/api";
+import { type Assistant, getAssistant } from "@/assistant/api";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { CapacityBar } from "@/domains/settings/components/capacity-bar";
 import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-version-unlock";
+import { healthzGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { HealthzGetResponse } from "@/generated/daemon/types.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { t, useTranslation } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
@@ -78,93 +77,94 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     },
     retry: false,
   });
-  const assistantId = assistant?.id;
+  const queryClient = useQueryClient();
+  /* A platform-mode read needs `Vellum-Organization-Id`, which the org store
+     hydrates after auth. Without this gate the request can go out headerless
+     and be rejected. Ready immediately when there is no platform session, so
+     self-hosted and gateway-only sessions are not held up by it. */
+  const isOrgReady = useIsOrgReady();
+  /* Keyed on the active assistant rather than on the resolved record, so the
+     two reads run side by side instead of nose to tail. Over a tunnel that
+     serialization was a second full round trip before this one could start. */
+  const healthzQueryOptions = useMemo(
+    () => healthzGetOptions({ path: { assistant_id: activeAssistantId } }),
+    [activeAssistantId],
+  );
+  const {
+    data: healthz = null,
+    isLoading: healthzLoading,
+    error: healthzError,
+  } = useQuery({
+    ...healthzQueryOptions,
+    enabled: isOrgReady,
+    retry: false,
+  });
 
-  const [healthz, setHealthz] = useState<HealthzGetResponse | null>(null);
-  const [healthzLoading, setHealthzLoading] = useState(false);
   const [healthzPolling, setHealthzPolling] = useState(false);
-  const healthzRequestIdRef = useRef(0);
   // Bumped to supersede any in-flight resize poll (a new poll, or unmount).
   const pollIdRef = useRef(0);
+  /* Read inside the reporting effect rather than listed as a dependency: a
+     failure that lands mid-poll must stay silent, and re-running the effect
+     when the poll ends would surface it late. */
+  const pollingRef = useRef(false);
 
-  const fetchHealthz = useCallback(
-    async (opts?: {
-      keepStaleOnError?: boolean;
-    }): Promise<HealthzGetResponse | null> => {
-      if (!assistantId) {
-        setHealthz(null);
-        setHealthzLoading(false);
-        return null;
-      }
-      healthzRequestIdRef.current += 1;
-      const requestId = healthzRequestIdRef.current;
-      setHealthzLoading(true);
-      try {
-        const result = await getAssistantHealthz(assistantId);
-        if (requestId !== healthzRequestIdRef.current) {
-          return null;
-        }
-        if (result.ok) {
-          setHealthz(result.data);
-          return result.data;
-        }
-        // While polling through a resize restart, keep the last-known values
-        // rather than blanking the card on a transient non-200.
-        if (!opts?.keepStaleOnError) {
-          setHealthz(null);
-        }
-        return null;
-      } catch (error) {
-        if (requestId !== healthzRequestIdRef.current) {
-          return null;
-        }
-        if (!opts?.keepStaleOnError) {
-          setHealthz(null);
-        }
-        // Transient unreachability during a resize restart is expected — don't
-        // report it while polling.
-        if (!isTransientNetworkError(error) && !opts?.keepStaleOnError) {
-          captureError(error, { context: "fetch_assistant_healthz" });
-          toast.error(t("settings:assistantStatusPanel.loadHealthzFailed"));
-        }
-        return null;
-      } finally {
-        if (requestId === healthzRequestIdRef.current) {
-          setHealthzLoading(false);
-        }
-      }
-    },
-    [assistantId],
-  );
-
+  /* A resize restart makes the endpoint briefly unreachable, and the transcript
+     of that is a transient network error, so those stay unreported. Anything
+     else is a real failure of a card the user is looking at. */
   useEffect(() => {
-    void fetchHealthz();
-  }, [fetchHealthz]);
+    if (!healthzError || pollingRef.current) {
+      return;
+    }
+    if (isTransientNetworkError(healthzError)) {
+      return;
+    }
+    captureError(healthzError, { context: "fetch_assistant_healthz" });
+    toast.error(t("settings:assistantStatusPanel.loadHealthzFailed"));
+  }, [healthzError]);
 
-  // When the active assistant changes (or on unmount), cancel any in-flight
-  // resize poll and drop the previous assistant's cached health. Without the
-  // cancel, a poll for the previous assistant keeps writing its data and holds
-  // its resize controls disabled; without clearing `healthz`, the cards would
-  // render the previous assistant's CPU/memory/disk until the new fetch
-  // resolves (both reproducible when switching with multiPlatformAssistant).
+  // Cancel any in-flight resize poll when the active assistant changes or the
+  // hook unmounts. Without it a poll for the previous assistant keeps running
+  // and holds its resize controls disabled. The reported health needs no
+  // cleanup: it is cached per assistant id, so a switch reads the new
+  // assistant's entry rather than the old one's values.
   useEffect(() => {
     return () => {
       pollIdRef.current += 1;
+      pollingRef.current = false;
       setHealthzPolling(false);
-      setHealthz(null);
     };
-  }, [assistantId]);
+  }, [activeAssistantId]);
+
+  /* `staleTime: 0` because this is an imperative re-check: the caller is asking
+     whether the allocation has changed since it last looked, which a cached
+     answer cannot report. */
+  const fetchFreshHealthz =
+    useCallback(async (): Promise<HealthzGetResponse | null> => {
+      try {
+        return await queryClient.fetchQuery({
+          ...healthzQueryOptions,
+          retry: false,
+          staleTime: 0,
+        });
+      } catch {
+        // The pod is rolling and the endpoint is briefly unreachable. The last
+        // good reading stays in the cache, so the cards keep their values
+        // instead of blanking, and the caller decides whether to keep polling.
+        return null;
+      }
+    }, [queryClient, healthzQueryOptions]);
 
   const refetch = useCallback(async () => {
     await refetchAssistant();
-    await fetchHealthz();
-  }, [refetchAssistant, fetchHealthz]);
+    await fetchFreshHealthz();
+  }, [refetchAssistant, fetchFreshHealthz]);
 
   const refetchUntilResized = useCallback(
     async (baseline: HealthzGetResponse | null) => {
       const pollId = ++pollIdRef.current;
       const deadline = Date.now() + HEALTHZ_POLL_TIMEOUT_MS;
       setHealthzPolling(true);
+      pollingRef.current = true;
       // `baseline` is null when metrics weren't loaded yet at resize time. In
       // that case the first reading could still be pre-resize values, so we
       // can't treat it as the resized allocation — adopt it as the baseline and
@@ -181,7 +181,7 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
           if (pollId !== pollIdRef.current) {
             return;
           }
-          const data = await fetchHealthz({ keepStaleOnError: true });
+          const data = await fetchFreshHealthz();
           if (pollId !== pollIdRef.current) {
             return;
           }
@@ -198,11 +198,12 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
         }
       } finally {
         if (pollId === pollIdRef.current) {
+          pollingRef.current = false;
           setHealthzPolling(false);
         }
       }
     },
-    [fetchHealthz, refetchAssistant],
+    [fetchFreshHealthz, refetchAssistant],
   );
 
   return {

--- a/clients/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -15,6 +15,7 @@ import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { CapacityBar } from "@/domains/settings/components/capacity-bar";
 import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-version-unlock";
 import { healthzGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { healthzGet } from "@/generated/daemon/sdk.gen";
 import type { HealthzGetResponse } from "@/generated/daemon/types.gen";
 import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { t, useTranslation } from "@/i18n";
@@ -52,6 +53,8 @@ export interface AssistantWithHealthz {
   assistantLoading: boolean;
   healthz: HealthzGetResponse | null;
   healthzLoading: boolean;
+  /** True while a request is in flight, including a refresh over existing values. */
+  healthzFetching: boolean;
   /** True while a post-resize poll is waiting for the new allocation to appear. */
   healthzPolling: boolean;
   refetch: () => Promise<void>;
@@ -93,7 +96,9 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
   const {
     data: healthz = null,
     isLoading: healthzQueryLoading,
+    isFetching: healthzFetching,
     error: healthzError,
+    refetch: refetchHealthz,
   } = useQuery({
     ...healthzQueryOptions,
     enabled: orgReadiness === "ready",
@@ -109,19 +114,14 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
   const [healthzPolling, setHealthzPolling] = useState(false);
   // Bumped to supersede any in-flight resize poll (a new poll, or unmount).
   const pollIdRef = useRef(0);
-  /* Read inside the reporting effect rather than listed as a dependency: a
-     failure that lands mid-poll must stay silent, and re-running the effect
-     when the poll ends would surface it late. */
-  const pollingRef = useRef(false);
 
-  /* A resize restart makes the endpoint briefly unreachable, and the transcript
-     of that is a transient network error, so those stay unreported. Anything
-     else is a real failure of a card the user is looking at. */
+  /* Transient unreachability is not worth a report: it is what a connection
+     blip looks like from here, and the query retries on its own terms.
+     Anything else is a real failure of a card the user is looking at. Only
+     failures the query publishes reach this, which is why the resize poll
+     reads outside it. */
   useEffect(() => {
-    if (!healthzError || pollingRef.current) {
-      return;
-    }
-    if (isTransientNetworkError(healthzError)) {
+    if (!healthzError || isTransientNetworkError(healthzError)) {
       return;
     }
     captureError(healthzError, { context: "fetch_assistant_healthz" });
@@ -136,41 +136,52 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
   useEffect(() => {
     return () => {
       pollIdRef.current += 1;
-      pollingRef.current = false;
       setHealthzPolling(false);
     };
   }, [activeAssistantId]);
 
-  /* `staleTime: 0` because this is an imperative re-check: the caller is asking
-     whether the allocation has changed since it last looked, which a cached
-     answer cannot report. */
-  const fetchFreshHealthz =
+  /**
+   * One reading for the resize poll, taken outside the query on purpose.
+   *
+   * A resize rolls the pod, so the endpoint is expected to fail for part of
+   * the window. Routing those failures through the query would publish them
+   * as its error, where they outlive the poll: the error stays on the cache
+   * entry, and the next mount of this hook reports a failure the poll had
+   * deliberately swallowed. Reading directly keeps a poll failure local to the
+   * poll, and a success is written into the cache so the cards follow the
+   * resize live.
+   */
+  const readHealthzOutsideQuery =
     useCallback(async (): Promise<HealthzGetResponse | null> => {
       try {
-        return await queryClient.fetchQuery({
-          ...healthzQueryOptions,
-          retry: false,
-          staleTime: 0,
+        const { data, response } = await healthzGet({
+          path: { assistant_id: activeAssistantId },
+          throwOnError: false,
         });
+        if (!response?.ok || !data) {
+          return null;
+        }
+        queryClient.setQueryData(healthzQueryOptions.queryKey, data);
+        return data;
       } catch {
-        // The pod is rolling and the endpoint is briefly unreachable. The last
-        // good reading stays in the cache, so the cards keep their values
-        // instead of blanking, and the caller decides whether to keep polling.
+        // Unreachable mid-restart. The last good reading stays in the cache,
+        // so the cards keep their values instead of blanking.
         return null;
       }
-    }, [queryClient, healthzQueryOptions]);
+    }, [activeAssistantId, queryClient, healthzQueryOptions]);
 
+  /* The user asked for this one, so it goes through the query: a failure here
+     is theirs to see, and the reporting effect above surfaces it. */
   const refetch = useCallback(async () => {
     await refetchAssistant();
-    await fetchFreshHealthz();
-  }, [refetchAssistant, fetchFreshHealthz]);
+    await refetchHealthz();
+  }, [refetchAssistant, refetchHealthz]);
 
   const refetchUntilResized = useCallback(
     async (baseline: HealthzGetResponse | null) => {
       const pollId = ++pollIdRef.current;
       const deadline = Date.now() + HEALTHZ_POLL_TIMEOUT_MS;
       setHealthzPolling(true);
-      pollingRef.current = true;
       // `baseline` is null when metrics weren't loaded yet at resize time. In
       // that case the first reading could still be pre-resize values, so we
       // can't treat it as the resized allocation — adopt it as the baseline and
@@ -187,7 +198,7 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
           if (pollId !== pollIdRef.current) {
             return;
           }
-          const data = await fetchFreshHealthz();
+          const data = await readHealthzOutsideQuery();
           if (pollId !== pollIdRef.current) {
             return;
           }
@@ -204,12 +215,11 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
         }
       } finally {
         if (pollId === pollIdRef.current) {
-          pollingRef.current = false;
           setHealthzPolling(false);
         }
       }
     },
-    [fetchFreshHealthz, refetchAssistant],
+    [readHealthzOutsideQuery, refetchAssistant],
   );
 
   return {
@@ -217,6 +227,7 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     assistantLoading,
     healthz,
     healthzLoading,
+    healthzFetching,
     healthzPolling,
     refetch,
     refetchUntilResized,

--- a/clients/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -10,12 +10,15 @@ import {
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { type Assistant, getAssistant } from "@/assistant/api";
+import {
+  type Assistant,
+  getAssistant,
+  getAssistantHealthz,
+} from "@/assistant/api";
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { CapacityBar } from "@/domains/settings/components/capacity-bar";
 import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-version-unlock";
 import { healthzGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
-import { healthzGet } from "@/generated/daemon/sdk.gen";
 import type { HealthzGetResponse } from "@/generated/daemon/types.gen";
 import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { t, useTranslation } from "@/i18n";
@@ -86,9 +89,10 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
      and be rejected. Ready immediately when there is no platform session, so
      self-hosted and gateway-only sessions are not held up by it. */
   const orgReadiness = useOrgHeaderReadiness();
-  /* Keyed on the active assistant rather than on the resolved record, so the
-     two reads run side by side instead of nose to tail. Over a tunnel that
-     serialization was a second full round trip before this one could start. */
+  /* Keyed on the active id rather than on the resolved record, so this read
+     and the record's own go out together. The record can only ever report the
+     id the hook already holds, so waiting for it would buy nothing and cost a
+     round trip on a tunnel. */
   const healthzQueryOptions = useMemo(
     () => healthzGetOptions({ path: { assistant_id: activeAssistantId } }),
     [activeAssistantId],
@@ -154,15 +158,12 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
   const readHealthzOutsideQuery =
     useCallback(async (): Promise<HealthzGetResponse | null> => {
       try {
-        const { data, response } = await healthzGet({
-          path: { assistant_id: activeAssistantId },
-          throwOnError: false,
-        });
-        if (!response?.ok || !data) {
+        const result = await getAssistantHealthz(activeAssistantId);
+        if (!result.ok) {
           return null;
         }
-        queryClient.setQueryData(healthzQueryOptions.queryKey, data);
-        return data;
+        queryClient.setQueryData(healthzQueryOptions.queryKey, result.data);
+        return result.data;
       } catch {
         // Unreachable mid-restart. The last good reading stays in the cache,
         // so the cards keep their values instead of blanking.
@@ -171,10 +172,10 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
     }, [activeAssistantId, queryClient, healthzQueryOptions]);
 
   /* The user asked for this one, so it goes through the query: a failure here
-     is theirs to see, and the reporting effect above surfaces it. */
+     is theirs to see, and the reporting effect above surfaces it. Both reads
+     go out together for the same reason the mount path does. */
   const refetch = useCallback(async () => {
-    await refetchAssistant();
-    await refetchHealthz();
+    await Promise.all([refetchAssistant(), refetchHealthz()]);
   }, [refetchAssistant, refetchHealthz]);
 
   const refetchUntilResized = useCallback(

--- a/clients/web/src/domains/settings/components/assistant-status-panel.tsx
+++ b/clients/web/src/domains/settings/components/assistant-status-panel.tsx
@@ -16,7 +16,7 @@ import { CapacityBar } from "@/domains/settings/components/capacity-bar";
 import { DevModeVersionUnlock } from "@/domains/settings/components/dev-mode-version-unlock";
 import { healthzGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { HealthzGetResponse } from "@/generated/daemon/types.gen";
-import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { t, useTranslation } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
@@ -82,7 +82,7 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
      hydrates after auth. Without this gate the request can go out headerless
      and be rejected. Ready immediately when there is no platform session, so
      self-hosted and gateway-only sessions are not held up by it. */
-  const isOrgReady = useIsOrgReady();
+  const orgReadiness = useOrgHeaderReadiness();
   /* Keyed on the active assistant rather than on the resolved record, so the
      two reads run side by side instead of nose to tail. Over a tunnel that
      serialization was a second full round trip before this one could start. */
@@ -92,13 +92,19 @@ export function useAssistantWithHealthz(): AssistantWithHealthz {
   );
   const {
     data: healthz = null,
-    isLoading: healthzLoading,
+    isLoading: healthzQueryLoading,
     error: healthzError,
   } = useQuery({
     ...healthzQueryOptions,
-    enabled: isOrgReady,
+    enabled: orgReadiness === "ready",
     retry: false,
   });
+  /* A disabled query reports `isLoading: false`, so the wait for the org
+     header would otherwise read as a settled "no metrics" and the cards would
+     show their empty dashes on the way to loading. `"resolving"` is that wait
+     and belongs with loading; `"unavailable"` is a decided answer, and holding
+     a spinner on it would spin for as long as the page is open. */
+  const healthzLoading = healthzQueryLoading || orgReadiness === "resolving";
 
   const [healthzPolling, setHealthzPolling] = useState(false);
   // Bumped to supersede any in-flight resize poll (a new poll, or unmount).

--- a/clients/web/src/domains/settings/components/resize-card.test.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.test.tsx
@@ -70,6 +70,7 @@ function renderCard(planId: SubscriptionResponse["plan_id"]) {
           assistant={assistant}
           healthz={null}
           healthzLoading={false}
+          healthzFetching={false}
           healthzPolling={false}
           refetch={() => {}}
           refetchUntilResized={() => {}}

--- a/clients/web/src/domains/settings/components/resize-card.tsx
+++ b/clients/web/src/domains/settings/components/resize-card.tsx
@@ -34,6 +34,8 @@ export interface ResizeCardProps {
   assistant: Assistant;
   healthz: HealthzGetResponse | null;
   healthzLoading: boolean;
+  /** True while a request is in flight, including a refresh over existing values. */
+  healthzFetching: boolean;
   /** True while a post-resize poll is waiting for the new allocation to appear. */
   healthzPolling: boolean;
   refetch: () => Promise<void> | void;
@@ -47,6 +49,7 @@ export function ResizeCard({
   assistant,
   healthz,
   healthzLoading,
+  healthzFetching,
   healthzPolling,
   refetch,
   refetchUntilResized,
@@ -276,7 +279,7 @@ export function ResizeCard({
             variant="ghost"
             size="compact"
             iconOnly={
-              healthzLoading || healthzPolling ? (
+              healthzFetching || healthzPolling ? (
                 <Loader2 className="animate-spin" />
               ) : (
                 <RefreshCw />
@@ -288,7 +291,7 @@ export function ResizeCard({
                 : t("resizeCard.refreshMetrics")
             }
             aria-label={t("resizeCard.refreshMetrics")}
-            disabled={healthzLoading || healthzPolling}
+            disabled={healthzFetching || healthzPolling}
             onClick={() => void refetch()}
           />
         }

--- a/clients/web/src/domains/settings/pages/general-page.tsx
+++ b/clients/web/src/domains/settings/pages/general-page.tsx
@@ -61,6 +61,7 @@ export function GeneralPage() {
     assistant,
     healthz,
     healthzLoading,
+    healthzFetching,
     healthzPolling,
     refetch,
     refetchUntilResized,
@@ -293,6 +294,7 @@ export function GeneralPage() {
           assistant={assistant}
           healthz={healthz}
           healthzLoading={healthzLoading}
+          healthzFetching={healthzFetching}
           healthzPolling={healthzPolling}
           refetch={refetch}
           refetchUntilResized={refetchUntilResized}


### PR DESCRIPTION
## TL;DR

The Settings health card held its response in `useState` and fetched it from an effect, so nothing cached it: every visit re-fetched and re-showed spinners over values it had just had. It also queued behind the assistant record, which over a tunnel is a second round trip for an id the hook already held. The read now goes through the generated query factory under TanStack Query, and the resize poll goes through `refetchInterval` rather than a hand-rolled loop.

## What changes for the user

| Moment | Before | After |
| --- | --- | --- |
| Opening Settings the first time | One request for the record, then one for health | Both go out together |
| Reopening Settings | Spinners over the disk, CPU and memory rows until the round trip returns | Last readings paint immediately, a fresh one arrives behind them |
| After a resize | Polls until the new allocation appears | Unchanged, but the query owns the cadence |
| A failed read with values on screen | Error toast | Silent, the last reading stands. See below |
| A failed read with nothing on screen | Error toast | Unchanged |

## Why `refetchInterval` and not the loop

The first cut of this PR kept the imperative poll and moved the *read* outside the query to stop its expected failures landing on the shared cache entry, where a later visit reported them. That was a workaround for a problem the shape created.

This codebase already has the answer. `assistant/queries.ts` polls while the lifecycle sits in a transient phase, `assistant-upgrades.tsx` polls while an upgrade runs, and `use-pro-provisioning.ts` polls while provisioning lands, all by returning a cadence from the data and `false` to stop. `docs/STATE_MANAGEMENT.md` names this exact migration and points at the first as the source of truth.

So `refetchUntilResized` now opens a watch and `resizePollInterval` decides the cadence. That deletes the `while` loop, the generation counter, the out-of-band read and the `setQueryData` write, and it dissolves the reporting problem instead of routing around it: one request path, and the report keyed on whether there is anything to show rather than on a flag that can flip after the fact.

## Why `staleTime: 0`

These are live readings. Inheriting the 10 second global default meant a revisit inside that window served a frozen number and issued no request at all, which is caching working against us. With `staleTime: 0` the cached values paint instantly *and* a fresh read goes out, which is the stale-while-revalidate the library is built around. `operational-status.ts` pairs the same two options for the same reason.

## Behaviour change worth calling out

A failed read with values still on the cards no longer toasts. The last reading stands as the truth of when it was taken, and interrupting for a blip is noise. This is also what keeps a resize quiet, structurally, with no flag to leak. A failure with nothing on screen still reports to Sentry and toasts.

## Conventions

`healthzGetOptions` and its generated key replace a hand-written `queryFn` over `@/assistant/api`, whose own header says to use the generated hooks. The organization-header gate reads the three-way `useOrgHeaderReadiness()` rather than the boolean, which `docs/STATE_MANAGEMENT.md` prescribes for exactly this case: `isLoading` is false for a disabled query, so the hydration window would otherwise read as a settled "no metrics". `"resolving"` joins the loading state, `"unavailable"` falls through to the empty state.

I left the sibling `getAssistant` query alone. It has the same hand-rolled key and no gate, so it deserves the same treatment, but that is a separate claim.

## Tests

Fourteen, split the way the canonical file splits them. `resizePollInterval` is at module scope and tested as a pure function, so the tests drive the same code the runtime does rather than a copy that can drift. The hook tests cover the watch opening and closing, the two organization-header outcomes, both failure-reporting cases, the parallel reads, and that a revisit paints without a loading state.

Verified the watch tests fail against a rule that never stops polling, and that the parallel-read test fails against the previous serialized version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
