### PR TITLE
fix(assistant): include app icons in container image

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -108,6 +108,7 @@ RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
 COPY --link --from=builder /app /app
 
 # Copy source after installing dependencies for better layer caching.
+COPY packages/app-icons /app/packages/app-icons
 COPY packages/avatar-catalog /app/packages/avatar-catalog
 COPY packages/avatar-manifest /app/packages/avatar-manifest
 COPY packages/ces-client /app/packages/ces-client
@@ -121,6 +122,10 @@ COPY packages/slack-text /app/packages/slack-text
 COPY packages/twilio-client /app/packages/twilio-client
 
 COPY assistant /app/assistant
+
+# Resolve production workspace dependencies from the filesystem layout shipped
+# in the image.
+RUN bun run scripts/smoke-container-workspace-dependencies.ts
 
 # The repo-root .dockerignore decides which skills (and files) ship.
 COPY skills /app/skills

--- a/assistant/scripts/smoke-container-workspace-dependencies.ts
+++ b/assistant/scripts/smoke-container-workspace-dependencies.ts
@@ -1,0 +1,19 @@
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+};
+
+const manifest = (await Bun.file(
+  new URL("../package.json", import.meta.url),
+).json()) as PackageManifest;
+
+const workspaceDependencies = Object.entries(manifest.dependencies ?? {})
+  .filter(([, version]) => version.startsWith("workspace:"))
+  .map(([name]) => name)
+  .sort();
+
+for (const dependency of workspaceDependencies) {
+  const resolvedPath = Bun.resolveSync(dependency, import.meta.dir);
+  console.log(`${dependency}: ${resolvedPath}`);
+}
+
+console.log(`Resolved ${workspaceDependencies.length} workspace dependencies.`);


### PR DESCRIPTION
## Summary

- copy the `@vellumai/app-icons` workspace package source into the assistant container
- resolve every production `workspace:*` dependency from the final runner-stage filesystem during the Docker build
- fail image construction when a workspace package manifest is installed but its source or exported entry point is missing

## Why

The assistant image installs workspace links before copying package source into the runner stage. `@vellumai/app-icons` was declared correctly in `assistant/package.json`, but its source directory was absent from the explicit Docker copy list. Bun therefore could not resolve the package when the assistant loaded `app-store.ts` at startup.

The generic resolution check protects all current and future production workspace dependencies from the same packaging drift.

## Test plan

- [x] `bun run scripts/smoke-container-workspace-dependencies.ts`
- [x] `bun run typecheck:fast`
- [x] Prettier and ESLint checks for the new script
- [ ] Full image build runs the smoke check inside the Docker runner stage