### PR TITLE
fix(web): review fixes for the ACP model tile and store tests

### DIFF
--- a/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
@@ -33,7 +33,8 @@ export function SkillsReferenceACPContent() {
             Setup required
           </SectionHeading>
           <p className="mb-0 text-zinc-600">
-            The protocol adapter is installed automatically at the version your Assistant pins.
+            The protocol adapter is installed automatically the first time you use an agent, at the
+            version your Assistant pins, and an adapter already on your PATH is left as it is.
             For Claude Code that is everything: sign-in runs through an in-app Connect card,
             so there is nothing to install yourself. The Codex adapter,
             @agentclientprotocol/codex-acp, includes Codex and reuses your existing Codex login. Say

--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import {
+  MAX_PENDING_MODEL_UPDATES,
   useAcpRunStore,
   type AcpRunEntry,
   type AcpRunRawEvent,
@@ -88,8 +89,8 @@ describe("spawnRun", () => {
   });
 
   it("applies a model update buffered before the spawn event", () => {
-    // The adapter reports the opening selection before `acp_session_spawned`,
-    // so the update arrives with no entry to hold it.
+    // An update the daemon publishes while the spawn is still pinning the
+    // model arrives with no entry to hold it.
     getState().setModel({
       acpSessionId: "acp-1",
       model: "sonnet",
@@ -816,7 +817,8 @@ describe("setModel", () => {
   });
 
   it("caps the buffer and drops the least recently updated session", () => {
-    for (let i = 0; i < 64; i += 1) {
+    const overflow = MAX_PENDING_MODEL_UPDATES * 2;
+    for (let i = 0; i < overflow; i += 1) {
       getState().setModel({
         acpSessionId: `acp-pending-${i}`,
         model: "opus",
@@ -825,9 +827,9 @@ describe("setModel", () => {
     }
 
     const pending = getState().pendingModelUpdates;
-    expect(pending.size).toBeLessThan(64);
+    expect(pending.size).toBe(MAX_PENDING_MODEL_UPDATES);
     expect(pending.has("acp-pending-0")).toBe(false);
-    expect(pending.has("acp-pending-63")).toBe(true);
+    expect(pending.has(`acp-pending-${overflow - 1}`)).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -128,7 +128,7 @@ export interface PendingModelUpdate {
 }
 
 /** How many sessions can hold a buffered model update at once. */
-const MAX_PENDING_MODEL_UPDATES = 32;
+export const MAX_PENDING_MODEL_UPDATES = 32;
 
 export interface AcpRunState {
   byId: Record<string, AcpRunEntry>;
@@ -145,12 +145,13 @@ export interface AcpRunState {
    */
   highWaterMark: Map<string, number>;
   /**
-   * Model updates that landed for a session with no entry yet: the daemon
-   * reports the opening selection (and an empty-picker withdrawal) before
-   * `acp_session_spawned`, and an `/acp/sessions` read can be answered after an
-   * update it predates. Whichever path creates the entry, a spawn or a
-   * snapshot, folds the buffered update in under the same ordering rule a live
-   * entry gets, so the selection is not lost. Bounded by
+   * Model updates that landed for a session with no entry yet: an adapter can
+   * report an unsolicited `config_option_update` while the spawn is still
+   * pinning the model, which the daemon publishes before it announces the
+   * session, and an `/acp/sessions` read can be answered after an update it
+   * predates. Whichever path creates the entry, a spawn or a snapshot, folds
+   * the buffered update in under the same ordering rule a live entry gets, so
+   * the selection is not lost. Bounded by
    * {@link MAX_PENDING_MODEL_UPDATES}, least recently updated id dropped first.
    */
   pendingModelUpdates: Map<string, PendingModelUpdate>;

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-model-stat-card.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-model-stat-card.tsx
@@ -25,6 +25,7 @@ export function AcpModelStatCard({
   // "Best available" rather than the `best` it is keyed by. An adapter that
   // advertises no list, or a model absent from one, keeps the wire value.
   const named = options?.find((option) => option.value === model)?.label;
+  const value = named ?? model;
   return (
     <MetricCard
       icon={
@@ -33,7 +34,9 @@ export function AcpModelStatCard({
           style={{ color: "var(--content-secondary)" }}
         />
       }
-      value={named ?? model}
+      value={value}
+      // A model id is longer than the tile, so the row ellipses it.
+      valueTitle={value}
       label={t("acpRunChatView.modelLabel")}
     />
   );

--- a/clients/web/src/domains/chat/components/metric-card.tsx
+++ b/clients/web/src/domains/chat/components/metric-card.tsx
@@ -81,10 +81,18 @@ export function MetricCard({
   icon,
   value,
   label,
+  valueTitle,
 }: {
   icon: ReactNode;
   value: string;
   label: string;
+  /**
+   * Native tooltip for the value row, the way the design library's own Select
+   * titles its trigger: a truncated value is unreadable without it. Opt-in,
+   * because a title repeating a value that is fully visible is noise a screen
+   * reader reads twice.
+   */
+  valueTitle?: string;
 }) {
   return (
     <div className="flex items-center gap-3 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-3 py-3">
@@ -94,9 +102,7 @@ export function MetricCard({
       <div className="min-w-0">
         <Typography
           variant="title-small"
-          // Truncated values are unreadable without it, the way the design
-          // library's own Select titles its trigger.
-          title={value || undefined}
+          title={valueTitle || undefined}
           className="block truncate text-[var(--content-default)]"
         >
           {value}

--- a/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/acp-handlers.test.ts
@@ -207,14 +207,18 @@ describe("handleAcpSessionModelUpdate", () => {
     expect(entry?.availableModels).toEqual([]);
   });
 
-  it("ignores a model update for an unknown session", () => {
+  it("buffers a model update for a session it has not seeded", () => {
     handleAcpSessionModelUpdate({
       type: "acp_session_model_update",
       acpSessionId: "acp-missing",
       model: "opus",
-      availableModels: [],
+      availableModels: [{ value: "opus", label: "Opus" }],
     });
     expect(getState().byId).toEqual({});
+    expect(getState().pendingModelUpdates.get("acp-missing")).toMatchObject({
+      model: "opus",
+      availableModels: [{ value: "opus", label: "Opus" }],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- The truncation tooltip on MetricCard's value is opt-in, so animated Input/Output tiles no longer rewrite a title every frame; only the MODEL tile sets it
- The handler test names and asserts the buffering an unknown-session model update gets; the buffer-cap test pins the cap; comments state the two real reasons the buffer exists
- The docs page says when the adapter is installed and that one already on PATH is left alone

Review fixes on the feature branch (web half), cycle 1.