### PR TITLE
fix(acp): review fixes for the decoded failure reason and non-Claude refusals

### DIFF
--- a/assistant/src/acp/__tests__/agent-process.test.ts
+++ b/assistant/src/acp/__tests__/agent-process.test.ts
@@ -336,6 +336,7 @@ describe("AcpAgentProcess auth_required retry", () => {
    * initialize() so the advertised authMethods are captured.
    */
   async function setupAuthProcess(options: {
+    command?: string;
     env?: Record<string, string>;
     authMethods?: AuthMethod[];
     /** Rejections to throw from successive newSession calls before succeeding. */
@@ -347,7 +348,7 @@ describe("AcpAgentProcess auth_required retry", () => {
   }) {
     const proc = new AcpAgentProcess(
       "codex",
-      { command: "echo", args: [], env: options.env },
+      { command: options.command ?? "echo", args: [], env: options.env },
       () => {
         throw new Error("client factory should not be called in this test");
       },
@@ -464,17 +465,39 @@ describe("AcpAgentProcess auth_required retry", () => {
     ).rejects.toThrow("Session not found");
   });
 
-  test("setConfigOption leaves Claude's message-shaped auth failure untyped", async () => {
-    const expired = new acp.RequestError(-32603, "Internal error", {
-      details: "Failed to authenticate. Please run /login",
-    });
+  test.each(["claude-agent-acp", "/usr/local/bin/claude-agent-acp"])(
+    "setConfigOption leaves Claude's message-shaped auth failure untyped (%s)",
+    async (command) => {
+      const expired = new acp.RequestError(-32603, "Internal error", {
+        details: "Not logged in",
+      });
+      const { proc } = await setupAuthProcess({
+        command,
+        setConfigOptionRejections: [expired],
+      });
+
+      await expect(
+        proc.setConfigOption("session-1", "model", "opus"),
+      ).rejects.toBe(expired);
+    },
+  );
+
+  test("setConfigOption reads Claude's login wording from another adapter as a refusal", async () => {
     const { proc } = await setupAuthProcess({
-      setConfigOptionRejections: [expired],
+      command: "codex-acp",
+      setConfigOptionRejections: [
+        new acp.RequestError(-32603, "Internal error", {
+          details: "Not logged in",
+        }),
+      ],
     });
 
-    await expect(
-      proc.setConfigOption("session-1", "model", "opus"),
-    ).rejects.toBe(expired);
+    const refusal = await proc
+      .setConfigOption("session-1", "model", "gpt-5")
+      .catch((err: unknown) => err);
+
+    expect(refusal).toBeInstanceOf(AcpConfigOptionRefusedError);
+    expect((refusal as Error).message).toBe("Not logged in");
   });
 
   test("setConfigOption leaves a transport failure untyped", async () => {

--- a/assistant/src/acp/__tests__/auth-required.test.ts
+++ b/assistant/src/acp/__tests__/auth-required.test.ts
@@ -124,12 +124,38 @@ describe("requestErrorReason", () => {
     );
   });
 
-  test("serializes a payload naming no reason, and falls back to the message", () => {
+  test("keeps the rejection's own message when the payload names no reason", () => {
     expect(requestErrorReason(new RequestError(-32603, "boom", { c: 7 }))).toBe(
-      '{"c":7}',
+      "boom",
     );
+    expect(
+      requestErrorReason(
+        RequestError.methodNotFound("session/set_config_option"),
+      ),
+    ).toBe('"Method not found": session/set_config_option');
     expect(requestErrorReason(new Error("Not logged in"))).toBe(
       "Not logged in",
+    );
+  });
+
+  test("serializes the payload behind a bare Internal error that names no reason", () => {
+    expect(
+      requestErrorReason(new RequestError(-32603, "Internal error", { c: 7 })),
+    ).toBe('{"c":7}');
+  });
+
+  test("decodes claude-agent-acp's prompt-time 401 from its message", () => {
+    // RequestError.internalError({ errorKind }, cliText) as the adapter raises
+    // it: the CLI's text rides the message and the payload only names a kind.
+    const rejection = new RequestError(
+      -32603,
+      "Internal error: Failed to authenticate. API Error: 401 OAuth access token has expired.",
+      { errorKind: "authentication_failed" },
+    );
+
+    expect(requestErrorReason(rejection)).toBe(rejection.message);
+    expect(isClaudeAuthFailureMessage(requestErrorReason(rejection))).toBe(
+      true,
     );
   });
 

--- a/assistant/src/acp/__tests__/auth-required.test.ts
+++ b/assistant/src/acp/__tests__/auth-required.test.ts
@@ -144,6 +144,15 @@ describe("requestErrorReason", () => {
     ).toBe('{"c":7}');
   });
 
+  test("serializes the payload behind a generic Invalid params", () => {
+    // How the agent-side SDK answers a request its schema rejects.
+    expect(
+      requestErrorReason(
+        RequestError.invalidParams({ _errors: ["model: Invalid option"] }),
+      ),
+    ).toBe('{"_errors":["model: Invalid option"]}');
+  });
+
   test("decodes claude-agent-acp's prompt-time 401 from its message", () => {
     // RequestError.internalError({ errorKind }, cliText) as the adapter raises
     // it: the CLI's text rides the message and the payload only names a kind.

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -6,6 +6,7 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import { basename } from "node:path";
 import { Readable, Writable } from "node:stream";
 
 import type {
@@ -26,6 +27,7 @@ import * as acp from "@agentclientprotocol/sdk";
 import { getLogger } from "../util/logger.js";
 import {
   AcpAuthRequiredError,
+  CLAUDE_ACP_COMMAND,
   isAcpAuthRequired,
   isClaudeAuthFailureMessage,
   requestErrorReason,
@@ -467,10 +469,14 @@ export class AcpAgentProcess {
         // an auth_required answer and a caller cannot confuse the adapter's
         // refusal with a transport or authentication failure. Claude's
         // expired-token failure travels as a generic error whose reason is
-        // the only signal, so it is left for the caller to classify.
+        // the only signal, so under the Claude adapter it is left for the
+        // caller to classify.
         if (err instanceof acp.RequestError && !isAcpAuthRequired(err)) {
           const reason = requestErrorReason(err);
-          if (!isClaudeAuthFailureMessage(reason)) {
+          const claudeAuthFailure =
+            basename(this.config.command) === CLAUDE_ACP_COMMAND &&
+            isClaudeAuthFailureMessage(reason);
+          if (!claudeAuthFailure) {
             throw new AcpConfigOptionRefusedError(reason);
           }
         }

--- a/assistant/src/acp/auth-required.ts
+++ b/assistant/src/acp/auth-required.ts
@@ -82,19 +82,27 @@ export function isClaudeAuthFailureMessage(
   );
 }
 
-/** The message `RequestError.internalError()` builds when given no text. */
-const BARE_INTERNAL_ERROR_MESSAGE = "Internal error";
+/** Messages the SDK's `RequestError` factories build when given no text. */
+const GENERIC_RPC_MESSAGES: ReadonlySet<string> = new Set([
+  "Parse error",
+  "Invalid request",
+  "Invalid params",
+  "Internal error",
+  "Request cancelled",
+  "Authentication required",
+  "Resource not found",
+]);
 
 /**
  * The sentence behind a JSON-RPC rejection. An adapter that throws a plain
  * Error reaches the client as a bare "Internal error" whose real text the
  * agent-side SDK moved into `data.details`, so that is read first. An adapter
  * that raises `RequestError.internalError(data, text)` keeps its words in the
- * message and only a kind in `data`, so the message comes next, and `data` is
- * serialized only behind the bare placeholder. Duck-typed like
- * {@link isAcpAuthRequired}: `message` is read as a property, so a rejection
- * that arrives as a plain object off the wire decodes the same as an `Error`
- * instance.
+ * message and only a kind in `data`, so the message comes next. Behind a
+ * generic message such as "Invalid params", `data` is the only reason given,
+ * so it is serialized instead. Duck-typed like {@link isAcpAuthRequired}:
+ * `message` is read as a property, so a rejection that arrives as a plain
+ * object off the wire decodes the same as an `Error` instance.
  */
 export function requestErrorReason(err: unknown): string {
   if (typeof err !== "object" || err === null) {
@@ -112,7 +120,7 @@ export function requestErrorReason(err: unknown): string {
   if (
     typeof message === "string" &&
     message.length > 0 &&
-    message !== BARE_INTERNAL_ERROR_MESSAGE
+    !GENERIC_RPC_MESSAGES.has(message)
   ) {
     return message;
   }

--- a/assistant/src/acp/auth-required.ts
+++ b/assistant/src/acp/auth-required.ts
@@ -82,13 +82,19 @@ export function isClaudeAuthFailureMessage(
   );
 }
 
+/** The message `RequestError.internalError()` builds when given no text. */
+const BARE_INTERNAL_ERROR_MESSAGE = "Internal error";
+
 /**
  * The sentence behind a JSON-RPC rejection. An adapter that throws a plain
- * Error reaches the client as a generic "Internal error" whose real text the
- * agent-side SDK moved into the `data` payload, so `data` is read before
- * `message`. Duck-typed like {@link isAcpAuthRequired}: `message` is read as a
- * property, so a rejection that arrives as a plain object off the wire decodes
- * the same as an `Error` instance.
+ * Error reaches the client as a bare "Internal error" whose real text the
+ * agent-side SDK moved into `data.details`, so that is read first. An adapter
+ * that raises `RequestError.internalError(data, text)` keeps its words in the
+ * message and only a kind in `data`, so the message comes next, and `data` is
+ * serialized only behind the bare placeholder. Duck-typed like
+ * {@link isAcpAuthRequired}: `message` is read as a property, so a rejection
+ * that arrives as a plain object off the wire decodes the same as an `Error`
+ * instance.
  */
 export function requestErrorReason(err: unknown): string {
   if (typeof err !== "object" || err === null) {
@@ -102,6 +108,13 @@ export function requestErrorReason(err: unknown): string {
   const details = (data as { details?: unknown }).details;
   if (typeof details === "string" && details.length > 0) {
     return details;
+  }
+  if (
+    typeof message === "string" &&
+    message.length > 0 &&
+    message !== BARE_INTERNAL_ERROR_MESSAGE
+  ) {
+    return message;
   }
   // JSON.stringify answers undefined for a value it cannot represent.
   const serialized: string | undefined = JSON.stringify(data);

--- a/assistant/src/acp/session-manager.test.ts
+++ b/assistant/src/acp/session-manager.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
+import { RequestError } from "@agentclientprotocol/sdk";
+
 import type { Conversation } from "../daemon/conversation.js";
 import {
   deleteConversation,
@@ -91,10 +93,10 @@ function mockConversation(opts?: { enqueueQueued?: boolean }) {
 }
 
 /** Fake AcpAgentProcess covering only the calls firePromptInBackground makes. */
-function fakeProcess(prompt: () => Promise<unknown>) {
+function fakeProcess(prompt: () => Promise<unknown>, stderr = "") {
   return {
     markStderr: () => 0,
-    stderrSince: () => "",
+    stderrSince: () => stderr,
     prompt,
     kill: mock(() => {}),
   };
@@ -366,6 +368,8 @@ describe("AcpSessionManager auth-required recovery surface", () => {
     parentToolUseId?: string;
     cancelled?: boolean;
     credentialDigest?: string;
+    failure?: () => Promise<never>;
+    stderr?: string;
   }) {
     const manager = new AcpSessionManager(1);
     const parentId = `parent-${opts.id}`;
@@ -377,7 +381,7 @@ describe("AcpSessionManager auth-required recovery surface", () => {
       manager,
       opts.id,
       parentId,
-      fakeProcess(authFailure),
+      fakeProcess(opts.failure ?? authFailure, opts.stderr),
     );
     entry.command = opts.command;
     (entry as { parentToolUseId?: string }).parentToolUseId =
@@ -511,6 +515,62 @@ describe("AcpSessionManager auth-required recovery surface", () => {
     expect(r.authEvent).toBeUndefined();
     expect(hasAcpConnectCardRaised(r.parentId)).toBe(false);
     expect(r.persistedContent).toBeUndefined();
+  });
+
+  test("claude's prompt-time 401 raises the surface when stderr names another failure", async () => {
+    // claude-agent-acp raises it as RequestError.internalError({ errorKind },
+    // cliText), and stderr supplies the failure message, so the auth text
+    // survives only on the rejection's own message.
+    refusedDigests.length = 0;
+    const digest = claudeTokenDigest("sk-ant-oat-prompt-401");
+    const r = await driveAuthFailure({
+      id: "sess-auth-prompt-401",
+      command: "claude-agent-acp",
+      parentToolUseId: "tool-anchor-prompt-401",
+      credentialDigest: digest,
+      failure: () =>
+        Promise.reject(
+          new RequestError(
+            -32603,
+            "Internal error: Failed to authenticate. API Error: 401 OAuth access token has expired.",
+            { errorKind: "authentication_failed" },
+          ),
+        ),
+      stderr: '{"error":{"message":"Something else happened"}}',
+    });
+
+    expect(r.authEvent).toMatchObject({
+      acpSessionId: "sess-auth-prompt-401",
+      authCode: "acp_claude_auth_required",
+      parentToolUseId: "tool-anchor-prompt-401",
+    });
+    expect(hasAcpConnectCardRaised(r.parentId)).toBe(true);
+    expect(refusedDigests).toContain(digest);
+  });
+
+  test("the rejection's own message is checked when its payload names a different reason", async () => {
+    refusedDigests.length = 0;
+    const digest = claudeTokenDigest("sk-ant-oat-own-message");
+    const r = await driveAuthFailure({
+      id: "sess-auth-own-message",
+      command: "claude-agent-acp",
+      parentToolUseId: "tool-anchor-own-message",
+      credentialDigest: digest,
+      failure: () =>
+        Promise.reject(
+          new RequestError(
+            -32603,
+            "Internal error: Failed to authenticate. API Error: 401",
+            { details: "Request failed" },
+          ),
+        ),
+      stderr: '{"error":{"message":"Something else happened"}}',
+    });
+
+    expect(r.authEvent).toMatchObject({
+      authCode: "acp_claude_auth_required",
+    });
+    expect(refusedDigests).toContain(digest);
   });
 
   test("a non-claude adapter never raises the surface, even on an auth-shaped failure", async () => {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -57,9 +57,9 @@ const log = getLogger("acp:session-manager");
  * and the marker promises a repair only the Connect Claude flow can perform.
  * Checks both auth-failure shapes (see `auth-required.ts`) against both the
  * raw rejection and the derived failure message, since `deriveFailureError`
- * may replace one with the other. The raw side reads the rejection's decoded
- * reason, because an adapter's own words travel in the payload rather than
- * the message.
+ * may replace one with the other. The raw side reads both the rejection's own
+ * message and its decoded reason, because an adapter's words travel in either
+ * depending on how it raised the error.
  */
 function claudeAuthRequiredCode(
   err: unknown,
@@ -69,9 +69,10 @@ function claudeAuthRequiredCode(
   if (entry.command !== CLAUDE_ACP_COMMAND) {
     return undefined;
   }
-  const rawMessage = requestErrorReason(err);
+  const rawMessage = err instanceof Error ? err.message : String(err);
   return isAcpAuthRequired(err) ||
     isClaudeAuthFailureMessage(rawMessage) ||
+    isClaudeAuthFailureMessage(requestErrorReason(err)) ||
     isClaudeAuthFailureMessage(failureMessage)
     ? ACP_CLAUDE_AUTH_REQUIRED_CODE
     : undefined;


### PR DESCRIPTION
## Summary
- The failure-reason decoder keeps a rejection's own message when its data carries no details, so Claude's prompt-time 401 (message text, errorKind data) is still recognised, and a method-not-found refusal reads as such; the auth check also tests the raw message as main did
- A non-Claude adapter whose refusal happens to use Claude's login wording is treated as a refusal (warning, session continues) instead of being torn down

Review fixes on the feature branch (daemon half), cycle 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvBMXkycpEpUhEDFh5r32D