### PR TITLE
Read MCP status without opening connections

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18377,7 +18377,7 @@ paths:
     get:
       operationId: internal_mcp_list_get
       summary: List MCP servers with health status
-      description: Returns configured MCP servers with live health-check results (connected, needs auth, error).
+      description: Returns configured MCP servers and recorded runtime state without opening connections.
       tags:
         - internal
       responses:
@@ -18397,6 +18397,41 @@ paths:
                           type: string
                         status:
                           type: string
+                        lifecycleState:
+                          type: string
+                          enum:
+                            - not-started
+                            - connecting
+                            - connected
+                            - needs-auth
+                            - error
+                            - declared
+                        source:
+                          type: string
+                          enum:
+                            - workspace
+                            - plugin
+                        pluginName:
+                          type: string
+                        supportedActions:
+                          type: array
+                          items:
+                            type: string
+                            enum:
+                              - configure
+                              - authenticate
+                              - remove
+                              - manage-plugin
+                        hasStaticAuth:
+                          type: boolean
+                        authType:
+                          type: string
+                          enum:
+                            - none
+                            - bearer
+                            - api-key
+                        authHeaderName:
+                          type: string
                         transport:
                           type: object
                           properties:
@@ -18414,6 +18449,11 @@ paths:
                       required:
                         - id
                         - status
+                        - lifecycleState
+                        - source
+                        - supportedActions
+                        - hasStaticAuth
+                        - authType
                         - transport
                         - hasOAuth
                       additionalProperties: false

--- a/assistant/src/__tests__/mcp-health-check.test.ts
+++ b/assistant/src/__tests__/mcp-health-check.test.ts
@@ -4,6 +4,10 @@ const mockConnect = jest.fn();
 const mockDisconnect = jest.fn();
 let mockIsConnected = true;
 let mockLastError: Error | null = null;
+let runtimeState: string | undefined;
+mock.module("../mcp/manager.js", () => ({
+  getMcpServerManager: () => ({ getServerState: () => runtimeState }),
+}));
 
 mock.module("../mcp/client.js", () => ({
   McpClient: class {
@@ -44,10 +48,6 @@ mock.module("../mcp/mcp-auth-orchestrator.js", () => ({
   }),
 }));
 
-mock.module("../mcp/mcp-auth-state.js", () => ({
-  getMcpAuthState: () => null,
-}));
-
 mock.module("../mcp/mcp-oauth-provider.js", () => ({
   hasMcpOAuthTokens: async () => false,
   deleteMcpOAuthCredentials: async () => ({ ok: true, failedKeys: [] }),
@@ -59,15 +59,17 @@ const listHandler = ROUTES.find(
   (r: { operationId: string }) => r.operationId === "internal_mcp_list",
 )!.handler;
 
-describe("checkServerHealth (via internal_mcp_list route)", () => {
+describe("passive runtime state (via internal_mcp_list route)", () => {
   beforeEach(() => {
     mockConnect.mockReset();
     mockDisconnect.mockReset();
     mockIsConnected = true;
     mockLastError = null;
+    runtimeState = undefined;
   });
 
-  test("returns connected when server connects successfully", async () => {
+  test("returns connected only when runtime reports connected", async () => {
+    runtimeState = "connected";
     mockConnect.mockResolvedValue(undefined);
     mockDisconnect.mockResolvedValue(undefined);
 
@@ -75,10 +77,12 @@ describe("checkServerHealth (via internal_mcp_list route)", () => {
       servers: { status: string }[];
     };
     expect(result.servers[0].status).toBe("connected");
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDisconnect).not.toHaveBeenCalled();
+    expect(mockConnect).not.toHaveBeenCalled();
   });
 
-  test("returns needs-auth when isConnected is false and no lastError", async () => {
+  test("returns recorded needs-auth state", async () => {
+    runtimeState = "needs-auth";
     mockConnect.mockResolvedValue(undefined);
     mockIsConnected = false;
 
@@ -88,7 +92,8 @@ describe("checkServerHealth (via internal_mcp_list route)", () => {
     expect(result.servers[0].status).toBe("needs-auth");
   });
 
-  test("returns error when connect fails with lastError", async () => {
+  test("returns recorded error state", async () => {
+    runtimeState = "error";
     mockConnect.mockResolvedValue(undefined);
     mockIsConnected = false;
     mockLastError = new Error("Connection refused");
@@ -98,5 +103,27 @@ describe("checkServerHealth (via internal_mcp_list route)", () => {
       servers: { status: string }[];
     };
     expect(result.servers[0].status).toBe("error");
+  });
+  test("repeated reads never connect unstarted remote or stdio servers", async () => {
+    const result = (await listHandler({})) as {
+      servers: { status: string; lifecycleState: string }[];
+    };
+    await listHandler({});
+    expect(result.servers[0]).toMatchObject({
+      status: "error",
+      lifecycleState: "not-started",
+    });
+    expect(mockConnect).not.toHaveBeenCalled();
+    expect(mockDisconnect).not.toHaveBeenCalled();
+  });
+  test("connecting is distinct from connected and uses a legacy status", async () => {
+    runtimeState = "connecting";
+    const result = (await listHandler({})) as {
+      servers: { status: string; lifecycleState: string }[];
+    };
+    expect(result.servers[0]).toMatchObject({
+      status: "error",
+      lifecycleState: "connecting",
+    });
   });
 });

--- a/assistant/src/__tests__/mcp-list-plugin-servers.test.ts
+++ b/assistant/src/__tests__/mcp-list-plugin-servers.test.ts
@@ -47,10 +47,6 @@ mock.module("../mcp/mcp-auth-orchestrator.js", () => ({
   }),
 }));
 
-mock.module("../mcp/mcp-auth-state.js", () => ({
-  getMcpAuthState: () => null,
-}));
-
 mock.module("../mcp/mcp-oauth-provider.js", () => ({
   // Stand in for a credential store that holds tokens for every id, which
   // is the condition under which a leak would be observable.
@@ -176,7 +172,7 @@ describe("internal_mcp_list, plugin-declared servers", () => {
     // The credential mocks above return a token and an Authorization header
     // for every id. Constructing a client for the plugin server is what
     // would ship them to the plugin-declared URL.
-    expect(connectedServerIds).toContain("from-workspace");
+    expect(connectedServerIds).toEqual([]);
     expect(connectedServerIds).not.toContain("unabyss");
   });
 

--- a/assistant/src/mcp/__tests__/manager-state.test.ts
+++ b/assistant/src/mcp/__tests__/manager-state.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let completeConnect: (() => void) | undefined;
+let connected = true;
+let lastError: Error | null = null;
+let waitForConnect = false;
+
+mock.module("../client.js", () => ({
+  McpClient: class {
+    get isConnected() {
+      return connected;
+    }
+    get lastError() {
+      return lastError;
+    }
+    async connect() {
+      if (waitForConnect) {
+        await new Promise<void>((resolve) => {
+          completeConnect = resolve;
+        });
+      }
+    }
+    async listTools() {
+      return [];
+    }
+    async disconnect() {
+      connected = false;
+    }
+  },
+}));
+
+const { McpServerManager } = await import("../manager.js");
+const config = {
+  servers: {
+    example: {
+      source: "workspace" as const,
+      transport: {
+        type: "streamable-http" as const,
+        url: "https://example.com/mcp",
+      },
+    },
+  },
+};
+
+describe("MCP manager runtime state", () => {
+  beforeEach(() => {
+    connected = true;
+    lastError = null;
+    waitForConnect = false;
+    completeConnect = undefined;
+  });
+
+  test("retains connecting state until initialization and discovery finish", async () => {
+    waitForConnect = true;
+    const manager = new McpServerManager();
+    const starting = manager.start(config);
+    expect(manager.getServerState("example", "workspace")).toBe("connecting");
+    completeConnect!();
+    await starting;
+    expect(manager.getServerState("example", "workspace")).toBe("connected");
+    expect(manager.getServerState("example", "plugin")).toBeUndefined();
+    connected = false;
+    expect(manager.getServerState("example", "workspace")).toBe("error");
+    await manager.stop();
+    expect(manager.getServerState("example", "workspace")).toBeUndefined();
+  });
+
+  test("retains authentication failures without reporting a live client", async () => {
+    connected = false;
+    const manager = new McpServerManager();
+    await manager.start(config);
+    expect(manager.getServerState("example", "workspace")).toBe("needs-auth");
+    expect(manager.getClient("example")).toBeUndefined();
+  });
+
+  test("keeps transport failure distinct from required authentication", async () => {
+    connected = false;
+    lastError = new Error("Connection refused");
+    const manager = new McpServerManager();
+    await manager.start(config);
+    expect(manager.getServerState("example", "workspace")).toBe("error");
+  });
+});

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -15,9 +15,18 @@ export interface McpServerToolInfo {
   tools: McpToolInfo[];
 }
 
+export type McpConnectionState =
+  | "connecting"
+  | "connected"
+  | "needs-auth"
+  | "error";
+
 export class McpServerManager {
   private clients = new Map<string, McpClient>();
-  private serverConfigs = new Map<string, ResolvedMcpServerConfig>();
+  private connectionStates = new Map<
+    string,
+    { source: ResolvedMcpServerConfig["source"]; state: McpConnectionState }
+  >();
 
   async start(config: ResolvedMcpConfig): Promise<McpServerToolInfo[]> {
     const results: McpServerToolInfo[] = [];
@@ -26,6 +35,10 @@ export class McpServerManager {
       `[MCP] Starting ${Object.keys(config.servers).length} server(s)...`,
     );
     for (const [serverId, serverConfig] of Object.entries(config.servers)) {
+      this.connectionStates.set(serverId, {
+        source: serverConfig.source,
+        state: "connecting",
+      });
       try {
         console.log(
           `[MCP] Starting server "${serverId}" (transport: ${serverConfig.transport.type})`,
@@ -45,12 +58,14 @@ export class McpServerManager {
         await client.connect(serverConfig.transport);
 
         if (!client.isConnected) {
-          // Server requires authentication — connect() logged guidance
+          this.connectionStates.set(serverId, {
+            source: serverConfig.source,
+            state: client.lastError ? "error" : "needs-auth",
+          });
           continue;
         }
 
         this.clients.set(serverId, client);
-        this.serverConfigs.set(serverId, serverConfig);
 
         let tools = await client.listTools();
         log.info(
@@ -71,7 +86,15 @@ export class McpServerManager {
         }
 
         results.push({ serverId, serverConfig, tools });
+        this.connectionStates.set(serverId, {
+          source: serverConfig.source,
+          state: "connected",
+        });
       } catch (err) {
+        this.connectionStates.set(serverId, {
+          source: serverConfig.source,
+          state: "error",
+        });
         console.error(`[MCP] Failed to connect to server "${serverId}":`, err);
         log.error({ err, serverId }, "Failed to connect to MCP server");
         // Clean up any partially-connected client
@@ -83,7 +106,6 @@ export class McpServerManager {
             /* ignore */
           }
           this.clients.delete(serverId);
-          this.serverConfigs.delete(serverId);
         }
       }
     }
@@ -119,7 +141,7 @@ export class McpServerManager {
     );
     await Promise.all(disconnects);
     this.clients.clear();
-    this.serverConfigs.clear();
+    this.connectionStates.clear();
     log.info("All MCP servers disconnected");
   }
 
@@ -138,6 +160,23 @@ export class McpServerManager {
 
   getClient(serverId: string): McpClient | undefined {
     return this.clients.get(serverId);
+  }
+
+  getServerState(
+    serverId: string,
+    source: ResolvedMcpServerConfig["source"],
+  ): McpConnectionState | undefined {
+    const entry = this.connectionStates.get(serverId);
+    if (entry?.source !== source) {
+      return undefined;
+    }
+    if (
+      entry.state === "connected" &&
+      !this.clients.get(serverId)?.isConnected
+    ) {
+      return "error";
+    }
+    return entry.state;
   }
 }
 

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -18,7 +18,6 @@ import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type { McpConfig, McpServerConfig } from "../../config/schemas/mcp.js";
 import { estimateToolDefinitionTokens } from "../../context/token-estimator.js";
 import { reloadMcpServers } from "../../daemon/mcp-reload-service.js";
-import { McpClient } from "../../mcp/client.js";
 import { getMcpServerManager } from "../../mcp/manager.js";
 import { orchestrateMcpOAuthConnect } from "../../mcp/mcp-auth-orchestrator.js";
 import { getMcpAuthState } from "../../mcp/mcp-auth-state.js";
@@ -157,59 +156,22 @@ function handleMcpReload(_args: { body?: Record<string, unknown> }): {
 }
 
 // ---------------------------------------------------------------------------
-// Health check helper
-// ---------------------------------------------------------------------------
-
-const HEALTH_CHECK_TIMEOUT_MS = 10_000;
-
-async function checkMachineReadableHealth(
-  serverId: string,
-  config: McpServerConfig,
-  timeoutMs = HEALTH_CHECK_TIMEOUT_MS,
-): Promise<string> {
-  const client = new McpClient(serverId);
-  try {
-    await Promise.race([
-      client.connect(config.transport),
-      new Promise<never>((_, reject) => {
-        const t = setTimeout(() => reject(new Error("timeout")), timeoutMs);
-        if (typeof t === "object" && "unref" in t) {
-          t.unref();
-        }
-      }),
-    ]);
-
-    if (client.isConnected) {
-      await client.disconnect();
-      return "connected";
-    }
-
-    const err = client.lastError;
-    if (err) {
-      if (err.message.includes("timeout")) {
-        return "error";
-      }
-      return "error";
-    }
-
-    return "needs-auth";
-  } catch {
-    try {
-      await client.disconnect();
-    } catch {
-      /* ignore */
-    }
-    return "error";
-  }
-}
-
-// ---------------------------------------------------------------------------
 // List
 // ---------------------------------------------------------------------------
 
 interface McpServerEntry {
   id: string;
   status: string;
+  lifecycleState:
+    | "not-started"
+    | "connecting"
+    | "connected"
+    | "needs-auth"
+    | "error"
+    | "declared";
+  supportedActions: Array<
+    "configure" | "authenticate" | "remove" | "manage-plugin"
+  >;
   transport: Omit<McpServerConfig["transport"], "headers"> & { type: string };
   hasOAuth: boolean;
   hasStaticAuth: boolean;
@@ -225,22 +187,6 @@ interface McpServerEntry {
   /** Plugin that declared this server. Present only when `source` is `plugin`. */
   pluginName?: string;
 }
-
-/**
- * Status reported for a plugin-declared server the MCP manager holds no
- * live client for — it has not been started yet, or its connection failed.
- *
- * A plugin server is never health-checked the way a workspace server is.
- * `checkMachineReadableHealth` constructs its own `McpClient`, which
- * resolves `mcp:<serverId>:headers` and `mcp:<serverId>:tokens` from the
- * credential store, and a plugin controls both its server key and its URL,
- * so probing one would send workspace-owned credentials to an endpoint the
- * plugin chose whenever an id happens to match a stored key. Skipping the
- * probe also avoids spawning a plugin's declared stdio command as a side
- * effect of listing. The manager's own client — started with credentials
- * isolated — is the only thing consulted instead.
- */
-const PLUGIN_SERVER_STATUS = "declared";
 
 function detectAuthType(headers: Record<string, string>): "bearer" | "api-key" {
   const authValue = headers["Authorization"] ?? headers["authorization"];
@@ -261,8 +207,13 @@ async function handleMcpList(_args: {
   ).filter(([, config]) => config && typeof config === "object");
 
   const workspaceEntries: McpServerEntry[] = await Promise.all(
-    configEntries.map(async ([id, config]) => {
-      const status = await checkMachineReadableHealth(id, config);
+    configEntries.map(async ([id, config]): Promise<McpServerEntry> => {
+      const lifecycleState =
+        getMcpServerManager().getServerState(id, "workspace") ?? "not-started";
+      const status =
+        lifecycleState === "connected" || lifecycleState === "needs-auth"
+          ? lifecycleState
+          : "error";
       const hasOAuth =
         config.transport.type !== "stdio" ? await hasMcpOAuthTokens(id) : false;
 
@@ -293,6 +244,14 @@ async function handleMcpList(_args: {
       return {
         id,
         status,
+        lifecycleState,
+        supportedActions: [
+          "configure",
+          "remove",
+          ...(config.transport.type === "stdio"
+            ? []
+            : ["authenticate" as const]),
+        ],
         transport: safeTransport as McpServerEntry["transport"],
         hasOAuth,
         hasStaticAuth,
@@ -313,8 +272,7 @@ async function handleMcpList(_args: {
  *
  * Nothing here touches the credential store or the network: a plugin
  * server carries no auth state the assistant owns, and its status comes
- * from the manager's in-memory client rather than a probe (see
- * {@link PLUGIN_SERVER_STATUS}).
+ * from the manager's recorded connection state.
  */
 function listPluginServerEntries(
   configEntries: [string, McpServerConfig][],
@@ -351,11 +309,13 @@ function listPluginServerEntries(
     .map((server) => {
       const { headers: _stripped, ...safeTransport } = server.config
         .transport as Record<string, unknown>;
+      const lifecycleState =
+        manager.getServerState(server.id, "plugin") ?? "declared";
       return {
         id: server.id,
-        status: manager.getClient(server.id)?.isConnected
-          ? "connected"
-          : PLUGIN_SERVER_STATUS,
+        status: lifecycleState === "connected" ? "connected" : "declared",
+        lifecycleState,
+        supportedActions: ["configure", "manage-plugin"],
         transport: safeTransport as McpServerEntry["transport"],
         // A plugin server has no assistant-owned credentials. Resolving
         // these against `mcp:<id>:*` would report, and could disclose, a
@@ -695,13 +655,29 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "List MCP servers with health status",
     description:
-      "Returns configured MCP servers with live health-check results (connected, needs auth, error).",
+      "Returns configured MCP servers and recorded runtime state without opening connections.",
     tags: ["internal"],
     responseBody: z.object({
       servers: z.array(
         z.object({
           id: z.string(),
           status: z.string(),
+          lifecycleState: z.enum([
+            "not-started",
+            "connecting",
+            "connected",
+            "needs-auth",
+            "error",
+            "declared",
+          ]),
+          source: z.enum(["workspace", "plugin"]),
+          pluginName: z.string().optional(),
+          supportedActions: z.array(
+            z.enum(["configure", "authenticate", "remove", "manage-plugin"]),
+          ),
+          hasStaticAuth: z.boolean(),
+          authType: z.enum(["none", "bearer", "api-key"]),
+          authHeaderName: z.string().optional(),
           transport: z
             .object({
               type: z.enum(["stdio", "sse", "streamable-http"]),


### PR DESCRIPTION
Opening Integrations reads recorded MCP runtime state without creating temporary clients, starting stdio processes, or sending authentication probes. The list advertises source ownership and supported actions, preserves legacy status values, and distinguishes connecting, authentication required, errors, and declared plugin servers.

Validation: 17 focused tests passed, including repeated passive reads and workspace/plugin identity isolation; assistant typecheck and scoped lint passed in an isolated index snapshot. OpenAPI was regenerated from exactly this PR's staged sources.

Part of #42552. PR 4 of 8 targeting `codex/integrations-qa`; earlier commits in the QA stack disappear from the diff as they merge.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->