### PR TITLE
feat(gateway): persist platform identity and add GET /v1/whoami

### DIFF
--- a/gateway/src/__tests__/platform-user-id.test.ts
+++ b/gateway/src/__tests__/platform-user-id.test.ts
@@ -2,30 +2,61 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import "./test-preload.js";
 
-let mockResult: { value: string | undefined; unreachable: boolean } = {
-  value: undefined,
-  unreachable: false,
-};
+import { credentialKey } from "../credential-key.js";
+
+type CredResult = { value: string | undefined; unreachable: boolean };
+
+const results = new Map<string, CredResult>();
 
 const actualCredentialReader = await import("../credential-reader.js");
 mock.module("../credential-reader.js", () => ({
   ...actualCredentialReader,
-  readCredentialResult: async () => mockResult,
+  readCredentialResult: async (account: string) =>
+    results.get(account) ?? { value: undefined, unreachable: false },
 }));
 
-const { readStoredPlatformUserId, _resetLastKnownPlatformUserIdForTest } =
-  await import("../platform-user-id.js");
+const {
+  readPlatformIdentity,
+  readStoredPlatformUserId,
+  _resetLastKnownPlatformUserIdForTest,
+  _dropPlatformIdentityMemoryForTest,
+} = await import("../platform-user-id.js");
+
+const { handleWhoami } = await import("../http/routes/whoami.js");
 
 const OWNER_ID = "user-123";
+const ASSISTANT_ID = "asst-123";
+const ORG_ID = "org-abc";
+
+function setLiveIdentity(identity: {
+  assistantId?: string;
+  userId?: string;
+  organizationId?: string;
+  unreachable?: boolean;
+}): void {
+  const unreachable = identity.unreachable ?? false;
+  results.set(credentialKey("vellum", "platform_assistant_id"), {
+    value: identity.assistantId,
+    unreachable,
+  });
+  results.set(credentialKey("vellum", "platform_user_id"), {
+    value: identity.userId,
+    unreachable,
+  });
+  results.set(credentialKey("vellum", "platform_organization_id"), {
+    value: identity.organizationId,
+    unreachable,
+  });
+}
 
 beforeEach(() => {
   _resetLastKnownPlatformUserIdForTest();
-  mockResult = { value: undefined, unreachable: false };
+  results.clear();
 });
 
 describe("readStoredPlatformUserId", () => {
   test("returns a live owner id and caches it", async () => {
-    mockResult = { value: OWNER_ID, unreachable: false };
+    setLiveIdentity({ userId: OWNER_ID });
     await expect(readStoredPlatformUserId()).resolves.toEqual({
       userId: OWNER_ID,
       unreachable: false,
@@ -33,10 +64,10 @@ describe("readStoredPlatformUserId", () => {
   });
 
   test("uses last known owner when the vault is unreachable", async () => {
-    mockResult = { value: OWNER_ID, unreachable: false };
+    setLiveIdentity({ userId: OWNER_ID });
     await readStoredPlatformUserId();
 
-    mockResult = { value: undefined, unreachable: true };
+    setLiveIdentity({ unreachable: true });
     await expect(readStoredPlatformUserId()).resolves.toEqual({
       userId: OWNER_ID,
       unreachable: false,
@@ -44,27 +75,94 @@ describe("readStoredPlatformUserId", () => {
   });
 
   test("reports unreachable when the vault is down and nothing is cached", async () => {
-    mockResult = { value: undefined, unreachable: true };
+    setLiveIdentity({ unreachable: true });
     await expect(readStoredPlatformUserId()).resolves.toEqual({
       userId: undefined,
       unreachable: true,
     });
   });
 
-  test("a genuine miss clears the last known owner", async () => {
-    mockResult = { value: OWNER_ID, unreachable: false };
+  test("keeps durable identity when the vault answers empty", async () => {
+    setLiveIdentity({ userId: OWNER_ID });
     await readStoredPlatformUserId();
 
-    mockResult = { value: undefined, unreachable: false };
+    setLiveIdentity({});
     await expect(readStoredPlatformUserId()).resolves.toEqual({
-      userId: undefined,
+      userId: OWNER_ID,
       unreachable: false,
     });
+  });
 
-    mockResult = { value: undefined, unreachable: true };
+  test("rereads the identity file after a process-local cache drop", async () => {
+    setLiveIdentity({ userId: OWNER_ID });
+    await readStoredPlatformUserId();
+    _dropPlatformIdentityMemoryForTest();
+
+    setLiveIdentity({ unreachable: true });
     await expect(readStoredPlatformUserId()).resolves.toEqual({
-      userId: undefined,
-      unreachable: true,
+      userId: OWNER_ID,
+      unreachable: false,
+    });
+  });
+});
+
+describe("readPlatformIdentity", () => {
+  test("returns all three ids from a live vault read", async () => {
+    setLiveIdentity({
+      assistantId: ASSISTANT_ID,
+      userId: OWNER_ID,
+      organizationId: ORG_ID,
+    });
+    await expect(readPlatformIdentity()).resolves.toEqual({
+      identity: {
+        assistantId: ASSISTANT_ID,
+        userId: OWNER_ID,
+        organizationId: ORG_ID,
+      },
+      unreachable: false,
+    });
+  });
+});
+
+describe("GET /v1/whoami", () => {
+  test("returns bound identity", async () => {
+    setLiveIdentity({
+      assistantId: ASSISTANT_ID,
+      userId: OWNER_ID,
+      organizationId: ORG_ID,
+    });
+    const res = await handleWhoami();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      assistantId: ASSISTANT_ID,
+      userId: OWNER_ID,
+      organizationId: ORG_ID,
+    });
+  });
+
+  test("returns 503 when the vault is down and nothing is cached", async () => {
+    setLiveIdentity({ unreachable: true });
+    const res = await handleWhoami();
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("unreachable");
+  });
+
+  test("keeps serving identity when the vault answers empty", async () => {
+    setLiveIdentity({
+      assistantId: ASSISTANT_ID,
+      userId: OWNER_ID,
+      organizationId: ORG_ID,
+    });
+    await handleWhoami();
+
+    setLiveIdentity({});
+    const res = await handleWhoami();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      assistantId: ASSISTANT_ID,
+      userId: OWNER_ID,
+      organizationId: ORG_ID,
     });
   });
 });

--- a/gateway/src/__tests__/platform-user-id.test.ts
+++ b/gateway/src/__tests__/platform-user-id.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
 
-import "./test-preload.js";
+import { testSecurityDir } from "./test-preload.js";
 
 import { credentialKey } from "../credential-key.js";
 
@@ -102,6 +104,37 @@ describe("readStoredPlatformUserId", () => {
     await expect(readStoredPlatformUserId()).resolves.toEqual({
       userId: OWNER_ID,
       unreachable: false,
+    });
+  });
+
+  test("does not rewrite the identity file when live ids are unchanged", async () => {
+    setLiveIdentity({ userId: OWNER_ID });
+    await readStoredPlatformUserId();
+
+    const path = join(testSecurityDir, "platform-identity.json");
+    const before = readFileSync(path, "utf-8");
+    const mtimeBefore = statSync(path).mtimeMs;
+
+    await readStoredPlatformUserId();
+    _dropPlatformIdentityMemoryForTest();
+    await readStoredPlatformUserId();
+
+    expect(readFileSync(path, "utf-8")).toBe(before);
+    expect(statSync(path).mtimeMs).toBe(mtimeBefore);
+  });
+
+  test("rewrites the identity file when live ids change", async () => {
+    setLiveIdentity({ userId: OWNER_ID });
+    await readStoredPlatformUserId();
+
+    setLiveIdentity({ userId: "user-456" });
+    await readStoredPlatformUserId();
+
+    const path = join(testSecurityDir, "platform-identity.json");
+    expect(JSON.parse(readFileSync(path, "utf-8"))).toEqual({
+      assistantId: null,
+      userId: "user-456",
+      organizationId: null,
     });
   });
 });

--- a/gateway/src/__tests__/schema.test.ts
+++ b/gateway/src/__tests__/schema.test.ts
@@ -56,6 +56,7 @@ describe("/schema route", () => {
     expect(body.paths["/schema"]).toBeDefined();
     expect(body.paths["/v1/health"]).toBeDefined();
     expect(body.paths["/v1/healthz"]).toBeDefined();
+    expect(body.paths["/v1/whoami"]).toBeDefined();
     expect(body.paths["/webhooks/telegram"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/voice"]).toBeDefined();
     expect(body.paths["/webhooks/twilio/status"]).toBeDefined();

--- a/gateway/src/http/routes/whoami.ts
+++ b/gateway/src/http/routes/whoami.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /v1/whoami — bound platform identity for this assistant.
+ *
+ * Returns assistant, user, and organization ids from the gateway-local
+ * identity store (live vault read with a durable last-known file). Callers
+ * that previously read `vellum:platform_*` from the credential vault should
+ * use this instead.
+ */
+
+import { readPlatformIdentity } from "../../platform-user-id.js";
+
+export async function handleWhoami(): Promise<Response> {
+  const { identity, unreachable } = await readPlatformIdentity();
+  if (unreachable) {
+    return Response.json(
+      { error: "Credential store is unreachable. Retry in a moment." },
+      { status: 503 },
+    );
+  }
+  return Response.json({
+    assistantId: identity.assistantId ?? null,
+    userId: identity.userId ?? null,
+    organizationId: identity.organizationId ?? null,
+  });
+}

--- a/gateway/src/http/routes/whoami.ts
+++ b/gateway/src/http/routes/whoami.ts
@@ -1,5 +1,5 @@
 /**
- * GET /v1/whoami — bound platform identity for this assistant.
+ * GET /v1/whoami: bound platform identity for this assistant.
  *
  * Returns assistant, user, and organization ids from the gateway-local
  * identity store (live vault read with a durable last-known file). Callers

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -125,6 +125,7 @@ import { createPlatformPushProxyHandler } from "./http/routes/platform-push-prox
 import { createPsHandler } from "./http/routes/ps.js";
 import { createVelayStatusHandler } from "./http/routes/velay-status.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
+import { handleWhoami } from "./http/routes/whoami.js";
 import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
 import {
   createMigrationExportProxyHandler,
@@ -863,6 +864,12 @@ async function main() {
       method: "GET",
       auth: "edge",
       handler: (req) => runtimeHealthProxy.handleRuntimeHealth(req),
+    },
+    {
+      path: "/v1/whoami",
+      method: "GET",
+      auth: "edge",
+      handler: () => handleWhoami(),
     },
 
     // ── Process status ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -871,6 +871,15 @@ async function main() {
       auth: "edge",
       handler: () => handleWhoami(),
     },
+    // Assistant-scoped mirror: self-hosted clients emit /v1/assistants/<id>/whoami
+    // and rewriteForSelfHostedIngress preserves that path, so a flat-only route
+    // would fall through to the runtime proxy and 404. The assistant id is discarded.
+    {
+      path: /^\/v1\/assistants\/[^/]+\/whoami\/?$/,
+      method: "GET",
+      auth: "edge-scoped",
+      handler: () => handleWhoami(),
+    },
 
     // ── Process status ──
     {

--- a/gateway/src/platform-user-id.ts
+++ b/gateway/src/platform-user-id.ts
@@ -44,6 +44,14 @@ function hasAnyId(identity: PlatformIdentity): boolean {
   );
 }
 
+function identitiesEqual(a: PlatformIdentity, b: PlatformIdentity): boolean {
+  return (
+    a.assistantId === b.assistantId &&
+    a.userId === b.userId &&
+    a.organizationId === b.organizationId
+  );
+}
+
 function parseStoredIdentity(raw: string): PlatformIdentity {
   const parsed: unknown = JSON.parse(raw);
   if (!parsed || typeof parsed !== "object") {
@@ -71,7 +79,23 @@ function readIdentityFile(): PlatformIdentity {
   }
 }
 
+function cachedIdentity(): PlatformIdentity {
+  if (memory && hasAnyId(memory)) {
+    return memory;
+  }
+  const fromFile = readIdentityFile();
+  if (hasAnyId(fromFile)) {
+    memory = fromFile;
+  }
+  return fromFile;
+}
+
 function persistIdentity(identity: PlatformIdentity): void {
+  const cached = cachedIdentity();
+  if (identitiesEqual(cached, identity)) {
+    memory = identity;
+    return;
+  }
   memory = identity;
   try {
     mkdirSync(getGatewaySecurityDir(), { recursive: true });
@@ -86,17 +110,6 @@ function persistIdentity(identity: PlatformIdentity): void {
   } catch (err) {
     log.warn({ err }, "failed to persist platform identity");
   }
-}
-
-function cachedIdentity(): PlatformIdentity {
-  if (memory && hasAnyId(memory)) {
-    return memory;
-  }
-  const fromFile = readIdentityFile();
-  if (hasAnyId(fromFile)) {
-    memory = fromFile;
-  }
-  return fromFile;
 }
 
 export type PlatformIdentityRead = {

--- a/gateway/src/platform-user-id.ts
+++ b/gateway/src/platform-user-id.ts
@@ -1,24 +1,152 @@
 /**
- * Bound platform owner id for managed-mode edge auth.
+ * Bound platform identity for managed-mode edge auth and whoami.
  *
- * The value is provisioned into the credential vault, but a vault outage
- * must not look like "no owner stored". Successful reads stick in memory
- * so health and feature-flag polls keep working while CES is down.
+ * Assistant, user, and organization ids are provisioned into the credential
+ * vault, but they are not secrets. Successful reads persist to
+ * `platform-identity.json` under the gateway security dir so a vault outage
+ * (or a vault that answers empty) does not look like a missing owner.
  */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { credentialKey } from "./credential-key.js";
 import { readCredentialResult } from "./credential-reader.js";
 import { getLogger } from "./logger.js";
+import { getGatewaySecurityDir } from "./paths.js";
 
-const log = getLogger("platform-user-id");
+const log = getLogger("platform-identity");
 
-const PLATFORM_USER_ID_ACCOUNT = credentialKey("vellum", "platform_user_id");
+const IDENTITY_FILENAME = "platform-identity.json";
 
-let lastKnownPlatformUserId: string | undefined;
+const ASSISTANT_ID_ACCOUNT = credentialKey("vellum", "platform_assistant_id");
+const USER_ID_ACCOUNT = credentialKey("vellum", "platform_user_id");
+const ORGANIZATION_ID_ACCOUNT = credentialKey(
+  "vellum",
+  "platform_organization_id",
+);
 
-/** @internal Test-only: drop the sticky owner id. */
-export function _resetLastKnownPlatformUserIdForTest(): void {
-  lastKnownPlatformUserId = undefined;
+export type PlatformIdentity = {
+  assistantId?: string;
+  userId?: string;
+  organizationId?: string;
+};
+
+let memory: PlatformIdentity | undefined;
+
+function identityPath(): string {
+  return join(getGatewaySecurityDir(), IDENTITY_FILENAME);
+}
+
+function hasAnyId(identity: PlatformIdentity): boolean {
+  return Boolean(
+    identity.assistantId || identity.userId || identity.organizationId,
+  );
+}
+
+function parseStoredIdentity(raw: string): PlatformIdentity {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object") {
+    return {};
+  }
+  const obj = parsed as Record<string, unknown>;
+  const identity: PlatformIdentity = {};
+  if (typeof obj.assistantId === "string" && obj.assistantId.length > 0) {
+    identity.assistantId = obj.assistantId;
+  }
+  if (typeof obj.userId === "string" && obj.userId.length > 0) {
+    identity.userId = obj.userId;
+  }
+  if (typeof obj.organizationId === "string" && obj.organizationId.length > 0) {
+    identity.organizationId = obj.organizationId;
+  }
+  return identity;
+}
+
+function readIdentityFile(): PlatformIdentity {
+  try {
+    return parseStoredIdentity(readFileSync(identityPath(), "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+function persistIdentity(identity: PlatformIdentity): void {
+  memory = identity;
+  try {
+    mkdirSync(getGatewaySecurityDir(), { recursive: true });
+    writeFileSync(
+      identityPath(),
+      `${JSON.stringify({
+        assistantId: identity.assistantId ?? null,
+        userId: identity.userId ?? null,
+        organizationId: identity.organizationId ?? null,
+      })}\n`,
+    );
+  } catch (err) {
+    log.warn({ err }, "failed to persist platform identity");
+  }
+}
+
+function cachedIdentity(): PlatformIdentity {
+  if (memory && hasAnyId(memory)) {
+    return memory;
+  }
+  const fromFile = readIdentityFile();
+  if (hasAnyId(fromFile)) {
+    memory = fromFile;
+  }
+  return fromFile;
+}
+
+export type PlatformIdentityRead = {
+  identity: PlatformIdentity;
+  unreachable: boolean;
+};
+
+/**
+ * Resolve the bound platform assistant/user/organization ids.
+ *
+ * `unreachable: true` only when the vault is down and no durable identity
+ * is cached. A cached identity is returned with `unreachable: false` so
+ * callers keep treating the assistant as reachable.
+ *
+ * A vault that answers successfully with no values does not overwrite a
+ * previously persisted identity.
+ */
+export async function readPlatformIdentity(): Promise<PlatformIdentityRead> {
+  const [assistant, user, org] = await Promise.all([
+    readCredentialResult(ASSISTANT_ID_ACCOUNT),
+    readCredentialResult(USER_ID_ACCOUNT),
+    readCredentialResult(ORGANIZATION_ID_ACCOUNT),
+  ]);
+
+  if (assistant.unreachable || user.unreachable || org.unreachable) {
+    const cached = cachedIdentity();
+    if (hasAnyId(cached)) {
+      log.warn(
+        "platform identity vault unreachable; using last known identity",
+      );
+      return { identity: cached, unreachable: false };
+    }
+    return { identity: {}, unreachable: true };
+  }
+
+  const live: PlatformIdentity = {
+    assistantId: assistant.value,
+    userId: user.value,
+    organizationId: org.value,
+  };
+  if (hasAnyId(live)) {
+    persistIdentity(live);
+    return { identity: live, unreachable: false };
+  }
+
+  const cached = cachedIdentity();
+  if (hasAnyId(cached)) {
+    return { identity: cached, unreachable: false };
+  }
+  return { identity: {}, unreachable: false };
 }
 
 export type StoredPlatformUserId = {
@@ -29,20 +157,24 @@ export type StoredPlatformUserId = {
 /**
  * Resolve the bound `platform_user_id`.
  *
- * `unreachable: true` only when the vault is down and no prior successful
- * read is cached. A cached owner is returned with `unreachable: false` so
- * callers keep treating the assistant as reachable.
+ * Wrapper over `readPlatformIdentity` for edge auth and the guardian pin.
  */
 export async function readStoredPlatformUserId(): Promise<StoredPlatformUserId> {
-  const result = await readCredentialResult(PLATFORM_USER_ID_ACCOUNT);
-  if (result.unreachable) {
-    if (lastKnownPlatformUserId) {
-      log.warn("platform_user_id vault unreachable; using last known owner id");
-      return { userId: lastKnownPlatformUserId, unreachable: false };
-    }
-    return { userId: undefined, unreachable: true };
-  }
+  const result = await readPlatformIdentity();
+  return { userId: result.identity.userId, unreachable: result.unreachable };
+}
 
-  lastKnownPlatformUserId = result.value;
-  return { userId: result.value, unreachable: false };
+/** @internal Test-only: drop in-memory identity. The on-disk file stays. */
+export function _dropPlatformIdentityMemoryForTest(): void {
+  memory = undefined;
+}
+
+/** @internal Test-only: drop in-memory and on-disk identity. */
+export function _resetLastKnownPlatformUserIdForTest(): void {
+  memory = undefined;
+  try {
+    rmSync(identityPath());
+  } catch {
+    // missing is fine
+  }
 }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -168,6 +168,50 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/whoami": {
+        get: {
+          summary: "Bound platform identity",
+          description:
+            "Authenticated gateway endpoint that returns this assistant's platform assistant, user, and organization ids. Values come from the gateway-local identity store, not a live credential-vault round trip on every request.",
+          operationId: "whoami",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "Bound platform identity returned",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      assistantId: { type: ["string", "null"] },
+                      userId: { type: ["string", "null"] },
+                      organizationId: { type: ["string", "null"] },
+                    },
+                    required: ["assistantId", "userId", "organizationId"],
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized: missing or invalid bearer token",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description:
+                "Credential store unreachable and no identity cached",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/v1/ps": {
         get: {
           summary: "Process status",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

PR 4 of 4 from a doctor diagnosis: start moving `vellum:platform_assistant_id`, `vellum:platform_user_id`, and `vellum:platform_organization_id` off CES. Those ids are not secrets. If the assistant needs them, it should call whoami rather than reading the vault.

Rebased onto `main` after:
- https://github.com/vellum-ai/vellum-assistant/pull/42529 (CES unreachable vs empty)
- https://github.com/vellum-ai/vellum-assistant/pull/42531 (watcher / cache keep-last-good)

## Summary

- Successful vault reads of the three platform ids persist to `GATEWAY_SECURITY_DIR/platform-identity.json`.
- A vault outage, or a vault that answers empty, keeps the durable identity so edge auth does not 403 (`no platform_user_id stored`) and the assistant does not look asleep.
- `GET /v1/whoami` (edge auth) returns `{ assistantId, userId, organizationId }` from that store.
- Self-hosted clients emit `/v1/assistants/<id>/whoami`. An `edge-scoped` mirror discards the id so that path does not fall through to the runtime proxy. Flat `/v1/whoami` stays for managed ingress.
- Unchanged live ids do not rewrite `platform-identity.json` on every edge-auth request.

Django hatch still writes the ids into CES. This is dual-read, not a cutover. Follow-ups: daemon rehydration via whoami/IPC instead of CES, then stop the CES writes.

`gateway/openapi.json` is unchanged on purpose. That file is generated from a subset of `ROUTES` arrays (contacts, trust-rules, and similar). Sibling GETs such as `/v1/ps`, `/v1/health`, and `/v1/velay/status` are also absent there. Runtime `/schema` already documents `/v1/whoami`.

## Test plan

- `cd gateway && bun test src/__tests__/platform-user-id.test.ts`
- `cd gateway && bun test src/__tests__/schema.test.ts`
- `cd gateway && bun test src/__tests__/edge-auth.test.ts`
- `cd gateway && bun test src/__tests__/edge-guardian-auth.test.ts`
- `cd gateway && bun test src/__tests__/route-schema-guard.test.ts`

Covered: live read, unreachable with cache, unreachable with no cache, empty vault keeps durable identity, file reread after memory drop, unchanged live ids skip rewrite, changed live ids rewrite, whoami 200/503.

## CLI verb checklist

Gateway HTTP route only. No new assistant IPC route in this PR. Daemon rehydration via whoami is a follow-up.

## Risk

Medium. Identity file is not a secret (platform ids only) and lives next to other gateway security files. Empty-vault keep-last-known means a genuine identity wipe will not take effect until new non-empty values arrive (warm-pool claim overwrites on the next live read). Django CES writes are unchanged.

No DB/workspace migrations. No feature flags. No companion platform PR yet (stop-writing-CES is the later platform change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e7b8efd-9a9e-419e-a6cf-484133b96d98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e7b8efd-9a9e-419e-a6cf-484133b96d98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

