### PR TITLE
fix(messaging): withdraw the person target nothing asks for

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5441,9 +5441,7 @@ paths:
     post:
       operationId: channels_send_post
       summary: Send text to a channel chat
-      description:
-        Deliver text to a chat or person on a channel through the channel's transport, recorded after the channel
-        acknowledges it.
+      description: Deliver text to a chat on a channel through the channel's transport, recorded after the channel acknowledges it.
       tags:
         - channels
       requestBody:
@@ -5468,36 +5466,22 @@ paths:
                     - plugin
                   description: Channel to send on
                 target:
-                  oneOf:
-                    - type: object
-                      properties:
-                        kind:
-                          type: string
-                          const: chat
-                        chatId:
-                          type: string
-                          minLength: 1
-                          description: Chat id in the channel's own id space
-                        threadId:
-                          description: Thread within the chat, in the channel's own id space
-                          type: string
-                          minLength: 1
-                      required:
-                        - kind
-                        - chatId
-                    - type: object
-                      properties:
-                        kind:
-                          type: string
-                          const: person
-                        userId:
-                          type: string
-                          minLength: 1
-                          description: Person to reach in their DM, in the channel's own id space
-                      required:
-                        - kind
-                        - userId
                   type: object
+                  properties:
+                    kind:
+                      type: string
+                      const: chat
+                    chatId:
+                      type: string
+                      minLength: 1
+                      description: Chat id in the channel's own id space
+                    threadId:
+                      description: Thread within the chat, in the channel's own id space
+                      type: string
+                      minLength: 1
+                  required:
+                    - kind
+                    - chatId
                 text:
                   type: string
                   minLength: 1

--- a/assistant/src/messaging/providers/__tests__/proactive-address.test.ts
+++ b/assistant/src/messaging/providers/__tests__/proactive-address.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-// The addressing capability resolves a neutral target into exactly what each
+// The addressing capability resolves a named chat into exactly what each
 // transport's own operations read: the callback URL `channelForCallback`
-// resolves and the params `deliver` consumes. These tests import the
-// transports' modules, which pull in their provider-API senders, so the
-// senders' credential lookups are stubbed to keep the import inert, and the
-// DM-opening calls a person target makes are stubbed to answer a channel id.
+// resolves and the params `deliver` consumes. Resolution is local, so these
+// assertions make no platform call; the tests import the transports'
+// modules, which pull in their provider-API senders, so the senders'
+// credential lookups are stubbed to keep the import inert.
 import { mock } from "bun:test";
 
 const actualSecureKeys = await import("../../../security/secure-keys.js");
@@ -14,18 +14,6 @@ mock.module("../../../security/secure-keys.js", () => ({
   getSecureKeyResultAsync: async () => ({ value: null }),
 }));
 
-const actualDiscordApi = await import("../discord/api.js");
-mock.module("../discord/api.js", () => ({
-  ...actualDiscordApi,
-  openDiscordDmChannel: async (userId: string) => `dm-of-${userId}`,
-}));
-
-const actualSlackApi = await import("../slack/api.js");
-mock.module("../slack/api.js", () => ({
-  ...actualSlackApi,
-  openSlackDmChannel: async (userId: string) => `D-of-${userId}`,
-}));
-
 const { channelForCallback } = await import("../callback-routing.js");
 const { discordTransport } = await import("../discord/transport.js");
 const { slackTransport } = await import("../slack/transport.js");
@@ -33,16 +21,13 @@ const { telegramTransport } = await import("../telegram-bot/transport.js");
 const { whatsappTransport } = await import("../whatsapp/transport.js");
 
 describe("addressFor resolves to the channel's own routing state", () => {
-  test("slack: a chat, optionally under a thread; a person is the DM the bot opens", async () => {
-    const room = await slackTransport.addressFor!({
-      kind: "chat",
-      chatId: "C123",
-    });
+  test("slack: a chat, optionally under a thread", () => {
+    const room = slackTransport.addressFor!({ kind: "chat", chatId: "C123" });
     expect(room).toEqual({
       ctx: { callbackUrl: "/deliver/slack", params: {} },
       chatId: "C123",
     });
-    const thread = await slackTransport.addressFor!({
+    const thread = slackTransport.addressFor!({
       kind: "chat",
       chatId: "C123",
       threadId: "1690000000.000001",
@@ -55,18 +40,12 @@ describe("addressFor resolves to the channel's own routing state", () => {
       chatId: "C123",
       threadId: "1690000000.000001",
     });
-    expect(
-      await slackTransport.addressFor!({ kind: "person", userId: "U1" }),
-    ).toEqual({
-      ctx: { callbackUrl: "/deliver/slack", params: {} },
-      chatId: "D-of-U1",
-    });
     expect(channelForCallback(thread!.ctx.callbackUrl)).toBe("slack");
   });
 
-  test("telegram: a chat with a topic; a person is their DM chat; binds on send", async () => {
+  test("telegram: a chat with a topic; binds on send", () => {
     expect(
-      await telegramTransport.addressFor!({
+      telegramTransport.addressFor!({
         kind: "chat",
         chatId: "123",
         threadId: "42",
@@ -79,23 +58,16 @@ describe("addressFor resolves to the channel's own routing state", () => {
       chatId: "123",
       threadId: "42",
     });
-    expect(
-      await telegramTransport.addressFor!({ kind: "person", userId: "777" }),
-    ).toEqual({
-      ctx: { callbackUrl: "/deliver/telegram", params: {} },
-      chatId: "777",
-    });
     expect(telegramTransport.bindsChatOnProactiveSend).toBe(true);
   });
 
-  test("discord: a chat with a thread; a person is the DM channel the transport opens", async () => {
-    expect(
-      await discordTransport.addressFor!({
-        kind: "chat",
-        chatId: "C1",
-        threadId: "T1",
-      }),
-    ).toEqual({
+  test("discord: a chat with a thread, which is its own channel", () => {
+    const thread = discordTransport.addressFor!({
+      kind: "chat",
+      chatId: "C1",
+      threadId: "T1",
+    });
+    expect(thread).toEqual({
       ctx: {
         callbackUrl: "/deliver/discord?threadId=T1",
         params: { threadId: "T1" },
@@ -103,33 +75,16 @@ describe("addressFor resolves to the channel's own routing state", () => {
       chatId: "C1",
       threadId: "T1",
     });
-    const person = await discordTransport.addressFor!({
-      kind: "person",
-      userId: "U1",
-    });
-    expect(person).toEqual({
-      ctx: { callbackUrl: "/deliver/discord", params: {} },
-      chatId: "dm-of-U1",
-    });
-    expect(channelForCallback(person!.ctx.callbackUrl)).toBe("discord");
+    expect(channelForCallback(thread!.ctx.callbackUrl)).toBe("discord");
     expect(discordTransport.bindsChatOnProactiveSend).toBeUndefined();
   });
 
-  test("whatsapp: a chat and a person are the same number; no threads; binds on send", async () => {
+  test("whatsapp: the number is the chat; no threads; binds on send", () => {
     expect(
-      await whatsappTransport.addressFor!({
+      whatsappTransport.addressFor!({
         kind: "chat",
         chatId: "12125550100",
         threadId: "ignored",
-      }),
-    ).toEqual({
-      ctx: { callbackUrl: "/deliver/whatsapp", params: {} },
-      chatId: "12125550100",
-    });
-    expect(
-      await whatsappTransport.addressFor!({
-        kind: "person",
-        userId: "12125550100",
       }),
     ).toEqual({
       ctx: { callbackUrl: "/deliver/whatsapp", params: {} },

--- a/assistant/src/messaging/providers/channel-transport.ts
+++ b/assistant/src/messaging/providers/channel-transport.ts
@@ -99,17 +99,20 @@ export interface ReactionTarget {
 
 /**
  * Where a proactive send goes, in the caller's vocabulary rather than any
- * channel's: a chat the caller already knows, optionally a thread within it,
- * or a person to reach in their DM. How a thread is spelled and how a person
- * becomes a DM is each channel's own business.
+ * channel's: a chat the caller already knows, optionally a thread within it.
+ * How a thread is spelled is each channel's own business.
+ *
+ * Tagged with its kind so a second way of naming a destination is additive
+ * rather than a reinterpretation of `chatId`. Reaching a person who has not
+ * been named as a chat is deliberately not a kind here: on Slack and Discord
+ * it costs a platform call whose result must be resolved at send time rather
+ * than stored, and nothing asks for it yet.
  */
-export type ProactiveTarget =
-  | {
-      readonly kind: "chat";
-      readonly chatId: string;
-      readonly threadId?: string;
-    }
-  | { readonly kind: "person"; readonly userId: string };
+export type ProactiveTarget = {
+  readonly kind: "chat";
+  readonly chatId: string;
+  readonly threadId?: string;
+};
 
 /**
  * A proactive target resolved into what this channel's operations read: the
@@ -142,15 +145,18 @@ export interface ChannelTransport {
    * for a send that no inbound message brought a callback for.
    *
    * Implementing it is the whole of declaring that the channel can be
-   * addressed from a named chat or person. A transport that can only answer
-   * on the callback an inbound message carried omits it, and a caller reads
-   * the omission as "not addressable" rather than switching on the channel's
-   * name. Returning `undefined` for a target shape this channel cannot
-   * address is the same answer for that shape alone.
+   * addressed from a named chat. A transport that can only answer on the
+   * callback an inbound message carried omits it, and a caller reads the
+   * omission as "not addressable" rather than switching on the channel's
+   * name. Returning `undefined` for a target this channel cannot address is
+   * the same answer for that target alone.
+   *
+   * Resolution is local: it reads the target and the channel's own
+   * vocabulary, and makes no platform call. A destination that has to be
+   * resolved over the network belongs behind its own capability, so this one
+   * stays cheap enough to call on every send.
    */
-  addressFor?(
-    target: ProactiveTarget,
-  ): ProactiveAddress | undefined | Promise<ProactiveAddress | undefined>;
+  addressFor?(target: ProactiveTarget): ProactiveAddress | undefined;
 
   /**
    * Whether a proactive send to a chat must also bind that chat's inbound

--- a/assistant/src/messaging/providers/discord/transport.ts
+++ b/assistant/src/messaging/providers/discord/transport.ts
@@ -54,18 +54,12 @@ export const discordTransport: ChannelTransport = {
 
   /**
    * A chat is a channel id, with `threadId` naming the thread, which is its
-   * own channel. A person is reached in their DM, which is opened here so
-   * the address names the DM channel the post lands in: that is the id
-   * Discord's later events carry for it, so the record and the chat's home
-   * are found again by it.
+   * own channel. Reaching a person who has not been named as a chat would
+   * mean opening their DM first, a platform call this resolution does not
+   * make; the inbound `dm` param below is how an event-carried callback says
+   * its `chatId` is a recipient rather than a room.
    */
-  async addressFor(target) {
-    if (target.kind === "person") {
-      return {
-        ctx: directDeliveryContext("discord"),
-        chatId: await openDiscordDmChannel(target.userId),
-      };
-    }
+  addressFor(target) {
     const threadId = target.threadId?.trim();
     return {
       ctx: directDeliveryContext("discord", threadId ? { threadId } : {}),

--- a/assistant/src/messaging/providers/slack/api.ts
+++ b/assistant/src/messaging/providers/slack/api.ts
@@ -23,7 +23,6 @@ import { conversationInfo } from "./client.js";
 import type {
   SlackApiResponse,
   SlackConversationInfoResponse,
-  SlackConversationsOpenResponse,
 } from "./types.js";
 import {
   SlackApiError,
@@ -82,19 +81,6 @@ export async function callSlackApi(
   body: Record<string, unknown>,
 ): Promise<SlackOutboundApiResponse> {
   return slackApiRequest<SlackOutboundApiResponse>("bot", method, { body });
-}
-
-/**
- * Open (or find) the bot's DM with a user and return its channel id, the id
- * Slack's later events carry for that conversation.
- */
-export async function openSlackDmChannel(userId: string): Promise<string> {
-  const opened = await slackApiRequest<SlackConversationsOpenResponse>(
-    "bot",
-    "conversations.open",
-    { body: { users: userId } },
-  );
-  return opened.channel.id;
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/transport.ts
+++ b/assistant/src/messaging/providers/slack/transport.ts
@@ -5,7 +5,7 @@ import { extractThreadTsFromCallbackUrl } from "../../../channels/slack-callback
 import { getLogger } from "../../../util/logger.js";
 import { directDeliveryContext } from "../callback-routing.js";
 import type { ChannelTransport } from "../channel-transport.js";
-import { openSlackDmChannel, SLACK_STREAM_MARKDOWN_LIMIT } from "./api.js";
+import { SLACK_STREAM_MARKDOWN_LIMIT } from "./api.js";
 import {
   describeSlackReactionEmoji,
   sendSlackAgentSessionStatus,
@@ -28,17 +28,11 @@ export const slackTransport: ChannelTransport = {
 
   /**
    * A chat is a channel or DM id, with `threadTs` naming the thread to post
-   * under. A person is reached in their DM, opened here as the bot
-   * (`conversations.open`) so the address names the DM channel the post
-   * lands in, the id Slack's later events carry for it.
+   * under. Reaching a person who has not been named as a chat would mean
+   * opening the DM first (`conversations.open`), a platform call this
+   * resolution does not make.
    */
-  async addressFor(target) {
-    if (target.kind === "person") {
-      return {
-        ctx: directDeliveryContext("slack"),
-        chatId: await openSlackDmChannel(target.userId),
-      };
-    }
+  addressFor(target) {
     const threadTs = target.threadId?.trim();
     return {
       ctx: directDeliveryContext("slack", threadTs ? { threadTs } : {}),

--- a/assistant/src/messaging/providers/telegram-bot/transport.ts
+++ b/assistant/src/messaging/providers/telegram-bot/transport.ts
@@ -69,15 +69,10 @@ export const telegramTransport: ChannelTransport = {
 
   /**
    * A chat is a chat id, with `threadId` naming a forum topic. A person's DM
-   * chat id is their user id, so a person is addressed as that chat.
+   * chat id is their user id on Telegram, so reaching one is naming that
+   * chat and needs no resolution of its own.
    */
   addressFor(target) {
-    if (target.kind === "person") {
-      return {
-        ctx: directDeliveryContext("telegram"),
-        chatId: target.userId,
-      };
-    }
     const threadId = target.threadId?.trim();
     return {
       ctx: directDeliveryContext("telegram", threadId ? { threadId } : {}),

--- a/assistant/src/messaging/providers/whatsapp/transport.ts
+++ b/assistant/src/messaging/providers/whatsapp/transport.ts
@@ -11,14 +11,14 @@ export const whatsappTransport: ChannelTransport = {
   channel: "whatsapp",
 
   /**
-   * A chat and a person are the same address on WhatsApp: the phone number.
-   * There are no threads, so a chat target's thread is not carried and the
-   * post lands in the chat itself.
+   * A chat is the phone number, which is also how a person is named, so
+   * reaching one needs no resolution of its own. There are no threads, so a
+   * target's thread is not carried and the post lands in the chat itself.
    */
   addressFor(target) {
     return {
       ctx: directDeliveryContext("whatsapp"),
-      chatId: target.kind === "person" ? target.userId : target.chatId,
+      chatId: target.chatId,
     };
   },
 

--- a/assistant/src/runtime/__tests__/channel-send.test.ts
+++ b/assistant/src/runtime/__tests__/channel-send.test.ts
@@ -22,7 +22,7 @@ let deliverResult: Record<string, unknown> = {
 
 function fakeTransport(
   channel: "slack" | "telegram",
-  opts: { binds?: boolean; addressable?: boolean } = {},
+  opts: { binds?: boolean; addressable?: boolean; refuses?: boolean } = {},
 ): ChannelTransport {
   const transport: ChannelTransport = {
     channel,
@@ -37,9 +37,8 @@ function fakeTransport(
     },
   };
   if (opts.addressable !== false) {
-    // Asynchronous, as a transport that opens a DM to address a person is.
-    transport.addressFor = async (target: ProactiveTarget) => {
-      if (target.kind === "person") {
+    transport.addressFor = (target: ProactiveTarget) => {
+      if (opts.refuses) {
         return undefined;
       }
       const threadId = target.threadId?.trim();
@@ -167,7 +166,7 @@ describe("addressability", () => {
     expect(isProactivelyAddressable("not-a-channel")).toBe(false);
   });
 
-  test("refuses before delivery when the channel or the target shape cannot be addressed", async () => {
+  test("refuses before delivery when the channel has no addressing, or refuses the chat", async () => {
     await expect(
       sendChannelText({
         channel: "email",
@@ -175,10 +174,12 @@ describe("addressability", () => {
         text: "hi",
       }),
     ).rejects.toBeInstanceOf(ChannelNotAddressableError);
+
+    transports.slack = fakeTransport("slack", { refuses: true });
     await expect(
       sendChannelText({
         channel: "slack",
-        target: { kind: "person", userId: "U1" },
+        target: { kind: "chat", chatId: "C-unreachable" },
         text: "hi",
       }),
     ).rejects.toBeInstanceOf(ChannelNotAddressableError);

--- a/assistant/src/runtime/channel-send.ts
+++ b/assistant/src/runtime/channel-send.ts
@@ -109,8 +109,8 @@ export class ChannelSendFailedError extends Error {
 
 /**
  * Whether a channel's transport declares it can be addressed from a named
- * chat or person. A channel with no transport, or one that only answers on
- * an inbound callback, is not.
+ * chat. A channel with no transport, or one that only answers on an inbound
+ * callback, is not.
  */
 export function isProactivelyAddressable(channel: string): boolean {
   return getTransportForChannel(channel)?.addressFor !== undefined;
@@ -139,12 +139,9 @@ export async function sendChannelText(
       "cannot be addressed from a named chat",
     );
   }
-  const address = await transport.addressFor(target);
+  const address = transport.addressFor(target);
   if (!address) {
-    throw new ChannelNotAddressableError(
-      channel,
-      `cannot be addressed by ${target.kind}`,
-    );
+    throw new ChannelNotAddressableError(channel, "cannot address that chat");
   }
 
   const result = await transport.deliver(address.ctx, {

--- a/assistant/src/runtime/routes/channel-send-routes.ts
+++ b/assistant/src/runtime/routes/channel-send-routes.ts
@@ -1,8 +1,8 @@
 /**
  * Route handler for a model-directed text send to a channel chat.
  *
- * POST /v1/channels/send: deliver text to a chat or person on a channel
- * through the channel's transport, recorded after acknowledgement. The
+ * POST /v1/channels/send: deliver text to a chat on a channel through the
+ * channel's transport, recorded after acknowledgement. The
  * messaging tool's channel branch runs the same function in-process; this
  * route is the door for the CLI and scripts, so the two doors share one
  * seam and one record.
@@ -21,24 +21,15 @@ import { BadGatewayError, BadRequestError } from "./errors.js";
 import { parseBody } from "./parse-body.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
-const ProactiveTargetSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("chat"),
-    chatId: z.string().min(1).describe("Chat id in the channel's own id space"),
-    threadId: z
-      .string()
-      .min(1)
-      .optional()
-      .describe("Thread within the chat, in the channel's own id space"),
-  }),
-  z.object({
-    kind: z.literal("person"),
-    userId: z
-      .string()
-      .min(1)
-      .describe("Person to reach in their DM, in the channel's own id space"),
-  }),
-]);
+const ProactiveTargetSchema = z.object({
+  kind: z.literal("chat"),
+  chatId: z.string().min(1).describe("Chat id in the channel's own id space"),
+  threadId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Thread within the chat, in the channel's own id space"),
+});
 
 const ChannelSendRequestSchema = z.object({
   channel: z.enum(CHANNEL_IDS).describe("Channel to send on"),
@@ -85,7 +76,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Send text to a channel chat",
     description:
-      "Deliver text to a chat or person on a channel through the channel's transport, recorded after the channel acknowledges it.",
+      "Deliver text to a chat on a channel through the channel's transport, recorded after the channel acknowledges it.",
     tags: ["channels"],
     handler: handleChannelSend,
     requestBody: ChannelSendRequestSchema,


### PR DESCRIPTION
**TL;DR:** Proactive addressing shipped with two target shapes, a chat and a person, and nothing constructs a person target. This withdraws it. The target is a chat, tagged with its kind so a second shape stays additive; address resolution is local and makes no platform call, which is now the contract's own rule; and the Slack DM opener that came with it, which nothing called, is deleted. Discord's DM opener and its cache are untouched. Not in today's release, since the send seam merged after the release branch was cut. Part of JARVIS-1733.

## Why

Nothing in the repo builds a person target. The messaging tool and the CLI both name chats. The three paths that genuinely reach a person's DM, guardian notification delivery, channel verification, and card withdrawal, call the Discord API helper directly and never go through this contract. Only a raw call to the route could reach the person shape.

Reaching a person who has not been named as a chat is not a small addition. On Slack and Discord it costs a platform call, and the capability map records a decision about how that call must behave: the notification adapter resolves the guardian's DM from their user snowflake at send time, so a stored room id can never become a delivery target. Whether a command-line caller should reach a person by raw platform id at all, rather than through the contact model, is a question nobody has answered.

Built ahead of a caller, the shape did real harm to the code around it. It left one channel opening a DM behind a private module-level cache and its sibling opening one with no cache at all, an asymmetry with no caller to justify either choice, and it put a network call inside a resolution step every send runs. Removing the shape removes the asymmetry at its cause instead of building a general mechanism to paper over it.

## What changes for the user

| Before | After |
| --- | --- |
| The send route accepted a person target that nothing constructed | It accepts a chat, still tagged by kind so a person shape can be added later without a wire break |
| Address resolution could make a platform call, on a step every send runs | Resolution is local, and the contract says so |
| Slack had a DM opener reachable only through the route | Deleted |
| Discord's DM opener and cache, used by notification delivery, verification, and withdrawal | Unchanged |
| A model-directed or CLI send to a chat | Unchanged |

## Design

- **The target keeps its discriminator.** One shape today, tagged, so adding a way to name a destination is additive rather than a reinterpretation of `chatId`. That tag is what stops a person id from being passed as a chat id, which is the ambiguity Discord's inbound marker exists to resolve.
- **Resolution is local, by contract.** The capability's doc comment now states that it reads the target and the channel's own vocabulary and makes no platform call, and that a destination needing the network belongs behind its own capability. That is the rule that would have caught this.
- **Discord is untouched on purpose.** Its DM opener has three callers that predate this work, and its cache is there because Discord's own documentation warns that opening DMs in volume gets a bot rate limited or blocked. One channel's answer to one platform's documented limit is not a layering problem; it looked like one only because this arc added a second, uncalled occupant.

## Why this is safe

- Nothing constructed a person target, so no caller changes behaviour. The route's schema narrows, and the route has never shipped: the send seam merged after today's release branch was cut, so there is nothing to cherry-pick and no wire compatibility to keep.
- Address resolution becomes synchronous again, which is a narrowing of the contract, so every implementation still satisfies it.
- Tests: each transport's resolution against the callback routing that parses it, the send function's two refusal paths (a channel with no addressing, and a transport that refuses a chat), the route's schema, and the messaging tool's delegation. Typecheck clean; tests run on CI at exact HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->