### PR TITLE
fix(web): metric value truncation is opt-in; a resume clears the stale model

### DIFF
--- a/clients/web/src/domains/chat/acp-run-store.test.ts
+++ b/clients/web/src/domains/chat/acp-run-store.test.ts
@@ -31,6 +31,21 @@ function spawn(
   });
 }
 
+/** A run that reported Opus and then completed, ready to be resumed. */
+function spawnCompletedRunOnOpus() {
+  spawn();
+  getState().setModel({
+    acpSessionId: "acp-1",
+    model: "opus",
+    availableModels: [{ value: "opus", label: "Opus" }],
+  });
+  getState().setTerminal({
+    acpSessionId: "acp-1",
+    status: "completed",
+    completedAt: NOW + 1000,
+  });
+}
+
 function event(overrides: Partial<AcpRunRawEvent> = {}): AcpRunRawEvent {
   return {
     seq: 1,
@@ -199,6 +214,72 @@ describe("spawnRun", () => {
 
     expect(getState().byId["acp-1"]!.parentToolUseId).toBe("tool-use-1");
     expect(getState().byToolUseId.get("tool-use-1")).toBe("acp-1");
+  });
+
+  // An adapter without a model selector gets no model event after the spawn,
+  // so the resume itself retires the pair the earlier session reported.
+  it("a resume with no model report drops the pre-resume model", () => {
+    spawnCompletedRunOnOpus();
+
+    spawn();
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.status).toBe("running");
+    expect(entry.model).toBeUndefined();
+    expect(entry.availableModels).toBeUndefined();
+  });
+
+  it("a model update after the resume shows the new model", () => {
+    spawnCompletedRunOnOpus();
+    spawn();
+
+    getState().setModel({
+      acpSessionId: "acp-1",
+      model: "sonnet",
+      availableModels: [{ value: "sonnet", label: "Sonnet" }],
+    });
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBe("sonnet");
+    expect(entry.availableModels).toEqual([
+      { value: "sonnet", label: "Sonnet" },
+    ]);
+  });
+
+  it("a snapshot after the resume that carries no model keeps it cleared", () => {
+    spawnCompletedRunOnOpus();
+    spawn();
+    const resumedAt = getState().byId["acp-1"]!.modelUpdatedAt!;
+
+    getState().seedFromHistory(
+      [historyEntry({ acpSessionId: "acp-1", status: "running" })],
+      { fetchedAt: resumedAt + 1 },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBeUndefined();
+    expect(entry.availableModels).toBeUndefined();
+  });
+
+  it("a snapshot fetched before the resume cannot restore the old model", () => {
+    spawnCompletedRunOnOpus();
+    spawn();
+    const resumedAt = getState().byId["acp-1"]!.modelUpdatedAt!;
+
+    getState().seedFromHistory(
+      [
+        historyEntry({
+          acpSessionId: "acp-1",
+          model: "opus",
+          availableModels: [{ value: "opus", label: "Opus" }],
+        }),
+      ],
+      { fetchedAt: resumedAt - 1 },
+    );
+
+    const entry = getState().byId["acp-1"]!;
+    expect(entry.model).toBeUndefined();
+    expect(entry.availableModels).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/acp-run-store.ts
+++ b/clients/web/src/domains/chat/acp-run-store.ts
@@ -110,10 +110,10 @@ export interface AcpRunEntry {
   /** Models the session can switch to; absent when the adapter has no selector. */
   availableModels?: AcpModelOption[];
   /**
-   * When `setModel` last recorded a live selection, in `Date.now()` ms. Store
-   * local, never on the wire: it orders a live update against a snapshot whose
-   * fetch began earlier, so an in-flight `/acp/sessions` read cannot replace a
-   * selection the adapter has already moved past.
+   * When `setModel` or a resume last set the live selection, in `Date.now()`
+   * ms. Store local, never on the wire: it orders a live update against a
+   * snapshot whose fetch began earlier, so an in-flight `/acp/sessions` read
+   * cannot replace a selection the adapter has already moved past.
    */
   modelUpdatedAt?: number;
   events: AcpRunRawEvent[];
@@ -602,6 +602,12 @@ const useAcpRunStoreBase = create<AcpRunStore>()((set, get) => ({
           completedAt: undefined,
           task: existing.task ?? params.task,
           parentToolUseId: existing.parentToolUseId ?? params.parentToolUseId,
+          // The resumed session reports its own model right after this event
+          // when its adapter has a selector. The stamp keeps a snapshot
+          // requested before the resume from restoring the old pair.
+          model: undefined,
+          availableModels: undefined,
+          modelUpdatedAt: Date.now(),
         },
         pending,
       );

--- a/clients/web/src/domains/chat/components/metric-card.test.tsx
+++ b/clients/web/src/domains/chat/components/metric-card.test.tsx
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { AnimatedMetricCard, formatNumber, MetricCard } from "./metric-card";
+
+afterEach(cleanup);
+
+describe("MetricCard", () => {
+  // Usage tiles sit two or three to a row in the workflow and subagent panels,
+  // where a compact count can be wider than its value box.
+  test("shows a value in full, with no tooltip, when the caller gives none", () => {
+    render(
+      <AnimatedMetricCard
+        icon={null}
+        label="Input"
+        target={257_400}
+        format={formatNumber}
+      />,
+    );
+
+    const row = screen.getByText("257.4K");
+    expect(row.classList.contains("truncate")).toBe(false);
+    expect(row.hasAttribute("title")).toBe(false);
+  });
+
+  test("truncates with room for descenders when the caller gives a tooltip", () => {
+    render(
+      <MetricCard icon={null} value="Opus" label="Model" valueTitle="Opus" />,
+    );
+
+    const row = screen.getByText("Opus");
+    expect(row.getAttribute("title")).toBe("Opus");
+    expect(row.classList.contains("truncate")).toBe(true);
+    expect(row.classList.contains("pb-1")).toBe(true);
+    expect(row.classList.contains("-mb-1")).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/components/metric-card.tsx
+++ b/clients/web/src/domains/chat/components/metric-card.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useReducedMotion } from "motion/react";
 
-import { Typography } from "@vellumai/design-library";
+import { cn, Typography } from "@vellumai/design-library";
 
 /** Format a number compactly (e.g. 257400 -> "257.4K"). */
 export function formatNumber(n: number): string {
@@ -87,10 +87,11 @@ export function MetricCard({
   value: string;
   label: string;
   /**
-   * Native tooltip for the value row, the way the design library's own Select
-   * titles its trigger: a truncated value is unreadable without it. Opt-in,
-   * because a title repeating a value that is fully visible is noise a screen
-   * reader reads twice.
+   * Truncates the value row and carries the whole value as its native tooltip,
+   * the way the design library's own Select pairs the two on its trigger: a
+   * truncated value is unreadable without it. Opt-in: without it the row shows
+   * the value in full, and a title repeating a fully visible value is noise a
+   * screen reader reads twice.
    */
   valueTitle?: string;
 }) {
@@ -103,7 +104,13 @@ export function MetricCard({
         <Typography
           variant="title-small"
           title={valueTitle || undefined}
-          className="block truncate text-[var(--content-default)]"
+          className={cn(
+            "block text-[var(--content-default)]",
+            // `title-small` sets `line-height: 1`, which leaves descenders
+            // outside the line box. The padding keeps them inside the clip and
+            // the matching negative margin keeps the tile's height.
+            valueTitle && "-mb-1 truncate pb-1",
+          )}
         >
           {value}
         </Typography>


### PR DESCRIPTION
## Summary
- MetricCard truncates its value only when the caller gives it a tooltip, so animated usage tiles in the workflow and subagent panels read in full again, as on main
- The truncating row keeps room for descenders, so Opus is not clipped
- A run resumed by steering drops the model it had before; the resumed session's own model event (sent right after the spawned event when the adapter has a selector) fills it back in

Review fixes on the feature branch (web half), cycle 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D