### PR TITLE
Align mobile Library navigation with Figma

### DIFF
--- a/clients/web/src/components/layout/chat-layout-slots-store.ts
+++ b/clients/web/src/components/layout/chat-layout-slots-store.ts
@@ -1,8 +1,8 @@
 /**
  * Header-slot state for `ChatLayout`'s shared `ChatLayoutHeader`.
  *
- * Routes under `ChatLayout` populate the header's center and right
- * section. The setters are actions on this
+ * Routes under `ChatLayout` populate the header's center and right section,
+ * or replace the complete mobile top bar. The setters are actions on this
  * store; consumers register their content from a `useEffect` and
  * clear it on unmount.
  *
@@ -23,6 +23,12 @@ import type { ReactNode } from "react";
 
 import { createSelectors } from "@/utils/create-selectors";
 import type { Conversation } from "@/types/conversation-types";
+
+export interface MobileTopBarSlot {
+  leading: ReactNode;
+  center: ReactNode;
+  trailing: ReactNode;
+}
 
 // ---------------------------------------------------------------------------
 // Header supplements — data-only values that ChatPage contributes to the
@@ -59,12 +65,14 @@ export interface ChatHeaderSupplements {
 interface ChatLayoutSlotsState {
   topBarCenter: ReactNode;
   topBarRightSlot: ReactNode;
+  mobileTopBar: MobileTopBarSlot | null;
   headerSupplements: ChatHeaderSupplements | null;
 }
 
 interface ChatLayoutSlotsActions {
   setTopBarCenter: (node: ReactNode) => void;
   setTopBarRightSlot: (node: ReactNode) => void;
+  setMobileTopBar: (slot: MobileTopBarSlot | null) => void;
   setHeaderSupplements: (supplements: ChatHeaderSupplements | null) => void;
 }
 
@@ -73,9 +81,11 @@ type ChatLayoutSlotsStore = ChatLayoutSlotsState & ChatLayoutSlotsActions;
 const useChatLayoutSlotsStoreBase = create<ChatLayoutSlotsStore>((set) => ({
   topBarCenter: null,
   topBarRightSlot: null,
+  mobileTopBar: null,
   headerSupplements: null,
   setTopBarCenter: (topBarCenter) => set({ topBarCenter }),
   setTopBarRightSlot: (topBarRightSlot) => set({ topBarRightSlot }),
+  setMobileTopBar: (mobileTopBar) => set({ mobileTopBar }),
   setHeaderSupplements: (headerSupplements) => set({ headerSupplements }),
 }));
 

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -210,6 +210,7 @@ describe("ChatLayoutHeader mobile affordances", () => {
     expect(customTopBar?.className).toContain(
       "grid-cols-[max-content_minmax(0,1fr)_max-content]",
     );
+    expect(customTopBar?.style.minHeight).toBe("44px");
     expect(screen.getByText("Library").parentElement?.className).toContain(
       "overflow-hidden",
     );

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -133,6 +133,43 @@ describe("ChatLayoutHeader mobile affordances", () => {
       screen.getByRole("button", { name: "Search (Ctrl+K)" }),
     ).toBeTruthy();
   });
+
+  test("replaces the standard clusters with a route-owned mobile top bar", () => {
+    renderHeader({
+      topBarRightSlot: <button type="button">Notifications</button>,
+      mobileTopBar: {
+        leading: <button type="button">Back</button>,
+        center: <span>Library</span>,
+        trailing: <button type="button">Import</button>,
+      },
+    });
+
+    expect(screen.getByRole("button", { name: "Back" })).toBeTruthy();
+    expect(screen.getByText("Library")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Import" })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Open navigation" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Search (Ctrl+K)" }),
+    ).toBeNull();
+    expect(screen.queryByText("Notifications")).toBeNull();
+  });
+
+  test("ignores a mobile top-bar override on desktop", () => {
+    renderHeader({
+      isMobile: false,
+      mobileTopBar: {
+        leading: <span>Mobile back</span>,
+        center: <span>Mobile title</span>,
+        trailing: <span>Mobile action</span>,
+      },
+      topBarCenter: <span>Desktop title</span>,
+    });
+
+    expect(screen.getByText("Desktop title")).toBeTruthy();
+    expect(screen.queryByText("Mobile title")).toBeNull();
+  });
 });
 
 describe("ChatLayoutHeader page surface", () => {

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -32,6 +32,14 @@ stubModule("@/runtime/is-electron", await import("@/runtime/is-electron"), {
   isElectron: () => mockIsElectron,
 });
 
+stubModule(
+  "@/components/windows-menu-bar",
+  await import("@/components/windows-menu-bar"),
+  {
+    WindowsMenuBar: () => <div data-testid="windows-menu-bar" />,
+  },
+);
+
 // The two stores the header writes through are driven by their own state
 // rather than a module stub, so the spies are checked against the real store
 // shapes. Both stores are process-global, so the real actions go back below.
@@ -147,6 +155,7 @@ describe("ChatLayoutHeader mobile affordances", () => {
     expect(screen.getByRole("button", { name: "Back" })).toBeTruthy();
     expect(screen.getByText("Library")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Import" })).toBeTruthy();
+    expect(screen.getByTestId("windows-menu-bar")).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: "Open navigation" }),
     ).toBeNull();

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -155,7 +155,6 @@ describe("ChatLayoutHeader mobile affordances", () => {
     expect(screen.getByRole("button", { name: "Back" })).toBeTruthy();
     expect(screen.getByText("Library")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Import" })).toBeTruthy();
-    expect(screen.getByTestId("windows-menu-bar")).toBeTruthy();
     expect(
       screen.queryByRole("button", { name: "Open navigation" }),
     ).toBeNull();
@@ -196,7 +195,7 @@ describe("ChatLayoutHeader mobile affordances", () => {
     );
   });
 
-  test("allocates intrinsic menu width in a narrowed Windows shell", () => {
+  test("keeps menu and actions separate in a narrowed Windows shell", () => {
     mockIsElectron = true;
     mockElectronHostOS = "windows";
     renderHeader({
@@ -213,6 +212,11 @@ describe("ChatLayoutHeader mobile affordances", () => {
     );
     expect(screen.getByText("Library").parentElement?.className).toContain(
       "overflow-hidden",
+    );
+    const windowsMenu = screen.getByTestId("windows-menu-bar");
+    expect(customTopBar?.contains(windowsMenu)).toBe(false);
+    expect(windowsMenu.parentElement?.style.width).toBe(
+      "calc(100% + 150px)",
     );
   });
 });

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -179,6 +179,22 @@ describe("ChatLayoutHeader mobile affordances", () => {
     expect(screen.getByText("Desktop title")).toBeTruthy();
     expect(screen.queryByText("Mobile title")).toBeNull();
   });
+
+  test("keeps custom mobile controls clear of macOS traffic lights", () => {
+    mockIsElectron = true;
+    mockElectronHostOS = "macos";
+    renderHeader({
+      mobileTopBar: {
+        leading: <span>Back</span>,
+        center: <span>Library</span>,
+        trailing: <span>Import</span>,
+      },
+    });
+
+    expect(screen.getByText("Back").parentElement?.style.paddingLeft).toBe(
+      "80px",
+    );
+  });
 });
 
 describe("ChatLayoutHeader page surface", () => {

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -195,6 +195,26 @@ describe("ChatLayoutHeader mobile affordances", () => {
       "80px",
     );
   });
+
+  test("allocates intrinsic menu width in a narrowed Windows shell", () => {
+    mockIsElectron = true;
+    mockElectronHostOS = "windows";
+    renderHeader({
+      mobileTopBar: {
+        leading: <span>Back</span>,
+        center: <span>Library</span>,
+        trailing: <span>Import</span>,
+      },
+    });
+
+    const customTopBar = screen.getByText("Library").parentElement?.parentElement;
+    expect(customTopBar?.className).toContain(
+      "grid-cols-[max-content_minmax(0,1fr)_max-content]",
+    );
+    expect(screen.getByText("Library").parentElement?.className).toContain(
+      "overflow-hidden",
+    );
+  });
 });
 
 describe("ChatLayoutHeader page surface", () => {

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -160,6 +160,12 @@ export function ChatLayoutHeader({
     electronHostOS === "windows"
       ? "grid-cols-[max-content_minmax(0,1fr)_max-content]"
       : "grid-cols-[1fr_auto_1fr]";
+  const windowsMenuRowStyle =
+    electronHostOS === "windows"
+      ? {
+          width: `calc(100% + ${WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX}px)`,
+        }
+      : undefined;
 
   return (
     <header
@@ -182,24 +188,33 @@ export function ChatLayoutHeader({
       {customMobileTopBar ? (
         <div
           inert={controlsHidden || undefined}
-          className={`grid w-full items-center ${customMobileGridColumns} transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
+          className={`flex w-full min-w-0 flex-col transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
         >
-          <div
-            className="flex min-w-0 items-center justify-start gap-2"
-            style={macosTrafficLightStyle}
-          >
-            {customMobileTopBar.leading}
-            <WindowsMenuBar />
+          <div className={`grid w-full items-center ${customMobileGridColumns}`}>
+            <div
+              className="flex min-w-0 items-center justify-start gap-2"
+              style={macosTrafficLightStyle}
+            >
+              {customMobileTopBar.leading}
+            </div>
+            <div
+              inert={centerHidden || undefined}
+              className={`min-w-0 overflow-hidden text-center transition-opacity duration-300${centerHidden ? " pointer-events-none opacity-0" : ""}`}
+            >
+              {customMobileTopBar.center}
+            </div>
+            <div className="flex min-w-0 items-center justify-end">
+              {customMobileTopBar.trailing}
+            </div>
           </div>
-          <div
-            inert={centerHidden || undefined}
-            className={`min-w-0 overflow-hidden text-center transition-opacity duration-300${centerHidden ? " pointer-events-none opacity-0" : ""}`}
-          >
-            {customMobileTopBar.center}
-          </div>
-          <div className="flex min-w-0 items-center justify-end">
-            {customMobileTopBar.trailing}
-          </div>
+          {electronHostOS === "windows" ? (
+            <div
+              className="mt-1 flex min-w-0 items-center"
+              style={windowsMenuRowStyle}
+            >
+              <WindowsMenuBar />
+            </div>
+          ) : null}
         </div>
       ) : (
         <>

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -33,6 +33,7 @@ import { useTranslation } from "@/i18n";
 // (≈ button left edge at 96px, leaving a ~25px gap past the green control).
 // Off Electron the inset is 0.
 const ELECTRON_TRAFFIC_LIGHT_CLEARANCE = 80;
+const ELECTRON_TITLE_BAR_HEIGHT_PX = 44;
 
 /**
  * The `data-slot` this header publishes, and the selector that finds it.
@@ -166,6 +167,10 @@ export function ChatLayoutHeader({
           width: `calc(100% + ${WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX}px)`,
         }
       : undefined;
+  const customMobileActionRowStyle =
+    electronHostOS === "windows"
+      ? { minHeight: ELECTRON_TITLE_BAR_HEIGHT_PX }
+      : undefined;
 
   return (
     <header
@@ -177,7 +182,9 @@ export function ChatLayoutHeader({
       }`}
       style={{
         background: headerBackground,
-        minHeight: usesCustomTitleBar ? "44px" : "40px",
+        minHeight: usesCustomTitleBar
+          ? `${ELECTRON_TITLE_BAR_HEIGHT_PX}px`
+          : "40px",
         paddingTop: usesCustomTitleBar ? 0 : undefined,
         paddingRight:
           electronHostOS === "windows"
@@ -190,7 +197,10 @@ export function ChatLayoutHeader({
           inert={controlsHidden || undefined}
           className={`flex w-full min-w-0 flex-col transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
         >
-          <div className={`grid w-full items-center ${customMobileGridColumns}`}>
+          <div
+            className={`grid w-full items-center ${customMobileGridColumns}`}
+            style={customMobileActionRowStyle}
+          >
             <div
               className="flex min-w-0 items-center justify-start gap-2"
               style={macosTrafficLightStyle}
@@ -209,7 +219,7 @@ export function ChatLayoutHeader({
           </div>
           {electronHostOS === "windows" ? (
             <div
-              className="mt-1 flex min-w-0 items-center"
+              className="flex min-w-0 items-center"
               style={windowsMenuRowStyle}
             >
               <WindowsMenuBar />

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -176,8 +176,9 @@ export function ChatLayoutHeader({
           inert={controlsHidden || undefined}
           className={`grid w-full grid-cols-[1fr_auto_1fr] items-center transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
         >
-          <div className="flex min-w-0 items-center justify-start">
+          <div className="flex min-w-0 items-center justify-start gap-2">
             {customMobileTopBar.leading}
+            <WindowsMenuBar />
           </div>
           <div
             inert={centerHidden || undefined}

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, type ReactNode } from "react";
 
 import { WindowsMenuBar } from "@/components/windows-menu-bar";
+import type { MobileTopBarSlot } from "@/components/layout/chat-layout-slots-store";
 import { NATIVE_MOBILE_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-mobile-button-constants";
 import { WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX } from "@/runtime/electron-window-chrome";
 import {
@@ -62,6 +63,8 @@ export interface ChatLayoutHeaderProps {
    *  them visible for context but pulls them out of the attention field. */
   controlsDimmed?: boolean;
   topBarCenter?: ReactNode;
+  /** Replaces the standard mobile navigation clusters for section-specific chrome. */
+  mobileTopBar?: MobileTopBarSlot | null;
   /**
    * Leads the right cluster, ahead of the mobile search button. The
    * voice-session pill sits here so a live session reads as the leftmost
@@ -86,6 +89,7 @@ export function ChatLayoutHeader({
   centerHidden = false,
   controlsDimmed = false,
   topBarCenter,
+  mobileTopBar,
   topBarRightLeading,
   topBarRightSlot,
   canGoBack,
@@ -147,6 +151,7 @@ export function ChatLayoutHeader({
     pageSurface,
     isNativeMobile(),
   );
+  const customMobileTopBar = isMobile ? mobileTopBar : null;
 
   return (
     <header
@@ -166,104 +171,121 @@ export function ChatLayoutHeader({
             : undefined,
       }}
     >
-      <div
-        // `inert` (not just opacity/pointer-events) so the faded-out
-        // controls also leave the tab order and accessibility tree.
-        inert={controlsHidden || undefined}
-        className={`flex items-center gap-2 transition-[min-width,opacity] duration-300 ease-in-out max-md:shrink-0${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
-        style={{
-          // `minWidth` reserves the sidebar column on desktop only. The Electron
-          // inset clears the inline traffic lights regardless of `isMobile` —
-          // they stay put even in the narrow mobile layout.
-          ...(isMobile
-            ? {}
-            : { minWidth: collapsed ? 48 : (sidebarWidth ?? 230) }),
-          ...(electronHostOS === "macos"
-            ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
-            : {}),
-        }}
-      >
-        {isMobile ? (
-          <Button
-            variant="ghost"
-            iconOnly={<MenuIcon />}
-            aria-label={t("chatLayoutHeader.openNavigationAria")}
-            aria-expanded={drawerOpen}
-            aria-controls="chat-side-menu"
-            tooltip={t("chatLayoutHeader.openNavigationAria")}
-            onClick={toggleSidebar}
-          />
-        ) : (
-          <Button
-            variant="ghost"
-            iconOnly={<PanelLeft />}
-            aria-label={t("chatLayoutHeader.toggleSidebarAria")}
-            aria-expanded={!collapsed}
-            aria-controls="chat-side-menu"
-            tooltip={t("chatLayoutHeader.toggleSidebarAria")}
-            onClick={toggleSidebar}
-          />
-        )}
-        {!isMobile ? (
-          <>
-            <Button
-              variant="ghost"
-              iconOnly={<Search />}
-              aria-label={t("chatLayoutHeader.searchAria")}
-              tooltip={t("chatLayoutHeader.searchAria")}
-              onClick={handleSearchClick}
-            />
-            <Button
-              variant="ghost"
-              iconOnly={<ChevronLeft />}
-              aria-label={t("chatLayoutHeader.backAria")}
-              tooltip={t("chatLayoutHeader.backAria")}
-              disabled={!canGoBack}
-              className={!canGoBack ? "opacity-35" : undefined}
-              onClick={onGoBack}
-            />
-            <Button
-              variant="ghost"
-              iconOnly={<ChevronRight />}
-              aria-label={t("chatLayoutHeader.forwardAria")}
-              tooltip={t("chatLayoutHeader.forwardAria")}
-              disabled={!canGoForward}
-              className={!canGoForward ? "opacity-35" : undefined}
-              onClick={onGoForward}
-            />
-          </>
-        ) : null}
-        {/* Outside the isMobile branch: while this header is mounted the
-            fallback strip yields, so a narrow (zoomed) Windows window would
-            otherwise lose the menus entirely. Self-gates to the Windows
-            shell (renders nothing elsewhere), so no `electronHostOS`
-            branch here. */}
-        <WindowsMenuBar />
-      </div>
+      {customMobileTopBar ? (
+        <div
+          inert={controlsHidden || undefined}
+          className={`grid w-full grid-cols-[1fr_auto_1fr] items-center transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
+        >
+          <div className="flex min-w-0 items-center justify-start">
+            {customMobileTopBar.leading}
+          </div>
+          <div
+            inert={centerHidden || undefined}
+            className={`min-w-0 transition-opacity duration-300${centerHidden ? " pointer-events-none opacity-0" : ""}`}
+          >
+            {customMobileTopBar.center}
+          </div>
+          <div className="flex min-w-0 items-center justify-end">
+            {customMobileTopBar.trailing}
+          </div>
+        </div>
+      ) : (
+        <>
+          <div
+            // `inert` (not just opacity/pointer-events) so the faded-out
+            // controls also leave the tab order and accessibility tree.
+            inert={controlsHidden || undefined}
+            className={`flex items-center gap-2 transition-[min-width,opacity] duration-300 ease-in-out max-md:shrink-0${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
+            style={{
+              // `minWidth` reserves the sidebar column on desktop only. The
+              // Electron inset clears the inline traffic lights at any width.
+              ...(isMobile
+                ? {}
+                : { minWidth: collapsed ? 48 : (sidebarWidth ?? 230) }),
+              ...(electronHostOS === "macos"
+                ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
+                : {}),
+            }}
+          >
+            {isMobile ? (
+              <Button
+                variant="ghost"
+                iconOnly={<MenuIcon />}
+                aria-label={t("chatLayoutHeader.openNavigationAria")}
+                aria-expanded={drawerOpen}
+                aria-controls="chat-side-menu"
+                tooltip={t("chatLayoutHeader.openNavigationAria")}
+                onClick={toggleSidebar}
+              />
+            ) : (
+              <Button
+                variant="ghost"
+                iconOnly={<PanelLeft />}
+                aria-label={t("chatLayoutHeader.toggleSidebarAria")}
+                aria-expanded={!collapsed}
+                aria-controls="chat-side-menu"
+                tooltip={t("chatLayoutHeader.toggleSidebarAria")}
+                onClick={toggleSidebar}
+              />
+            )}
+            {!isMobile ? (
+              <>
+                <Button
+                  variant="ghost"
+                  iconOnly={<Search />}
+                  aria-label={t("chatLayoutHeader.searchAria")}
+                  tooltip={t("chatLayoutHeader.searchAria")}
+                  onClick={handleSearchClick}
+                />
+                <Button
+                  variant="ghost"
+                  iconOnly={<ChevronLeft />}
+                  aria-label={t("chatLayoutHeader.backAria")}
+                  tooltip={t("chatLayoutHeader.backAria")}
+                  disabled={!canGoBack}
+                  className={!canGoBack ? "opacity-35" : undefined}
+                  onClick={onGoBack}
+                />
+                <Button
+                  variant="ghost"
+                  iconOnly={<ChevronRight />}
+                  aria-label={t("chatLayoutHeader.forwardAria")}
+                  tooltip={t("chatLayoutHeader.forwardAria")}
+                  disabled={!canGoForward}
+                  className={!canGoForward ? "opacity-35" : undefined}
+                  onClick={onGoForward}
+                />
+              </>
+            ) : null}
+            {/* Outside the isMobile branch: while this header is mounted the
+                fallback strip yields, so a narrow Windows window keeps its
+                menus. The component renders nothing outside Windows. */}
+            <WindowsMenuBar />
+          </div>
 
-      <div
-        inert={controlsHidden || centerHidden || undefined}
-        // Left-aligned on mobile, pulled in 12px past the header's own
-        // `gap-4` (16px) to sit closer to the menu button, 4px total.
-        // Desktop keeps the title centered in the remaining space.
-        className={`flex min-w-0 flex-1 items-center max-md:-ml-3 max-md:justify-start justify-center transition-opacity duration-300${controlsHidden || centerHidden ? " pointer-events-none opacity-0" : ""}`}
-      >
-        {topBarCenter}
-      </div>
+          <div
+            inert={controlsHidden || centerHidden || undefined}
+            // Left-aligned on mobile, pulled in 12px past the header's own
+            // `gap-4` (16px) to sit closer to the menu button, 4px total.
+            // Desktop keeps the title centered in the remaining space.
+            className={`flex min-w-0 flex-1 items-center max-md:-ml-3 max-md:justify-start justify-center transition-opacity duration-300${controlsHidden || centerHidden ? " pointer-events-none opacity-0" : ""}`}
+          >
+            {topBarCenter}
+          </div>
 
-      {/* `shrink-0`, not `flex-1`: these are fixed-size controls, and a wide
-          occupant (the voice-session pill) would otherwise either squash them
-          into each other or hold the row at its intrinsic width and push the
-          trailing ones off-screen. The centre slot is the only zone that
-          gives. */}
-      <div
-        inert={controlsHidden || undefined}
-        className={`flex shrink-0 items-center gap-2 max-md:justify-end transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
-      >
-        {topBarRightLeading}
-        {searchButton}
-        {topBarRightSlot}
-      </div>
+          {/* `shrink-0`, not `flex-1`: these are fixed-size controls, and a
+              wide occupant (the voice-session pill) would otherwise squash
+              them or push the trailing controls off-screen. */}
+          <div
+            inert={controlsHidden || undefined}
+            className={`flex shrink-0 items-center gap-2 max-md:justify-end transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
+          >
+            {topBarRightLeading}
+            {searchButton}
+            {topBarRightSlot}
+          </div>
+        </>
+      )}
     </header>
   );
 }

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -156,6 +156,10 @@ export function ChatLayoutHeader({
     electronHostOS === "macos"
       ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
       : {};
+  const customMobileGridColumns =
+    electronHostOS === "windows"
+      ? "grid-cols-[max-content_minmax(0,1fr)_max-content]"
+      : "grid-cols-[1fr_auto_1fr]";
 
   return (
     <header
@@ -178,7 +182,7 @@ export function ChatLayoutHeader({
       {customMobileTopBar ? (
         <div
           inert={controlsHidden || undefined}
-          className={`grid w-full grid-cols-[1fr_auto_1fr] items-center transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
+          className={`grid w-full items-center ${customMobileGridColumns} transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
         >
           <div
             className="flex min-w-0 items-center justify-start gap-2"
@@ -189,7 +193,7 @@ export function ChatLayoutHeader({
           </div>
           <div
             inert={centerHidden || undefined}
-            className={`min-w-0 transition-opacity duration-300${centerHidden ? " pointer-events-none opacity-0" : ""}`}
+            className={`min-w-0 overflow-hidden text-center transition-opacity duration-300${centerHidden ? " pointer-events-none opacity-0" : ""}`}
           >
             {customMobileTopBar.center}
           </div>

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -152,6 +152,10 @@ export function ChatLayoutHeader({
     isNativeMobile(),
   );
   const customMobileTopBar = isMobile ? mobileTopBar : null;
+  const macosTrafficLightStyle =
+    electronHostOS === "macos"
+      ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
+      : {};
 
   return (
     <header
@@ -176,7 +180,10 @@ export function ChatLayoutHeader({
           inert={controlsHidden || undefined}
           className={`grid w-full grid-cols-[1fr_auto_1fr] items-center transition-opacity duration-300${controlsHidden ? " pointer-events-none opacity-0" : controlsDimmed ? " opacity-40" : ""}`}
         >
-          <div className="flex min-w-0 items-center justify-start gap-2">
+          <div
+            className="flex min-w-0 items-center justify-start gap-2"
+            style={macosTrafficLightStyle}
+          >
             {customMobileTopBar.leading}
             <WindowsMenuBar />
           </div>
@@ -203,9 +210,7 @@ export function ChatLayoutHeader({
               ...(isMobile
                 ? {}
                 : { minWidth: collapsed ? 48 : (sidebarWidth ?? 230) }),
-              ...(electronHostOS === "macos"
-                ? { paddingLeft: ELECTRON_TRAFFIC_LIGHT_CLEARANCE }
-                : {}),
+              ...macosTrafficLightStyle,
             }}
           >
             {isMobile ? (

--- a/clients/web/src/domains/chat/chat-layout-top-bar-slots.test.ts
+++ b/clients/web/src/domains/chat/chat-layout-top-bar-slots.test.ts
@@ -43,6 +43,10 @@ describe("ChatLayout top-bar slots", () => {
     expect(layoutSource).toContain("{topBarPill}");
   });
 
+  test("the shared header receives the route-owned mobile top bar", () => {
+    expect(layoutSource).toContain("mobileTopBar={mobileTopBar}");
+  });
+
   // Both land in the header's one route slot, so their order in the cluster is
   // the order the layout writes them in: pill first, bell after.
   test("the top bar seats the pill ahead of the accessory", () => {

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -354,6 +354,7 @@ export function ChatLayout({
   const topBarCenterSlot = useChatLayoutSlotsStore.use.topBarCenter();
   const headerSupplements = useChatLayoutSlotsStore.use.headerSupplements();
   const topBarRightSlot = useChatLayoutSlotsStore.use.topBarRightSlot();
+  const mobileTopBar = useChatLayoutSlotsStore.use.mobileTopBar();
   const showInternalActions = useCanUseInternalThreadActions();
   const isNative = useIsNativePlatform();
   const electron = isElectron();
@@ -1154,6 +1155,7 @@ export function ChatLayout({
           // the tour runs, so it doubles as the dim signal.)
           controlsDimmed={headerCenterHidden}
           topBarCenter={topBarCenter}
+          mobileTopBar={mobileTopBar}
           // The voice-session pill is composed here — NOT registered through
           // useChatLayoutSlotsStore — because slot registration is owned by
           // per-route hooks that unmount on navigation, exactly when the pill

--- a/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -25,6 +25,7 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 
 const isMobileRef = { value: false };
 const setTopBarCenterMock = mock((_node: unknown) => {});
+const setMobileTopBarMock = mock((_slot: unknown) => {});
 
 mock.module("@/hooks/use-is-mobile", () => ({
   useIsMobile: () => isMobileRef.value,
@@ -35,6 +36,7 @@ mock.module("@/components/layout/chat-layout-slots-store", () => ({
   useChatLayoutSlotsStore: {
     use: {
       setTopBarCenter: () => setTopBarCenterMock,
+      setMobileTopBar: () => setMobileTopBarMock,
     },
   },
 }));
@@ -54,6 +56,7 @@ const renderLayoutAt = (path: string) =>
 beforeEach(() => {
   isMobileRef.value = false;
   setTopBarCenterMock.mockClear();
+  setMobileTopBarMock.mockClear();
   useAssistantIdentityStore.getState().setIdentity("Ada", null);
 });
 
@@ -134,9 +137,37 @@ describe("IntelligenceLayout — section pages", () => {
     );
   });
 
+  test("on mobile, Library registers one back, title, and action top bar", () => {
+    isMobileRef.value = true;
+    useIntelligenceLayoutSlotsStore
+      .getState()
+      .setHeaderTrailing(<button type="button">Import</button>);
+    const { container } = renderLayoutAt("/assistant/library");
+
+    const slot = setMobileTopBarMock.mock.calls.at(-1)?.[0] as
+      | {
+          leading: React.ReactNode;
+          center: React.ReactNode;
+          trailing: React.ReactNode;
+        }
+      | undefined;
+    expect(slot).toBeDefined();
+    expect(
+      renderToStaticMarkup(slot?.center as React.ReactElement),
+    ).toContain("Library");
+    expect(
+      renderToStaticMarkup(slot?.trailing as React.ReactElement),
+    ).toContain("Import");
+    expect(isValidElement(slot?.leading)).toBe(true);
+    expect(container.querySelector("h1")).toBeNull();
+    expect(container.querySelector("a")).toBeNull();
+    expect(setTopBarCenterMock).toHaveBeenLastCalledWith(null);
+  });
+
   test("on desktop, clears the top-bar center", () => {
     renderLayoutAt("/assistant/contacts");
     expect(setTopBarCenterMock).toHaveBeenLastCalledWith(null);
+    expect(setMobileTopBarMock).toHaveBeenLastCalledWith(null);
   });
 
   /**

--- a/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.test.tsx
@@ -159,6 +159,14 @@ describe("IntelligenceLayout — section pages", () => {
       renderToStaticMarkup(slot?.trailing as React.ReactElement),
     ).toContain("Import");
     expect(isValidElement(slot?.leading)).toBe(true);
+    expect(
+      (
+        slot?.leading as
+          | { props?: { className?: string } }
+          | null
+          | undefined
+      )?.props?.className,
+    ).toContain("rounded-full");
     expect(container.querySelector("h1")).toBeNull();
     expect(container.querySelector("a")).toBeNull();
     expect(setTopBarCenterMock).toHaveBeenLastCalledWith(null);

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -89,7 +89,7 @@ export function IntelligenceLayout() {
             iconOnly={<ArrowLeft aria-hidden />}
             aria-label={backAriaLabel}
             tooltip={backTitle}
-            className="max-md:bg-[var(--surface-active)]"
+            className="rounded-full max-md:bg-[var(--surface-active)]"
           >
             <Link to={routes.identity} />
           </Button>

--- a/clients/web/src/domains/intelligence/intelligence-layout.tsx
+++ b/clients/web/src/domains/intelligence/intelligence-layout.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
-import { ChevronLeft } from "lucide-react";
+import { ArrowLeft, ChevronLeft } from "lucide-react";
 import { Link, Outlet, useLocation } from "react-router";
 
-import { Typography } from "@vellumai/design-library";
+import { Button, Typography } from "@vellumai/design-library";
 
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
 import { PageShell } from "@/components/page-shell";
@@ -58,20 +58,54 @@ export function IntelligenceLayout() {
   const { pathname } = useLocation();
   const isMobile = useIsMobile();
   const setTopBarCenter = useChatLayoutSlotsStore.use.setTopBarCenter();
+  const setMobileTopBar = useChatLayoutSlotsStore.use.setMobileTopBar();
   const headerTrailing = useIntelligenceLayoutSlotsStore.use.headerTrailing();
 
   const section = aboutAssistantSectionForPath(pathname);
   const sectionTitle = section
     ? t(SECTION_LABEL_KEY[section.key as AboutAssistantSectionKey])
     : null;
+  const usesLibraryMobileTopBar = isMobile && section?.key === "library";
+  const fallbackAssistantName =
+    assistantName || t("identityOverview.defaultAssistantName");
+  const backAriaLabel = t("intelligenceLayout.backToAriaLabel", {
+    name: fallbackAssistantName,
+  });
+  const backTitle = t("intelligenceLayout.backToTitle", {
+    name: fallbackAssistantName,
+  });
 
-  // On mobile the section title moves out of the page body and into the
-  // shared top bar — centered between the hamburger menu and the search
-  // icon. The bare pages (overview, personality) set no title: the
-  // greeting on the stage already names the assistant. Desktop keeps the
-  // in-body <h1> (section pages only) and leaves the top-bar center empty.
+  // Library owns the complete mobile top bar so its back, title, and import
+  // affordances form one centered navigation row. Other mobile sections keep
+  // the shared menu and search chrome and register only their title.
   useEffect(() => {
-    if (isMobile && sectionTitle) {
+    if (usesLibraryMobileTopBar && sectionTitle) {
+      setTopBarCenter(null);
+      setMobileTopBar({
+        leading: (
+          <Button
+            asChild
+            variant="ghost"
+            iconOnly={<ArrowLeft aria-hidden />}
+            aria-label={backAriaLabel}
+            tooltip={backTitle}
+            className="max-md:bg-[var(--surface-active)]"
+          >
+            <Link to={routes.identity} />
+          </Button>
+        ),
+        center: (
+          <Typography
+            variant="body-medium-default"
+            className="max-w-[50vw] truncate text-[var(--content-secondary)]"
+          >
+            {sectionTitle}
+          </Typography>
+        ),
+        trailing: headerTrailing,
+      });
+    } else if (isMobile && sectionTitle) {
+      setMobileTopBar(null);
       setTopBarCenter(
         <Typography
           variant="body-medium-default"
@@ -81,12 +115,23 @@ export function IntelligenceLayout() {
         </Typography>,
       );
     } else {
+      setMobileTopBar(null);
       setTopBarCenter(null);
     }
     return () => {
+      setMobileTopBar(null);
       setTopBarCenter(null);
     };
-  }, [isMobile, sectionTitle, setTopBarCenter]);
+  }, [
+    backAriaLabel,
+    backTitle,
+    headerTrailing,
+    isMobile,
+    sectionTitle,
+    setMobileTopBar,
+    setTopBarCenter,
+    usesLibraryMobileTopBar,
+  ]);
 
   // The overview and personality pages paint their own full-bleed stage —
   // no shell, heading, or back chrome.
@@ -100,34 +145,29 @@ export function IntelligenceLayout() {
 
   return (
     <PageShell>
-      {/* The heading row: back chevron and title on the left, and on the
-          right whatever the section page has registered as its header
-          action (the Library's Import button), so a page-level command sits
-          on the title line rather than taking a row of its own above the
-          page body. On mobile the title has moved to the top bar, so the row
-          is the chevron and that action alone. */}
-      <div className="mb-4 flex shrink-0 items-center gap-1.5">
-        <Link
-          to={routes.identity}
-          className="-ml-2 flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-[var(--content-secondary)] transition-colors outline-none hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)] focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
-          aria-label={t("intelligenceLayout.backToAriaLabel", {
-            name: assistantName || t("identityOverview.defaultAssistantName"),
-          })}
-          title={t("intelligenceLayout.backToTitle", {
-            name: assistantName || t("identityOverview.defaultAssistantName"),
-          })}
-        >
-          <ChevronLeft className="h-5 w-5" aria-hidden />
-        </Link>
-        <h1 className="text-title-large text-[var(--content-default)] max-md:hidden">
-          {sectionTitle}
-        </h1>
-        {headerTrailing ? (
-          <div className="ml-auto flex shrink-0 items-center">
-            {headerTrailing}
-          </div>
-        ) : null}
-      </div>
+      {/* Desktop section chrome and the existing mobile chrome for sections
+          that still use the shared app bar. Library's mobile header is fully
+          registered above, so it does not render a second body row. */}
+      {!usesLibraryMobileTopBar ? (
+        <div className="mb-4 flex shrink-0 items-center gap-1.5">
+          <Link
+            to={routes.identity}
+            className="-ml-2 flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-md text-[var(--content-secondary)] transition-colors outline-none hover:bg-[var(--surface-hover)] hover:text-[var(--content-default)] focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+            aria-label={backAriaLabel}
+            title={backTitle}
+          >
+            <ChevronLeft className="h-5 w-5" aria-hidden />
+          </Link>
+          <h1 className="text-title-large text-[var(--content-default)] max-md:hidden">
+            {sectionTitle}
+          </h1>
+          {headerTrailing ? (
+            <div className="ml-auto flex shrink-0 items-center">
+              {headerTrailing}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         <Outlet />

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -163,7 +163,7 @@ export function LibraryAppCard({
           onClick={() => onOpen(app.id)}
           className="flex cursor-pointer flex-col gap-0.5 px-0.5 text-left outline-none"
         >
-          <span className="truncate text-body-large-default text-[color:var(--content-emphasised)]">
+          <span className="truncate text-body-large-default text-[color:var(--content-emphasised)] max-md:text-body-medium-lighter max-md:text-[color:var(--content-secondary)]">
             {app.name}
           </span>
           <span className="text-body-small-default text-[color:var(--content-tertiary)] max-md:hidden">

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -166,7 +166,7 @@ export function LibraryAppCard({
           <span className="truncate text-body-large-default text-[color:var(--content-emphasised)]">
             {app.name}
           </span>
-          <span className="text-body-small-default text-[color:var(--content-tertiary)]">
+          <span className="text-body-small-default text-[color:var(--content-tertiary)] max-md:hidden">
             {formatFriendlyDate(new Date(app.createdAt))}
           </span>
         </button>

--- a/clients/web/src/domains/library/components/library-grid-section.test.tsx
+++ b/clients/web/src/domains/library/components/library-grid-section.test.tsx
@@ -60,5 +60,8 @@ describe("LibraryGridSection card surface", () => {
     expect(grid?.className).toContain(
       "[--swipe-item-surface:var(--surface-base)]",
     );
+    expect(container.querySelector("h2")?.className).toContain(
+      "max-md:sr-only",
+    );
   });
 });

--- a/clients/web/src/domains/library/components/library-grid-section.test.tsx
+++ b/clients/web/src/domains/library/components/library-grid-section.test.tsx
@@ -1,0 +1,64 @@
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import type { AppSummary } from "@/types/app-types";
+import {
+  restoreStubbedModules,
+  stubModule,
+} from "@/utils/module-mock.test-helper";
+
+stubModule(
+  "@/domains/library/components/library-app-card",
+  await import("@/domains/library/components/library-app-card"),
+  {
+    LibraryAppCard: ({ app }: { app: AppSummary }) => (
+      <article>{app.name}</article>
+    ),
+  },
+);
+
+const { LibraryGridSection } = await import(
+  "@/domains/library/components/library-grid-section"
+);
+
+const APP: AppSummary = {
+  id: "app-123",
+  name: "Example App",
+  createdAt: 1767225600000,
+  updatedAt: 1767225600000,
+  version: "1",
+  contentId: "content-123",
+  origin: "workspace",
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  restoreStubbedModules();
+});
+
+describe("LibraryGridSection card surface", () => {
+  test("backs swipe content with the same surface as the library page", () => {
+    const { container } = render(
+      <LibraryGridSection
+        title="Recents"
+        apps={[APP]}
+        assistantId="assistant-123"
+        pinnedAppIds={new Set()}
+        onOpen={() => {}}
+        onPin={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const grid = container.querySelector(".grid");
+    expect(grid?.className).toContain(
+      "max-md:[--swipe-item-surface:var(--surface-overlay)]",
+    );
+    expect(grid?.className).toContain(
+      "[--swipe-item-surface:var(--surface-base)]",
+    );
+  });
+});

--- a/clients/web/src/domains/library/components/library-grid-section.tsx
+++ b/clients/web/src/domains/library/components/library-grid-section.tsx
@@ -40,9 +40,9 @@ export function LibraryGridSection({
       <h2 className="mb-4 text-body-small-emphasised text-[color:var(--content-secondary)]">
         {title}
       </h2>
-      {/* On mobile the title and date sit directly on the page surface. The
-          swipe item uses that same opaque surface so its actions stay covered
-          at rest, while desktop keeps its established card surface. */}
+      {/* On mobile the title sits directly on the page surface. The swipe item
+          uses that same opaque surface so its actions stay covered at rest,
+          while desktop keeps its established card surface. */}
       <div className="grid grid-cols-[repeat(auto-fill,minmax(max(220px,calc((100%-6rem)/5)),1fr))] gap-6 [--swipe-item-surface:var(--surface-base)] max-md:[--swipe-item-surface:var(--surface-overlay)]">
         {apps.map((app) => (
           <LibraryAppCard

--- a/clients/web/src/domains/library/components/library-grid-section.tsx
+++ b/clients/web/src/domains/library/components/library-grid-section.tsx
@@ -40,11 +40,10 @@ export function LibraryGridSection({
       <h2 className="mb-4 text-body-small-emphasised text-[color:var(--content-secondary)]">
         {title}
       </h2>
-      {/* The colour the cards sit on: the page paints `--surface-base` and
-          the grid nothing of its own. A card's title and date are transparent
-          on it, and the swipe wrapper backs the card with this so a swiped
-          card covers the action behind it instead of showing it through. */}
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(max(220px,calc((100%-6rem)/5)),1fr))] gap-6 [--swipe-item-surface:var(--surface-base)]">
+      {/* On mobile the title and date sit directly on the page surface. The
+          swipe item uses that same opaque surface so its actions stay covered
+          at rest, while desktop keeps its established card surface. */}
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(max(220px,calc((100%-6rem)/5)),1fr))] gap-6 [--swipe-item-surface:var(--surface-base)] max-md:[--swipe-item-surface:var(--surface-overlay)]">
         {apps.map((app) => (
           <LibraryAppCard
             key={app.id}

--- a/clients/web/src/domains/library/components/library-grid-section.tsx
+++ b/clients/web/src/domains/library/components/library-grid-section.tsx
@@ -37,12 +37,12 @@ export function LibraryGridSection({
 
   return (
     <section>
-      <h2 className="mb-4 text-body-small-emphasised text-[color:var(--content-secondary)]">
+      <h2 className="mb-4 text-body-small-emphasised text-[color:var(--content-secondary)] max-md:sr-only">
         {title}
       </h2>
-      {/* On mobile the title sits directly on the page surface. The swipe item
-          uses that same opaque surface so its actions stay covered at rest,
-          while desktop keeps its established card surface. */}
+      {/* On mobile each app name sits directly on the page surface. The swipe
+          item uses that same opaque surface so its actions stay covered at
+          rest, while desktop keeps its established card surface. */}
       <div className="grid grid-cols-[repeat(auto-fill,minmax(max(220px,calc((100%-6rem)/5)),1fr))] gap-6 [--swipe-item-surface:var(--surface-base)] max-md:[--swipe-item-surface:var(--surface-overlay)]">
         {apps.map((app) => (
           <LibraryAppCard

--- a/clients/web/src/domains/library/library-view.test.tsx
+++ b/clients/web/src/domains/library/library-view.test.tsx
@@ -138,6 +138,14 @@ describe("LibraryView import affordance", () => {
     expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
   });
 
+  test("hides app dates at mobile widths", () => {
+    apps = [APP];
+    renderView();
+
+    const appName = screen.getByText("Example App");
+    expect(appName.nextElementSibling?.className).toContain("max-md:hidden");
+  });
+
   test("uses an icon-only import action in the mobile top bar", () => {
     isMobileRef.value = true;
     renderView();
@@ -147,6 +155,7 @@ describe("LibraryView import affordance", () => {
     expect(importButton.className).toContain(
       "max-md:bg-[var(--surface-active)]",
     );
+    expect(importButton.className).toContain("rounded-full");
   });
 
   test("constrains the picker to .vellum on a fine-pointer device", () => {

--- a/clients/web/src/domains/library/library-view.test.tsx
+++ b/clients/web/src/domains/library/library-view.test.tsx
@@ -18,6 +18,12 @@ import type { AppSummary } from "@/types/app-types";
 
 let apps: AppSummary[] = [];
 let pointerIsCoarse = false;
+const isMobileRef = { value: false };
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => isMobileRef.value,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
 
 mock.module("@/utils/pointer", () => ({
   isPointerCoarse: () => pointerIsCoarse,
@@ -106,6 +112,7 @@ function renderView() {
 beforeEach(() => {
   apps = [];
   pointerIsCoarse = false;
+  isMobileRef.value = false;
 });
 
 afterEach(() => {
@@ -129,6 +136,17 @@ describe("LibraryView import affordance", () => {
     expect(screen.queryByText("Your library is empty")).toBeNull();
     expect(screen.getByRole("button", { name: /Import/ })).not.toBeNull();
     expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
+  });
+
+  test("uses an icon-only import action in the mobile top bar", () => {
+    isMobileRef.value = true;
+    renderView();
+
+    const importButton = screen.getByRole("button", { name: "Import" });
+    expect(importButton.textContent).toBe("");
+    expect(importButton.className).toContain(
+      "max-md:bg-[var(--surface-active)]",
+    );
   });
 
   test("constrains the picker to .vellum on a fine-pointer device", () => {

--- a/clients/web/src/domains/library/library-view.test.tsx
+++ b/clients/web/src/domains/library/library-view.test.tsx
@@ -146,6 +146,17 @@ describe("LibraryView import affordance", () => {
     expect(appName.nextElementSibling?.className).toContain("max-md:hidden");
   });
 
+  test("uses compact secondary app-name typography at mobile widths", () => {
+    apps = [APP];
+    renderView();
+
+    const appName = screen.getByText("Example App");
+    expect(appName.className).toContain("max-md:text-body-medium-lighter");
+    expect(appName.className).toContain(
+      "max-md:text-[color:var(--content-secondary)]",
+    );
+  });
+
   test("uses an icon-only import action in the mobile top bar", () => {
     isMobileRef.value = true;
     renderView();

--- a/clients/web/src/domains/library/library-view.tsx
+++ b/clients/web/src/domains/library/library-view.tsx
@@ -177,7 +177,7 @@ export function LibraryView({
           iconOnly={importIcon}
           aria-label={t("libraryView.import")}
           tooltip={t("libraryView.import")}
-          className="max-md:bg-[var(--surface-active)]"
+          className="rounded-full max-md:bg-[var(--surface-active)]"
           onClick={() => fileInputRef.current?.click()}
           disabled={isImporting}
         />

--- a/clients/web/src/domains/library/library-view.tsx
+++ b/clients/web/src/domains/library/library-view.tsx
@@ -29,6 +29,7 @@ import { appsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useAppDelete } from "@/hooks/use-app-delete";
 import { usePinnedApps } from "@/hooks/use-pinned-apps";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import type { AppSummary } from "@/types/app-types";
 import { getCachedAppHtml } from "@/utils/app-html-cache";
 import { importBundle } from "@/utils/import-bundle";
@@ -53,6 +54,7 @@ export function LibraryView({
   onOpenApp,
 }: LibraryViewProps) {
   const { t } = useTranslation("library");
+  const isMobile = useIsMobile();
   const queryClient = useQueryClient();
   const { togglePin, pinnedAppIds } = usePinnedApps(assistantId);
   const isDeploying = useDeployStore.use.isDeploying();
@@ -163,25 +165,38 @@ export function LibraryView({
       setHeaderTrailing(null);
       return;
     }
+    const importIcon = isImporting ? (
+      <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+    ) : (
+      <Download aria-hidden />
+    );
     setHeaderTrailing(
-      <Button
-        variant="outlined"
-        size="regular"
-        onClick={() => fileInputRef.current?.click()}
-        disabled={isImporting}
-      >
-        {isImporting ? (
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-        ) : (
-          <Download size={14} />
-        )}
-        <span className="ml-1.5">{t("libraryView.import")}</span>
-      </Button>,
+      isMobile ? (
+        <Button
+          variant="ghost"
+          iconOnly={importIcon}
+          aria-label={t("libraryView.import")}
+          tooltip={t("libraryView.import")}
+          className="max-md:bg-[var(--surface-active)]"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isImporting}
+        />
+      ) : (
+        <Button
+          variant="outlined"
+          size="regular"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isImporting}
+        >
+          {importIcon}
+          <span className="ml-1.5">{t("libraryView.import")}</span>
+        </Button>
+      ),
     );
     return () => {
       setHeaderTrailing(null);
     };
-  }, [showsImport, isImporting, setHeaderTrailing, t]);
+  }, [isMobile, showsImport, isImporting, setHeaderTrailing, t]);
 
   // --- Render: loading ---
   if (loading) {

--- a/clients/web/src/mobile-library-page.stories.tsx
+++ b/clients/web/src/mobile-library-page.stories.tsx
@@ -1,0 +1,226 @@
+/**
+ * The mobile Library route as it is assembled in the app: LibraryView fills
+ * the IntelligenceLayout action slot, IntelligenceLayout publishes the
+ * complete mobile navigation row, and ChatLayoutHeader renders that row above
+ * the full-bleed page surface. Keeping the whole chain in one story protects
+ * the layout-slot handoff as well as the individual controls and cards.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, useState } from "react";
+import { Route, Routes } from "react-router";
+
+import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
+import { useIntelligenceLayoutSlotsStore } from "@/components/layout/intelligence-layout-slots-store";
+import { ChatLayoutHeader } from "@/domains/chat/chat-layout-header";
+import { IntelligenceLayout } from "@/domains/intelligence/intelligence-layout";
+import { LibraryView } from "@/domains/library/library-view";
+import {
+  appsGetQueryKey,
+  documentsGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import type {
+  AppsGetResponse,
+  DocumentsGetResponse,
+} from "@/generated/daemon/types.gen";
+import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import type { AppSummary } from "@/types/app-types";
+import {
+  clearAppHtmlCache,
+  primeAppHtmlCache,
+} from "@/utils/app-html-cache";
+
+const ASSISTANT_ID = "assistant-library-story";
+
+const STORY_APPS: AppSummary[] = [
+  {
+    id: "app-threadkeeper",
+    name: "Threadkeeper",
+    createdAt: new Date("2026-08-17T12:00:00Z").getTime(),
+    updatedAt: new Date("2026-08-17T12:00:00Z").getTime(),
+    version: "1",
+    contentId: "content-threadkeeper",
+    origin: "workspace",
+  },
+  {
+    id: "app-calculator",
+    name: "Calculator",
+    createdAt: new Date("2026-06-22T12:00:00Z").getTime(),
+    updatedAt: new Date("2026-06-22T12:00:00Z").getTime(),
+    version: "1",
+    contentId: "content-calculator",
+    origin: "workspace",
+  },
+];
+
+const THREADKEEPER_PREVIEW = `<!doctype html>
+<html>
+  <body style="box-sizing:border-box;margin:0;padding:34px;background:#f4f3ea;color:#202624;font-family:ui-monospace,monospace">
+    <div style="font-size:11px;letter-spacing:3px;color:#67706b">THREADKEEPER / FIELD NOTES</div>
+    <h1 style="margin:12px 0 5px;font:42px Georgia,serif">Keep the thread.</h1>
+    <p style="margin:0;color:#6f7772;font:18px Georgia,serif">A quiet map of what you meant to return to.</p>
+    <div style="display:flex;gap:28px;margin-top:30px;padding:18px 0;border-top:1px solid #d8d7ce;border-bottom:1px solid #d8d7ce;font-size:12px;color:#6f7772">
+      <strong style="color:#202624">Open now</strong><span>Threads</span><span>Needs review</span><span>Connections</span>
+    </div>
+  </body>
+</html>`;
+
+const CALCULATOR_PREVIEW = `<!doctype html>
+<html>
+  <body style="box-sizing:border-box;margin:0;min-height:100vh;display:grid;place-items:center;background:#05050d;color:#f7f4ed;font-family:system-ui,sans-serif">
+    <div style="width:176px;padding:18px;background:#14141d;border-radius:20px;box-shadow:0 18px 50px #0008">
+      <div style="height:46px;margin-bottom:12px;text-align:right;font-size:34px">0</div>
+      <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:8px">
+        <span style="color:#ff6961">AC</span><span>+/−</span><span>%</span><span style="color:#ff8b32">÷</span>
+        <span>7</span><span>8</span><span>9</span><span style="color:#ff8b32">×</span>
+        <span>4</span><span>5</span><span>6</span><span style="color:#ff8b32">−</span>
+        <span>1</span><span>2</span><span>3</span><span style="color:#ff8b32">+</span>
+      </div>
+    </div>
+  </body>
+</html>`;
+
+function createStoryClient(): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData<AppsGetResponse>(
+    appsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+    { apps: STORY_APPS },
+  );
+  client.setQueryData<DocumentsGetResponse>(
+    documentsGetQueryKey({ path: { assistant_id: ASSISTANT_ID } }),
+    { documents: [] },
+  );
+  client.setQueryData(
+    ["assistant-capability", "appPins", ASSISTANT_ID],
+    true,
+  );
+  return client;
+}
+
+/**
+ * Seeds every external source before the route's first render and marks the
+ * preview as an iOS shell so native-mobile utilities match the shipped page.
+ */
+const withLibraryFixture: Decorator = function WithLibraryFixture(Story) {
+  const [client] = useState(createStoryClient);
+  const [previousState] = useState(() => {
+    const previous = {
+      assistantId:
+        useResolvedAssistantsStore.getState().activeAssistantId ?? null,
+      identity: {
+        name: useAssistantIdentityStore.getState().name,
+        version: useAssistantIdentityStore.getState().version,
+        assistantId: useAssistantIdentityStore.getState().assistantId,
+      },
+      nativePlatform: document.documentElement.dataset.nativePlatform,
+    };
+
+    useResolvedAssistantsStore.setState({ activeAssistantId: ASSISTANT_ID });
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("Example Assistant", "1.0.0", ASSISTANT_ID);
+    useChatLayoutSlotsStore.getState().setTopBarCenter(null);
+    useChatLayoutSlotsStore.getState().setMobileTopBar(null);
+    useIntelligenceLayoutSlotsStore.getState().setHeaderTrailing(null);
+    document.documentElement.dataset.nativePlatform = "ios";
+    primeAppHtmlCache(
+      ASSISTANT_ID,
+      "app-threadkeeper",
+      THREADKEEPER_PREVIEW,
+    );
+    primeAppHtmlCache(ASSISTANT_ID, "app-calculator", CALCULATOR_PREVIEW);
+
+    return previous;
+  });
+
+  useEffect(() => {
+    return () => {
+      useResolvedAssistantsStore.setState({
+        activeAssistantId: previousState.assistantId,
+      });
+      useAssistantIdentityStore.getState().setIdentity(
+        previousState.identity.name,
+        previousState.identity.version,
+        previousState.identity.assistantId,
+      );
+      useChatLayoutSlotsStore.getState().setTopBarCenter(null);
+      useChatLayoutSlotsStore.getState().setMobileTopBar(null);
+      useIntelligenceLayoutSlotsStore.getState().setHeaderTrailing(null);
+      if (previousState.nativePlatform == null) {
+        delete document.documentElement.dataset.nativePlatform;
+      } else {
+        document.documentElement.dataset.nativePlatform =
+          previousState.nativePlatform;
+      }
+      clearAppHtmlCache(ASSISTANT_ID, "app-threadkeeper");
+      clearAppHtmlCache(ASSISTANT_ID, "app-calculator");
+    };
+  }, [previousState]);
+
+  return (
+    <QueryClientProvider client={client}>
+      <Story />
+    </QueryClientProvider>
+  );
+};
+
+function MobileLibraryPage() {
+  const isMobile = useIsMobile();
+  const mobileTopBar = useChatLayoutSlotsStore.use.mobileTopBar();
+
+  return (
+    <div className="flex h-dvh min-h-0 flex-col overflow-hidden bg-[var(--surface-overlay)]">
+      <ChatLayoutHeader
+        isMobile={isMobile}
+        drawerOpen={false}
+        collapsed
+        toggleSidebar={() => {}}
+        mobileTopBar={mobileTopBar}
+      />
+      <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <Routes>
+          <Route element={<IntelligenceLayout />}>
+            <Route
+              path="/assistant/library"
+              element={
+                <LibraryView
+                  assistantId={ASSISTANT_ID}
+                  assistantName="Example Assistant"
+                  onOpenApp={() => {}}
+                />
+              }
+            />
+          </Route>
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+const meta: Meta<typeof MobileLibraryPage> = {
+  title: "Library/LibraryPage",
+  component: MobileLibraryPage,
+  tags: ["!autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    controls: { disable: true },
+    router: { initialEntries: ["/assistant/library"] },
+  },
+  decorators: [withLibraryFixture],
+};
+
+export default meta;
+type Story = StoryObj<typeof MobileLibraryPage>;
+
+/** Phone-width route with the consolidated top bar and labels below cards. */
+export const Mobile: Story = {
+  globals: {
+    theme: "dark",
+    viewport: { value: "sbMobile", isRotated: false },
+  },
+};


### PR DESCRIPTION
## Summary

- add a route-owned mobile top bar with Back, a centered Library title, and Import
- use an icon-only mobile Import action while preserving the desktop control and file-picker behavior
- align the mobile swipe-item surface with the Library page so app names and dates sit below thumbnails without a contrasting card band
- add focused regression coverage for mobile header composition, import behavior, and card surfaces

## Design

- https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=8621-9754

## Testing

- 38 targeted Bun tests passed
- bunx tsc --noEmit
- bunx eslint on all changed web files
- git diff --check