### PR TITLE
refactor(web): trim the sidebar shell's duplicated rationale

### DIFF
--- a/clients/web/src/components/sidebar-shell.tsx
+++ b/clients/web/src/components/sidebar-shell.tsx
@@ -56,12 +56,9 @@ export function SidebarShell({
   // a sub-page is the content, so one signal decides which is on screen rather
   // than each hiding itself at its own breakpoint.
   const showsMobileMenu = isMobile && isMenuRoute;
-  // A page that is on screen for nobody can also skip mounting, but only where
-  // the caller says its menu-route child has nothing to do out of sight. A
-  // mounted page runs its render, its effects and its request fan-out whether
-  // or not anything shows it, which on a phone is the whole Settings landing
-  // tree behind a list of links. The route's chunk is fetched either way: the
-  // router resolves it before this renders.
+  // A mounted page runs its render, its effects and its request fan-out
+  // whether or not anything shows it. Its chunk arrives either way, since the
+  // router resolves a lazy component before this renders.
   const contentMounted = !(showsMobileMenu && menuReplacesContentOnMobile);
 
   // Edge-swipe back gesture for the mobile two-page flow. It mirrors the
@@ -183,14 +180,14 @@ export function SidebarShell({
 
         {/* Body — sidebar + content */}
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          {isMobile ? null : (
+          {!isMobile ? (
             <aside
               className="w-64 shrink-0 overflow-y-auto"
               aria-label={t("sidebarShell.navigationAria", { title })}
             >
               {sidebar}
             </aside>
-          )}
+          ) : null}
 
           {showsMobileMenu ? (
             /* `overflow-x-hidden`: `overflow-y: auto` alone computes


### PR DESCRIPTION
## TL;DR

Comment-only follow-up to #42522, which merged before this landed on the branch. No behaviour change.

## What changes

- The comment above `contentMounted` restated the rule the `menuReplacesContentOnMobile` docstring already states. The docstring keeps that; the comment keeps only the cost of a mounted page and the fact that its chunk arrives regardless, which is the part that is not obvious from reading the code.
- The nav rail's conditional now reads the same shape as the two beside it (`cond ? … : null`), so the three sibling branches in that block scan alike.

## Why it is safe

Nothing outside the comment and the ternary's spelling changed. The rendered tree is identical at every viewport. The existing sixteen tests across `sidebar-shell.test.tsx` and `settings-layout.test.tsx` pass unchanged, which is the point: a refactor that needed a test edit would not be one.

Found by a reuse and quality pass over the merged diff rather than by review.

Part of the mobile Settings work in #42522, #42523, #42524 and #42527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->