### PR TITLE
test(ces): deflake process-manager transport-close tests

### DIFF
--- a/assistant/src/credential-execution/process-manager.test.ts
+++ b/assistant/src/credential-execution/process-manager.test.ts
@@ -12,7 +12,14 @@ import {
   test,
 } from "bun:test";
 
+import { waitFor } from "../__tests__/helpers/wait-for.js";
 import { createCesProcessManager } from "./process-manager.js";
+
+const untilClosed = (predicate: () => boolean) =>
+  waitFor(predicate, {
+    timeoutMs: 2000,
+    message: "socket close never propagated to the transport",
+  });
 
 // ---------------------------------------------------------------------------
 // onTransportClose tests
@@ -79,10 +86,7 @@ describe("CesProcessManager.onTransportClose", () => {
       sock.destroy();
     }
 
-    // Give the close event a tick to propagate.
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(closeFired).toBe(true);
+    await untilClosed(() => closeFired);
     expect(transport.isAlive()).toBe(false);
 
     await pm.stop();
@@ -112,8 +116,7 @@ describe("CesProcessManager.onTransportClose", () => {
     for (const sock of connections) {
       sock.destroy();
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(transport.isAlive()).toBe(false);
+    await untilClosed(() => !transport.isAlive());
 
     // Register handler AFTER transport is already dead.
     let closeFired = false;
@@ -190,14 +193,12 @@ describe("CesProcessManager transport-death logging", () => {
     for (const sock of connections) {
       sock.destroy();
     }
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(transport.isAlive()).toBe(false);
-
-    expect(
+    await untilClosed(() =>
       calls.some(
         (c) => c.level === "warn" && c.msg.includes("died unexpectedly"),
       ),
-    ).toBe(true);
+    );
+    expect(transport.isAlive()).toBe(false);
 
     await pm.stop();
   });
@@ -208,19 +209,17 @@ describe("CesProcessManager transport-death logging", () => {
     await pm.start();
 
     await pm.stop();
-    // Let the socket close event propagate after destroy().
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await untilClosed(() =>
+      calls.some(
+        (c) =>
+          c.level === "debug" && c.msg.includes("CES socket transport closed"),
+      ),
+    );
 
     expect(
       calls.some(
         (c) => c.level === "warn" && c.msg.includes("died unexpectedly"),
       ),
     ).toBe(false);
-    expect(
-      calls.some(
-        (c) =>
-          c.level === "debug" && c.msg.includes("CES socket transport closed"),
-      ),
-    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Replace the fixed 50ms sleeps in `process-manager.test.ts` with polled waits (shared `waitFor` helper, 2s budget) on the signal each case actually exercises: the `onTransportClose` handler firing, `isAlive()` flipping, or the WARN/debug log line landing.
- The first case (`fires handler when the transport dies`) failed on seven post-merge main CI runs since 2026-08-10 and on today's release/v0.12.0 Release run, with the file unchanged since it landed in July. Under CPU load the client socket's `close` event can take longer than 50ms to fire. Reproduced locally at 1/15 under load; 0/30 after this change.
- The negative case (`does not fire handler before the transport dies`) keeps its fixed wait on purpose, since it asserts that nothing happens.

## Original prompt
The question was whether the `process-manager.test.ts` failure on the release/v0.12.0 Release run was flaky. Investigation showed the same assertion had failed on seven post-merge main runs since August with the test unchanged, and the failure reproduced locally under CPU stress, so the answer was yes. The follow-up ask was a fix so the test isn't flaky anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EVaxnEtutPnUa9wuqmcGj