### PR TITLE
fix(acp): review fixes for pin refusals and resume on the model branch

### DIFF
--- a/assistant/src/acp/__tests__/agent-process.test.ts
+++ b/assistant/src/acp/__tests__/agent-process.test.ts
@@ -417,26 +417,57 @@ describe("AcpAgentProcess auth_required retry", () => {
     };
   }
 
+  // An adapter that throws a plain Error reaches the client as a generic
+  // "Internal error" carrying the real sentence in `data.details`, which is
+  // the shape these fixtures reproduce.
   test("setConfigOption surfaces the adapter's error answer as a refusal", async () => {
     const { proc } = await setupAuthProcess({
       setConfigOptionRejections: [
-        new acp.RequestError(
-          -32603,
-          "Invalid value for config option model: nope",
-        ),
+        new acp.RequestError(-32603, "Internal error", {
+          details: "Invalid value for config option model: nope",
+        }),
+      ],
+    });
+
+    const refusal = await proc
+      .setConfigOption("session-1", "model", "nope")
+      .catch((err: unknown) => err);
+
+    expect(refusal).toBeInstanceOf(AcpConfigOptionRefusedError);
+    // The adapter's sentence, not the message the SDK framed it in.
+    expect((refusal as Error).message).toBe(
+      "Invalid value for config option model: nope",
+    );
+  });
+
+  test("setConfigOption serializes a payload that names no reason", async () => {
+    const { proc } = await setupAuthProcess({
+      setConfigOptionRejections: [
+        new acp.RequestError(-32603, "Internal error", { code: 7 }),
       ],
     });
 
     await expect(
       proc.setConfigOption("session-1", "model", "nope"),
-    ).rejects.toBeInstanceOf(AcpConfigOptionRefusedError);
+    ).rejects.toThrow('{"code":7}');
+  });
+
+  test("setConfigOption falls back to the message when there is no payload", async () => {
+    const { proc } = await setupAuthProcess({
+      setConfigOptionRejections: [
+        new acp.RequestError(-32603, "Session not found"),
+      ],
+    });
+
+    await expect(
+      proc.setConfigOption("session-1", "model", "nope"),
+    ).rejects.toThrow("Session not found");
   });
 
   test("setConfigOption leaves Claude's message-shaped auth failure untyped", async () => {
-    const expired = new acp.RequestError(
-      -32603,
-      "Failed to authenticate. Please run /login",
-    );
+    const expired = new acp.RequestError(-32603, "Internal error", {
+      details: "Failed to authenticate. Please run /login",
+    });
     const { proc } = await setupAuthProcess({
       setConfigOptionRejections: [expired],
     });

--- a/assistant/src/acp/__tests__/auth-required.test.ts
+++ b/assistant/src/acp/__tests__/auth-required.test.ts
@@ -108,6 +108,22 @@ describe("requestErrorReason", () => {
     );
   });
 
+  test("reads the message off a rejection that carries no payload", () => {
+    // Straight off the wire: a plain object, not an instance of any class we
+    // control, and with the auth text where the SDK leaves a framed one.
+    const rejection = {
+      code: -32603,
+      message: "Failed to authenticate. Please run /login",
+    };
+
+    expect(requestErrorReason(rejection)).toBe(
+      "Failed to authenticate. Please run /login",
+    );
+    expect(isClaudeAuthFailureMessage(requestErrorReason(rejection))).toBe(
+      true,
+    );
+  });
+
   test("serializes a payload naming no reason, and falls back to the message", () => {
     expect(requestErrorReason(new RequestError(-32603, "boom", { c: 7 }))).toBe(
       '{"c":7}',
@@ -115,7 +131,12 @@ describe("requestErrorReason", () => {
     expect(requestErrorReason(new Error("Not logged in"))).toBe(
       "Not logged in",
     );
+  });
+
+  test("stringifies a rejection that is not an object at all", () => {
     expect(requestErrorReason("plain string")).toBe("plain string");
+    expect(requestErrorReason(-32603)).toBe("-32603");
+    expect(requestErrorReason(null)).toBe("null");
   });
 });
 

--- a/assistant/src/acp/__tests__/auth-required.test.ts
+++ b/assistant/src/acp/__tests__/auth-required.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, expect, test } from "bun:test";
 
+import { RequestError } from "@agentclientprotocol/sdk";
+
 import { AcpAuthRequiredEventSchema } from "../../api/events/acp-auth-required.js";
 import { AcpSessionErrorEventSchema } from "../../api/events/acp-session-error.js";
 import {
@@ -15,6 +17,7 @@ import {
   CLAUDE_ACP_COMMAND,
   isAcpAuthRequired,
   isClaudeAuthFailureMessage,
+  requestErrorReason,
 } from "../auth-required.js";
 
 describe("isAcpAuthRequired", () => {
@@ -86,6 +89,33 @@ describe("isClaudeAuthFailureMessage", () => {
     ).toBe(false);
     expect(isClaudeAuthFailureMessage(undefined)).toBe(false);
     expect(isClaudeAuthFailureMessage("")).toBe(false);
+  });
+});
+
+describe("requestErrorReason", () => {
+  test("decodes the sentence the SDK moved into the payload", () => {
+    const rejection = new RequestError(-32603, "Internal error", {
+      details: "Failed to authenticate. Please run /login",
+    });
+
+    expect(requestErrorReason(rejection)).toBe(
+      "Failed to authenticate. Please run /login",
+    );
+    // The point of decoding: the generic message never matches.
+    expect(isClaudeAuthFailureMessage(rejection.message)).toBe(false);
+    expect(isClaudeAuthFailureMessage(requestErrorReason(rejection))).toBe(
+      true,
+    );
+  });
+
+  test("serializes a payload naming no reason, and falls back to the message", () => {
+    expect(requestErrorReason(new RequestError(-32603, "boom", { c: 7 }))).toBe(
+      '{"c":7}',
+    );
+    expect(requestErrorReason(new Error("Not logged in"))).toBe(
+      "Not logged in",
+    );
+    expect(requestErrorReason("plain string")).toBe("plain string");
   });
 });
 

--- a/assistant/src/acp/__tests__/helpers/acp-model-option.ts
+++ b/assistant/src/acp/__tests__/helpers/acp-model-option.ts
@@ -22,6 +22,15 @@ export function modelOption(currentValue: string): SessionConfigOption {
 }
 
 /**
+ * A model selector sitting on nothing. `deriveModelInfo` reads an empty
+ * `currentValue` as "no model reported", which is the only shape that leaves a
+ * resumed session with a selector to pin through.
+ */
+export function modelOptionWithoutCurrent(): SessionConfigOption {
+  return modelOption("");
+}
+
+/**
  * A selector that is not the model one, so a set carrying only this reads as
  * an adapter that advertises no model selection.
  */

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -796,29 +796,35 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     );
   });
 
-  test("resume pins the fresh adapter process through the same ladder a spawn walks", async () => {
+  test("a resume keeps the model the adapter restored from the session", async () => {
     fakeCaps.resume = true;
-    // The bundled Claude profile: a resumed run reaches it the way a spawn
-    // does, so it comes back on Opus rather than the adapter's own default.
+    // The bundled Claude profile names opus, but the reattached session was
+    // running on sonnet and the adapter reports it back.
     resolveImpl = () => ({
       ok: true,
       agent: { command: "claude-agent-acp", args: [], model: "opus" },
     });
-    resumeConfigOptions = [modelOption("default")];
+    resumeConfigOptions = [modelOption("sonnet")];
     insertHistoryRow({ id: "resume-model-2" });
 
     const manager = new AcpSessionManager(4);
     const sent: AssistantEvent[] = [];
     await manager.resumeFromHistory("resume-model-2", (msg) => sent.push(msg));
 
-    expect(setConfigOptionCalls).toEqual([
-      { sessionId: "proto-old", configId: "model", value: "opus" },
-    ]);
+    expect(setConfigOptionCalls).toEqual([]);
     const state = manager.getStatus("resume-model-2") as AcpSessionState;
-    expect(state.model).toBe("opus");
+    expect(state.model).toBe("sonnet");
     expect(sent.map((m) => m.type)).toEqual([
       "acp_session_spawned",
       "acp_session_model_update",
+    ]);
+    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId: "resume-model-2",
+        model: "sonnet",
+        availableModels: MODEL_OPTION_MODELS,
+      },
     ]);
   });
 
@@ -900,8 +906,9 @@ describe("AcpSessionManager.resumeFromHistory", () => {
   });
 
   test("a re-pin the connection cannot carry tears the resume down", async () => {
-    fakeCaps.resume = true;
-    resumeConfigOptions = [modelOption("default")];
+    fakeCaps.loadSession = true;
+    replayConfigOptionUpdates = [[modelOption("default")]];
+    resumeConfigOptions = [];
     setConfigOptionError = new Error("ACP connection closed");
     resolveImpl = () => ({
       ok: true,
@@ -920,15 +927,23 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       ),
     ).rejects.toThrow("ACP connection closed");
 
-    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual(
-      [],
-    );
+    // Only the selector the replay announced; the pin that failed adds none.
+    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId: "resume-pin-transport",
+        model: "default",
+        availableModels: MODEL_OPTION_MODELS,
+      },
+    ]);
+    expect(sent.filter((m) => m.type === "acp_session_spawned")).toEqual([]);
     expect(manager.getStatus()).toEqual([]);
   });
 
   test("a resume the adapter refuses to re-pin runs on the adapter's model", async () => {
-    fakeCaps.resume = true;
-    resumeConfigOptions = [modelOption("default")];
+    fakeCaps.loadSession = true;
+    replayConfigOptionUpdates = [[modelOption("default")]];
+    resumeConfigOptions = [];
     setConfigOptionError = new AcpConfigOptionRefusedError(
       "Invalid value for config option model: opus",
     );
@@ -947,19 +962,23 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       sent.push(msg),
     );
 
-    // State and the published event name the model the run is really on, not
-    // the one it could not be put back on.
+    // State and the published events name the model the run is really on, not
+    // the one it could not be put back on: the selector the replay announced,
+    // then the same model again once the refused pin settles.
     expect(
       (manager.getStatus("resume-refused-model") as AcpSessionState).model,
     ).toBe("default");
-    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual([
-      {
-        type: "acp_session_model_update",
-        acpSessionId: "resume-refused-model",
-        model: "default",
-        availableModels: MODEL_OPTION_MODELS,
-      },
+    const refusedModelEvents = sent.filter(
+      (m) => m.type === "acp_session_model_update",
+    );
+    expect(refusedModelEvents.map((m) => m.model)).toEqual([
+      "default",
+      "default",
     ]);
+    expect(refusedModelEvents[1]).toMatchObject({
+      acpSessionId: "resume-refused-model",
+      availableModels: MODEL_OPTION_MODELS,
+    });
   });
 
   test("concurrent resumes of the same id: one wins, the loser fails cleanly without leaking a process", async () => {

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -17,6 +17,7 @@ import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import {
   MODEL_OPTION_MODELS,
   modelOption,
+  modelOptionWithoutCurrent,
   nonModelOption,
 } from "./helpers/acp-model-option.js";
 
@@ -828,11 +829,11 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     ]);
   });
 
-  test("a session/load answering with no config options keeps the replayed selector", async () => {
+  test("a model named only by the load replay keeps the session off the re-pin", async () => {
     fakeCaps.loadSession = true;
     // The selector reaches the manager only through the replayed
     // notification: the load itself answers with no config options at all.
-    replayConfigOptionUpdates = [[modelOption("default")]];
+    replayConfigOptionUpdates = [[modelOption("sonnet")]];
     resumeConfigOptions = [];
     resolveImpl = () => ({
       ok: true,
@@ -846,19 +847,16 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       sent.push(msg),
     );
 
-    // The re-pin still reaches the adapter, so the run comes back on the
-    // model its agent config names.
-    expect(setConfigOptionCalls).toEqual([
-      { sessionId: "proto-old", configId: "model", value: "opus" },
-    ]);
+    // The replay is the adapter reporting what the session came back on, so
+    // the per-agent default has nothing to put right.
+    expect(setConfigOptionCalls).toEqual([]);
     expect(
       (manager.getStatus("resume-replay-only") as AcpSessionState).model,
-    ).toBe("opus");
-    // The announced default, then the model the run was put back on.
+    ).toBe("sonnet");
     const modelEvents = sent.filter(
       (m) => m.type === "acp_session_model_update",
     );
-    expect(modelEvents.map((m) => m.model)).toEqual(["default", "opus"]);
+    expect(modelEvents.map((m) => m.model)).toEqual(["sonnet", "sonnet"]);
     expect(modelEvents[1]).toMatchObject({
       acpSessionId: "resume-replay-only",
       availableModels: MODEL_OPTION_MODELS,
@@ -868,8 +866,9 @@ describe("AcpSessionManager.resumeFromHistory", () => {
   test("a re-pin answered without the selector withdraws the picker the replay announced", async () => {
     fakeCaps.loadSession = true;
     // The replay puts the selector in front of clients before the re-pin
-    // runs, so the answer that drops it has something to correct.
-    replayConfigOptionUpdates = [[modelOption("default")]];
+    // runs, so the answer that drops it has something to correct. It names no
+    // model, which is what leaves the ladder something to apply.
+    replayConfigOptionUpdates = [[modelOptionWithoutCurrent()]];
     resumeConfigOptions = [];
     setConfigOptionResult = [nonModelOption()];
     resolveImpl = () => ({
@@ -894,7 +893,6 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       {
         type: "acp_session_model_update",
         acpSessionId: "resume-selector-gone",
-        model: "default",
         availableModels: MODEL_OPTION_MODELS,
       },
       {
@@ -906,9 +904,8 @@ describe("AcpSessionManager.resumeFromHistory", () => {
   });
 
   test("a re-pin the connection cannot carry tears the resume down", async () => {
-    fakeCaps.loadSession = true;
-    replayConfigOptionUpdates = [[modelOption("default")]];
-    resumeConfigOptions = [];
+    fakeCaps.resume = true;
+    resumeConfigOptions = [modelOptionWithoutCurrent()];
     setConfigOptionError = new Error("ACP connection closed");
     resolveImpl = () => ({
       ok: true,
@@ -927,23 +924,15 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       ),
     ).rejects.toThrow("ACP connection closed");
 
-    // Only the selector the replay announced; the pin that failed adds none.
-    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual([
-      {
-        type: "acp_session_model_update",
-        acpSessionId: "resume-pin-transport",
-        model: "default",
-        availableModels: MODEL_OPTION_MODELS,
-      },
-    ]);
-    expect(sent.filter((m) => m.type === "acp_session_spawned")).toEqual([]);
+    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual(
+      [],
+    );
     expect(manager.getStatus()).toEqual([]);
   });
 
   test("a resume the adapter refuses to re-pin runs on the adapter's model", async () => {
-    fakeCaps.loadSession = true;
-    replayConfigOptionUpdates = [[modelOption("default")]];
-    resumeConfigOptions = [];
+    fakeCaps.resume = true;
+    resumeConfigOptions = [modelOptionWithoutCurrent()];
     setConfigOptionError = new AcpConfigOptionRefusedError(
       "Invalid value for config option model: opus",
     );
@@ -962,23 +951,18 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       sent.push(msg),
     );
 
-    // State and the published events name the model the run is really on, not
-    // the one it could not be put back on: the selector the replay announced,
-    // then the same model again once the refused pin settles.
+    // State and the published event name the model the run is really on, which
+    // is whatever the adapter reported, never the one it refused.
     expect(
       (manager.getStatus("resume-refused-model") as AcpSessionState).model,
-    ).toBe("default");
-    const refusedModelEvents = sent.filter(
-      (m) => m.type === "acp_session_model_update",
-    );
-    expect(refusedModelEvents.map((m) => m.model)).toEqual([
-      "default",
-      "default",
+    ).toBeUndefined();
+    expect(sent.filter((m) => m.type === "acp_session_model_update")).toEqual([
+      {
+        type: "acp_session_model_update",
+        acpSessionId: "resume-refused-model",
+        availableModels: MODEL_OPTION_MODELS,
+      },
     ]);
-    expect(refusedModelEvents[1]).toMatchObject({
-      acpSessionId: "resume-refused-model",
-      availableModels: MODEL_OPTION_MODELS,
-    });
   });
 
   test("concurrent resumes of the same id: one wins, the loser fails cleanly without leaking a process", async () => {

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -10,9 +10,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import * as acp from "@agentclientprotocol/sdk";
 
 import type { AssistantEvent } from "../../api/index.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import { claudeCredentialRefused } from "../acp-auth-marker-store.js";
 import { AcpAuthRequiredError, isAcpAuthRequired } from "../auth-required.js";
 import type { VellumAcpClientHandler } from "../client-handler.js";
 import type { AcpSessionState } from "../types.js";
@@ -456,16 +458,21 @@ describe("AcpSessionManager: model selection at spawn", () => {
   test("Claude's message-shaped 401 during the pin surfaces as auth required", async () => {
     scriptedConfigOptions = [[modelOption("default")]];
     // Not the structured auth_required answer: the CLI's own words, which the
-    // spawn boundary only recognises once the manager has classified them.
-    setConfigOptionResult = new Error(
-      "Failed to authenticate. Please run /login",
-    );
+    // adapter relays as a generic internal error carrying them in `data`, and
+    // which the spawn boundary only recognises once the manager classifies.
+    setConfigOptionResult = new acp.RequestError(-32603, "Internal error", {
+      details: "Failed to authenticate. Please run /login",
+    });
 
     const manager = new AcpSessionManager(5);
     const sent: AssistantEvent[] = [];
     const spawned = manager.spawn(
       "claude",
-      { command: "claude-agent-acp", args: [] },
+      {
+        command: "claude-agent-acp",
+        args: [],
+        credentialDigest: "digest-pin-401",
+      },
       "task",
       "/tmp",
       "conv-pin-auth-message",
@@ -477,17 +484,49 @@ describe("AcpSessionManager: model selection at spawn", () => {
       () => undefined,
       (err: unknown) => err,
     );
+    expect(failure).toBeInstanceOf(AcpAuthRequiredError);
     expect(isAcpAuthRequired(failure)).toBe(true);
     expect((failure as Error).message).toBe(
       "Failed to authenticate. Please run /login",
     );
+    // The refused credential is written down, so no later spawn resolves it.
+    expect(claudeCredentialRefused("digest-pin-401")).toBe(true);
     expect(sent).toEqual([]);
     expect(manager.getStatus()).toEqual([]);
   });
 
+  test("a message-shaped 401 with no payload classifies off the message", async () => {
+    scriptedConfigOptions = [[modelOption("default")]];
+    setConfigOptionResult = new Error(
+      "Failed to authenticate. Please run /login",
+    );
+
+    const failure = await new AcpSessionManager(5)
+      .spawn(
+        "claude",
+        { command: "claude-agent-acp", args: [] },
+        "task",
+        "/tmp",
+        "conv-pin-auth-plain",
+        () => {},
+        { model: "opus" },
+      )
+      .then(
+        () => undefined,
+        (err: unknown) => err,
+      );
+
+    expect(failure).toBeInstanceOf(AcpAuthRequiredError);
+    expect((failure as Error).message).toBe(
+      "Failed to authenticate. Please run /login",
+    );
+  });
+
   test("the message-shaped 401 is still recognised when the adapter runs by full path", async () => {
     scriptedConfigOptions = [[modelOption("default")]];
-    setConfigOptionResult = new Error("Not logged in");
+    setConfigOptionResult = new acp.RequestError(-32603, "Internal error", {
+      details: "Not logged in",
+    });
 
     const manager = new AcpSessionManager(5);
     const failure = await manager

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -28,6 +28,7 @@ import {
   AcpAuthRequiredError,
   isAcpAuthRequired,
   isClaudeAuthFailureMessage,
+  requestErrorReason,
 } from "./auth-required.js";
 import { type AcpAgentConfig, AcpConfigOptionRefusedError } from "./types.js";
 
@@ -48,25 +49,6 @@ function normalizeConfigOptions(
   configOptions: SessionConfigOption[] | null | undefined,
 ): SessionConfigOption[] {
   return configOptions ?? [];
-}
-
-/**
- * The sentence behind a JSON-RPC rejection. An adapter that throws a plain
- * Error reaches the client as a generic "Internal error" whose real text the
- * agent-side SDK moved into the payload, so `data` is read before `message`.
- */
-function requestErrorReason(err: acp.RequestError): string {
-  const { data } = err;
-  if (data == null) {
-    return err.message;
-  }
-  const details = (data as { details?: unknown }).details;
-  if (typeof details === "string" && details.length > 0) {
-    return details;
-  }
-  // JSON.stringify answers undefined for a value it cannot represent.
-  const serialized: string | undefined = JSON.stringify(data);
-  return serialized ?? err.message;
 }
 
 function isEnvVarMethod(

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -50,6 +50,25 @@ function normalizeConfigOptions(
   return configOptions ?? [];
 }
 
+/**
+ * The sentence behind a JSON-RPC rejection. An adapter that throws a plain
+ * Error reaches the client as a generic "Internal error" whose real text the
+ * agent-side SDK moved into the payload, so `data` is read before `message`.
+ */
+function requestErrorReason(err: acp.RequestError): string {
+  const { data } = err;
+  if (data == null) {
+    return err.message;
+  }
+  const details = (data as { details?: unknown }).details;
+  if (typeof details === "string" && details.length > 0) {
+    return details;
+  }
+  // JSON.stringify answers undefined for a value it cannot represent.
+  const serialized: string | undefined = JSON.stringify(data);
+  return serialized ?? err.message;
+}
+
 function isEnvVarMethod(
   method: AuthMethod,
 ): method is AuthMethodEnvVar & { type: "env_var" } {
@@ -465,14 +484,13 @@ export class AcpAgentProcess {
         // Wrapped here, at the request itself, so `withAuthRetry` still sees
         // an auth_required answer and a caller cannot confuse the adapter's
         // refusal with a transport or authentication failure. Claude's
-        // expired-token failure travels as a generic error whose message is
+        // expired-token failure travels as a generic error whose reason is
         // the only signal, so it is left for the caller to classify.
-        if (
-          err instanceof acp.RequestError &&
-          !isAcpAuthRequired(err) &&
-          !isClaudeAuthFailureMessage(err.message)
-        ) {
-          throw new AcpConfigOptionRefusedError(err.message);
+        if (err instanceof acp.RequestError && !isAcpAuthRequired(err)) {
+          const reason = requestErrorReason(err);
+          if (!isClaudeAuthFailureMessage(reason)) {
+            throw new AcpConfigOptionRefusedError(reason);
+          }
         }
         throw err;
       }

--- a/assistant/src/acp/auth-required.ts
+++ b/assistant/src/acp/auth-required.ts
@@ -8,7 +8,8 @@
  * 2. Credentials present but rejected (the expired/revoked case): the CLI
  *    surfaces the API 401 as an error message it authors, and the adapter
  *    relays it as a generic -32603 internal error, NOT as `auth_required`.
- *    {@link isClaudeAuthFailureMessage}.
+ *    {@link isClaudeAuthFailureMessage}, over the text
+ *    {@link requestErrorReason} decodes out of the rejection.
  *
  * A positive detection becomes {@link ACP_CLAUDE_AUTH_REQUIRED_CODE} on the
  * `acp_auth_required` event, which the client turns into the inline
@@ -79,6 +80,32 @@ export function isClaudeAuthFailureMessage(
     message != null &&
     CLAUDE_AUTH_FAILURE_PATTERNS.some((pattern) => pattern.test(message))
   );
+}
+
+/**
+ * The sentence behind a JSON-RPC rejection. An adapter that throws a plain
+ * Error reaches the client as a generic "Internal error" whose real text the
+ * agent-side SDK moved into the `data` payload, so `data` is read before
+ * `message`. Duck-typed like {@link isAcpAuthRequired}, so a plain JSON-RPC
+ * error object decodes too, and an error carrying no payload answers with its
+ * own message.
+ */
+export function requestErrorReason(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  if (typeof err !== "object" || err === null) {
+    return message;
+  }
+  const { data } = err as { data?: unknown };
+  if (data == null) {
+    return message;
+  }
+  const details = (data as { details?: unknown }).details;
+  if (typeof details === "string" && details.length > 0) {
+    return details;
+  }
+  // JSON.stringify answers undefined for a value it cannot represent.
+  const serialized: string | undefined = JSON.stringify(data);
+  return serialized ?? message;
 }
 
 /** The adapter whose auth failures the Connect Claude flow can repair. */

--- a/assistant/src/acp/auth-required.ts
+++ b/assistant/src/acp/auth-required.ts
@@ -86,18 +86,18 @@ export function isClaudeAuthFailureMessage(
  * The sentence behind a JSON-RPC rejection. An adapter that throws a plain
  * Error reaches the client as a generic "Internal error" whose real text the
  * agent-side SDK moved into the `data` payload, so `data` is read before
- * `message`. Duck-typed like {@link isAcpAuthRequired}, so a plain JSON-RPC
- * error object decodes too, and an error carrying no payload answers with its
- * own message.
+ * `message`. Duck-typed like {@link isAcpAuthRequired}: `message` is read as a
+ * property, so a rejection that arrives as a plain object off the wire decodes
+ * the same as an `Error` instance.
  */
 export function requestErrorReason(err: unknown): string {
-  const message = err instanceof Error ? err.message : String(err);
   if (typeof err !== "object" || err === null) {
-    return message;
+    return String(err);
   }
-  const { data } = err as { data?: unknown };
+  const { data, message } = err as { data?: unknown; message?: unknown };
+  const own = typeof message === "string" ? message : String(err);
   if (data == null) {
-    return message;
+    return own;
   }
   const details = (data as { details?: unknown }).details;
   if (typeof details === "string" && details.length > 0) {
@@ -105,7 +105,7 @@ export function requestErrorReason(err: unknown): string {
   }
   // JSON.stringify answers undefined for a value it cannot represent.
   const serialized: string | undefined = JSON.stringify(data);
-  return serialized ?? message;
+  return serialized ?? own;
 }
 
 /** The adapter whose auth failures the Connect Claude flow can repair. */

--- a/assistant/src/acp/resolve-agent.ts
+++ b/assistant/src/acp/resolve-agent.ts
@@ -225,9 +225,11 @@ function directLookup(
 /**
  * Fill a user config entry from the bundled profile for the same id. An entry
  * that runs the profile's adapter (it omits `command`, or names the same
- * binary, by full path or not) inherits every leaf it leaves out: `command`
- * itself, the description, and the `model` a session starts on. An entry that
- * points the id at a different adapter stands alone, like any user-only entry,
+ * binary, by full path or not) inherits the leaves it leaves out: `command`
+ * itself, the description, and the `model` a session starts on. `args` is the
+ * exception, because the schema defaults it to `[]`: a parsed entry always
+ * carries its own, so the profile's never reaches it. An entry that points
+ * the id at a different adapter stands alone, like any user-only entry,
  * so a config that reuses the `claude` id for something else never carries
  * Claude's description or has Claude's `opus` sent to it. Zod omits absent
  * optional keys, so an omission never spreads as an undefined override.

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -31,6 +31,7 @@ import {
   CLAUDE_ACP_COMMAND,
   isAcpAuthRequired,
   isClaudeAuthFailureMessage,
+  requestErrorReason,
 } from "./auth-required.js";
 import { resolveAgentWithAutoInstall } from "./auto-install.js";
 import { VellumAcpClientHandler } from "./client-handler.js";
@@ -56,7 +57,9 @@ const log = getLogger("acp:session-manager");
  * and the marker promises a repair only the Connect Claude flow can perform.
  * Checks both auth-failure shapes (see `auth-required.ts`) against both the
  * raw rejection and the derived failure message, since `deriveFailureError`
- * may replace one with the other.
+ * may replace one with the other. The raw side reads the rejection's decoded
+ * reason, because an adapter's own words travel in the payload rather than
+ * the message.
  */
 function claudeAuthRequiredCode(
   err: unknown,
@@ -66,7 +69,7 @@ function claudeAuthRequiredCode(
   if (entry.command !== CLAUDE_ACP_COMMAND) {
     return undefined;
   }
-  const rawMessage = err instanceof Error ? err.message : String(err);
+  const rawMessage = requestErrorReason(err);
   return isAcpAuthRequired(err) ||
     isClaudeAuthFailureMessage(rawMessage) ||
     isClaudeAuthFailureMessage(failureMessage)
@@ -498,7 +501,7 @@ export class AcpSessionManager {
     agentId: string,
     agentConfig: { command: string; credentialDigest?: string },
   ): unknown {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = requestErrorReason(err);
     const authCode = claudeAuthRequiredCode(err, message, {
       command: basename(agentConfig.command),
     });

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -438,21 +438,19 @@ export class AcpSessionManager {
 
   /**
    * Records the model state a `session/new`, `session/load`, or
-   * `session/resume` response reports, and returns what it reported. The
-   * response is authoritative when it names a selector, or when nothing has
-   * announced one yet; otherwise the selector a `config_option_update`
-   * announced while the call was open stands, because an omitted optional
-   * field is not a removal.
+   * `session/resume` response reports. The response is authoritative when it
+   * names a selector, or when nothing has announced one yet; otherwise the
+   * selector a `config_option_update` announced while the call was open
+   * stands, because an omitted optional field is not a removal.
    */
   private applyOpeningModelInfo(
     entry: SessionEntry,
     configOptions: SessionConfigOption[],
-  ): AcpModelInfo {
+  ): void {
     const info = deriveModelInfo(configOptions);
     if (info.modelConfigId || entry.modelConfigId === undefined) {
       this.recordModelInfo(entry, info);
     }
-    return info;
   }
 
   /**
@@ -522,18 +520,15 @@ export class AcpSessionManager {
     options?: { keepReportedModel?: boolean },
   ): Promise<ModelPinResult> {
     const { state } = entry;
-    const opening = this.applyOpeningModelInfo(entry, configOptions);
+    this.applyOpeningModelInfo(entry, configOptions);
 
     // A resume reattaches a session the adapter restored from its own
-    // transcript, so a reply that names the model it came back on is the
-    // model the run stays on.
-    if (options?.keepReportedModel && opening.model) {
+    // transcript, so any model it has named by now is the model the run stays
+    // on, whether the opening reply carried it or a replayed
+    // `config_option_update` did.
+    if (options?.keepReportedModel && state.model) {
       log.info(
-        {
-          acpSessionId: state.id,
-          agentId: state.agentId,
-          model: opening.model,
-        },
+        { acpSessionId: state.id, agentId: state.agentId, model: state.model },
         "ACP agent reported the resumed session's model; leaving it there",
       );
       return { applied: true };

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -435,19 +435,21 @@ export class AcpSessionManager {
 
   /**
    * Records the model state a `session/new`, `session/load`, or
-   * `session/resume` response reports. The response is authoritative when it
-   * names a selector, or when nothing has announced one yet; otherwise the
-   * selector a `config_option_update` announced while the call was open
-   * stands, because an omitted optional field is not a removal.
+   * `session/resume` response reports, and returns what it reported. The
+   * response is authoritative when it names a selector, or when nothing has
+   * announced one yet; otherwise the selector a `config_option_update`
+   * announced while the call was open stands, because an omitted optional
+   * field is not a removal.
    */
   private applyOpeningModelInfo(
     entry: SessionEntry,
     configOptions: SessionConfigOption[],
-  ): void {
+  ): AcpModelInfo {
     const info = deriveModelInfo(configOptions);
     if (info.modelConfigId || entry.modelConfigId === undefined) {
       this.recordModelInfo(entry, info);
     }
+    return info;
   }
 
   /**
@@ -514,9 +516,25 @@ export class AcpSessionManager {
     configOptions: SessionConfigOption[],
     requestedModel: string | undefined,
     resolvedModel: string | undefined,
+    options?: { keepReportedModel?: boolean },
   ): Promise<ModelPinResult> {
     const { state } = entry;
-    this.applyOpeningModelInfo(entry, configOptions);
+    const opening = this.applyOpeningModelInfo(entry, configOptions);
+
+    // A resume reattaches a session the adapter restored from its own
+    // transcript, so a reply that names the model it came back on is the
+    // model the run stays on.
+    if (options?.keepReportedModel && opening.model) {
+      log.info(
+        {
+          acpSessionId: state.id,
+          agentId: state.agentId,
+          model: opening.model,
+        },
+        "ACP agent reported the resumed session's model; leaving it there",
+      );
+      return { applied: true };
+    }
 
     if (!resolvedModel || resolvedModel === state.model) {
       return { applied: true };
@@ -1015,8 +1033,8 @@ export class AcpSessionManager {
       throw err;
     }
 
-    // A fresh adapter process starts on its own default, so the resumed run
-    // is pinned through the same ladder a spawn walks.
+    // The ladder a spawn walks, for the case the adapter reports no model of
+    // its own; a reattached session that comes back naming one keeps it.
     const resolvedModel = resolveAcpModel({ agentModel: agentConfig.model });
     let applied: boolean;
     try {
@@ -1025,6 +1043,7 @@ export class AcpSessionManager {
         configOptions,
         undefined,
         resolvedModel,
+        { keepReportedModel: true },
       ));
     } catch (err) {
       log.error(

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -96,7 +96,7 @@ Do NOT put API keys (or any secret) in the workspace config file - secrets never
 
 - Two agents are supported out-of-box: `claude` (via the `claude-agent-acp` adapter) and `codex` (via the `codex-acp` adapter).
 - NEVER use `claude`, `claude -p`, `claude --acp`, or the bare `codex` CLI as the ACP `command`. Claude and Codex only speak the protocol through their dedicated `*-acp` adapters.
-- Default profiles for both ship out-of-box. Users only need an `agents.<id>` entry in config if they want to override the defaults (e.g. point to a custom binary path or pass extra args/env). An entry that still runs the bundled adapter, whether it omits `command` or names the same binary by name or full path, inherits every field it leaves out, so a single-field change such as `acp.agents.claude.model` is all it takes. An entry that points the id at a different binary stands on its own, so it must spell out everything it needs, `command` included.
+- Default profiles for both ship out-of-box. Users only need an `agents.<id>` entry in config if they want to override the defaults (e.g. point to a custom binary path or pass extra args/env). An entry that still runs the bundled adapter, whether it omits `command` or names the same binary by name or full path, inherits the `command`, `description` and `model` it leaves out, so a single-field change such as `acp.agents.claude.model` is all it takes. An entry that points the id at a different binary stands on its own, so it must spell out everything it needs, `command` included.
 - NEVER change an existing ACP config to use a different command. If the config already has `claude-agent-acp` or `codex-acp`, leave it alone.
 
 ## Updating an adapter

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1710,11 +1710,11 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
       written.source = "managed";
     }
   }
+  scrubNulledAcpAgentLeaves(raw);
   // A SET can create `services.stt` with a leaf like `language` and no
   // `provider`, which SttServiceSchema requires whenever the block exists;
   // the same seeding that guards PATCH keeps this write's persisted block
   // schema-valid.
-  scrubNulledAcpAgentLeaves(raw);
   seedSttProviderForSparseBlock(raw);
 
   await commitConfigWrite(raw, "set");

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "548a4447683044036d78bcbfd9a5175426b851e6977e29b7a8d7abf3b2f56b5c"
+      "sha256": "5eab3cfce6afecdc6fc8c0c25cf7e3070c31b9fc276030290ebb73a6a5659ad2"
     },
     "app-builder": {
       "docsSlug": "app-builder",


### PR DESCRIPTION
## Summary
- A set_config_option failure is read from the adapter's error data, where the SDK puts the real sentence behind a generic Internal error message; the warning names the reason and a Claude auth failure raised during the pin is classified as such
- A resumed Claude session keeps the model the adapter restored from its transcript instead of being re-pinned to the per-agent default; spawn still pins
- Docs say args is defaulted and never inherited; the SET-path scrub sits above the STT comment it was splitting

Review fixes on the feature branch (daemon half), cycle 1.