### PR TITLE
fix(credentials): list from live CES and fail closed on outage

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11146,7 +11146,9 @@ paths:
     post:
       operationId: credentials_list_post
       summary: List all credentials with metadata
-      description: Return all stored credentials with metadata, OAuth connection info, and platform-managed credentials.
+      description:
+        Return credentials from the live credential vault, with OAuth connection info and platform-managed
+        credentials. Fails if the vault is unreachable.
       tags:
         - credentials
       requestBody:

--- a/assistant/src/__tests__/credential-record-retire.test.ts
+++ b/assistant/src/__tests__/credential-record-retire.test.ts
@@ -8,6 +8,7 @@ import type { CredentialRecord } from "@vellumai/service-contracts/credential-rp
 import type { CredentialRecordBackend } from "../security/ces-rpc-record-backend.js";
 import {
   _ensureCesRecordsLoaded,
+  _setHttpRecordBackendForTests,
   _setMetadataPath,
   getCredentialMetadata,
   listCredentialRecordsLive,
@@ -36,7 +37,9 @@ function leftoverContents(): string {
   return readFileSync(leftoverPath(), "utf-8");
 }
 
-function makeBackend(): CredentialRecordBackend & {
+function makeBackend(
+  name?: string,
+): CredentialRecordBackend & {
   store: Map<string, CredentialRecord>;
   bulkSetCalls: number;
   listCalls: number;
@@ -47,6 +50,7 @@ function makeBackend(): CredentialRecordBackend & {
     bulkSetCalls: number;
     listCalls: number;
   } = {
+    name,
     store,
     bulkSetCalls: 0,
     listCalls: 0,
@@ -84,6 +88,7 @@ function makeBackend(): CredentialRecordBackend & {
 describe("CES credential record cache", () => {
   beforeEach(() => {
     setCredentialRecordBackend(undefined);
+    _setHttpRecordBackendForTests(null);
     _setMetadataPath(null);
     const leftover = leftoverPath();
     if (existsSync(leftover)) {
@@ -93,6 +98,7 @@ describe("CES credential record cache", () => {
 
   afterEach(() => {
     setCredentialRecordBackend(undefined);
+    _setHttpRecordBackendForTests(null);
     _setMetadataPath(null);
     const leftover = leftoverPath();
     if (existsSync(leftover)) {
@@ -251,6 +257,132 @@ describe("CES credential record cache", () => {
   });
 
   test("live catalog list reports unreachable when no record backend is attached", async () => {
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(true);
+    expect(live.records).toEqual([]);
+  });
+
+  test("live catalog list fails over to CES HTTP when CES RPC list fails", async () => {
+    const rpc = makeBackend("ces-rpc");
+    rpc.list = async () => null;
+    setCredentialRecordBackend(rpc);
+
+    const http = makeBackend("ces-http");
+    const record: CredentialRecord = {
+      credentialId: "cred-http",
+      service: "github",
+      field: "token",
+      allowedTools: ["bash"],
+      allowedDomains: [],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    http.store.set(credentialKey("github", "token"), record);
+    _setHttpRecordBackendForTests(http);
+
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(false);
+    expect(live.records).toHaveLength(1);
+    expect(live.records[0]?.credentialId).toBe("cred-http");
+    expect(http.listCalls).toBe(1);
+  });
+
+  test("live catalog list fails over to CES HTTP when CES RPC is unavailable", async () => {
+    const rpc = makeBackend("ces-rpc");
+    rpc.isAvailable = () => false;
+    setCredentialRecordBackend(rpc);
+
+    const http = makeBackend("ces-http");
+    const record: CredentialRecord = {
+      credentialId: "cred-http-down-rpc",
+      service: "github",
+      field: "token",
+      allowedTools: ["bash"],
+      allowedDomains: [],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    http.store.set(credentialKey("github", "token"), record);
+    _setHttpRecordBackendForTests(http);
+
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(false);
+    expect(live.records[0]?.credentialId).toBe("cred-http-down-rpc");
+  });
+
+  test("live catalog list uses CES HTTP when no record backend is attached", async () => {
+    const http = makeBackend("ces-http");
+    const record: CredentialRecord = {
+      credentialId: "cred-http-only",
+      service: "github",
+      field: "token",
+      allowedTools: ["bash"],
+      allowedDomains: [],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    http.store.set(credentialKey("github", "token"), record);
+    _setHttpRecordBackendForTests(http);
+
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(false);
+    expect(live.records[0]?.credentialId).toBe("cred-http-only");
+  });
+
+  test("live catalog list does not fail over when CES RPC returns an empty catalog", async () => {
+    const rpc = makeBackend("ces-rpc");
+    setCredentialRecordBackend(rpc);
+
+    const http = makeBackend("ces-http");
+    http.store.set(credentialKey("github", "token"), {
+      credentialId: "cred-http-ignored",
+      service: "github",
+      field: "token",
+      allowedTools: ["bash"],
+      allowedDomains: [],
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    _setHttpRecordBackendForTests(http);
+
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(false);
+    expect(live.records).toEqual([]);
+    expect(http.listCalls).toBe(0);
+  });
+
+  test("live catalog list does not fail over for a non-RPC record backend", async () => {
+    const backend = makeBackend();
+    backend.list = async () => null;
+    setCredentialRecordBackend(backend);
+
+    const http = makeBackend("ces-http");
+    http.store.set(credentialKey("github", "token"), {
+      credentialId: "cred-http-ignored",
+      service: "github",
+      field: "token",
+      allowedTools: ["bash"],
+      allowedDomains: [],
+      createdAt: 1,
+      updatedAt: 2,
+    });
+    _setHttpRecordBackendForTests(http);
+
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(true);
+    expect(live.records).toEqual([]);
+    expect(http.listCalls).toBe(0);
+  });
+
+  test("live catalog list reports unreachable when CES RPC and HTTP both fail", async () => {
+    const rpc = makeBackend("ces-rpc");
+    rpc.list = async () => null;
+    setCredentialRecordBackend(rpc);
+
+    const http = makeBackend("ces-http");
+    http.list = async () => null;
+    _setHttpRecordBackendForTests(http);
+
     const live = await listCredentialRecordsLive();
     expect(live.unreachable).toBe(true);
     expect(live.records).toEqual([]);

--- a/assistant/src/__tests__/credential-record-retire.test.ts
+++ b/assistant/src/__tests__/credential-record-retire.test.ts
@@ -10,6 +10,7 @@ import {
   _ensureCesRecordsLoaded,
   _setMetadataPath,
   getCredentialMetadata,
+  listCredentialRecordsLive,
   setCredentialRecordBackend,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
@@ -216,6 +217,43 @@ describe("CES credential record cache", () => {
 
     getCredentialMetadata("github", "token");
     await _ensureCesRecordsLoaded();
+  });
+
+  test("live catalog list returns CES records without the in-process cache", async () => {
+    const backend = makeBackend();
+    const record: CredentialRecord = {
+      credentialId: "cred-live",
+      service: "github",
+      field: "token",
+      allowedTools: ["bash"],
+      allowedDomains: [],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    backend.store.set(credentialKey("github", "token"), record);
+    setCredentialRecordBackend(backend);
+
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(false);
+    expect(live.records).toHaveLength(1);
+    expect(live.records[0]?.credentialId).toBe("cred-live");
+    expect(getCredentialMetadata("github", "token")).toBeUndefined();
+  });
+
+  test("live catalog list reports unreachable when CES list fails", async () => {
+    const backend = makeBackend();
+    backend.list = async () => null;
+    setCredentialRecordBackend(backend);
+
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(true);
+    expect(live.records).toEqual([]);
+  });
+
+  test("live catalog list reports unreachable when no record backend is attached", async () => {
+    const live = await listCredentialRecordsLive();
+    expect(live.unreachable).toBe(true);
+    expect(live.records).toEqual([]);
   });
 
   test("upsert write-throughs to CES without updating leftover metadata.json", async () => {

--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { BadRequestError, ForbiddenError } from "../runtime/routes/errors.js";
+import {
+  BadRequestError,
+  ForbiddenError,
+  InternalError,
+} from "../runtime/routes/errors.js";
 import type { CredentialMetadata } from "../tools/credentials/metadata-store.js";
 
 // ---------------------------------------------------------------------------
@@ -15,6 +19,8 @@ let disconnectedProviders: string[];
 let credentialIdCounter: number;
 let scrubbedValues: string[];
 let scrubRejects: boolean;
+let liveRecordsUnreachable: boolean;
+let secretGetUnreachable: boolean;
 
 function metaKey(service: string, field: string): string {
   return `${service}:${field}`;
@@ -49,7 +55,7 @@ mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: mock(async (key: string) => secureStore.get(key)),
   getSecureKeyResultAsync: mock(async (key: string) => ({
     value: secureStore.get(key),
-    unreachable: false,
+    unreachable: secretGetUnreachable,
   })),
   deleteSecureKeyAsync: mock(async (key: string) =>
     secureStore.delete(key) ? "deleted" : "not-found",
@@ -60,7 +66,10 @@ mock.module("../security/secure-keys.js", () => ({
 
 mock.module("../tools/credentials/metadata-store.js", () => ({
   assertMetadataWritable: () => {},
-  listCredentialMetadata: mock(() => Array.from(metadataStore.values())),
+  listCredentialRecordsLive: mock(async () => ({
+    records: Array.from(metadataStore.values()),
+    unreachable: liveRecordsUnreachable,
+  })),
   getCredentialMetadata: mock((service: string, field: string) =>
     metadataStore.get(metaKey(service, field)),
   ),
@@ -201,6 +210,8 @@ describe("credentials routes", () => {
     credentialIdCounter = 0;
     scrubbedValues = [];
     scrubRejects = false;
+    liveRecordsUnreachable = false;
+    secretGetUnreachable = false;
     _resetRevealSuccessRegistryForTest();
     resetForChatMintRegistryForTest();
     chatCredentialRevealFlag = false;
@@ -798,6 +809,31 @@ describe("credentials routes", () => {
       // THEN only the matching credential is returned
       expect(result.credentials).toHaveLength(1);
       expect(result.credentials[0].service).toBe("github");
+    });
+
+    test("fails immediately when the credential vault is unreachable", async () => {
+      liveRecordsUnreachable = true;
+      await setRoute!.handler({
+        body: { service: "vercel", field: "api_token", value: SECRET_VALUE },
+      });
+
+      await expect(listRoute!.handler({ body: {} })).rejects.toThrow(
+        InternalError,
+      );
+      await expect(listRoute!.handler({ body: {} })).rejects.toThrow(
+        /Credential store is unreachable/,
+      );
+    });
+
+    test("fails immediately when a secret fetch reports the vault unreachable", async () => {
+      await setRoute!.handler({
+        body: { service: "vercel", field: "api_token", value: SECRET_VALUE },
+      });
+      secretGetUnreachable = true;
+
+      await expect(listRoute!.handler({ body: {} })).rejects.toThrow(
+        InternalError,
+      );
     });
   });
 

--- a/assistant/src/cli/commands/credentials.help.ts
+++ b/assistant/src/cli/commands/credentials.help.ts
@@ -45,8 +45,12 @@ Examples:
         },
       ],
       helpText: `
-Lists all credentials in the vault. Each entry includes the same fields as
-"inspect" — scrubbed value, timestamps, policy, and metadata.
+Lists credentials from the live credential vault. Each entry includes the same
+fields as inspect: scrubbed value, timestamps, policy, and metadata.
+
+Fails immediately with an error if the credential vault is unreachable. An
+empty list means the vault answered and has no matching credentials, not that
+the store is down.
 
 The --search flag filters results by case-insensitive substring match against
 the credential's service name, field name, label, or description. For example, --search

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -344,7 +344,7 @@ export function registerCredentialsCommand(program: Command): void {
             printCredentialHuman(output);
             if (output.brokerUnreachable) {
               log.info(
-                "    ⚠ Credential store is unreachable — ensure the assistant is running",
+                "    Credential store is unreachable. Retry in a moment, or check that the credential vault is running.",
               );
             }
           }

--- a/assistant/src/cli/commands/credentials.ts
+++ b/assistant/src/cli/commands/credentials.ts
@@ -343,7 +343,7 @@ export function registerCredentialsCommand(program: Command): void {
           } else {
             printCredentialHuman(output);
             if (output.brokerUnreachable) {
-              log.info(
+              log.warn(
                 "    Credential store is unreachable. Retry in a moment, or check that the credential vault is running.",
               );
             }

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -43,7 +43,7 @@ import {
   deleteCredentialMetadata,
   getCredentialMetadata,
   getCredentialMetadataById,
-  listCredentialMetadata,
+  listCredentialRecordsLive,
 } from "../../tools/credentials/metadata-store.js";
 import type { CredentialInjectionTemplate } from "../../tools/credentials/policy-types.js";
 import {
@@ -228,6 +228,9 @@ function assertNotPlatformManaged(
   }
 }
 
+const CREDENTIAL_STORE_UNREACHABLE =
+  "Credential store is unreachable. Retry in a moment, or check that the credential vault is running.";
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -235,9 +238,14 @@ function assertNotPlatformManaged(
 async function handleCredentialsList({ body }: RouteHandlerArgs) {
   const search = (body as { search?: string } | undefined)?.search;
 
+  const live = await listCredentialRecordsLive();
+  if (live.unreachable) {
+    throw new InternalError(CREDENTIAL_STORE_UNREACHABLE);
+  }
+
   // Platform-provisioned credentials are not the user's to act on, so they
   // never become a Settings row (and never a click-to-reveal).
-  let allMetadata = listCredentialMetadata().filter(
+  let allMetadata = live.records.filter(
     (m) => !isPlatformManagedCredential(m.service, m.field),
   );
 
@@ -272,7 +280,12 @@ async function handleCredentialsList({ body }: RouteHandlerArgs) {
 
   const credentials = await Promise.all(
     allMetadata.map(async (m) => {
-      const secret = await getSecureKeyAsync(credentialKey(m.service, m.field));
+      const { value: secret, unreachable } = await getSecureKeyResultAsync(
+        credentialKey(m.service, m.field),
+      );
+      if (unreachable) {
+        throw new InternalError(CREDENTIAL_STORE_UNREACHABLE);
+      }
       const connection = connectionsByProvider.get(m.service);
       return buildCredentialOutput(m, secret, connection);
     }),
@@ -310,9 +323,7 @@ async function handleCredentialsInspect({ body }: RouteHandlerArgs) {
 
   if (!lookup.metadata && (secret == null || secret.length === 0)) {
     if (unreachable) {
-      throw new InternalError(
-        "Credential store is unreachable — ensure the assistant is running",
-      );
+      throw new InternalError(CREDENTIAL_STORE_UNREACHABLE);
     }
     throw new BadRequestError("Credential not found");
   }
@@ -374,9 +385,7 @@ async function handleCredentialsReveal({ body, headers }: RouteHandlerArgs) {
 
   if (secret == null || secret.length === 0) {
     if (unreachable) {
-      throw new InternalError(
-        "Credential store is unreachable — ensure the assistant is running",
-      );
+      throw new InternalError(CREDENTIAL_STORE_UNREACHABLE);
     }
     throw new BadRequestError("Credential not found");
   }
@@ -620,7 +629,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "List all credentials with metadata",
     description:
-      "Return all stored credentials with metadata, OAuth connection info, and platform-managed credentials.",
+      "Return credentials from the live credential vault, with OAuth connection info and platform-managed credentials. Fails if the vault is unreachable.",
     tags: ["credentials"],
     requestBody: z.object({
       search: z.string().optional().describe("Filter by substring match"),

--- a/assistant/src/security/__tests__/ces-http-record-backend.test.ts
+++ b/assistant/src/security/__tests__/ces-http-record-backend.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import type { CredentialRecord } from "@vellumai/service-contracts/credential-rpc";
+
+import * as envRegistry from "../../config/env-registry.js";
+import {
+  CesHttpRecordBackend,
+  createCesHttpRecordBackendIfConfigured,
+} from "../ces-http-record-backend.js";
+
+const ORIGINAL_URL = process.env.CES_CREDENTIAL_URL;
+const ORIGINAL_TOKEN = process.env.CES_SERVICE_TOKEN;
+
+function restoreCesHttpEnv(): void {
+  if (ORIGINAL_URL === undefined) {
+    delete process.env.CES_CREDENTIAL_URL;
+  } else {
+    process.env.CES_CREDENTIAL_URL = ORIGINAL_URL;
+  }
+  if (ORIGINAL_TOKEN === undefined) {
+    delete process.env.CES_SERVICE_TOKEN;
+  } else {
+    process.env.CES_SERVICE_TOKEN = ORIGINAL_TOKEN;
+  }
+}
+
+function fakeHttpClient(options: {
+  listRecords: () => Promise<{
+    records: Array<{ account: string; record: CredentialRecord }>;
+    unreachable: boolean;
+  }>;
+}) {
+  return {
+    getRecord: async () => ({ record: undefined, unreachable: false }),
+    setRecord: async () => false,
+    deleteRecord: async () => "error" as const,
+    listRecords: options.listRecords,
+    bulkSetRecords: async (records: Array<{ account: string }>) =>
+      records.map((entry) => ({ account: entry.account, ok: false })),
+  };
+}
+
+describe("CES HTTP credential record backend", () => {
+  afterEach(() => {
+    restoreCesHttpEnv();
+  });
+
+  test("factory returns null when the assistant is not containerized", () => {
+    const spy = spyOn(envRegistry, "getIsContainerized").mockReturnValue(false);
+    process.env.CES_CREDENTIAL_URL = "http://ces-container:8090";
+    process.env.CES_SERVICE_TOKEN = "token-123";
+    try {
+      expect(createCesHttpRecordBackendIfConfigured()).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("factory returns null when CES_CREDENTIAL_URL is unset", () => {
+    const spy = spyOn(envRegistry, "getIsContainerized").mockReturnValue(true);
+    delete process.env.CES_CREDENTIAL_URL;
+    process.env.CES_SERVICE_TOKEN = "token-123";
+    try {
+      expect(createCesHttpRecordBackendIfConfigured()).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("factory returns null when CES_SERVICE_TOKEN is unset", () => {
+    const spy = spyOn(envRegistry, "getIsContainerized").mockReturnValue(true);
+    process.env.CES_CREDENTIAL_URL = "http://ces-container:8090";
+    delete process.env.CES_SERVICE_TOKEN;
+    try {
+      expect(createCesHttpRecordBackendIfConfigured()).toBeNull();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("factory returns a backend when containerized with CES HTTP env", () => {
+    const spy = spyOn(envRegistry, "getIsContainerized").mockReturnValue(true);
+    process.env.CES_CREDENTIAL_URL = "http://ces-container:8090";
+    process.env.CES_SERVICE_TOKEN = "token-123";
+    try {
+      const backend = createCesHttpRecordBackendIfConfigured();
+      expect(backend?.name).toBe("ces-http");
+      expect(backend?.isAvailable()).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("list returns records when HTTP reports a reachable catalog", async () => {
+    const record: CredentialRecord = {
+      credentialId: "cred-http",
+      service: "github",
+      field: "token",
+      allowedTools: ["bash"],
+      allowedDomains: [],
+      createdAt: 1,
+      updatedAt: 2,
+    };
+    const backend = new CesHttpRecordBackend(
+      fakeHttpClient({
+        listRecords: async () => ({
+          records: [{ account: "github:token", record }],
+          unreachable: false,
+        }),
+      }),
+    );
+
+    const listed = await backend.list();
+    expect(listed).toEqual([{ account: "github:token", record }]);
+  });
+
+  test("list returns an empty catalog when HTTP is reachable and empty", async () => {
+    const backend = new CesHttpRecordBackend(
+      fakeHttpClient({
+        listRecords: async () => ({ records: [], unreachable: false }),
+      }),
+    );
+
+    const listed = await backend.list();
+    expect(listed).toEqual([]);
+  });
+
+  test("list returns null when HTTP reports the vault unreachable", async () => {
+    const backend = new CesHttpRecordBackend(
+      fakeHttpClient({
+        listRecords: async () => ({ records: [], unreachable: true }),
+      }),
+    );
+
+    expect(await backend.list()).toBeNull();
+  });
+});

--- a/assistant/src/security/ces-http-record-backend.ts
+++ b/assistant/src/security/ces-http-record-backend.ts
@@ -1,0 +1,120 @@
+/**
+ * CES HTTP backend for non-secret credential records (identity + policy).
+ *
+ * Used when the CES RPC socket is down but the CES HTTP sidecar is
+ * reachable (containerized deployments with CES_CREDENTIAL_URL).
+ */
+
+import {
+  type CesHttpCredentialClient,
+  createCesHttpCredentialClient,
+} from "@vellumai/ces-client/http-credentials";
+import type { CredentialRecord } from "@vellumai/service-contracts/credential-rpc";
+
+import { getIsContainerized } from "../config/env-registry.js";
+import { getLogger } from "../util/logger.js";
+import type { CredentialRecordBackend } from "./ces-rpc-record-backend.js";
+
+const log = getLogger("ces-http-record-backend");
+
+type RecordHttpClient = Pick<
+  CesHttpCredentialClient,
+  | "getRecord"
+  | "setRecord"
+  | "deleteRecord"
+  | "listRecords"
+  | "bulkSetRecords"
+>;
+
+function resolveEnvHttpClient(): RecordHttpClient | undefined {
+  const baseUrl = process.env.CES_CREDENTIAL_URL?.trim();
+  const serviceToken = process.env.CES_SERVICE_TOKEN?.trim();
+  if (!baseUrl || !serviceToken) {
+    return undefined;
+  }
+  return createCesHttpCredentialClient({ baseUrl, serviceToken }, log);
+}
+
+export class CesHttpRecordBackend implements CredentialRecordBackend {
+  readonly name = "ces-http";
+
+  constructor(private readonly client?: RecordHttpClient) {}
+
+  private resolveClient(): RecordHttpClient | undefined {
+    return this.client ?? resolveEnvHttpClient();
+  }
+
+  isAvailable(): boolean {
+    return this.resolveClient() !== undefined;
+  }
+
+  async get(account: string): Promise<CredentialRecord | undefined> {
+    const client = this.resolveClient();
+    if (!client) {
+      return undefined;
+    }
+    const result = await client.getRecord(account);
+    return result.record;
+  }
+
+  async set(account: string, record: CredentialRecord): Promise<boolean> {
+    const client = this.resolveClient();
+    if (!client) {
+      return false;
+    }
+    return client.setRecord(account, record);
+  }
+
+  async delete(
+    account: string,
+  ): Promise<"deleted" | "not-found" | "error"> {
+    const client = this.resolveClient();
+    if (!client) {
+      return "error";
+    }
+    return client.deleteRecord(account);
+  }
+
+  async list(): Promise<Array<{
+    account: string;
+    record: CredentialRecord;
+  }> | null> {
+    const client = this.resolveClient();
+    if (!client) {
+      return null;
+    }
+    const result = await client.listRecords();
+    if (result.unreachable) {
+      return null;
+    }
+    return result.records ?? [];
+  }
+
+  async bulkSet(
+    records: Array<{ account: string; record: CredentialRecord }>,
+  ): Promise<Array<{ account: string; ok: boolean }>> {
+    const client = this.resolveClient();
+    if (!client) {
+      return records.map((entry) => ({ account: entry.account, ok: false }));
+    }
+    return client.bulkSetRecords(records);
+  }
+}
+
+/**
+ * CES HTTP record backend when the assistant is containerized and the
+ * CES HTTP sidecar URL is configured. Returns null otherwise.
+ */
+export function createCesHttpRecordBackendIfConfigured(): CredentialRecordBackend | null {
+  if (!getIsContainerized()) {
+    return null;
+  }
+  if (!process.env.CES_CREDENTIAL_URL?.trim()) {
+    return null;
+  }
+  const backend = new CesHttpRecordBackend();
+  if (!backend.isAvailable()) {
+    return null;
+  }
+  return backend;
+}

--- a/assistant/src/security/ces-rpc-record-backend.ts
+++ b/assistant/src/security/ces-rpc-record-backend.ts
@@ -11,6 +11,11 @@ import { getLogger } from "../util/logger.js";
 const log = getLogger("ces-rpc-record-backend");
 
 export interface CredentialRecordBackend {
+  /**
+   * Transport id. `"ces-rpc"` is the attached CES socket backend; live
+   * catalog listing fails over to CES HTTP when that transport is down.
+   */
+  readonly name?: string;
   isAvailable(): boolean;
   get(account: string): Promise<CredentialRecord | undefined>;
   set(account: string, record: CredentialRecord): Promise<boolean>;
@@ -29,6 +34,8 @@ export interface CredentialRecordBackend {
 }
 
 export class CesRpcRecordBackend implements CredentialRecordBackend {
+  readonly name = "ces-rpc";
+
   constructor(private readonly client: CesClient) {}
 
   isAvailable(): boolean {

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -255,6 +255,48 @@ export function listCredentialMetadata(): CredentialMetadata[] {
   return getStore().list() as CredentialMetadata[];
 }
 
+export type CredentialRecordListResult = {
+  records: CredentialMetadata[];
+  unreachable: boolean;
+};
+
+/**
+ * Live catalog from the credential record backend. Does not read the
+ * daemon in-process cache, so an outage cannot be mistaken for an empty
+ * vault. `unreachable` is true when the backend is missing, down, or
+ * the list RPC fails.
+ *
+ * The file-backed test store is the catalog when a test override path is set.
+ */
+export async function listCredentialRecordsLive(): Promise<CredentialRecordListResult> {
+  if (_overridePath) {
+    return {
+      records: getStore().list() as CredentialMetadata[],
+      unreachable: false,
+    };
+  }
+  if (!_recordBackend) {
+    return { records: [], unreachable: true };
+  }
+  let available = false;
+  try {
+    available = _recordBackend.isAvailable();
+  } catch {
+    available = false;
+  }
+  if (!available) {
+    return { records: [], unreachable: true };
+  }
+  const remote = await _recordBackend.list();
+  if (remote === null) {
+    return { records: [], unreachable: true };
+  }
+  return {
+    records: remote.map((entry) => entry.record as CredentialMetadata),
+    unreachable: false,
+  };
+}
+
 /**
  * Delete metadata for a credential.
  */

--- a/assistant/src/tools/credentials/metadata-store.ts
+++ b/assistant/src/tools/credentials/metadata-store.ts
@@ -20,6 +20,7 @@ import {
 } from "@vellumai/credential-storage";
 import type { CredentialRecord } from "@vellumai/service-contracts/credential-rpc";
 
+import { createCesHttpRecordBackendIfConfigured } from "../../security/ces-http-record-backend.js";
 import type { CredentialRecordBackend } from "../../security/ces-rpc-record-backend.js";
 import { getLogger } from "../../util/logger.js";
 import type { CredentialInjectionTemplate } from "./policy-types.js";
@@ -55,6 +56,11 @@ const CES_MEMORY_PATH = "ces-in-memory-credential-metadata";
 let _store: StaticCredentialMetadataStore | undefined;
 let _overridePath: string | null = null;
 let _recordBackend: CredentialRecordBackend | undefined;
+/**
+ * Test override for the CES HTTP listing fallback. `undefined` uses the
+ * production factory. `null` disables HTTP fallback.
+ */
+let _httpRecordBackendOverride: CredentialRecordBackend | null | undefined;
 let _cesRecordsLoaded = false;
 let _cesLoad: Promise<void> | undefined;
 let _cesLoadGeneration = 0;
@@ -260,11 +266,53 @@ export type CredentialRecordListResult = {
   unreachable: boolean;
 };
 
+type ListedCredentialRecords = Array<{
+  account: string;
+  record: CredentialRecord;
+}>;
+
+function backendIsAvailable(backend: CredentialRecordBackend): boolean {
+  try {
+    return backend.isAvailable();
+  } catch {
+    return false;
+  }
+}
+
+async function listFromRecordBackend(
+  backend: CredentialRecordBackend,
+): Promise<ListedCredentialRecords | null> {
+  if (!backendIsAvailable(backend)) {
+    return null;
+  }
+  return backend.list();
+}
+
+function resolveHttpRecordBackend(): CredentialRecordBackend | null {
+  if (_httpRecordBackendOverride !== undefined) {
+    return _httpRecordBackendOverride;
+  }
+  return createCesHttpRecordBackendIfConfigured();
+}
+
+async function listFromHttpFallback(): Promise<ListedCredentialRecords | null> {
+  const httpBackend = resolveHttpRecordBackend();
+  if (!httpBackend) {
+    return null;
+  }
+  return listFromRecordBackend(httpBackend);
+}
+
 /**
  * Live catalog from the credential record backend. Does not read the
  * daemon in-process cache, so an outage cannot be mistaken for an empty
  * vault. `unreachable` is true when the backend is missing, down, or
- * the list RPC fails.
+ * the list RPC fails, and CES HTTP failover is also unavailable.
+ *
+ * When the attached backend is CES RPC (or none is attached), listing
+ * fails over to CES HTTP in containerized deployments so a down RPC
+ * socket does not hide a healthy vault sidecar. A successful empty
+ * catalog (`[]`) does not fall through to HTTP.
  *
  * The file-backed test store is the catalog when a test override path is set.
  */
@@ -275,26 +323,29 @@ export async function listCredentialRecordsLive(): Promise<CredentialRecordListR
       unreachable: false,
     };
   }
-  if (!_recordBackend) {
-    return { records: [], unreachable: true };
+  if (_recordBackend) {
+    const remote = await listFromRecordBackend(_recordBackend);
+    if (remote !== null) {
+      return {
+        records: remote.map((entry) => entry.record as CredentialMetadata),
+        unreachable: false,
+      };
+    }
+    if (_recordBackend.name !== "ces-rpc") {
+      return { records: [], unreachable: true };
+    }
   }
-  let available = false;
-  try {
-    available = _recordBackend.isAvailable();
-  } catch {
-    available = false;
+  const httpRemote = await listFromHttpFallback();
+  if (httpRemote !== null) {
+    log.warn(
+      "CES RPC credential record list unavailable. Failing over to CES HTTP.",
+    );
+    return {
+      records: httpRemote.map((entry) => entry.record as CredentialMetadata),
+      unreachable: false,
+    };
   }
-  if (!available) {
-    return { records: [], unreachable: true };
-  }
-  const remote = await _recordBackend.list();
-  if (remote === null) {
-    return { records: [], unreachable: true };
-  }
-  return {
-    records: remote.map((entry) => entry.record as CredentialMetadata),
-    unreachable: false,
-  };
+  return { records: [], unreachable: true };
 }
 
 /**
@@ -328,4 +379,11 @@ export function _setMetadataPath(path: string | null): void {
       _store = undefined;
     }
   }
+}
+
+/** @internal Test-only: override the CES HTTP listing fallback. */
+export function _setHttpRecordBackendForTests(
+  backend: CredentialRecordBackend | null | undefined,
+): void {
+  _httpRecordBackendOverride = backend;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
`credentials list` was building rows from the daemon in-process metadata cache and then fetching secrets per-row. When CES answered with no data (or the resolved backend was wedged), every row showed `(not set)` / `hasSecret: false` even though secrets still lived in CES.

This is the first of four PRs to stop treating a credential-store outage as empty identity:

1. This PR: list from the live CES catalog, fail immediately if the vault is unreachable
2. Gateway: CES unreachable is not "credential missing" (edge auth 503 / last-known identity)
3. CredentialWatcher: do not emit "credentials cleared" on CES outage
4. Start moving `vellum:platform_*` identity off CES onto a whoami route

## Summary
- `credentials list` inventories CES records via `listCredentialRecordsLive()`, not the daemon metadata cache
- If the record backend or a secret fetch reports unreachable, the route throws immediately instead of rendering `(not set)`
- When CES RPC is down, listing fails over to CES HTTP in containerized deployments, matching secret-read failover. A successful empty RPC catalog does not fall through to HTTP
- Inspect/reveal unreachable copy no longer tells the user to start the assistant (the assistant is already running)

## Test plan
- `cd assistant && bun test src/__tests__/credential-routes.test.ts src/__tests__/credential-record-retire.test.ts src/__tests__/credential-record-write-through.test.ts src/security/__tests__/ces-http-record-backend.test.ts`
- Covers: list still masks secrets, search, platform-managed omit, vault unreachable throws, secret-get unreachable throws, live CES list does not read the in-process cache, RPC-to-HTTP failover, empty RPC catalog does not failover

## CLI verb checklist
- Existing `assistant credentials list` verb. No new route.

## Risk
- Local/dev processes with no CES record backend attached will now get an error from `credentials list` instead of an empty/stale cache. That is the intended fail-closed behavior.
- Inspect still resolves identity through the daemon metadata cache; only list is migrated in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e7b8efd-9a9e-419e-a6cf-484133b96d98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e7b8efd-9a9e-419e-a6cf-484133b96d98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

