### PR TITLE
fix(notifications): a title still generating is not a title

### DIFF
--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -606,6 +606,17 @@ describe("emitAssistantReplyNotification", () => {
     });
   });
 
+  test("omits requestedTitle for the legacy generating placeholder", async () => {
+    conversationRow = makeConversation({ title: "Generating title..." });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].contextPayload).toEqual({
+      requestedMessage: "Sure, here is the plan.",
+    });
+  });
+
   test("omits requestedTitle for the untitled placeholder key", async () => {
     conversationRow = makeConversation({
       title: MESSAGE_KEYS.CONVERSATION_TITLE_UNTITLED,

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { MESSAGE_KEYS } from "../../i18n/index.js";
 import type { AttentionState } from "../../persistence/conversation-attention-store.js";
 import type {
   ConversationRow,
@@ -587,6 +588,49 @@ describe("emitAssistantReplyNotification", () => {
     expect(emitCalls[0].contextPayload).toEqual({
       requestedMessage: "Sure, here is the plan.",
     });
+  });
+
+  // A conversation whose title is still being written stores the message key
+  // itself, which is a non-empty string the sanitizer has no reason to reject.
+  // Sending it would put a raw key on the lock screen, so it counts as absent.
+  test("omits requestedTitle while the title is still generating", async () => {
+    conversationRow = makeConversation({
+      title: MESSAGE_KEYS.CONVERSATION_TITLE_GENERATING,
+    });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].contextPayload).toEqual({
+      requestedMessage: "Sure, here is the plan.",
+    });
+  });
+
+  test("omits requestedTitle for the untitled placeholder key", async () => {
+    conversationRow = makeConversation({
+      title: MESSAGE_KEYS.CONVERSATION_TITLE_UNTITLED,
+    });
+
+    await run();
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].contextPayload).toEqual({
+      requestedMessage: "Sure, here is the plan.",
+    });
+  });
+
+  // Only an exact key is a system constant. A title the user or the model
+  // wrote that happens to contain one is their copy and travels as written.
+  test("keeps a title that merely contains a message key", async () => {
+    conversationRow = makeConversation({
+      title: `notes on ${MESSAGE_KEYS.CONVERSATION_TITLE_GENERATING}`,
+    });
+
+    await run();
+
+    expect(emitCalls[0].contextPayload.requestedTitle).toBe(
+      "notes on conversation.title.generating",
+    );
   });
 
   test("caps the preview at 200 chars", async () => {

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -11,7 +11,6 @@
 import type pino from "pino";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
-import { isMessageKey } from "../i18n/index.js";
 import { getAttachmentMetadataForMessage } from "../persistence/attachments-store.js";
 import {
   getAttentionStateByConversationIds,
@@ -23,6 +22,7 @@ import {
   getMessageById,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
+import { isReplaceableTitle } from "../persistence/conversation-title-placeholders.js";
 import {
   isDesktopOriginatedUserMessage,
   isReplyPushIneligibleUserMessage,
@@ -249,12 +249,10 @@ export async function emitAssistantReplyNotification(params: {
     // title from the body, which reads better than an empty or placeholder
     // conversation title.
     //
-    // A title still being generated is persisted as the message key itself, so
-    // it arrives here as a plausible non-empty string and survives sanitizing.
-    // Resolving it would put "Generating title..." on the lock screen, so a
-    // stored key counts as absent and the body supplies the title instead.
+    // Placeholder titles are plausible non-empty strings and survive
+    // sanitizing. They count as absent so the body supplies the title instead.
     const storedTitle = conversation.title?.trim() ?? "";
-    const requestedTitle = isMessageKey(storedTitle)
+    const requestedTitle = isReplaceableTitle(storedTitle)
       ? ""
       : sanitizeNotificationTitle(flattenTitleWhitespace(storedTitle));
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -11,6 +11,7 @@
 import type pino from "pino";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { isMessageKey } from "../i18n/index.js";
 import { getAttachmentMetadataForMessage } from "../persistence/attachments-store.js";
 import {
   getAttentionStateByConversationIds,
@@ -247,9 +248,15 @@ export async function emitAssistantReplyNotification(params: {
     // lock screen. Absent `requestedTitle` lets the decision branch derive a
     // title from the body, which reads better than an empty or placeholder
     // conversation title.
-    const requestedTitle = sanitizeNotificationTitle(
-      flattenTitleWhitespace(conversation.title ?? ""),
-    );
+    //
+    // A title still being generated is persisted as the message key itself, so
+    // it arrives here as a plausible non-empty string and survives sanitizing.
+    // Resolving it would put "Generating title..." on the lock screen, so a
+    // stored key counts as absent and the body supplies the title instead.
+    const storedTitle = conversation.title?.trim() ?? "";
+    const requestedTitle = isMessageKey(storedTitle)
+      ? ""
+      : sanitizeNotificationTitle(flattenTitleWhitespace(storedTitle));
 
     // Read as close to the emit as possible: nothing short-circuits on it.
     // Presence only speaks for a turn the desktop itself opened, on that row's

--- a/assistant/src/persistence/conversation-title-placeholders.ts
+++ b/assistant/src/persistence/conversation-title-placeholders.ts
@@ -1,0 +1,23 @@
+import { isMessageKey } from "../i18n/index.js";
+
+const REPLACEABLE_PATTERNS = [
+  /^Runtime:\s/,
+  /^New Conversation$/,
+  /^Untitled$/,
+  /^Untitled Conversation$/,
+  /^Generating title\.\.\.$/,
+];
+
+/**
+ * Check whether a title is a system-generated placeholder that can be
+ * replaced or omitted without discarding user-provided copy.
+ */
+export function isReplaceableTitle(title: string | null): boolean {
+  if (title == null || title.trim() === "") {
+    return true;
+  }
+  if (isMessageKey(title.trim())) {
+    return true;
+  }
+  return REPLACEABLE_PATTERNS.some((pattern) => pattern.test(title));
+}

--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -8,7 +8,7 @@
  */
 
 import { SEND_USER_MESSAGE_DELIVERED_ACK } from "../config/send-user-message-constants.js";
-import { isMessageKey, MESSAGE_KEYS } from "../i18n/index.js";
+import { MESSAGE_KEYS } from "../i18n/index.js";
 import {
   requestShortLabel,
   type ShortLabelTool,
@@ -25,7 +25,10 @@ import {
   type MessageRow,
   updateConversationTitle,
 } from "./conversation-crud.js";
+import { isReplaceableTitle } from "./conversation-title-placeholders.js";
 import { projectPersistedAssistantContent } from "./user-facing-content.js";
+
+export { isReplaceableTitle } from "./conversation-title-placeholders.js";
 
 const log = getLogger("conversation-title-service");
 
@@ -83,31 +86,6 @@ export const AUTO_TITLE_LLM = 1;
  * (see `canReplaceTitle`).
  */
 export const AUTO_TITLE_DETERMINISTIC = 2;
-
-// ── Replaceability check ─────────────────────────────────────────────
-
-const REPLACEABLE_PATTERNS = [
-  /^Runtime:\s/,
-  /^New Conversation$/,
-  /^Untitled$/,
-  /^Untitled Conversation$/,
-  /^Generating title\.\.\.$/,
-];
-
-/**
- * Check whether a title is a system-generated placeholder that can be
- * safely overwritten by auto-generated titles. Returns `false` for
- * user-provided custom titles.
- */
-export function isReplaceableTitle(title: string | null): boolean {
-  if (title == null || title.trim() === "") {
-    return true;
-  }
-  if (isMessageKey(title.trim())) {
-    return true;
-  }
-  return REPLACEABLE_PATTERNS.some((pattern) => pattern.test(title));
-}
 
 /**
  * Whether auto-generation may overwrite the conversation's current title.


### PR DESCRIPTION
## Summary

The first notification of a new conversation showed `conversation.title.generating` as its second line instead of a title.

Conversation titles persist the i18n message key rather than translated text (`assistant/src/i18n/AGENTS.md`), and clients resolve it at render time. The reply producer read `conversation.title` straight through, and the key is a plausible non-empty string that `sanitizeNotificationTitle` has no reason to reject.

The producer's existing comment already states the intended behavior: an absent `requestedTitle` lets the decision branch derive a title from the body, "which reads better than an empty or placeholder conversation title". Only the detection was missing, so this guards with `isMessageKey` and treats a stored key as absent.

Resolving the key instead would put "Generating title..." on the lock screen, which is not the goal. On iOS an absent title means no group name, so the notification renders as a clean one to one Communication Notification with the assistant's name and the reply body.

## Scope

`isMessageKey` is an exact-match typed guard, so it also covers `conversation.title.untitled` and any key added later, without matching a real title that happens to contain similar text.

Every other notification path uses `copy.conversationTitle` from the decision engine rather than the stored title, so this producer is the only one affected.

## Verification

Three tests added alongside the existing title cases: both message keys emit no `requestedTitle`, and a title that merely contains a key still travels as written.

Local test execution was blocked by an unrelated environment issue (the worktree shares `node_modules` with a main checkout that is 237 commits behind, so `@vellumai/*` resolves against stale package sources). CI runs the suite.

## Found by

Device QA of the notification avatar rollout: the first push after the APNs key fix rendered with `conversation.title.generating` as its subtitle. A second message to the same conversation, by which point the real title existed, rendered correctly.