### PR TITLE
fix(desktop): ride out local gateway startup instead of Repair on cold boot

### DIFF
--- a/clients/linux/src/main/features/host-proxy.ts
+++ b/clients/linux/src/main/features/host-proxy.ts
@@ -59,7 +59,11 @@ const installBridge = (capabilities: DesktopCapabilityRegistry): void => {
             "[host-proxy] no CLI provider registered, skipping local assistant",
             { assistantId },
           );
-          return null;
+          return {
+            ok: false,
+            status: 500,
+            error: "no CLI provider registered",
+          };
         }
         const result = await getGuardianAccessToken(
           assistantId,
@@ -71,11 +75,11 @@ const installBridge = (capabilities: DesktopCapabilityRegistry): void => {
         if (!result.ok) {
           log.warn("[host-proxy] failed to obtain guardian token", {
             assistantId,
+            status: result.status,
             error: result.error,
           });
-          return null;
         }
-        return result.accessToken;
+        return result;
       },
       getSessionToken,
       onSessionTokenChange,

--- a/clients/linux/src/main/host-proxy-adapter.test.ts
+++ b/clients/linux/src/main/host-proxy-adapter.test.ts
@@ -4,7 +4,11 @@ import { createLinuxHostProxyRuntime } from "./host-proxy-adapter";
 
 test("creates a Linux runtime with only the committed portable executors", () => {
   const runtime = createLinuxHostProxyRuntime({
-    acquireGuardianToken: async () => null,
+    acquireGuardianToken: async () => ({
+      ok: false,
+      status: 404,
+      error: "unused",
+    }),
     getSessionToken: () => null,
     getLockfile: () => ({ assistants: [], activeAssistant: null }),
     onLockfileChange: () => () => undefined,
@@ -45,7 +49,11 @@ test("adds host_cu when the computer-use capability is installed", () => {
   };
 
   const runtime = createLinuxHostProxyRuntime({
-    acquireGuardianToken: async () => null,
+    acquireGuardianToken: async () => ({
+      ok: false,
+      status: 404,
+      error: "unused",
+    }),
     getSessionToken: () => null,
     getLockfile: () => ({ assistants: [], activeAssistant: null }),
     onLockfileChange: () => () => undefined,

--- a/clients/macos/src/main/host-proxy-adapter.ts
+++ b/clients/macos/src/main/host-proxy-adapter.ts
@@ -53,7 +53,7 @@ export const installHostProxyBridge = (
           assistantId,
           err,
         });
-        return null;
+        return { ok: false, status: 500, error: (err as Error).message };
       }
 
       const result = await getGuardianAccessToken(
@@ -66,11 +66,11 @@ export const installHostProxyBridge = (
       if (!result.ok) {
         log.warn("[host-proxy-router] failed to obtain guardian token", {
           assistantId,
+          status: result.status,
           error: result.error,
         });
-        return null;
       }
-      return result.accessToken;
+      return result;
     },
     getSessionToken,
     getLockfile: getWatchedLockfile,

--- a/clients/web/src/lib/local-mode-repair.test.ts
+++ b/clients/web/src/lib/local-mode-repair.test.ts
@@ -115,6 +115,74 @@ describe("primeLocalGatewayConnectionWithRepair", () => {
     expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(2);
   });
 
+  test("a mint 401 that later succeeds reconnects without waking", async () => {
+    // Login Item cold boot: the gateway opens traffic before its guardian
+    // binding backfill lands, so the mint answers 401 for a while. Waiting
+    // heals it; a plain wake cannot re-lease the mint and would restart an
+    // already-starting gateway.
+    process.env.VITE_PLATFORM_MODE = "";
+    let mintAttempts = 0;
+    ensureGatewayTokenImpl = async () => {
+      if (mintAttempts++ < 2) {
+        throw new GatewayTokenError(401, "Gateway token request failed: 401");
+      }
+    };
+
+    await primeLocalGatewayConnectionWithRepair();
+
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+    expect(mintAttempts).toBe(3);
+  });
+
+  test("a mint 401 that survives the ride-out surfaces without waking", async () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    let mintAttempts = 0;
+    ensureGatewayTokenImpl = async () => {
+      mintAttempts++;
+      throw new GatewayTokenError(401, "Gateway token request failed: 401");
+    };
+
+    const err = await primeLocalGatewayConnectionWithRepair().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GatewayTokenError);
+    expect((err as InstanceType<typeof GatewayTokenError>).status).toBe(401);
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+    expect(mintAttempts).toBe(LOCAL_GATEWAY_STARTUP_RETRY.attempts);
+  });
+
+  test("a transport error that later succeeds reconnects without waking", async () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    let mintAttempts = 0;
+    ensureGatewayTokenImpl = async () => {
+      if (mintAttempts++ < 2) {
+        throw new TypeError("Failed to fetch");
+      }
+    };
+
+    await primeLocalGatewayConnectionWithRepair();
+
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+    expect(mintAttempts).toBe(3);
+  });
+
+  test("a transport error that survives the ride-out wakes once, then reconnects", async () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    let mintAttempts = 0;
+    ensureGatewayTokenImpl = async () => {
+      mintAttempts++;
+      if (mintAttempts <= LOCAL_GATEWAY_STARTUP_RETRY.attempts) {
+        throw new TypeError("Failed to fetch");
+      }
+    };
+
+    await primeLocalGatewayConnectionWithRepair();
+
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    expect(mintAttempts).toBe(LOCAL_GATEWAY_STARTUP_RETRY.attempts + 1);
+  });
+
   test("a still-failing retry surfaces the original error and wakes only once", async () => {
     primeShouldSucceed = () => false;
 
@@ -313,7 +381,8 @@ describe("primeLocalGatewayConnectionWithStartupRetry", () => {
 
     await primeLocalGatewayConnectionWithStartupRetry();
 
-    // Boot must never spawn a daemon — the plain prime rides out the window.
+    // Boot must never spawn an assistant process: the plain prime rides out
+    // the window.
     expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
     expect(mintAttempts).toBe(3);
   });
@@ -337,7 +406,7 @@ describe("primeLocalGatewayConnectionWithStartupRetry", () => {
     expect(mintAttempts).toBe(3);
   });
 
-  test("does not ride out a 403 boundary refusal — surfaces immediately", async () => {
+  test("does not ride out a 403 boundary refusal, surfaces immediately", async () => {
     process.env.VITE_PLATFORM_MODE = "";
     let mintAttempts = 0;
     ensureGatewayTokenImpl = async () => {
@@ -351,15 +420,31 @@ describe("primeLocalGatewayConnectionWithStartupRetry", () => {
 
     expect(err).toBeInstanceOf(GatewayTokenError);
     expect((err as InstanceType<typeof GatewayTokenError>).status).toBe(403);
-    // A loopback-boundary refusal is terminal — no repair can change it.
+    // A loopback-boundary refusal is terminal. No repair can change it.
     expect(mintAttempts).toBe(1);
     expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
   });
 
-  test("does not stall on a gateway that isn't answering — a transport error falls through fast", async () => {
-    // A thrown transport error (connection refused) means the gateway isn't up
-    // at all — e.g. an intentionally stopped assistant. Boot must fall through
-    // promptly to the chooser rather than burning the whole retry budget.
+  test("rides out a transport error (Login Item port not bound yet) without waking, then connects", async () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    let mintAttempts = 0;
+    ensureGatewayTokenImpl = async () => {
+      if (mintAttempts++ < 2) {
+        throw new TypeError("Failed to fetch");
+      }
+    };
+
+    await primeLocalGatewayConnectionWithStartupRetry();
+
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+    expect(mintAttempts).toBe(3);
+  });
+
+  test("a gateway that never answers spends the transport budget, then falls through without waking", async () => {
+    // A thrown transport error is how both a starting Login Item and a stopped
+    // assistant look. Boot rides the budget (never waking) so a starting
+    // gateway can bind its port. A stopped assistant still reaches the chooser
+    // after the budget, where connect-with-repair may wake it.
     process.env.VITE_PLATFORM_MODE = "";
     let mintAttempts = 0;
     ensureGatewayTokenImpl = async () => {
@@ -372,7 +457,40 @@ describe("primeLocalGatewayConnectionWithStartupRetry", () => {
     );
 
     expect(err).toBeInstanceOf(TypeError);
-    expect(mintAttempts).toBe(1);
+    expect(mintAttempts).toBe(LOCAL_GATEWAY_STARTUP_RETRY.attempts);
     expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("does not ride out a missing guardian token, surfaces immediately", async () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    fetchGuardianTokenHost = mock(async () => {
+      throw new GuardianTokenError(404, "token gone");
+    });
+
+    const err = await primeLocalGatewayConnectionWithStartupRetry().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GuardianTokenError);
+    expect((err as InstanceType<typeof GuardianTokenError>).status).toBe(404);
+    expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(1);
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+  });
+
+  test("rides out a guardian refresh 503 without waking, then connects", async () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    let fetches = 0;
+    fetchGuardianTokenHost = mock(async (_id: string) => {
+      fetches++;
+      if (fetches < 3) {
+        throw new GuardianTokenError(503, "Assistant gateway is unreachable");
+      }
+      return "tok";
+    });
+
+    await primeLocalGatewayConnectionWithStartupRetry();
+
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+    expect(fetches).toBe(3);
   });
 });

--- a/clients/web/src/lib/local-mode-repair.test.ts
+++ b/clients/web/src/lib/local-mode-repair.test.ts
@@ -477,6 +477,22 @@ describe("primeLocalGatewayConnectionWithStartupRetry", () => {
     expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
   });
 
+  test("does not ride out a guardian 500 (malformed file, spawn, or timeout)", async () => {
+    process.env.VITE_PLATFORM_MODE = "";
+    fetchGuardianTokenHost = mock(async () => {
+      throw new GuardianTokenError(500, "Guardian token refresh timed out");
+    });
+
+    const err = await primeLocalGatewayConnectionWithStartupRetry().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GuardianTokenError);
+    expect((err as InstanceType<typeof GuardianTokenError>).status).toBe(500);
+    expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(1);
+    expect(wakeLocalAssistantHost).not.toHaveBeenCalled();
+  });
+
   test("rides out a guardian refresh 503 without waking, then connects", async () => {
     process.env.VITE_PLATFORM_MODE = "";
     let fetches = 0;

--- a/clients/web/src/lib/local-mode.test.ts
+++ b/clients/web/src/lib/local-mode.test.ts
@@ -1350,11 +1350,10 @@ describe("primeLocalGatewayConnection", () => {
 });
 
 describe("primeLocalGatewayConnectionWithStartupRetry (paired target)", () => {
-  // The startup ride-out exists for the LOCAL gateway's reboot window and only
-  // retries GatewayTokenErrors, which the paired proxy prime never throws. A
-  // paired failure (failed host credential read, remote transport error) falls through
-  // promptly to the chooser instead of stalling the 8x1s retry budget on a
-  // machine that waiting cannot fix.
+  // The startup ride-out exists for the LOCAL gateway's Login Item window.
+  // Paired failures (failed host credential read, remote transport error) fall
+  // through promptly to the chooser instead of stalling the boot retry budget
+  // on a machine that waiting cannot start.
   test("a failing paired credential read is not ridden out", async () => {
     enableLocalMode();
     const fetchMock = mock(

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -1093,19 +1093,26 @@ export const LOCAL_GATEWAY_STARTUP_RETRY = {
   intervalMs: 1_000,
 };
 
+/** Guardian refresh `503`: the loopback gateway is unreachable or still starting. */
+function isTransientGuardianTokenError(error: unknown): boolean {
+  return error instanceof GuardianTokenError && error.status === 503;
+}
+
 /**
  * A local loopback gateway that is still coming up: a thrown transport error
  * (Login Item has not bound the port yet), a `503`/`5xx` "starting" mint, a
  * repairable mint `401` after traffic opens but before the guardian-binding
- * backfill lands, or a guardian refresh `5xx` while the host cannot reach a
+ * backfill lands, or a guardian refresh `503` while the host cannot reach a
  * gateway that is still binding its port. These heal on their own, so boot
  * and the pre-wake connect path ride them out instead of spawning `wake`.
  *
  * A `403` loopback-boundary refusal is terminal. A missing (`404`) or
  * rejected (`401`) guardian token will not heal by waiting (the credential
- * is missing or spent on disk). An unresolved local gateway (no recorded
- * port) needs `wake` to establish one. Paired/remote failures are never
- * ridden out: waiting cannot fix a machine this device does not start.
+ * is missing or spent on disk). A guardian `500` is a malformed file, CLI
+ * spawn failure, or refresh timeout, not a starting gateway. An unresolved
+ * local gateway (no recorded port) needs `wake` to establish one.
+ * Paired/remote failures are never ridden out: waiting cannot fix a machine
+ * this device does not start.
  */
 function isGatewayStillStarting(
   error: unknown,
@@ -1119,7 +1126,7 @@ function isGatewayStillStarting(
     return false;
   }
   if (error instanceof GuardianTokenError) {
-    return error.status >= 500;
+    return isTransientGuardianTokenError(error);
   }
   if (error instanceof GatewayTokenError) {
     return error.status !== 403;
@@ -1133,16 +1140,17 @@ function isGatewayStillStarting(
  * A `wake`-restarted gateway that hasn't finished coming back up: it refuses
  * connections (a thrown transport error), answers `503`/`5xx`, or rejects the
  * mint with a repairable `401` while it re-provisions its guardian binding.
- * A guardian refresh `5xx` is the same window: the host shells out to
+ * A guardian refresh `503` is the same window: the host shells out to
  * `vellum gateway token refresh`, which cannot reach a gateway that is still
- * binding its port. A `403` loopback-boundary refusal is terminal, and a
- * missing (`404`) or rejected (`401`) guardian token will not heal by
+ * binding its port. A `403` loopback-boundary refusal is terminal. A missing
+ * (`404`) or rejected (`401`) guardian token, or a guardian `500`
+ * (malformed file, CLI spawn failure, refresh timeout), will not heal by
  * waiting (the just-run `wake` already re-seeded the token and recorded the
  * port), so those fall through.
  */
 function isGatewayRestartTransient(error: unknown): boolean {
   if (error instanceof GuardianTokenError) {
-    return error.status >= 500;
+    return isTransientGuardianTokenError(error);
   }
   if (error instanceof UnresolvedLocalGatewayError) {
     return false;

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -1060,15 +1060,20 @@ export async function primeLocalGatewayConnection(
 }
 
 /**
- * Classify a connect failure as repairable by `wake`. A `403` means the host
- * refused the loopback boundary — a security decision wake can't change — so
- * it surfaces as-is. Every other failure (a missing/expired/malformed guardian
- * token, or an unreachable or stopped gateway) is something `wake` can fix by
- * re-seeding the token and restarting the daemon + gateway.
+ * Classify a connect failure as something a plain `wake` can fix. A `403`
+ * is a loopback-boundary refusal, a security decision wake cannot change, so
+ * it surfaces as-is. A mint `401` (`GatewayTokenError`) is also excluded: a
+ * plain wake cannot re-lease a guardian token the running gateway rejects at
+ * `/auth/token`. Remaining failures (a missing/expired/malformed guardian
+ * token, an unresolved port, or an unreachable/stopped gateway) are what
+ * `wake` can fix by re-seeding the token and restarting the assistant + gateway.
  */
 function isRepairableConnectError(error: unknown): boolean {
   if (error instanceof GuardianTokenError) {
     return error.status !== 403;
+  }
+  if (error instanceof GatewayTokenError) {
+    return error.status !== 403 && error.status !== 401;
   }
   return true;
 }
@@ -1076,35 +1081,52 @@ function isRepairableConnectError(error: unknown): boolean {
 /**
  * Retry budget for riding out the local gateway's startup window. On reboot the
  * gateway (a macOS Login Item) restarts concurrently with the desktop app, and
- * a `wake` restarts it in place — in both cases the loopback `/auth/token` mint
- * refuses connections or answers transiently (a `503` "starting", or a
- * repairable `401` before the guardian binding backfill lands) for the first
- * few seconds. A single prime races that window and dead-ends to the recovery
- * controls even though the gateway becomes usable moments later. Mutable so
- * tests can shrink the window.
+ * a `wake` restarts it in place. In both cases the loopback `/auth/token` mint
+ * refuses connections for tens of seconds (port not bound yet), then answers
+ * transiently (a `503` "starting", or a repairable `401` before the guardian
+ * binding backfill lands). A single prime races that window and dead-ends to
+ * the recovery controls even though the gateway becomes usable on its own.
+ * Mutable so tests can shrink the window.
  */
 export const LOCAL_GATEWAY_STARTUP_RETRY = {
-  attempts: 8,
+  attempts: 90,
   intervalMs: 1_000,
 };
 
 /**
- * A gateway that is UP but transiently rejecting the mint as it finishes
- * starting after a reboot: a `503` "starting" (or another `5xx`) before its
- * post-assistant-ready work completes, or a repairable `401` in the window
- * after traffic opens but before the guardian-binding backfill lands — the
- * reported reboot symptom. Both heal on their own within seconds, so the boot
- * restore rides them out (never `wake`ing).
+ * A local loopback gateway that is still coming up: a thrown transport error
+ * (Login Item has not bound the port yet), a `503`/`5xx` "starting" mint, a
+ * repairable mint `401` after traffic opens but before the guardian-binding
+ * backfill lands, or a guardian refresh `5xx` while the host cannot reach a
+ * gateway that is still binding its port. These heal on their own, so boot
+ * and the pre-wake connect path ride them out instead of spawning `wake`.
  *
- * A `403` loopback-boundary refusal is terminal. A thrown transport error is
- * deliberately excluded: the gateway isn't answering at all (an intentionally
- * stopped assistant, not a starting one), so the boot restore falls through to
- * the chooser promptly instead of stalling the whole retry budget on an
- * assistant the user isn't running — the chooser's connect-with-repair path
- * (which may `wake`) handles that case.
+ * A `403` loopback-boundary refusal is terminal. A missing (`404`) or
+ * rejected (`401`) guardian token will not heal by waiting (the credential
+ * is missing or spent on disk). An unresolved local gateway (no recorded
+ * port) needs `wake` to establish one. Paired/remote failures are never
+ * ridden out: waiting cannot fix a machine this device does not start.
  */
-function isGatewayStillStarting(error: unknown): boolean {
-  return error instanceof GatewayTokenError && error.status !== 403;
+function isGatewayStillStarting(
+  error: unknown,
+  target: LockfileAssistant | undefined,
+): boolean {
+  const assistant = target ?? getSelectedAssistant();
+  if (!assistant || !expectsLocalGateway(assistant)) {
+    return false;
+  }
+  if (error instanceof UnresolvedLocalGatewayError) {
+    return false;
+  }
+  if (error instanceof GuardianTokenError) {
+    return error.status >= 500;
+  }
+  if (error instanceof GatewayTokenError) {
+    return error.status !== 403;
+  }
+  // Thrown fetch/transport error: the loopback port is not accepting
+  // connections yet.
+  return true;
 }
 
 /**
@@ -1128,7 +1150,7 @@ function isGatewayRestartTransient(error: unknown): boolean {
   if (error instanceof GatewayTokenError) {
     return error.status !== 403;
   }
-  // A thrown fetch/transport error — the gateway isn't accepting connections
+  // A thrown fetch/transport error: the gateway isn't accepting connections
   // yet as it restarts.
   return true;
 }
@@ -1136,9 +1158,9 @@ function isGatewayRestartTransient(error: unknown): boolean {
 /**
  * Prime the local gateway connection, retrying on a bounded interval while the
  * failure is a transient startup condition (`shouldRideOut`). Rides out the
- * local gateway's startup window without spawning anything — the plain prime
- * only reads the on-disk guardian token and mints a gateway session — so it
- * respects the "app launch never spawns daemon processes" boot contract. The
+ * local gateway's startup window without spawning anything: the plain prime
+ * only reads the on-disk guardian token and mints a gateway session, so it
+ * respects the "app launch never spawns assistant processes" boot contract. The
  * last error propagates once the retry budget is spent or the failure is not a
  * ride-out-able one, so the existing connect-error classification is preserved.
  */
@@ -1163,33 +1185,39 @@ async function primeLocalGatewayWithStartupRideout(
 
 /**
  * Boot restore path: prime the selected local assistant's gateway connection,
- * riding out the gateway's startup window when it is up but still starting
- * ({@link isGatewayStillStarting}). Unlike the interactive
- * {@link primeLocalGatewayConnectionWithRepair}, this never `wake`s — app launch
- * must not spawn daemon processes — so a gateway that is down entirely, or one
- * that rejects the mint (a repairable `401`), falls through promptly to the
- * chooser, where the auto-connect flow's repair handles it.
+ * riding out the gateway's startup window ({@link isGatewayStillStarting}).
+ * Unlike the interactive {@link primeLocalGatewayConnectionWithRepair}, this
+ * never `wake`s: app launch must not spawn assistant processes. A missing or
+ * spent guardian token, an unresolved port, or a `403` falls through to the
+ * chooser. A mint `401` or transport failure rides the budget; if it is still
+ * failing after that, the chooser's connect-with-repair path handles it.
  */
 export async function primeLocalGatewayConnectionWithStartupRetry(
   target?: LockfileAssistant,
 ): Promise<void> {
-  await primeLocalGatewayWithStartupRideout(target, isGatewayStillStarting);
+  await primeLocalGatewayWithStartupRideout(target, (error) =>
+    isGatewayStillStarting(error, target),
+  );
 }
 
 /**
  * Prime the local gateway connection, transparently repairing the assistant in
- * place when the first attempt fails for a repairable reason.
+ * place when a startup ride-out still fails for a reason a plain `wake` can
+ * fix.
  *
  * This mirrors the native client's bootstrap, which revives a stopped or
- * unresolved local assistant before the failure ever reaches the user: on a
- * repairable failure it runs a plain `wake` (restarts the daemon + gateway,
- * leaving the assistant's data and identity untouched), then primes the
- * connection once more. A non-repairable failure, a wake that itself fails, or
- * a still-failing retry propagate the original error so the existing
- * connect-error UI surfaces it unchanged.
+ * unresolved local assistant before the failure ever reaches the user. The
+ * first pass rides out {@link isGatewayStillStarting} without waking, so a
+ * Login Item that is still binding its port is not restarted. A remaining
+ * repairable failure (unreachable gateway, unresolved port, missing
+ * guardian token) runs a plain `wake` (restarts the assistant + gateway,
+ * leaving the assistant's data and identity untouched), then primes again.
+ * A non-repairable failure, a wake that itself fails, or a still-failing
+ * retry propagate the original error so the existing connect-error UI
+ * surfaces it unchanged.
  *
  * A plain wake cannot re-lease a guardian token the gateway rejects at the
- * `/auth/token` mint, so a `401` that survives the retry propagates as a
+ * `/auth/token` mint, so a `401` that survives the ride-out propagates as a
  * {@link GatewayTokenError} for callers to route to the guardian re-provision
  * (`wakeLocalAssistantHost` with `repairGuardian`), the one repair that clears
  * it and the one this path must never run on its own.
@@ -1200,7 +1228,11 @@ export async function primeLocalGatewayConnectionWithRepair(
 ): Promise<void> {
   const assistant = target ?? getSelectedAssistant();
   try {
-    await primeLocalGatewayConnection(assistant, options);
+    await primeLocalGatewayWithStartupRideout(
+      assistant,
+      (error) => isGatewayStillStarting(error, assistant),
+      options,
+    );
     return;
   } catch (error) {
     // Wake operates only on plain local assistants (see
@@ -1219,15 +1251,15 @@ export async function primeLocalGatewayConnectionWithRepair(
       throw error;
     }
     // Wake may have established resources the renderer hadn't recorded (a legacy
-    // entry's gateway port) — reload so the retry resolves the fresh gateway.
+    // entry's gateway port). Reload so the retry resolves the fresh gateway.
     const lockfile = await loadLockfile();
     const refreshed = lockfile.assistants.find(
       (a) => a.assistantId === assistantId,
     );
-    // Wake restarts the daemon + gateway, so the retry races the gateway coming
-    // back up — a single prime here fails while it is still starting and the
-    // connect dead-ends to the recovery controls. Ride out that restart window
-    // instead, so a persisted local assistant reconnects on its own.
+    // Wake restarts the assistant + gateway, so the retry races the gateway
+    // coming back up. A single prime here fails while it is still starting and
+    // the connect dead-ends to the recovery controls. Ride out that restart
+    // window instead, so a persisted local assistant reconnects on its own.
     await primeLocalGatewayWithStartupRideout(
       refreshed ?? assistant,
       isGatewayRestartTransient,

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -2871,11 +2871,10 @@ describe("paired selection in the gateway-auth session paths", () => {
   });
 
   test("boot with a paired proxy authorization failure settles unauthenticated after one prime", async () => {
-    // The startup ride-out only retries GatewayTokenErrors, which the paired
-    // prime never throws; the budget pin for that lives in local-mode.test.ts
-    // ("a failing paired credential read is not ridden out"). Here: the boot
-    // path routes the paired selection through the generalized prime once and
-    // falls through promptly to the chooser.
+    // Paired failures are not ridden out (the budget pin lives in
+    // local-mode.test.ts, "a failing paired credential read is not ridden out").
+    // Here: the boot path routes the paired selection through the generalized
+    // prime once and falls through promptly to the chooser.
     mockIsLocalClient = true;
     mockIsGatewayAuth = true;
     mockSelectedAssistant = pairedSelection;

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -992,12 +992,13 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
 
     if (isGatewayAuthEnabled()) {
       try {
-        // Ride out the gateway's startup window: on reboot the gateway restarts
-        // concurrently with the app and answers the mint with a transient
-        // "starting" 503 for a few seconds. A single prime there would drop the
-        // session to unauthenticated and surface the recovery controls for an
-        // assistant that reconnects on its own moments later. Still no `wake` —
-        // app launch must not spawn daemon processes.
+        // Ride out the gateway's startup window: on reboot the gateway (a
+        // Login Item) restarts concurrently with the app. The mint fails to
+        // fetch while the port is unbound, then answers a transient 503 or
+        // 401 before the guardian binding lands. A single prime there would
+        // drop the session to unauthenticated and surface the recovery
+        // controls for an assistant that reconnects on its own. Still no
+        // `wake`: app launch must not spawn assistant processes.
         await primeLocalGatewayConnectionWithStartupRetry();
         set(authenticatedLocalUser());
       } catch {
@@ -1139,10 +1140,11 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
    * probe and swallows failures, this rethrows so the caller can surface the
    * reason — including the typed `GuardianTokenError` from the host seam — and
    * offer recovery instead of dead-ending. It primes through
-   * `primeLocalGatewayConnectionWithRepair`, which self-heals a stopped or
-   * mis-seeded assistant via `wake` before surfacing any error — matching the
-   * native client's re-pair-on-connect bootstrap. The boot probe deliberately
-   * stays on the plain primitive so app launch never spawns daemon processes.
+   * `primeLocalGatewayConnectionWithRepair`, which rides out a starting
+   * gateway and self-heals a stopped or mis-seeded assistant via `wake` before
+   * surfacing any error, matching the native client's re-pair-on-connect
+   * bootstrap. The boot probe deliberately stays on the startup-retry
+   * primitive so app launch never spawns assistant processes.
    */
   connectLocalAssistant: async (assistantId: string) => {
     const target = getLocalAssistants().find(

--- a/clients/windows/src/main/features/host-proxy.ts
+++ b/clients/windows/src/main/features/host-proxy.ts
@@ -59,7 +59,11 @@ const installBridge = (capabilities: DesktopCapabilityRegistry): void => {
             "[host-proxy] no CLI provider registered, skipping local assistant",
             { assistantId },
           );
-          return null;
+          return {
+            ok: false,
+            status: 500,
+            error: "no CLI provider registered",
+          };
         }
         const result = await getGuardianAccessToken(
           assistantId,
@@ -71,11 +75,11 @@ const installBridge = (capabilities: DesktopCapabilityRegistry): void => {
         if (!result.ok) {
           log.warn("[host-proxy] failed to obtain guardian token", {
             assistantId,
+            status: result.status,
             error: result.error,
           });
-          return null;
         }
-        return result.accessToken;
+        return result;
       },
       getSessionToken,
       onSessionTokenChange,

--- a/clients/windows/src/main/host-proxy-adapter.test.ts
+++ b/clients/windows/src/main/host-proxy-adapter.test.ts
@@ -4,7 +4,11 @@ import { createWindowsHostProxyRuntime } from "./host-proxy-adapter";
 
 test("creates a Windows runtime with only the committed portable executors", () => {
   const runtime = createWindowsHostProxyRuntime({
-    acquireGuardianToken: async () => null,
+    acquireGuardianToken: async () => ({
+      ok: false,
+      status: 404,
+      error: "unused",
+    }),
     getSessionToken: () => null,
     getLockfile: () => ({ assistants: [], activeAssistant: null }),
     onLockfileChange: () => () => undefined,
@@ -47,7 +51,11 @@ test("adds host_cu when the computer-use capability is installed", () => {
 
   // WHEN the Windows host-proxy runtime is created with them
   const runtime = createWindowsHostProxyRuntime({
-    acquireGuardianToken: async () => null,
+    acquireGuardianToken: async () => ({
+      ok: false,
+      status: 404,
+      error: "unused",
+    }),
     getSessionToken: () => null,
     getLockfile: () => ({ assistants: [], activeAssistant: null }),
     onLockfileChange: () => () => undefined,

--- a/packages/electron-desktop/src/host-proxy/router.test.ts
+++ b/packages/electron-desktop/src/host-proxy/router.test.ts
@@ -42,9 +42,13 @@ const {
   installHostProxyBridge,
   setExecutor,
   removeExecutor,
+  LOCAL_GATEWAY_TOKEN_RETRY,
   __testing,
 } = await import("./router");
 type HostProxyRuntime = import("./router").HostProxyRuntime;
+
+// Keep the mint ride-out loop fast: many attempts, no real wait between them.
+LOCAL_GATEWAY_TOKEN_RETRY.intervalMs = 0;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -503,6 +507,112 @@ describe("host-proxy-router", () => {
       await flush();
 
       expect(__testing.connections.has("a1")).toBe(false);
+    });
+
+    test("rides out a fetch-failed mint, then connects", async () => {
+      let mintAttempts = 0;
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/auth/token")) {
+          mintAttempts++;
+          if (mintAttempts < 3) {
+            throw new TypeError("fetch failed");
+          }
+        }
+        return mockGatewayTokenFetch(input);
+      }) as typeof globalThis.fetch;
+      installHostProxyBridge(testRuntime);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+
+      expect(mintAttempts).toBe(3);
+      expect(__testing.connections.has("a1")).toBe(true);
+    });
+
+    test("rides out a 401 mint, then connects", async () => {
+      let mintAttempts = 0;
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/auth/token")) {
+          mintAttempts++;
+          if (mintAttempts < 3) {
+            return new Response("unauthorized", { status: 401 });
+          }
+        }
+        return mockGatewayTokenFetch(input);
+      }) as typeof globalThis.fetch;
+      installHostProxyBridge(testRuntime);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+
+      expect(mintAttempts).toBe(3);
+      expect(__testing.connections.has("a1")).toBe(true);
+    });
+
+    test("a 403 mint is terminal and does not retry", async () => {
+      let mintAttempts = 0;
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/auth/token")) {
+          mintAttempts++;
+          return new Response("forbidden", { status: 403 });
+        }
+        return mockGatewayTokenFetch(input);
+      }) as typeof globalThis.fetch;
+      installHostProxyBridge(testRuntime);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+
+      expect(mintAttempts).toBe(1);
+      expect(__testing.connections.has("a1")).toBe(false);
+    });
+
+    test("a mint that never comes up spends the budget and skips the connection", async () => {
+      const originalAttempts = LOCAL_GATEWAY_TOKEN_RETRY.attempts;
+      LOCAL_GATEWAY_TOKEN_RETRY.attempts = 5;
+      let mintAttempts = 0;
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url.includes("/auth/token")) {
+          mintAttempts++;
+          throw new TypeError("fetch failed");
+        }
+        return mockGatewayTokenFetch(input);
+      }) as typeof globalThis.fetch;
+      installHostProxyBridge(testRuntime);
+
+      try {
+        lockfileListener?.({
+          assistants: [
+            { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+          ],
+          activeAssistant: "a1",
+        });
+        await flush();
+
+        expect(mintAttempts).toBe(5);
+        expect(__testing.connections.has("a1")).toBe(false);
+      } finally {
+        LOCAL_GATEWAY_TOKEN_RETRY.attempts = originalAttempts;
+      }
     });
   });
 

--- a/packages/electron-desktop/src/host-proxy/router.test.ts
+++ b/packages/electron-desktop/src/host-proxy/router.test.ts
@@ -60,8 +60,7 @@ const unavailableExecutor = {
 };
 const testRuntime: HostProxyRuntime = {
   acquireGuardianToken: async (assistantId) => {
-    const result = await mockGetGuardianAccessToken(assistantId);
-    return result.ok ? result.accessToken : null;
+    return mockGetGuardianAccessToken(assistantId);
   },
   getSessionToken: () => mockSessionToken,
   getLockfile: () => mockCurrentLockfile,
@@ -506,6 +505,57 @@ describe("host-proxy-router", () => {
       });
       await flush();
 
+      expect(__testing.connections.has("a1")).toBe(false);
+    });
+
+    test("rides out a guardian refresh 503, then connects", async () => {
+      let attempts = 0;
+      mockGetGuardianAccessToken.mockImplementation(async () => {
+        attempts++;
+        if (attempts < 3) {
+          return {
+            ok: false,
+            status: 503,
+            error: "Assistant gateway is unreachable",
+          };
+        }
+        return { ok: true, accessToken: "test-token" };
+      });
+      installHostProxyBridge(testRuntime);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+
+      expect(attempts).toBe(3);
+      expect(__testing.connections.has("a1")).toBe(true);
+    });
+
+    test("a guardian 500 is terminal and does not retry", async () => {
+      let attempts = 0;
+      mockGetGuardianAccessToken.mockImplementation(async () => {
+        attempts++;
+        return {
+          ok: false,
+          status: 500,
+          error: "Guardian token refresh timed out",
+        };
+      });
+      installHostProxyBridge(testRuntime);
+
+      lockfileListener?.({
+        assistants: [
+          { assistantId: "a1", cloud: "local", resources: { gatewayPort: 9001, daemonPort: 9002 } },
+        ],
+        activeAssistant: "a1",
+      });
+      await flush();
+
+      expect(attempts).toBe(1);
       expect(__testing.connections.has("a1")).toBe(false);
     });
 

--- a/packages/electron-desktop/src/host-proxy/router.ts
+++ b/packages/electron-desktop/src/host-proxy/router.ts
@@ -504,12 +504,31 @@ function seedPresence(assistantId: string): void {
 // ---------------------------------------------------------------------------
 
 /**
+ * Retry budget for riding out the local gateway's Login Item startup window.
+ * Matches the renderer `LOCAL_GATEWAY_STARTUP_RETRY` window: fetch-failed
+ * while the port is unbound, then a transient 401/503 before the guardian
+ * binding lands. Mutable so tests can shrink the wait.
+ */
+export const LOCAL_GATEWAY_TOKEN_RETRY = {
+  attempts: 90,
+  intervalMs: 1_000,
+};
+
+type GatewayTokenExchange =
+  | { kind: "ok"; token: string; expiresAt: number }
+  | { kind: "retryable" }
+  | { kind: "terminal" };
+
+/**
  * Exchange a guardian access token for a gateway JWT via POST /auth/token.
+ * A loopback-boundary `403` is terminal. Transport errors, `401`, and `5xx`
+ * are retryable: the gateway may still be binding its port or backfilling
+ * the guardian binding.
  */
 async function exchangeForGatewayToken(
   gatewayPort: number,
   guardianToken: string,
-): Promise<{ token: string; expiresAt: number } | null> {
+): Promise<GatewayTokenExchange> {
   try {
     const url = `http://127.0.0.1:${gatewayPort}/auth/token`;
     const res = await fetch(url, {
@@ -521,13 +540,13 @@ async function exchangeForGatewayToken(
     });
     if (!res.ok) {
       log.warn("[host-proxy-router] gateway token exchange failed", { status: res.status });
-      return null;
+      return { kind: res.status === 403 ? "terminal" : "retryable" };
     }
     const body = (await res.json()) as { token: string; expiresAt: number };
-    return body;
+    return { kind: "ok", token: body.token, expiresAt: body.expiresAt };
   } catch (err) {
     log.warn("[host-proxy-router] gateway token exchange error", { err });
-    return null;
+    return { kind: "retryable" };
   }
 }
 
@@ -553,9 +572,41 @@ async function acquireGatewayToken(
   if (!guardianToken) return null;
 
   const exchanged = await exchangeForGatewayToken(gatewayPort, guardianToken);
-  if (!exchanged) return null;
+  if (exchanged.kind !== "ok") return null;
 
   return exchanged.token;
+}
+
+/**
+ * Prime-time mint for a local connect. Rides out retryable mint failures
+ * (port not bound yet, starting 503, transient 401) without skipping the
+ * connection. A missing guardian token or a `403` falls through immediately.
+ * `isCurrentAttempt` aborts when lockfile reconcile cancels this connect.
+ */
+async function acquireGatewayTokenRidingStartup(
+  assistantId: string,
+  gatewayPort: number,
+  isCurrentAttempt: () => boolean,
+): Promise<string | null> {
+  const { attempts, intervalMs } = LOCAL_GATEWAY_TOKEN_RETRY;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (!isCurrentAttempt()) {
+      return null;
+    }
+    const guardianToken = await acquireGuardianToken(assistantId);
+    if (!guardianToken) {
+      return null;
+    }
+    const exchanged = await exchangeForGatewayToken(gatewayPort, guardianToken);
+    if (exchanged.kind === "ok") {
+      return exchanged.token;
+    }
+    if (exchanged.kind === "terminal" || attempt >= attempts) {
+      return null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  return null;
 }
 
 // A connection's fingerprint encodes everything that, if changed, requires a
@@ -577,7 +628,7 @@ const cloudFingerprint = (runtimeUrl: string, organizationId?: string): string =
 async function connectWithPendingGuard(
   assistantId: string,
   fingerprint: string,
-  acquireToken: () => Promise<string | null>,
+  acquireToken: (isCurrentAttempt: () => boolean) => Promise<string | null>,
   open: (token: string) => void,
 ): Promise<void> {
   if (connections.has(assistantId)) return;
@@ -585,9 +636,10 @@ async function connectWithPendingGuard(
 
   const pending: PendingConnect = { fingerprint };
   pendingConnects.set(assistantId, pending);
+  const isCurrentAttempt = () => pendingConnects.get(assistantId) === pending;
   try {
-    const token = await acquireToken();
-    if (pendingConnects.get(assistantId) !== pending || connections.has(assistantId)) {
+    const token = await acquireToken(isCurrentAttempt);
+    if (!isCurrentAttempt() || connections.has(assistantId)) {
       log.info("[host-proxy-router] lockfile changed during token acquisition, aborting stale connect", { assistantId, fingerprint });
       return;
     }
@@ -612,7 +664,8 @@ async function connectLocalAssistant(
   await connectWithPendingGuard(
     assistantId,
     fingerprint,
-    () => acquireGatewayToken(assistantId, gatewayPort),
+    (isCurrentAttempt) =>
+      acquireGatewayTokenRidingStartup(assistantId, gatewayPort, isCurrentAttempt),
     (token) => openLocalConnection(assistantId, gatewayPort, token, fingerprint),
   );
 }

--- a/packages/electron-desktop/src/host-proxy/router.ts
+++ b/packages/electron-desktop/src/host-proxy/router.ts
@@ -44,8 +44,20 @@ export interface HostProxyLogger {
   error(message: string, context?: unknown): void;
 }
 
+/**
+ * Guardian-token result for a local host-proxy connect. Mirrors the
+ * `TokenResult` from `@vellumai/local-mode` so the startup ride-out can
+ * retry a still-starting gateway (`503`) without stalling on a missing
+ * (`404`), spent (`401`), refused (`403`), or permanent (`500`) credential.
+ */
+export type HostProxyGuardianTokenResult =
+  | { ok: true; accessToken: string }
+  | { ok: false; status: number; error?: string };
+
 export interface HostProxyRuntime {
-  acquireGuardianToken: (assistantId: string) => Promise<string | null>;
+  acquireGuardianToken: (
+    assistantId: string,
+  ) => Promise<HostProxyGuardianTokenResult>;
   getSessionToken: () => string | null;
   getLockfile: () => Lockfile;
   onLockfileChange: (listener: (lockfile: Lockfile) => void) => () => void;
@@ -552,7 +564,7 @@ async function exchangeForGatewayToken(
 
 async function acquireGuardianToken(
   assistantId: string,
-): Promise<string | null> {
+): Promise<HostProxyGuardianTokenResult> {
   try {
     return await requireRuntime().acquireGuardianToken(assistantId);
   } catch (err) {
@@ -560,7 +572,7 @@ async function acquireGuardianToken(
       assistantId,
       err,
     });
-    return null;
+    return { ok: false, status: 500 };
   }
 }
 
@@ -569,18 +581,32 @@ async function acquireGatewayToken(
   gatewayPort: number,
 ): Promise<string | null> {
   const guardianToken = await acquireGuardianToken(assistantId);
-  if (!guardianToken) return null;
+  if (!guardianToken.ok) return null;
 
-  const exchanged = await exchangeForGatewayToken(gatewayPort, guardianToken);
+  const exchanged = await exchangeForGatewayToken(
+    gatewayPort,
+    guardianToken.accessToken,
+  );
   if (exchanged.kind !== "ok") return null;
 
   return exchanged.token;
 }
 
 /**
+ * `503` is the CLI's labeled "gateway unreachable / still starting" status
+ * (`parseGuardianRefreshCliFailure`). Missing (404), spent (401), refused
+ * (403), and permanent 500 failures (malformed file, spawn failure, refresh
+ * timeout) do not heal by waiting.
+ */
+function isTransientGuardianStatus(status: number): boolean {
+  return status === 503;
+}
+
+/**
  * Prime-time mint for a local connect. Rides out retryable mint failures
- * (port not bound yet, starting 503, transient 401) without skipping the
- * connection. A missing guardian token or a `403` falls through immediately.
+ * (port not bound yet, starting 503, transient 401) and a guardian refresh
+ * `503` without skipping the connection. A missing or spent guardian token
+ * or a `403` falls through immediately.
  * `isCurrentAttempt` aborts when lockfile reconcile cancels this connect.
  */
 async function acquireGatewayTokenRidingStartup(
@@ -594,10 +620,17 @@ async function acquireGatewayTokenRidingStartup(
       return null;
     }
     const guardianToken = await acquireGuardianToken(assistantId);
-    if (!guardianToken) {
-      return null;
+    if (!guardianToken.ok) {
+      if (!isTransientGuardianStatus(guardianToken.status) || attempt >= attempts) {
+        return null;
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      continue;
     }
-    const exchanged = await exchangeForGatewayToken(gatewayPort, guardianToken);
+    const exchanged = await exchangeForGatewayToken(
+      gatewayPort,
+      guardianToken.accessToken,
+    );
     if (exchanged.kind === "ok") {
       return exchanged.token;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

After some cold boots / Login Item launches, an existing self-hosted assistant is shown as unavailable and the user is forced through select assistant → Wake → Repair. Identity, credentials, conversations, and workspace stay intact. The same assistant becomes healthy once the local runtime finishes starting.

Electron logs (including 0.11.9 on Sep 7) show ~56s of `TypeError: fetch failed` (`could not acquire token, skipping connection`), then mint 401, then `selectAssistant.handleConnect failed GatewayTokenError: 401` (Repair UI), then `connected to local assistant` ~19s later with no re-pair.

Root cause: the startup ride-out from #39202 is an 8s budget and treats transport errors as "assistant is stopped." Login Item cold boot has not bound the loopback port yet. Interactive connect then `wake`s on almost any error, which restarts an already-starting gateway. A plain wake cannot re-lease a mint 401. The host proxy also skips the connection on the first failed mint.

This PR:
- Extends the renderer ride-out to ~90s and treats loopback transport errors, mint 401/5xx, and guardian **503** as still-starting (not paired/remote, not 403, not missing guardian, not unresolved port, not guardian 500).
- Rides that window on both boot and the pre-wake connect path, so a starting Login Item is not restarted.
- Does not wake on a mint 401 that survives the budget. Repair remains for a persistent mint 401.
- Retries the Electron host-proxy `/auth/token` mint on the same window instead of skipping.
- Preserves guardian-token status through the host-proxy runtime so a refresh 503 can be ridden out. Missing (404), spent (401), refused (403), and permanent 500 failures (malformed file, CLI spawn, 15s refresh timeout) stay terminal.

Tradeoff: a genuinely stopped local assistant waits up to the boot ride-out before the chooser, then connect-with-repair may wait the same window before waking.

## Test plan

- `clients/web`: `bun test src/lib/local-mode-repair.test.ts` and `src/lib/local-mode.test.ts`
- `packages/electron-desktop`: `bun test src/host-proxy/router.test.ts`
- Cases covered: transport then success without wake, surviving mint 401 without wake, transport exhausted then wake, paired failures still fail immediately, host-proxy 401/fetch-failed then connect, 403 mint does not retry, guardian 503 then connect, guardian 500 does not retry
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebb7404d-c972-4bfa-aab8-4a4f66d1c35f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebb7404d-c972-4bfa-aab8-4a4f66d1c35f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

