### PR TITLE
Make MCP disconnect and auth cancellation reliable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 | Public docs site (`clients/docs`)           | [`clients/docs/README.md`](clients/docs/README.md)                                                 |
 | Assistant memory deep dive                  | [`assistant/docs/architecture/memory.md`](assistant/docs/architecture/memory.md)                   |
 | Assistant integrations deep dive            | [`assistant/docs/architecture/integrations.md`](assistant/docs/architecture/integrations.md)       |
+| MCP credential lifecycle | [`assistant/docs/architecture/mcp-lifecycle.md`](assistant/docs/architecture/mcp-lifecycle.md) |
 | Assistant scheduling deep dive              | [`assistant/docs/architecture/scheduling.md`](assistant/docs/architecture/scheduling.md)           |
 | Assistant security deep dive                | [`assistant/docs/architecture/security.md`](assistant/docs/architecture/security.md)               |
 | Trusted contact access design               | [`assistant/docs/trusted-contact-access.md`](assistant/docs/trusted-contact-access.md)             |

--- a/assistant/docs/architecture/mcp-lifecycle.md
+++ b/assistant/docs/architecture/mcp-lifecycle.md
@@ -1,0 +1,85 @@
+# MCP connection lifecycle
+
+Workspace MCP mutations use a per-server operation mutex. Add, update, removal,
+and legacy-header migration also serialize asynchronous configuration writes.
+Existing server IDs and credential keys remain unchanged. Plugin-owned
+servers cannot authorize workspace credential operations.
+
+`internal_mcp_remove` and `internal_mcp_auth_revoke` share
+`teardownMcpConnection`. Removal clears OAuth tokens, client registration,
+client binding, discovery metadata, and static headers before removing the
+saved server. Legacy revoke clears only OAuth records and retains the server
+and static headers. Missing keys count as successful cleanup; failed deletion
+retains configuration for retry. If runtime reload fails after removal is
+saved, repeating remove retries runtime cleanup without looking up credentials
+for an absent configuration.
+
+```mermaid
+sequenceDiagram
+    participant UI as Client
+    participant Route as MCP route
+    participant Lock as Credential coordination
+    participant Store as CES
+    participant Runtime as MCP manager
+    UI->>Route: Remove workspace server
+    Route->>Lock: Drain credential writes and advance generation
+    Route->>Store: Delete OAuth records and static headers
+    alt Cleanup acknowledged
+        Route->>Route: Save configuration removal
+        Route->>Lock: Advance generation and release
+        Route->>Runtime: Reload through final queued snapshot
+        Runtime-->>Route: Local cleanup result
+        Route-->>UI: Removed, or saved removal with retryable runtime error
+    else Credential cleanup fails
+        Route->>Lock: Advance generation and release
+        Route-->>UI: Retryable error, configuration retained
+    end
+```
+
+Each OAuth provider captures a random credential generation. Its persistence
+operations obtain a process-shared lock, check that generation and the current
+configured endpoint, then write through the existing credential backend.
+Tokens, client registration/binding, discovery, and invalidation all use this
+boundary. Closing a provider also rejects queued writes. This covers silent
+refresh in the schedule worker as well as browser authorization in the main
+process.
+
+The coordination file is `signals/mcp-credential-coordination.sqlite`. It holds
+only hashed server IDs, random generations, and lock owner PID/token metadata.
+It contains no credentials, server definitions, or enable/disable state. Its
+local schema is initialized idempotently; no application database migration or
+existing plugin conversion is required. SQLite transactions arbitrate lock
+ownership without holding a SQL transaction across network I/O. A dead PID can
+be reclaimed atomically; a live owner is never stolen on timeout. PID reuse can
+conservatively block an operation, which fails with a retryable error. Handles
+are closed after each operation.
+
+A scoped credential-completion context prevents the secure-key wrapper's outer
+deadline from releasing a mutation lock while its underlying promise still
+runs. Lock acquisition is bounded, so a blocked writer prevents a later remove
+from claiming successful cleanup.
+
+Auth start returns an additive `attempt_id`. Status retains the existing
+pending/complete/error vocabulary and also returns `attempt_id`. Cancel takes
+`{serverId, attemptId}` and only cancels a matching pending attempt. It closes
+the callback, fences writes, clears that attempt's OAuth records, and keeps
+configuration for retry. A stale cancellation returns `{cancelled: false}`.
+
+## Acknowledgement boundaries
+
+Explicit teardown requests strict local cleanup. The manager retains client
+handles whose SDK close failed, unregisters their tools, and reports failure;
+a later remove retries those handles. Ordinary shutdown remains tolerant.
+Queued reloads retain a strict request and converge to the last requested
+configuration snapshot.
+
+The worker reload signal does not acknowledge worker shutdown. Other processes
+can retain a connection briefly while handling the notification, although their
+older provider generation cannot persist credentials.
+
+The persistence guarantee covers local storage and normally acknowledged CES
+operations. CES HTTP and RPC transports can lose an acknowledgement for an
+already-sent write. A client-side generation check cannot prove that remote
+write's final outcome after a transport timeout or process crash. Strong fencing
+across that failure requires CES-side generation/compare-and-set support. No
+provider-side OAuth grant revocation is performed.

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18303,6 +18303,42 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/internal/mcp/auth/cancel:
+    post:
+      operationId: internal_mcp_auth_cancel_post
+      summary: Cancel an MCP authorization attempt
+      description: Cancels only the pending attempt matching the supplied attempt ID and clears its OAuth credentials.
+      tags:
+        - internal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                serverId:
+                  type: string
+                  minLength: 1
+                attemptId:
+                  type: string
+                  minLength: 1
+              required:
+                - serverId
+                - attemptId
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cancelled:
+                    type: boolean
+                required:
+                  - cancelled
+                additionalProperties: false
   /v1/internal/mcp/auth/revoke:
     post:
       operationId: internal_mcp_auth_revoke_post
@@ -18319,6 +18355,7 @@ paths:
               properties:
                 serverId:
                   type: string
+                  minLength: 1
               required:
                 - serverId
       responses:
@@ -18350,11 +18387,30 @@ paths:
               properties:
                 serverId:
                   type: string
+                  minLength: 1
               required:
                 - serverId
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  auth_url:
+                    type: string
+                  state:
+                    type: string
+                  attempt_id:
+                    type: string
+                  already_authenticated:
+                    type: boolean
+                required:
+                  - auth_url
+                  - state
+                  - attempt_id
+                additionalProperties: false
   /v1/internal/mcp/auth/status/{serverId}:
     get:
       operationId: internal_mcp_auth_status_by_serverId_get
@@ -18371,6 +18427,50 @@ paths:
       responses:
         "200":
           description: Successful response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      status:
+                        type: string
+                        const: pending
+                      auth_url:
+                        type: string
+                      attempt_id:
+                        type: string
+                    required:
+                      - status
+                      - auth_url
+                      - attempt_id
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      status:
+                        type: string
+                        const: complete
+                      attempt_id:
+                        type: string
+                    required:
+                      - status
+                      - attempt_id
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      status:
+                        type: string
+                        const: error
+                      error:
+                        type: string
+                      attempt_id:
+                        type: string
+                    required:
+                      - status
+                      - error
+                      - attempt_id
+                    additionalProperties: false
+                type: object
         "404":
           description: No active OAuth flow for the given serverId
   /v1/internal/mcp/list:

--- a/assistant/src/__tests__/mcp-auth-routes.test.ts
+++ b/assistant/src/__tests__/mcp-auth-routes.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Module mocks (must precede imports) ───────────────────────────────────────
 
-const mockReloadMcpServers = mock(async () => {});
+const mockReloadMcpServers = mock(async () => ({ success: true }));
 
 mock.module("../daemon/mcp-reload-service.js", () => ({
   reloadMcpServers: () => mockReloadMcpServers(),
@@ -11,6 +11,7 @@ mock.module("../daemon/mcp-reload-service.js", () => ({
 const mockOrchestrateConnect = mock(
   async (_args: { serverId: string; transport: unknown }) => ({
     auth_url: "https://provider.example.com/authorize?state=abc",
+    attempt_id: "test-attempt",
   }),
 );
 
@@ -21,6 +22,7 @@ mock.module("../mcp/mcp-auth-orchestrator.js", () => ({
 const mockGetMcpAuthState = mock((_serverId: string) => null as unknown);
 
 mock.module("../mcp/mcp-auth-state.js", () => ({
+  cancelCurrentMcpAuth: () => {},
   getMcpAuthState: mockGetMcpAuthState,
 }));
 
@@ -69,6 +71,7 @@ describe("mcp-auth-routes", () => {
 
       expect(result).toEqual({
         auth_url: "https://provider.example.com/authorize?state=abc",
+        attempt_id: "test-attempt",
         state: "my-server",
       });
     });
@@ -105,6 +108,7 @@ describe("mcp-auth-routes", () => {
       mockGetMcpAuthState.mockImplementation(() => ({
         status: "pending",
         authUrl: "https://auth.example.com",
+        attemptId: "test-attempt",
         expiresAt: Date.now() + 300_000,
       }));
 
@@ -116,12 +120,14 @@ describe("mcp-auth-routes", () => {
       expect(result).toEqual({
         status: "pending",
         auth_url: "https://auth.example.com",
+        attempt_id: "test-attempt",
       });
     });
 
     test("returns complete state", async () => {
       mockGetMcpAuthState.mockImplementation(() => ({
         status: "complete",
+        attemptId: "test-attempt",
         serverId: "my-server",
         completedAt: Date.now(),
       }));
@@ -131,12 +137,16 @@ describe("mcp-auth-routes", () => {
         pathParams: { serverId: "my-server" },
       });
 
-      expect(result).toEqual({ status: "complete" });
+      expect(result).toEqual({
+        status: "complete",
+        attempt_id: "test-attempt",
+      });
     });
 
     test("returns error state", async () => {
       mockGetMcpAuthState.mockImplementation(() => ({
         status: "error",
+        attemptId: "test-attempt",
         error: "access_denied",
         failedAt: Date.now(),
       }));
@@ -146,7 +156,11 @@ describe("mcp-auth-routes", () => {
         pathParams: { serverId: "my-server" },
       });
 
-      expect(result).toEqual({ status: "error", error: "access_denied" });
+      expect(result).toEqual({
+        status: "error",
+        attempt_id: "test-attempt",
+        error: "access_denied",
+      });
     });
 
     test("throws NotFoundError for unknown serverId", async () => {

--- a/assistant/src/__tests__/mcp-client-auth.test.ts
+++ b/assistant/src/__tests__/mcp-client-auth.test.ts
@@ -147,3 +147,28 @@ describe("McpOAuthProvider redirectUrl", () => {
     expect(interactive.redirectUrl).toBeUndefined();
   });
 });
+
+describe("McpClient cleanup failures", () => {
+  test("strict cleanup reports a failed SDK close and remains retryable", async () => {
+    const client = new McpClient("cleanup-server");
+    const internals = client as unknown as {
+      client: { close: () => Promise<void> };
+      connected: boolean;
+    };
+    let fails = true;
+    internals.connected = true;
+    internals.client = {
+      close: async () => {
+        if (fails) {
+          throw new Error("socket close failed");
+        }
+      },
+    };
+    await expect(client.disconnect({ requireCleanup: true })).rejects.toThrow(
+      "socket close failed",
+    );
+    expect(client.isConnected).toBe(false);
+    fails = false;
+    await client.disconnect({ requireCleanup: true });
+  });
+});

--- a/assistant/src/daemon/__tests__/mcp-reload-convergence.test.ts
+++ b/assistant/src/daemon/__tests__/mcp-reload-convergence.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+let stopHook: (() => Promise<void>) | undefined;
+const starts: string[][] = [];
+const strictStops: boolean[] = [];
+mock.module("../../mcp/manager.js", () => ({
+  getMcpServerManager: () => ({
+    stop: async (options: { requireCleanup?: boolean }) => {
+      strictStops.push(options.requireCleanup ?? false);
+      await stopHook?.();
+    },
+    start: async (config: { servers: Record<string, unknown> }) => {
+      starts.push(Object.keys(config.servers).sort());
+      return [];
+    },
+  }),
+}));
+mock.module("../../mcp/mcp-header-store.js", () => ({
+  migrateLegacyMcpHeaders: async () => {},
+}));
+mock.module("../../plugins/mcp-servers.js", () => ({
+  readPluginMcpServers: () => ({ servers: [], issues: [] }),
+}));
+const signal = mock(() => {});
+mock.module("../../mcp/reload-signal.js", () => ({
+  signalMcpReloaded: signal,
+}));
+const { reloadMcpServers } = await import("../mcp-reload-service.js");
+
+function configure(ids: string[]) {
+  setConfig("mcp", {
+    servers: Object.fromEntries(
+      ids.map((id) => [
+        id,
+        {
+          transport: {
+            type: "streamable-http",
+            url: `https://${id}.example.com/mcp`,
+          },
+        },
+      ]),
+    ),
+  });
+}
+
+beforeEach(() => {
+  starts.length = 0;
+  strictStops.length = 0;
+  stopHook = undefined;
+  signal.mockClear();
+});
+
+describe("MCP reload convergence", () => {
+  test("remove and add during a reload converge to the final saved server set", async () => {
+    configure(["removed", "retained"]);
+    const stopped = deferred();
+    const release = deferred();
+    let first = true;
+    stopHook = async () => {
+      if (first) {
+        first = false;
+        stopped.resolve();
+        await release.promise;
+      }
+    };
+    const initial = reloadMcpServers();
+    await stopped.promise;
+    configure(["retained"]);
+    const removal = reloadMcpServers({ requireCleanup: true });
+    configure(["added", "retained"]);
+    const addition = reloadMcpServers();
+    expect(removal).toBe(initial);
+    expect(addition).toBe(initial);
+    release.resolve();
+    const final = await removal;
+    expect(strictStops).toEqual([false, true]);
+    expect(starts).toEqual([
+      ["removed", "retained"],
+      ["added", "retained"],
+    ]);
+    expect(final.servers?.map((server) => server.id).sort()).toEqual([
+      "added",
+      "retained",
+    ]);
+  });
+
+  test("completion signals workers without claiming an acknowledgement", async () => {
+    configure(["example"]);
+    const result = await reloadMcpServers();
+    expect(result.success).toBe(true);
+    expect(signal).toHaveBeenCalledTimes(1);
+    expect(result).not.toHaveProperty("workersStopped");
+  });
+});

--- a/assistant/src/daemon/mcp-reload-service.ts
+++ b/assistant/src/daemon/mcp-reload-service.ts
@@ -36,21 +36,33 @@ export interface McpReloadResult {
 }
 
 let reloadInProgress: Promise<McpReloadResult> | null = null;
+let reloadQueued = false;
+let requireCleanup = false;
 
 /**
  * Stop all MCP servers, reload configuration from disk, and restart
  * servers with the updated config. Returns a summary of the reload.
  *
- * Concurrent calls are serialized — if a reload is already in progress
- * the caller receives the same promise instead of starting a second one.
+ * Concurrent callers wait for the final queued configuration snapshot.
  */
-export function reloadMcpServers(): Promise<McpReloadResult> {
+export function reloadMcpServers(
+  options: { requireCleanup?: boolean } = {},
+): Promise<McpReloadResult> {
+  requireCleanup ||= options.requireCleanup ?? false;
   if (reloadInProgress) {
-    log.info("MCP reload already in progress, awaiting existing operation");
+    reloadQueued = true;
     return reloadInProgress;
   }
-  reloadInProgress = doReload().finally(() => {
+  reloadInProgress = (async () => {
+    let result: McpReloadResult;
+    do {
+      reloadQueued = false;
+      result = await doReload(requireCleanup);
+    } while (reloadQueued);
+    return result;
+  })().finally(() => {
     reloadInProgress = null;
+    requireCleanup = false;
   });
   return reloadInProgress;
 }
@@ -78,7 +90,7 @@ export async function reconcilePluginMcpServers(): Promise<void> {
   await reloadMcpServers();
 }
 
-async function doReload(): Promise<McpReloadResult> {
+async function doReload(requireCleanup: boolean): Promise<McpReloadResult> {
   try {
     const manager = getMcpServerManager();
 
@@ -98,8 +110,11 @@ async function doReload(): Promise<McpReloadResult> {
     const config = getConfig();
 
     // 2. Stop existing MCP servers + unregister their tools
-    await manager.stop();
-    unregisterAllMcpTools();
+    try {
+      await manager.stop({ requireCleanup });
+    } finally {
+      unregisterAllMcpTools();
+    }
 
     // Plugins are re-read here too: installing or removing one changes the
     // server set exactly like editing config.json does, and both arrive

--- a/assistant/src/mcp/__tests__/connection-lifecycle.test.ts
+++ b/assistant/src/mcp/__tests__/connection-lifecycle.test.ts
@@ -1,0 +1,289 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+
+const credentials = new Map<string, string>();
+let failedKeys = new Set<string>();
+let saveHook: (() => Promise<void>) | undefined;
+let deleteHook: ((key: string) => Promise<void>) | undefined;
+let reloadResult = { success: true, error: undefined as string | undefined };
+const reload = mock(async () => reloadResult);
+mock.module("../../daemon/mcp-reload-service.js", () => ({
+  reloadMcpServers: reload,
+}));
+const actualSecureKeys = await import("../../security/secure-keys.js");
+mock.module("../../security/secure-keys.js", () => ({
+  ...actualSecureKeys,
+  getSecureKeyAsync: async (key: string) => credentials.get(key) ?? null,
+  setSecureKeyAsync: async (key: string, value: string) => {
+    await saveHook?.();
+    credentials.set(key, value);
+    return true;
+  },
+  deleteSecureKeyAsync: async (key: string) => {
+    await deleteHook?.(key);
+    if (failedKeys.has(key)) {
+      return "error";
+    }
+    return credentials.delete(key) ? "deleted" : "not-found";
+  },
+}));
+mock.module("../../plugins/mcp-servers.js", () => ({
+  readPluginMcpServers: () => ({
+    servers: [
+      {
+        id: "plugin__server",
+        pluginName: "plugin",
+        config: {
+          transport: {
+            type: "streamable-http",
+            url: "https://plugin.example.com/mcp",
+          },
+        },
+      },
+    ],
+    issues: [],
+  }),
+}));
+const { loadRawConfig } = await import("../../config/loader.js");
+const { ROUTES } = await import("../../runtime/routes/mcp-auth-routes.js");
+const { McpOAuthProvider } = await import("../mcp-oauth-provider.js");
+const { beginMcpConnection } = await import("../connection-lifecycle.js");
+const {
+  setMcpAuthPending,
+  setMcpAuthComplete,
+  setMcpAuthError,
+  getMcpAuthState,
+  registerMcpAuthCancellation,
+} = await import("../mcp-auth-state.js");
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+function handler(operation: string, body: Record<string, unknown>) {
+  return ROUTES.find((entry) => entry.operationId === operation)!.handler({
+    body,
+  });
+}
+function savedServers(): Record<string, unknown> {
+  return (loadRawConfig().mcp as { servers: Record<string, unknown> }).servers;
+}
+function provider() {
+  return new McpOAuthProvider("example", "https://mcp.example.com/mcp", false, {
+    requireConfigured: true,
+  });
+}
+function seed() {
+  setConfig("mcp", {
+    servers: {
+      example: {
+        transport: {
+          type: "streamable-http",
+          url: "https://mcp.example.com/mcp",
+        },
+      },
+      unrelated: { transport: { type: "stdio", command: "example-command" } },
+    },
+  });
+  for (const key of [
+    "tokens",
+    "client_info",
+    "client_binding",
+    "discovery",
+    "headers",
+  ]) {
+    credentials.set(`mcp:example:${key}`, "{}");
+  }
+}
+beforeEach(() => {
+  credentials.clear();
+  failedKeys = new Set();
+  saveHook = undefined;
+  deleteHook = undefined;
+  reloadResult = { success: true, error: undefined };
+  reload.mockClear();
+  seed();
+});
+
+describe("MCP connection teardown", () => {
+  test("removes every credential before removing configuration and reloading", async () => {
+    expect(await handler("internal_mcp_remove", { name: "example" })).toEqual({
+      removed: true,
+    });
+    expect(credentials.size).toBe(0);
+    expect(savedServers()).not.toHaveProperty("example");
+    expect(savedServers()).toHaveProperty("unrelated");
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+  test("partial credential failures retain the server ID for a successful retry", async () => {
+    failedKeys.add("mcp:example:client_binding");
+    failedKeys.add("mcp:example:headers");
+    await expect(
+      handler("internal_mcp_remove", { name: "example" }),
+    ).rejects.toThrow("retry disconnecting");
+    expect(savedServers()).toHaveProperty("example");
+    expect(reload).not.toHaveBeenCalled();
+    expect(credentials.has("mcp:example:tokens")).toBe(false);
+    failedKeys.clear();
+    await handler("internal_mcp_remove", { name: "example" });
+    expect(credentials.size).toBe(0);
+  });
+  test("cleanup waits for sibling deletions even when one deletion throws", async () => {
+    const entered = deferred();
+    const release = deferred();
+    deleteHook = async (key) => {
+      if (key.endsWith(":tokens")) {
+        throw new Error("store unavailable");
+      }
+      if (key.endsWith(":client_binding")) {
+        entered.resolve();
+        await release.promise;
+      }
+    };
+    const removal = handler("internal_mcp_remove", { name: "example" });
+    await entered.promise;
+    expect(savedServers()).toHaveProperty("example");
+    release.resolve();
+    await expect(removal).rejects.toThrow("retry disconnecting");
+    expect(credentials.has("mcp:example:client_binding")).toBe(false);
+    expect(savedServers()).toHaveProperty("example");
+  });
+  test("late refresh, registration, discovery and invalidation cannot change newer credentials", async () => {
+    const old = provider();
+    await handler("internal_mcp_remove", { name: "example" });
+    seed();
+    await beginMcpConnection("example");
+    const current = provider();
+    await current.saveTokens({
+      access_token: "new-token",
+      token_type: "Bearer",
+    });
+    await expect(
+      old.saveTokens({ access_token: "late-token", token_type: "Bearer" }),
+    ).rejects.toThrow("connection changed");
+    await expect(
+      old.saveClientInformation({ client_id: "late-client" }),
+    ).rejects.toThrow("connection changed");
+    await expect(
+      old.saveDiscoveryState({
+        authorizationServerUrl: "https://auth.example.com",
+      }),
+    ).rejects.toThrow("connection changed");
+    await expect(old.invalidateCredentials("all")).rejects.toThrow(
+      "connection changed",
+    );
+    expect(
+      JSON.parse(credentials.get("mcp:example:tokens")!).access_token,
+    ).toBe("new-token");
+  });
+  test("removal drains a credential write already in progress before deleting it", async () => {
+    const entered = deferred();
+    const release = deferred();
+    saveHook = async () => {
+      entered.resolve();
+      await release.promise;
+    };
+    const write = provider().saveTokens({
+      access_token: "refreshed-token",
+      token_type: "Bearer",
+    });
+    await entered.promise;
+    const removal = handler("internal_mcp_remove", { name: "example" });
+    expect(savedServers()).toHaveProperty("example");
+    release.resolve();
+    await write;
+    await removal;
+    expect(credentials.size).toBe(0);
+    expect(savedServers()).not.toHaveProperty("example");
+  });
+  test("runtime failure reports saved removal and retry does not delete credentials for an absent source", async () => {
+    reloadResult = { success: false, error: "runtime unavailable" };
+    await expect(
+      handler("internal_mcp_remove", { name: "example" }),
+    ).rejects.toThrow("Removal was saved");
+    expect(savedServers()).not.toHaveProperty("example");
+    credentials.set("mcp:example:tokens", "other-owner");
+    reloadResult = { success: true, error: undefined };
+    expect(await handler("internal_mcp_remove", { name: "example" })).toEqual({
+      removed: true,
+    });
+    expect(credentials.get("mcp:example:tokens")).toBe("other-owner");
+  });
+  test("plugin-owned names never authorize workspace credential cleanup", async () => {
+    credentials.set("mcp:plugin__server:tokens", "workspace-secret");
+    await expect(
+      handler("internal_mcp_remove", { name: "plugin__server" }),
+    ).rejects.toThrow("not found");
+    expect(credentials.get("mcp:plugin__server:tokens")).toBe(
+      "workspace-secret",
+    );
+  });
+  test("legacy revoke keeps configuration and static headers", async () => {
+    expect(
+      await handler("internal_mcp_auth_revoke", { serverId: "example" }),
+    ).toEqual({ revoked: true });
+    expect(savedServers()).toHaveProperty("example");
+    expect([...credentials.keys()]).toEqual(["mcp:example:headers"]);
+  });
+  test("attempt-scoped cancellation rejects old IDs and fences the current attempt", async () => {
+    const pending = provider();
+    setMcpAuthPending("example", "https://auth.example.com", "current-attempt");
+    registerMcpAuthCancellation("example", "current-attempt", () =>
+      pending.close(),
+    );
+    expect(
+      await handler("internal_mcp_auth_cancel", {
+        serverId: "example",
+        attemptId: "older-attempt",
+      }),
+    ).toEqual({ cancelled: false });
+    expect(getMcpAuthState("example")?.status).toBe("pending");
+    expect(
+      await handler("internal_mcp_auth_cancel", {
+        serverId: "example",
+        attemptId: "current-attempt",
+      }),
+    ).toEqual({ cancelled: true });
+    await expect(
+      pending.saveTokens({ access_token: "late-token", token_type: "Bearer" }),
+    ).rejects.toThrow("connection changed");
+    expect(setMcpAuthComplete("example", "current-attempt")).toBe(false);
+    expect(setMcpAuthError("example", "late error", "current-attempt")).toBe(
+      false,
+    );
+    expect(savedServers()).toHaveProperty("example");
+    expect([...credentials.keys()]).toEqual(["mcp:example:headers"]);
+  });
+  test("concurrent add and remove preserve unrelated configuration writes", async () => {
+    const entered = deferred();
+    const release = deferred();
+    saveHook = async () => {
+      entered.resolve();
+      await release.promise;
+    };
+    const addition = handler("internal_mcp_add", {
+      name: "added",
+      transportType: "streamable-http",
+      url: "https://added.example.com/mcp",
+      headers: { Authorization: "Bearer example-token" },
+    });
+    await entered.promise;
+    const removal = handler("internal_mcp_remove", { name: "example" });
+    release.resolve();
+    await addition;
+    await removal;
+    expect(Object.keys(savedServers()).sort()).toEqual(["added", "unrelated"]);
+    expect(credentials.has("mcp:added:headers")).toBe(true);
+  });
+  test("missing auth state cannot be recreated by a stale completion", () => {
+    expect(setMcpAuthComplete("missing-server", "old-attempt")).toBe(false);
+    expect(setMcpAuthError("missing-server", "late error", "old-attempt")).toBe(
+      false,
+    );
+    expect(getMcpAuthState("missing-server")).toBeNull();
+  });
+});

--- a/assistant/src/mcp/__tests__/credential-completion.test.ts
+++ b/assistant/src/mcp/__tests__/credential-completion.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, mock, test } from "bun:test";
+
+import type { CesClient } from "../../credential-execution/client.js";
+import {
+  _resetBackend,
+  setCesClient,
+  setSecureKeyAsync,
+} from "../../security/secure-keys.js";
+import { withMcpCredentialLock } from "../credential-coordination.js";
+
+const originalSetTimeout = globalThis.setTimeout;
+afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+  _resetBackend();
+});
+
+test("MCP mutation lock remains held until CES persistence acknowledges completion", async () => {
+  let entered!: () => void;
+  const began = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  let release!: () => void;
+  const pendingWrite = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  setCesClient({
+    isReady: () => true,
+    call: mock(async () => {
+      entered();
+      await pendingWrite;
+      return { ok: true };
+    }),
+  } as unknown as CesClient);
+  let earlyDeadlineScheduled = false;
+  globalThis.setTimeout = ((
+    callback: (...args: unknown[]) => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    if (delay === 45_000) {
+      earlyDeadlineScheduled = true;
+      queueMicrotask(() => callback(...args));
+    }
+    return originalSetTimeout(callback, delay, ...args);
+  }) as typeof setTimeout;
+
+  const write = withMcpCredentialLock("acknowledged-write", () =>
+    setSecureKeyAsync("mcp:acknowledged-write:tokens", "example-token"),
+  );
+  await began;
+  await expect(
+    withMcpCredentialLock("acknowledged-write", async () => {}, 0),
+  ).rejects.toThrow("storage is busy");
+  expect(earlyDeadlineScheduled).toBe(false);
+  release();
+  expect(await write).toBe(true);
+  await withMcpCredentialLock("acknowledged-write", async () => {}, 0);
+});

--- a/assistant/src/mcp/__tests__/credential-coordination.test.ts
+++ b/assistant/src/mcp/__tests__/credential-coordination.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createMcpCredentialFence,
+  withMcpCredentialLock,
+} from "../credential-coordination.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function child(code: string) {
+  const moduleUrl = new URL("../credential-coordination.ts", import.meta.url)
+    .href;
+  return Bun.spawn(
+    [
+      process.execPath,
+      "--eval",
+      `
+    import { createMcpCredentialFence, withMcpCredentialLock } from ${JSON.stringify(
+      moduleUrl,
+    )};
+    ${code}
+  `,
+    ],
+    {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: process.env,
+      windowsHide: true,
+    },
+  );
+}
+
+async function readLine(reader: ReadableStreamDefaultReader<Uint8Array>) {
+  const chunk = await reader.read();
+  if (chunk.done) {
+    throw new Error("Child exited before signalling readiness");
+  }
+  return new TextDecoder().decode(chunk.value).trim();
+}
+
+describe("MCP credential coordination", () => {
+  test("a live writer is never stolen even when the acquisition deadline expires", async () => {
+    const worker =
+      child(`await withMcpCredentialLock("live-owner", async () => {
+      console.log("LOCKED"); await Bun.stdin.text();
+    });`);
+    try {
+      const output = worker.stdout.getReader();
+      expect(await readLine(output)).toBe("LOCKED");
+      await expect(
+        withMcpCredentialLock("live-owner", async () => {}, 0),
+      ).rejects.toThrow("storage is busy");
+      worker.stdin.end();
+      expect(await worker.exited).toBe(0);
+      await withMcpCredentialLock("live-owner", async () => {});
+    } finally {
+      worker.kill();
+    }
+  });
+
+  test("a dead owner's lock is reclaimed without stealing another live owner's lease", async () => {
+    const worker =
+      child(`await withMcpCredentialLock("crashed-owner", async () => {
+      console.log("LOCKED"); await Bun.stdin.text();
+    });`);
+    try {
+      expect(await readLine(worker.stdout.getReader())).toBe("LOCKED");
+      worker.kill("SIGKILL");
+      await worker.exited;
+      const entered = deferred();
+      const release = deferred();
+      const recovered = withMcpCredentialLock("crashed-owner", async () => {
+        entered.resolve();
+        await release.promise;
+      });
+      await entered.promise;
+      await expect(
+        withMcpCredentialLock("crashed-owner", async () => {}, 0),
+      ).rejects.toThrow("storage is busy");
+      release.resolve();
+      await recovered;
+    } finally {
+      worker.kill();
+    }
+  });
+
+  test("a worker refresh from a removed generation cannot write after teardown", async () => {
+    const worker = child(`
+      const fence = createMcpCredentialFence("worker-refresh");
+      console.log("READY"); await Bun.stdin.text();
+      try { await fence.write(async () => { console.log("WROTE"); }); }
+      catch { console.log("STALE"); }
+    `);
+    try {
+      const output = worker.stdout.getReader();
+      expect(await readLine(output)).toBe("READY");
+      await withMcpCredentialLock("worker-refresh", async (lease) => {
+        lease.advance();
+      });
+      worker.stdin.end();
+      expect(await readLine(output)).toBe("STALE");
+      expect(await worker.exited).toBe(0);
+    } finally {
+      worker.kill();
+    }
+  });
+
+  test("closing a provider fences writes queued behind an earlier writer", async () => {
+    const fence = createMcpCredentialFence("queued-write");
+    const entered = deferred();
+    const release = deferred();
+    const first = fence.write(async () => {
+      entered.resolve();
+      await release.promise;
+    });
+    await entered.promise;
+    const queued = fence.write(async () => {
+      throw new Error("must not execute");
+    });
+    fence.close();
+    release.resolve();
+    await first;
+    await expect(queued).rejects.toThrow("connection changed");
+  });
+
+  test("closure during asynchronous ownership validation prevents persistence", async () => {
+    const entered = deferred();
+    const release = deferred();
+    const fence = createMcpCredentialFence("validation-race", async () => {
+      entered.resolve();
+      await release.promise;
+      return true;
+    });
+    const write = fence.write(async () => {
+      throw new Error("must not execute");
+    });
+    await entered.promise;
+    fence.close();
+    release.resolve();
+    await expect(write).rejects.toThrow("connection changed");
+  });
+
+  test("an exception releases the lease", async () => {
+    await expect(
+      withMcpCredentialLock("failed-operation", async () => {
+        throw new Error("failure");
+      }),
+    ).rejects.toThrow("failure");
+    expect(
+      await withMcpCredentialLock(
+        "failed-operation",
+        async () => "recovered",
+        0,
+      ),
+    ).toBe("recovered");
+  });
+});

--- a/assistant/src/mcp/__tests__/manager-cleanup.test.ts
+++ b/assistant/src/mcp/__tests__/manager-cleanup.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let failClose = true;
+let failListTools = false;
+let closeCalls = 0;
+mock.module("../client.js", () => ({
+  McpClient: class {
+    isConnected = true;
+    constructor(
+      readonly serverId: string,
+      readonly source: string,
+    ) {}
+    async connect() {}
+    async listTools() {
+      if (failListTools) {
+        throw new Error("tool discovery failed");
+      }
+      return [];
+    }
+    async disconnect(options: { requireCleanup?: boolean }) {
+      expect(options.requireCleanup).toBe(true);
+      closeCalls++;
+      if (failClose) {
+        throw new Error("socket close failed");
+      }
+      this.isConnected = false;
+    }
+  },
+}));
+const { McpServerManager } = await import("../manager.js");
+const config = {
+  servers: {
+    example: {
+      source: "workspace" as const,
+      transport: {
+        type: "streamable-http" as const,
+        url: "https://mcp.example.com/mcp",
+      },
+    },
+  },
+};
+beforeEach(() => {
+  failClose = true;
+  failListTools = false;
+  closeCalls = 0;
+});
+
+describe("MCP local cleanup acknowledgement", () => {
+  test("failed tool discovery retains an unclosed connection for strict cleanup", async () => {
+    failListTools = true;
+    const manager = new McpServerManager();
+    expect(await manager.start(config)).toEqual([]);
+    expect(manager.getClient("example")).toBeUndefined();
+    expect(manager.hasWorkspaceConnection("example")).toBe(true);
+    await expect(manager.stop({ requireCleanup: true })).rejects.toThrow(
+      "could not be closed",
+    );
+    failClose = false;
+    await manager.stop({ requireCleanup: true });
+    expect(closeCalls).toBe(3);
+    expect(manager.hasWorkspaceConnection("example")).toBe(false);
+  });
+  test("strict cleanup reports failure and retains the handle for retry", async () => {
+    const manager = new McpServerManager();
+    await manager.start(config);
+    await expect(manager.stop({ requireCleanup: true })).rejects.toThrow(
+      "could not be closed",
+    );
+    expect(manager.getClient("example")).toBeUndefined();
+    expect(manager.hasWorkspaceConnection("example")).toBe(true);
+    failClose = false;
+    await manager.stop({ requireCleanup: true });
+    expect(closeCalls).toBe(2);
+    expect(manager.hasWorkspaceConnection("example")).toBe(false);
+  });
+  test("normal shutdown tolerates failure but explicit cleanup can retry it", async () => {
+    const manager = new McpServerManager();
+    await manager.start(config);
+    await manager.stop();
+    await expect(manager.stop({ requireCleanup: true })).rejects.toThrow(
+      "could not be closed",
+    );
+    failClose = false;
+    await manager.stop({ requireCleanup: true });
+    expect(closeCalls).toBe(3);
+  });
+});

--- a/assistant/src/mcp/__tests__/mcp-auth-orchestrator.test.ts
+++ b/assistant/src/mcp/__tests__/mcp-auth-orchestrator.test.ts
@@ -31,6 +31,7 @@ mock.module("../mcp-oauth-provider.js", () => ({
     invalidateCredentials = mockInvalidateCredentials;
     startCallbackServer = mockStartCallbackServer;
     stopCallbackServer = mockStopCallbackServer;
+    close = mockStopCallbackServer;
   },
 }));
 
@@ -46,7 +47,16 @@ const mockSetMcpAuthError = mock(
   (_serverId: string, _error: string, _attemptId: string): boolean => true,
 );
 
+mock.module("../mcp-header-store.js", () => ({
+  getMcpHeaders: async () => undefined,
+}));
+mock.module("../connection-lifecycle.js", () => ({
+  beginMcpConnection: async () => {},
+}));
 mock.module("../mcp-auth-state.js", () => ({
+  cancelCurrentMcpAuth: () => {},
+  clearMcpAuthCancellation: () => {},
+  registerMcpAuthCancellation: () => {},
   setMcpAuthPending: (...args: unknown[]) =>
     mockSetMcpAuthPending(...(args as [string, string, string])),
   setMcpAuthComplete: (...args: unknown[]) =>
@@ -56,7 +66,7 @@ mock.module("../mcp-auth-state.js", () => ({
 }));
 
 const mockReloadMcpServers = mock(async () => ({
-  ok: true,
+  success: true,
   reloaded: 0,
   servers: [],
 }));
@@ -163,7 +173,7 @@ describe("orchestrateMcpOAuthConnect", () => {
     });
 
     expect(result.auth_url).toBe("https://auth.example.com/oauth");
-    expect(mockSetMcpAuthPending.mock.calls[0]).toEqual([
+    expect(mockSetMcpAuthPending.mock.calls[1]).toEqual([
       "test-server",
       "https://auth.example.com/oauth",
       expect.any(String) as unknown as string, // attemptId UUID
@@ -251,12 +261,12 @@ describe("orchestrateMcpOAuthConnect", () => {
       transport: { url: "https://example.com", type: "sse" },
     });
 
-    expect(mockSetMcpAuthPending.mock.calls).toHaveLength(2);
+    expect(mockSetMcpAuthPending.mock.calls).toHaveLength(4);
     expect(mockSetMcpAuthPending.mock.calls[0][0]).toBe("srv");
     expect(mockSetMcpAuthPending.mock.calls[1][0]).toBe("srv");
     // Each attempt gets a distinct UUID so superseded tails can be detected.
     const firstAttemptId = mockSetMcpAuthPending.mock.calls[0][2];
-    const secondAttemptId = mockSetMcpAuthPending.mock.calls[1][2];
+    const secondAttemptId = mockSetMcpAuthPending.mock.calls[2][2];
     expect(firstAttemptId).not.toBe(secondAttemptId);
   });
 

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -96,6 +96,10 @@ export class McpClient {
         "MCP SDK transport error (non-fatal)",
       );
     };
+    this.client.onclose = () => {
+      this.connected = false;
+      this.oauthProvider?.close();
+    };
   }
 
   async connect(transportConfig: McpTransport): Promise<void> {
@@ -121,6 +125,7 @@ export class McpClient {
           this.serverId,
           transportConfig.url,
           /* interactive */ false,
+          { requireConfigured: true },
         );
       }
     }
@@ -273,17 +278,18 @@ export class McpClient {
     };
   }
 
-  async disconnect(): Promise<void> {
-    if (!this.connected) {
-      return;
-    }
+  async disconnect(options: { requireCleanup?: boolean } = {}): Promise<void> {
+    this.oauthProvider?.close();
+    this.connected = false;
 
     try {
       await this.client.close();
     } catch (err) {
       log.warn({ err, serverId: this.serverId }, "Error closing MCP client");
+      if (options.requireCleanup) {
+        throw err;
+      }
     }
-    this.connected = false;
     this.transport = null;
     log.info({ serverId: this.serverId }, "MCP client disconnected");
   }

--- a/assistant/src/mcp/config-write-lock.ts
+++ b/assistant/src/mcp/config-write-lock.ts
@@ -1,0 +1,8 @@
+import { Mutex } from "../util/mutex.js";
+
+const configWrites = new Mutex();
+
+/** Serializes MCP configuration read-modify-write operations across awaits. */
+export function withMcpConfigWrite<T>(operation: () => Promise<T>): Promise<T> {
+  return configWrites.withLock(operation);
+}

--- a/assistant/src/mcp/connection-lifecycle.ts
+++ b/assistant/src/mcp/connection-lifecycle.ts
@@ -1,0 +1,143 @@
+import { loadRawConfig, saveRawConfig } from "../config/loader.js";
+import type { McpConfig } from "../config/schemas/mcp.js";
+import { reloadMcpServers } from "../daemon/mcp-reload-service.js";
+import { Mutex } from "../util/mutex.js";
+import { withMcpConfigWrite } from "./config-write-lock.js";
+import { withMcpCredentialLock } from "./credential-coordination.js";
+import { cancelCurrentMcpAuth, getMcpAuthState } from "./mcp-auth-state.js";
+import { deleteMcpHeaders } from "./mcp-header-store.js";
+
+export { withMcpConfigWrite } from "./config-write-lock.js";
+
+const servers = new Map<string, { mutex: Mutex; users: number }>();
+
+export async function withMcpServerOperation<T>(
+  serverId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  let state = servers.get(serverId);
+  if (!state) {
+    state = { mutex: new Mutex(), users: 0 };
+    servers.set(serverId, state);
+  }
+  state.users++;
+  try {
+    return await state.mutex.withLock(operation);
+  } finally {
+    state.users--;
+    if (state.users === 0) {
+      servers.delete(serverId);
+    }
+  }
+}
+
+/** Called inside the server operation lock before a new authorization attempt. */
+export function beginMcpConnection(serverId: string): Promise<void> {
+  return withMcpCredentialLock(serverId, async (lease) => {
+    lease.advance();
+  });
+}
+
+export class McpTeardownError extends Error {
+  constructor(
+    message: string,
+    readonly removalSaved: boolean,
+  ) {
+    super(message);
+  }
+}
+
+export async function cancelMcpConnectionAttempt(
+  serverId: string,
+  attemptId: string,
+): Promise<boolean> {
+  const { deleteMcpOAuthCredentials } = await import("./mcp-oauth-provider.js");
+  return withMcpCredentialLock(serverId, async (lease) => {
+    const state = getMcpAuthState(serverId);
+    if (state?.status !== "pending" || state.attemptId !== attemptId) {
+      return false;
+    }
+    cancelCurrentMcpAuth(serverId);
+    lease.advance();
+    try {
+      const result = await deleteMcpOAuthCredentials(serverId);
+      if (!result.ok) {
+        throw new Error(
+          "Authorization cancelled, but credential cleanup failed; retry disconnecting",
+        );
+      }
+      return true;
+    } finally {
+      lease.advance();
+    }
+  });
+}
+
+/** The caller validates workspace ownership while holding the server lock. */
+export async function teardownMcpConnection(
+  serverId: string,
+  options: { removeConfig: boolean },
+): Promise<void> {
+  const { deleteMcpOAuthCredentials } = await import("./mcp-oauth-provider.js");
+  cancelCurrentMcpAuth(serverId);
+  let removalSaved = false;
+  try {
+    await withMcpConfigWrite(() =>
+      withMcpCredentialLock(serverId, async (lease) => {
+        lease.advance();
+        try {
+          const oauth = await deleteMcpOAuthCredentials(serverId);
+          const headers = options.removeConfig
+            ? await deleteMcpHeaders(serverId)
+            : true;
+          if (!oauth.ok || !headers) {
+            const failed = [
+              ...oauth.failedKeys,
+              ...(!headers ? ["headers"] : []),
+            ];
+            throw new McpTeardownError(
+              `Credential cleanup failed (${failed.join(
+                ", ",
+              )}); retry disconnecting`,
+              false,
+            );
+          }
+          if (options.removeConfig) {
+            const raw = loadRawConfig();
+            const servers = (raw.mcp as Partial<McpConfig> | undefined)
+              ?.servers;
+            if (servers) {
+              delete servers[serverId];
+              saveRawConfig(raw);
+              removalSaved = true;
+            }
+          }
+        } finally {
+          // A provider constructed during cleanup must not inherit its generation.
+          lease.advance();
+        }
+      }),
+    );
+  } catch (err) {
+    if (removalSaved) {
+      throw new McpTeardownError(
+        "Removal was saved, but runtime cleanup failed; retry removing the integration",
+        true,
+      );
+    }
+    throw err;
+  }
+  try {
+    const result = await reloadMcpServers({ requireCleanup: true });
+    if (!result.success) {
+      throw new Error(result.error);
+    }
+  } catch {
+    throw new McpTeardownError(
+      options.removeConfig
+        ? "Removal was saved, but runtime cleanup failed; retry removing the integration"
+        : "Credentials were cleared, but runtime cleanup failed; retry disconnecting",
+      options.removeConfig,
+    );
+  }
+}

--- a/assistant/src/mcp/credential-coordination.ts
+++ b/assistant/src/mcp/credential-coordination.ts
@@ -1,0 +1,155 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { withCredentialCompletion } from "../security/credential-completion.js";
+import { getSignalsDir } from "../util/platform.js";
+
+interface CredentialLock {
+  generation: string;
+  owner_pid: number | null;
+  owner_token: string | null;
+}
+
+function openCoordination(): Database {
+  const directory = getSignalsDir();
+  mkdirSync(directory, { recursive: true });
+  const db = new Database(
+    join(directory, "mcp-credential-coordination.sqlite"),
+  );
+  try {
+    db.exec("PRAGMA busy_timeout = 1000");
+    db.exec(`CREATE TABLE IF NOT EXISTS credential_locks (
+    server_key TEXT PRIMARY KEY,
+    generation TEXT NOT NULL,
+    owner_pid INTEGER,
+    owner_token TEXT
+  )`);
+    return db;
+  } catch (err) {
+    db.close();
+    throw err;
+  }
+}
+
+function keyFor(serverId: string): string {
+  return createHash("sha256").update(serverId).digest("hex");
+}
+
+function ensureLock(db: Database, key: string): CredentialLock {
+  db.query(
+    "INSERT OR IGNORE INTO credential_locks (server_key, generation) VALUES (?, ?)",
+  ).run(key, randomUUID());
+  return db
+    .query<
+      CredentialLock,
+      [string]
+    >("SELECT generation, owner_pid, owner_token FROM credential_locks WHERE server_key = ?")
+    .get(key)!;
+}
+
+function ownerIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+export function readMcpCredentialGeneration(serverId: string): string {
+  const db = openCoordination();
+  try {
+    return ensureLock(db, keyFor(serverId)).generation;
+  } finally {
+    db.close();
+  }
+}
+
+interface CredentialLease {
+  generation(): string;
+  advance(): void;
+}
+
+/** SQLite arbitrates async CES writers across the assistant and its workers. */
+export async function withMcpCredentialLock<T>(
+  serverId: string,
+  operation: (lease: CredentialLease) => Promise<T>,
+  timeoutMs = 10_000,
+): Promise<T> {
+  const db = openCoordination();
+  const key = keyFor(serverId);
+  const token = randomUUID();
+  const deadline = Date.now() + timeoutMs;
+  let acquired = false;
+  try {
+    ensureLock(db, key);
+    const acquire = db.transaction(() => {
+      const current = ensureLock(db, key);
+      if (current.owner_pid !== null && ownerIsAlive(current.owner_pid)) {
+        return false;
+      }
+      db.query(
+        "UPDATE credential_locks SET owner_pid = ?, owner_token = ? WHERE server_key = ?",
+      ).run(process.pid, token, key);
+      return true;
+    });
+    while (!acquired) {
+      acquired = acquire.immediate();
+      if (acquired) {
+        break;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error("MCP credential storage is busy; retry the operation");
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    }
+    return await withCredentialCompletion(() =>
+      operation({
+        generation: () => ensureLock(db, key).generation,
+        advance: () => {
+          db.query(
+            "UPDATE credential_locks SET generation = ? WHERE server_key = ? AND owner_token = ?",
+          ).run(randomUUID(), key, token);
+        },
+      }),
+    );
+  } finally {
+    try {
+      if (acquired) {
+        db.query(
+          "UPDATE credential_locks SET owner_pid = NULL, owner_token = NULL WHERE server_key = ? AND owner_token = ?",
+        ).run(key, token);
+      }
+    } finally {
+      db.close();
+    }
+  }
+}
+
+export interface McpCredentialFence {
+  write<T>(operation: () => Promise<T>): Promise<T>;
+  close(): void;
+}
+
+export function createMcpCredentialFence(
+  serverId: string,
+  isCurrent: () => boolean | Promise<boolean> = () => true,
+): McpCredentialFence {
+  const generation = readMcpCredentialGeneration(serverId);
+  let closed = false;
+  return {
+    write: (operation) =>
+      withMcpCredentialLock(serverId, async (lease) => {
+        const current = await isCurrent();
+        if (closed || generation !== lease.generation() || !current) {
+          throw new Error("MCP connection changed; retry connecting");
+        }
+        return operation();
+      }),
+    close: () => {
+      closed = true;
+    },
+  };
+}

--- a/assistant/src/mcp/manager.ts
+++ b/assistant/src/mcp/manager.ts
@@ -23,6 +23,7 @@ export type McpConnectionState =
 
 export class McpServerManager {
   private clients = new Map<string, McpClient>();
+  private pendingDisconnects = new Set<McpClient>();
   private connectionStates = new Map<
     string,
     { source: ResolvedMcpServerConfig["source"]; state: McpConnectionState }
@@ -62,6 +63,11 @@ export class McpServerManager {
             source: serverConfig.source,
             state: client.lastError ? "error" : "needs-auth",
           });
+          try {
+            await client.disconnect({ requireCleanup: true });
+          } catch {
+            this.pendingDisconnects.add(client);
+          }
           continue;
         }
 
@@ -101,9 +107,9 @@ export class McpServerManager {
         const staleClient = this.clients.get(serverId);
         if (staleClient) {
           try {
-            await staleClient.disconnect();
+            await staleClient.disconnect({ requireCleanup: true });
           } catch {
-            /* ignore */
+            this.pendingDisconnects.add(staleClient);
           }
           this.clients.delete(serverId);
         }
@@ -130,18 +136,32 @@ export class McpServerManager {
     return results;
   }
 
-  async stop(): Promise<void> {
-    const disconnects = Array.from(this.clients.values()).map((client) =>
-      client.disconnect().catch((err) => {
-        log.warn(
-          { err, serverId: client.serverId },
-          "Error disconnecting MCP server",
-        );
-      }),
-    );
-    await Promise.all(disconnects);
+  async stop(options: { requireCleanup?: boolean } = {}): Promise<void> {
+    const clients = new Set([
+      ...this.clients.values(),
+      ...this.pendingDisconnects,
+    ]);
     this.clients.clear();
     this.connectionStates.clear();
+    await Promise.all(
+      Array.from(clients, async (client) => {
+        try {
+          await client.disconnect({ requireCleanup: true });
+          this.pendingDisconnects.delete(client);
+        } catch (err) {
+          this.pendingDisconnects.add(client);
+          log.warn(
+            { err, serverId: client.serverId },
+            "Error disconnecting MCP server",
+          );
+        }
+      }),
+    );
+    if (options.requireCleanup && this.pendingDisconnects.size > 0) {
+      throw new Error(
+        "MCP connections could not be closed; retry disconnecting",
+      );
+    }
     log.info("All MCP servers disconnected");
   }
 
@@ -160,6 +180,16 @@ export class McpServerManager {
 
   getClient(serverId: string): McpClient | undefined {
     return this.clients.get(serverId);
+  }
+
+  hasWorkspaceConnection(serverId: string): boolean {
+    return (
+      this.clients.get(serverId)?.source === "workspace" ||
+      Array.from(this.pendingDisconnects).some(
+        (client) =>
+          client.serverId === serverId && client.source === "workspace",
+      )
+    );
   }
 
   getServerState(

--- a/assistant/src/mcp/mcp-auth-orchestrator.ts
+++ b/assistant/src/mcp/mcp-auth-orchestrator.ts
@@ -1,13 +1,3 @@
-/**
- * Daemon-side orchestrator for MCP OAuth flows.
- *
- * Runs the entire OAuth exchange (callback registration, auth URL capture,
- * code exchange, token persistence) inside the daemon heap so that
- * registerPendingCallback and consumeCallback always execute in the same
- * process.  The CLI receives only the authorization URL via IPC and polls
- * for completion.
- */
-
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -15,7 +5,11 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 
 import { reloadMcpServers } from "../daemon/mcp-reload-service.js";
 import { getLogger } from "../util/logger.js";
+import { beginMcpConnection } from "./connection-lifecycle.js";
 import {
+  cancelCurrentMcpAuth,
+  clearMcpAuthCancellation,
+  registerMcpAuthCancellation,
   setMcpAuthComplete,
   setMcpAuthError,
   setMcpAuthPending,
@@ -24,6 +18,7 @@ import { getMcpHeaders } from "./mcp-header-store.js";
 import { McpOAuthProvider } from "./mcp-oauth-provider.js";
 
 const log = getLogger("mcp-auth-orchestrator");
+const CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;
 
 export interface McpAuthTransportConfig {
   url: string;
@@ -33,179 +28,119 @@ export interface McpAuthTransportConfig {
 
 export interface OrchestrateMcpOAuthConnectResult {
   auth_url: string;
+  attempt_id: string;
   already_authenticated?: true;
 }
 
-/**
- * Start a daemon-owned MCP OAuth flow.
- *
- * Returns immediately with the authorization URL for the CLI to open in
- * the browser.  The token exchange runs in the background in the daemon heap
- * and updates the in-memory auth state map on completion.
- */
+/** The route holds the server operation lock while preparing authorization. */
 export async function orchestrateMcpOAuthConnect(args: {
   serverId: string;
   transport: McpAuthTransportConfig;
 }): Promise<OrchestrateMcpOAuthConnectResult> {
   const { serverId, transport } = args;
+  cancelCurrentMcpAuth(serverId);
+  await beginMcpConnection(serverId);
+  const attemptId = crypto.randomUUID();
+  setMcpAuthPending(serverId, "", attemptId);
 
   let capturedAuthUrl: string | undefined;
-  const provider = new McpOAuthProvider(
-    serverId,
-    transport.url,
-    /* interactive */ false,
-    {
-      onAuthorizationUrl: (url) => {
-        capturedAuthUrl = url;
-      },
+  const provider = new McpOAuthProvider(serverId, transport.url, false, {
+    requireConfigured: true,
+    onAuthorizationUrl: (url) => {
+      capturedAuthUrl = url;
     },
-  );
-
-  // Re-discover, but keep the client registration. Discovery is a read and
-  // costs a request; registration is a write on the authorization server,
-  // and remaking it per attempt leaves a record behind every time. The
-  // provider drops a stored registration on its own when the redirect URI
-  // or the authorization server it was made against has changed.
-  await provider.invalidateCredentials("discovery");
-
-  // Register the pending callback in the daemon heap
-  const { codePromise } = await provider.startCallbackServer();
-
-  // Resolve effective headers: credential store takes precedence, then config
-  const storedHeaders = await getMcpHeaders(serverId);
-  const effectiveHeaders = storedHeaders ?? transport.headers;
-
-  // Build the MCP transport and client
-  const serverUrl = new URL(transport.url);
-  const TransportClass =
-    transport.type === "sse"
-      ? SSEClientTransport
-      : StreamableHTTPClientTransport;
-  const mcpTransport = new TransportClass(serverUrl, {
-    authProvider: provider,
-    requestInit: effectiveHeaders ? { headers: effectiveHeaders } : undefined,
   });
   const client = new Client({ name: "vellum-assistant", version: "1.0.0" });
+  registerMcpAuthCancellation(serverId, attemptId, () => provider.close());
+
+  const close = async (): Promise<void> => {
+    clearMcpAuthCancellation(serverId, attemptId);
+    provider.close();
+    try {
+      await client.close();
+    } catch (err) {
+      log.debug({ err, serverId }, "MCP OAuth transport close failed");
+    }
+  };
 
   try {
-    await client.connect(mcpTransport);
-    // No error — server is already authenticated
-    provider.stopCallbackServer();
+    // Discovery is refreshed while a valid client registration is retained.
+    await provider.invalidateCredentials("discovery");
+    const { codePromise } = await provider.startCallbackServer();
+    const storedHeaders = await getMcpHeaders(serverId);
+    const effectiveHeaders = storedHeaders ?? transport.headers;
+    const TransportClass =
+      transport.type === "sse"
+        ? SSEClientTransport
+        : StreamableHTTPClientTransport;
+    const mcpTransport = new TransportClass(new URL(transport.url), {
+      authProvider: provider,
+      requestInit: effectiveHeaders ? { headers: effectiveHeaders } : undefined,
+    });
     try {
-      await client.close();
-    } catch {
-      /* ignore */
-    }
-    return { auth_url: "", already_authenticated: true };
-  } catch (err) {
-    if (err instanceof UnauthorizedError) {
-      // Expected — onAuthorizationUrl has fired, capturedAuthUrl is set
-    } else {
-      provider.stopCallbackServer();
-      try {
-        await client.close();
-      } catch {
-        /* ignore */
-      }
-      throw err;
-    }
-  }
-
-  if (!capturedAuthUrl) {
-    provider.stopCallbackServer();
-    try {
-      await client.close();
-    } catch {
-      /* ignore */
-    }
-    throw new Error("No authorization URL captured from OAuth provider");
-  }
-
-  // Per-attempt token. Gates fire-and-forget state writes so that a
-  // re-run of `assistant mcp auth <serverId>` before the previous attempt
-  // finishes cannot have its slot overwritten by stale completion writes
-  // from the older attempt.
-  const attemptId = crypto.randomUUID();
-  setMcpAuthPending(serverId, capturedAuthUrl, attemptId);
-
-  // Fire-and-forget background tail — completes the token exchange once
-  // the user approves in the browser.
-  // Note: we do NOT call client.connect() again here — both SSEClientTransport
-  // and StreamableHTTPClientTransport throw "already started" on a second
-  // connect() call.  The tokens are persisted by saveTokens inside finishAuth,
-  // so the daemon can reconnect on the next MCP reload without re-connecting here.
-  void (async () => {
-    try {
-      // Apply an explicit timeout: the deferred code promise relies on the
-      // caller for time-boxing. Without this race, a tail leaks forever if
-      // the user never completes the OAuth handshake.
-      const code = await Promise.race([
-        codePromise,
-        new Promise<never>((_, reject) => {
-          const t = setTimeout(
-            () => reject(new Error("OAuth callback timed out")),
-            CALLBACK_TIMEOUT_MS,
-          );
-          // Don't keep the event loop alive solely for this timer
-          if (typeof t.unref === "function") {
-            t.unref();
-          }
-        }),
-      ]);
-      await mcpTransport.finishAuth(code);
-      const applied = setMcpAuthComplete(serverId, attemptId);
-      if (!applied) {
-        log.info(
-          { serverId, attemptId },
-          "MCP OAuth completion superseded by newer attempt — skipping state write",
-        );
-        return;
-      }
-      log.info({ serverId }, "MCP OAuth flow completed");
-      // Trigger MCP reload from inside the daemon so the CLI doesn't need
-      // to fall back on the deprecated file-based signal mechanism.
-      // Best-effort: reload failures are logged but don't poison the
-      // success status the polling CLI is about to observe.
-      try {
-        await reloadMcpServers();
-      } catch (reloadErr) {
-        log.warn(
-          {
-            serverId,
-            err:
-              reloadErr instanceof Error
-                ? reloadErr.message
-                : String(reloadErr),
-          },
-          "MCP reload after auth completion failed",
-        );
-      }
+      await client.connect(mcpTransport);
+      setMcpAuthComplete(serverId, attemptId);
+      await close();
+      await reloadMcpServers();
+      return {
+        auth_url: "",
+        attempt_id: attemptId,
+        already_authenticated: true,
+      };
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const applied = setMcpAuthError(serverId, message, attemptId);
-      if (!applied) {
-        log.info(
-          { serverId, attemptId, error: message },
-          "MCP OAuth error superseded by newer attempt — skipping state write",
-        );
-      } else {
-        log.warn({ serverId, error: message }, "MCP OAuth flow failed");
-      }
-    } finally {
-      provider.stopCallbackServer();
-      try {
-        await client.close();
-      } catch {
-        /* ignore */
+      if (!(err instanceof UnauthorizedError)) {
+        throw err;
       }
     }
-  })();
+    if (!capturedAuthUrl) {
+      throw new Error("No authorization URL captured from OAuth provider");
+    }
+    setMcpAuthPending(serverId, capturedAuthUrl, attemptId);
 
-  return { auth_url: capturedAuthUrl };
+    void (async () => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const code = await Promise.race([
+          codePromise,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new Error("OAuth callback timed out")),
+              CALLBACK_TIMEOUT_MS,
+            );
+            timer.unref();
+          }),
+        ]);
+        // Credential persistence itself checks the provider's generation.
+        await mcpTransport.finishAuth(code);
+        if (!setMcpAuthComplete(serverId, attemptId)) {
+          return;
+        }
+        try {
+          const reload = await reloadMcpServers();
+          if (!reload.success) {
+            throw new Error(reload.error);
+          }
+        } catch (err) {
+          log.warn({ serverId, err }, "MCP reload after authorization failed");
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        if (setMcpAuthError(serverId, error, attemptId)) {
+          log.warn({ serverId, error }, "MCP OAuth flow failed");
+        }
+      } finally {
+        clearTimeout(timer);
+        await close();
+      }
+    })();
+    return { auth_url: capturedAuthUrl, attempt_id: attemptId };
+  } catch (err) {
+    setMcpAuthError(
+      serverId,
+      err instanceof Error ? err.message : String(err),
+      attemptId,
+    );
+    await close();
+    throw err;
+  }
 }
-
-// How long a user has to complete the browser handshake before the tail
-// gives up. Shorter than the callback registry's own 5-minute TTL, so the
-// failure surfaces here with a clear message rather than as a registry
-// expiry the caller cannot attribute.
-const CALLBACK_TIMEOUT_MS = 2 * 60 * 1000;

--- a/assistant/src/mcp/mcp-auth-state.ts
+++ b/assistant/src/mcp/mcp-auth-state.ts
@@ -25,6 +25,37 @@ type McpAuthState =
   | { status: "error"; error: string; attemptId: string; failedAt: number };
 
 const activeMcpAuthFlows = new Map<string, McpAuthState>();
+const cancellations = new Map<
+  string,
+  { attemptId: string; cancel: () => void }
+>();
+
+export function registerMcpAuthCancellation(
+  serverId: string,
+  attemptId: string,
+  cancel: () => void,
+): void {
+  cancellations.set(serverId, { attemptId, cancel });
+}
+
+export function clearMcpAuthCancellation(
+  serverId: string,
+  attemptId: string,
+): void {
+  if (cancellations.get(serverId)?.attemptId === attemptId) {
+    cancellations.delete(serverId);
+  }
+}
+
+export function cancelCurrentMcpAuth(serverId: string): void {
+  const current = activeMcpAuthFlows.get(serverId);
+  if (current?.status !== "pending") {
+    return;
+  }
+  setMcpAuthError(serverId, "Connection cancelled", current.attemptId);
+  cancellations.get(serverId)?.cancel();
+  cancellations.delete(serverId);
+}
 
 const PENDING_TTL_MS = 5 * 60 * 1000; // 5 min — matches oauth-callback-registry.ts
 const COMPLETION_GRACE_MS = 60 * 1000; // 60s so the polling CLI gets one final read
@@ -61,7 +92,7 @@ export function setMcpAuthComplete(
   attemptId: string,
 ): boolean {
   const current = activeMcpAuthFlows.get(serverId);
-  if (current && current.attemptId !== attemptId) {
+  if (current?.status !== "pending" || current.attemptId !== attemptId) {
     return false; // superseded
   }
   activeMcpAuthFlows.set(serverId, {
@@ -83,7 +114,7 @@ export function setMcpAuthError(
   attemptId: string,
 ): boolean {
   const current = activeMcpAuthFlows.get(serverId);
-  if (current && current.attemptId !== attemptId) {
+  if (current?.status !== "pending" || current.attemptId !== attemptId) {
     return false; // superseded
   }
   activeMcpAuthFlows.set(serverId, {
@@ -104,6 +135,8 @@ export function getMcpAuthState(serverId: string): McpAuthState | null {
   const now = Date.now();
   for (const [id, state] of activeMcpAuthFlows) {
     if (state.status === "pending" && now > state.expiresAt) {
+      cancellations.get(id)?.cancel();
+      cancellations.delete(id);
       activeMcpAuthFlows.delete(id);
     } else if (
       state.status === "complete" &&

--- a/assistant/src/mcp/mcp-header-store.ts
+++ b/assistant/src/mcp/mcp-header-store.ts
@@ -15,6 +15,8 @@ import {
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
+import { withMcpConfigWrite } from "./config-write-lock.js";
+import { withMcpCredentialLock } from "./credential-coordination.js";
 
 const log = getLogger("mcp-header-store");
 
@@ -48,9 +50,8 @@ export async function setMcpHeaders(
   serverId: string,
   headers: Record<string, string>,
 ): Promise<boolean> {
-  const ok = await setSecureKeyAsync(
-    headersKey(serverId),
-    JSON.stringify(headers),
+  const ok = await withMcpCredentialLock(serverId, () =>
+    setSecureKeyAsync(headersKey(serverId), JSON.stringify(headers)),
   );
   if (!ok) {
     log.warn({ serverId }, "Failed to persist MCP headers to secure storage");
@@ -78,59 +79,63 @@ export async function deleteMcpHeaders(serverId: string): Promise<boolean> {
  * Safe to call on every MCP reload — no-ops when no legacy headers remain.
  */
 export async function migrateLegacyMcpHeaders(): Promise<void> {
-  const raw = loadRawConfig();
-  const mcpConfig = raw.mcp as
-    | { servers?: Record<string, Record<string, unknown>> }
-    | undefined;
-  const servers = mcpConfig?.servers;
-  if (!servers) {
-    return;
-  }
-
-  let configDirty = false;
-  for (const [id, server] of Object.entries(servers)) {
-    const transport = server?.transport as Record<string, unknown> | undefined;
-    if (
-      !transport ||
-      (transport.type !== "sse" && transport.type !== "streamable-http")
-    ) {
-      continue;
-    }
-    const legacyHeaders = transport.headers as
-      | Record<string, string>
+  return withMcpConfigWrite(async () => {
+    const raw = loadRawConfig();
+    const mcpConfig = raw.mcp as
+      | { servers?: Record<string, Record<string, unknown>> }
       | undefined;
-    if (!legacyHeaders || Object.keys(legacyHeaders).length === 0) {
-      continue;
+    const servers = mcpConfig?.servers;
+    if (!servers) {
+      return;
     }
 
-    // Only migrate if credential store doesn't already have headers for
-    // this server (idempotent — safe to re-run after partial failure).
-    const existing = await getMcpHeaders(id);
-    if (existing) {
-      // Credential store already has headers; just strip the config copy.
-      delete transport.headers;
-      configDirty = true;
-      continue;
+    let configDirty = false;
+    for (const [id, server] of Object.entries(servers)) {
+      const transport = server?.transport as
+        | Record<string, unknown>
+        | undefined;
+      if (
+        !transport ||
+        (transport.type !== "sse" && transport.type !== "streamable-http")
+      ) {
+        continue;
+      }
+      const legacyHeaders = transport.headers as
+        | Record<string, string>
+        | undefined;
+      if (!legacyHeaders || Object.keys(legacyHeaders).length === 0) {
+        continue;
+      }
+
+      // Only migrate if credential store doesn't already have headers for
+      // this server (idempotent, safe to re-run after partial failure).
+      const existing = await getMcpHeaders(id);
+      if (existing) {
+        // Credential store already has headers; just strip the config copy.
+        delete transport.headers;
+        configDirty = true;
+        continue;
+      }
+
+      const ok = await setMcpHeaders(id, legacyHeaders);
+      if (ok) {
+        delete transport.headers;
+        configDirty = true;
+        log.info(
+          { serverId: id },
+          "Migrated legacy MCP headers to credential store",
+        );
+      } else {
+        log.warn(
+          { serverId: id },
+          "Skipping legacy header migration: credential store write failed; will retry on next reload",
+        );
+      }
     }
 
-    const ok = await setMcpHeaders(id, legacyHeaders);
-    if (ok) {
-      delete transport.headers;
-      configDirty = true;
-      log.info(
-        { serverId: id },
-        "Migrated legacy MCP headers to credential store",
-      );
-    } else {
-      log.warn(
-        { serverId: id },
-        "Skipping legacy header migration — credential store write failed; will retry on next reload",
-      );
+    if (configDirty) {
+      saveRawConfig(raw);
+      log.info("Config updated: legacy MCP headers removed after migration");
     }
-  }
-
-  if (configDirty) {
-    saveRawConfig(raw);
-    log.info("Config updated: legacy MCP headers removed after migration");
-  }
+  });
 }

--- a/assistant/src/mcp/mcp-oauth-provider.ts
+++ b/assistant/src/mcp/mcp-oauth-provider.ts
@@ -29,6 +29,7 @@ import type {
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 
 import { getPlatformAssistantId } from "../config/env.js";
+import type { McpConfig } from "../config/schemas/mcp.js";
 import { getAssistantName } from "../daemon/identity-helpers.js";
 import {
   deleteSecureKeyAsync,
@@ -38,6 +39,8 @@ import {
 import { openInHostBrowser } from "../util/browser.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
+import type { McpCredentialFence } from "./credential-coordination.js";
+import { createMcpCredentialFence } from "./credential-coordination.js";
 
 const log = getLogger("mcp-oauth");
 
@@ -91,10 +94,13 @@ export interface McpOAuthProviderOptions {
    * URL to the IPC caller (CLI / web client).
    */
   onAuthorizationUrl?: (url: string) => void;
+  requireConfigured?: boolean;
 }
 
 export class McpOAuthProvider implements OAuthClientProvider {
   private readonly serverId: string;
+  private readonly credentialFence: McpCredentialFence;
+  private cancelRegisteredCallback: (() => void) | undefined;
   private readonly serverUrl: string;
   private readonly interactive: boolean;
   private _codeVerifier: string | undefined;
@@ -118,6 +124,22 @@ export class McpOAuthProvider implements OAuthClientProvider {
     options: McpOAuthProviderOptions = {},
   ) {
     this.serverId = serverId;
+    this.credentialFence = createMcpCredentialFence(
+      serverId,
+      options.requireConfigured
+        ? async () => {
+            const { loadRawConfig } = await import("../config/loader.js");
+            const raw = loadRawConfig();
+            const mcp = raw.mcp as Partial<McpConfig> | undefined;
+            const transport = mcp?.servers?.[serverId]?.transport;
+            return (
+              !!transport &&
+              transport.type !== "stdio" &&
+              transport.url === serverUrl
+            );
+          }
+        : undefined,
+    );
     this.serverUrl = serverUrl;
     this.interactive = interactive;
     this._onAuthorizationUrl = options.onAuthorizationUrl;
@@ -183,38 +205,40 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveTokens(tokens: OAuthTokens): Promise<void> {
-    // RFC 6749 §6 lets a token endpoint rotate the refresh_token, omit
-    // it, or leave it unchanged. Many MCP servers issue a fresh
-    // access_token without a new refresh_token on every refresh grant;
-    // overwriting storage verbatim would then drop the refresh_token
-    // we still need to send on the next silent refresh. Carry forward
-    // the previous refresh_token when the incoming response omits one.
-    let toPersist: OAuthTokens = tokens;
-    if (!tokens.refresh_token) {
-      const previous = await getSecureKeyAsync(tokensKey(this.serverId));
-      if (previous) {
-        try {
-          const parsed = JSON.parse(previous) as OAuthTokens;
-          if (parsed.refresh_token) {
-            toPersist = { ...tokens, refresh_token: parsed.refresh_token };
+    await this.credentialFence.write(async () => {
+      // RFC 6749 §6 lets a token endpoint rotate the refresh_token, omit
+      // it, or leave it unchanged. Many MCP servers issue a fresh
+      // access_token without a new refresh_token on every refresh grant;
+      // overwriting storage verbatim would then drop the refresh_token
+      // we still need to send on the next silent refresh. Carry forward
+      // the previous refresh_token when the incoming response omits one.
+      let toPersist: OAuthTokens = tokens;
+      if (!tokens.refresh_token) {
+        const previous = await getSecureKeyAsync(tokensKey(this.serverId));
+        if (previous) {
+          try {
+            const parsed = JSON.parse(previous) as OAuthTokens;
+            if (parsed.refresh_token) {
+              toPersist = { ...tokens, refresh_token: parsed.refresh_token };
+            }
+          } catch {
+            // Existing payload is malformed; fall through and save as-is.
           }
-        } catch {
-          // Existing payload is malformed; fall through and save as-is.
         }
       }
-    }
-    const ok = await setSecureKeyAsync(
-      tokensKey(this.serverId),
-      JSON.stringify(toPersist),
-    );
-    if (!ok) {
-      log.warn(
-        { serverId: this.serverId },
-        "Failed to persist OAuth tokens to secure storage",
+      const ok = await setSecureKeyAsync(
+        tokensKey(this.serverId),
+        JSON.stringify(toPersist),
       );
-      return;
-    }
-    log.info({ serverId: this.serverId }, "OAuth tokens saved");
+      if (!ok) {
+        log.warn(
+          { serverId: this.serverId },
+          "Failed to persist OAuth tokens to secure storage",
+        );
+        throw new Error("Failed to save OAuth credentials; retry connecting");
+      }
+      log.info({ serverId: this.serverId }, "OAuth tokens saved");
+    });
   }
 
   // --- Refresh-Token Grant ---
@@ -293,38 +317,45 @@ export class McpOAuthProvider implements OAuthClientProvider {
   async saveClientInformation(
     info: OAuthClientInformationMixed,
   ): Promise<void> {
-    const ok = await setSecureKeyAsync(
-      clientInfoKey(this.serverId),
-      JSON.stringify(info),
-    );
-    if (!ok) {
-      log.warn(
-        { serverId: this.serverId },
-        "Failed to persist OAuth client information to secure storage",
+    await this.credentialFence.write(async () => {
+      const ok = await setSecureKeyAsync(
+        clientInfoKey(this.serverId),
+        JSON.stringify(info),
       );
-      return;
-    }
-
-    // Record what the registration was made against, so a later run can tell
-    // whether reusing it is still valid.
-    if (this._redirectUrl) {
-      const binding: ClientRegistrationBinding = {
-        issuer: await this.currentIssuer(),
-        redirectUri: this._redirectUrl,
-      };
-      const boundOk = await setSecureKeyAsync(
-        clientBindingKey(this.serverId),
-        JSON.stringify(binding),
-      );
-      if (!boundOk) {
+      if (!ok) {
         log.warn(
           { serverId: this.serverId },
-          "Failed to persist OAuth client binding; the registration will be remade on the next flow",
+          "Failed to persist OAuth client information to secure storage",
+        );
+        throw new Error(
+          "Failed to save OAuth client information; retry connecting",
         );
       }
-    }
 
-    log.info({ serverId: this.serverId }, "OAuth client information saved");
+      // Record what the registration was made against, so a later run can tell
+      // whether reusing it is still valid.
+      if (this._redirectUrl) {
+        const binding: ClientRegistrationBinding = {
+          issuer: await this.currentIssuer(),
+          redirectUri: this._redirectUrl,
+        };
+        const boundOk = await setSecureKeyAsync(
+          clientBindingKey(this.serverId),
+          JSON.stringify(binding),
+        );
+        if (!boundOk) {
+          log.warn(
+            { serverId: this.serverId },
+            "Failed to persist OAuth client binding; the registration will be remade on the next flow",
+          );
+          throw new Error(
+            "Failed to save OAuth client binding; retry connecting",
+          );
+        }
+      }
+
+      log.info({ serverId: this.serverId }, "OAuth client information saved");
+    });
   }
 
   /** Issuer of the authorization server currently in play, when known. */
@@ -422,16 +453,19 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
-    const ok = await setSecureKeyAsync(
-      discoveryKey(this.serverId),
-      JSON.stringify(state),
-    );
-    if (!ok) {
-      log.warn(
-        { serverId: this.serverId },
-        "Failed to persist OAuth discovery state to secure storage",
+    await this.credentialFence.write(async () => {
+      const ok = await setSecureKeyAsync(
+        discoveryKey(this.serverId),
+        JSON.stringify(state),
       );
-    }
+      if (!ok) {
+        log.warn(
+          { serverId: this.serverId },
+          "Failed to persist OAuth discovery state to secure storage",
+        );
+        throw new Error("Failed to save OAuth discovery; retry connecting");
+      }
+    });
   }
 
   // --- Redirect to Authorization ---
@@ -446,9 +480,12 @@ export class McpOAuthProvider implements OAuthClientProvider {
       const sdkState = authorizationUrl.searchParams.get("state");
       if (sdkState) {
         // Dynamic import to avoid circular deps
-        const { registerPendingCallback } =
+        const { registerPendingCallback, consumeCallbackError } =
           await import("../security/oauth-callback-registry.js");
         registerPendingCallback(sdkState, this._codeResolve, this._codeReject);
+        this.cancelRegisteredCallback = () => {
+          consumeCallbackError(sdkState, "MCP OAuth callback cancelled");
+        };
         log.info(
           { serverId: this.serverId, state: sdkState },
           "MCP OAuth callback registered with SDK state",
@@ -492,61 +529,63 @@ export class McpOAuthProvider implements OAuthClientProvider {
   async invalidateCredentials(
     scope: "all" | "client" | "tokens" | "verifier" | "discovery",
   ): Promise<void> {
-    log.info(
-      { serverId: this.serverId, scope },
-      "Invalidating OAuth credentials",
-    );
+    await this.credentialFence.write(async () => {
+      log.info(
+        { serverId: this.serverId, scope },
+        "Invalidating OAuth credentials",
+      );
 
-    if (scope === "all" || scope === "tokens") {
-      const result = await deleteSecureKeyAsync(tokensKey(this.serverId));
-      if (result === "error") {
-        log.warn(
-          { serverId: this.serverId },
-          "Failed to delete OAuth tokens from secure storage",
-        );
-      } else if (result === "not-found") {
-        log.debug(
-          { serverId: this.serverId },
-          "OAuth tokens key not found in secure storage (already removed)",
-        );
+      if (scope === "all" || scope === "tokens") {
+        const result = await deleteSecureKeyAsync(tokensKey(this.serverId));
+        if (result === "error") {
+          log.warn(
+            { serverId: this.serverId },
+            "Failed to delete OAuth tokens from secure storage",
+          );
+        } else if (result === "not-found") {
+          log.debug(
+            { serverId: this.serverId },
+            "OAuth tokens key not found in secure storage (already removed)",
+          );
+        }
       }
-    }
-    if (scope === "all" || scope === "client") {
-      const result = await deleteSecureKeyAsync(clientInfoKey(this.serverId));
-      if (result === "error") {
-        log.warn(
-          { serverId: this.serverId },
-          "Failed to delete OAuth client information from secure storage",
-        );
-      } else if (result === "not-found") {
-        log.debug(
-          { serverId: this.serverId },
-          "OAuth client information key not found in secure storage (already removed)",
-        );
+      if (scope === "all" || scope === "client") {
+        const result = await deleteSecureKeyAsync(clientInfoKey(this.serverId));
+        if (result === "error") {
+          log.warn(
+            { serverId: this.serverId },
+            "Failed to delete OAuth client information from secure storage",
+          );
+        } else if (result === "not-found") {
+          log.debug(
+            { serverId: this.serverId },
+            "OAuth client information key not found in secure storage (already removed)",
+          );
+        }
+        // The binding describes the registration being dropped, so it goes
+        // with it. Leaving it would let a later registration inherit the
+        // previous one's issuer and redirect URI.
+        await deleteSecureKeyAsync(clientBindingKey(this.serverId));
       }
-      // The binding describes the registration being dropped, so it goes
-      // with it. Leaving it would let a later registration inherit the
-      // previous one's issuer and redirect URI.
-      await deleteSecureKeyAsync(clientBindingKey(this.serverId));
-    }
-    if (scope === "all" || scope === "verifier") {
-      this._codeVerifier = undefined;
-      this._state = undefined;
-    }
-    if (scope === "all" || scope === "discovery") {
-      const result = await deleteSecureKeyAsync(discoveryKey(this.serverId));
-      if (result === "error") {
-        log.warn(
-          { serverId: this.serverId },
-          "Failed to delete OAuth discovery state from secure storage",
-        );
-      } else if (result === "not-found") {
-        log.debug(
-          { serverId: this.serverId },
-          "OAuth discovery state key not found in secure storage (already removed)",
-        );
+      if (scope === "all" || scope === "verifier") {
+        this._codeVerifier = undefined;
+        this._state = undefined;
       }
-    }
+      if (scope === "all" || scope === "discovery") {
+        const result = await deleteSecureKeyAsync(discoveryKey(this.serverId));
+        if (result === "error") {
+          log.warn(
+            { serverId: this.serverId },
+            "Failed to delete OAuth discovery state from secure storage",
+          );
+        } else if (result === "not-found") {
+          log.debug(
+            { serverId: this.serverId },
+            "OAuth discovery state key not found in secure storage (already removed)",
+          );
+        }
+      }
+    });
   }
 
   // --- Callback ---
@@ -599,11 +638,15 @@ export class McpOAuthProvider implements OAuthClientProvider {
     return this._codePromise;
   }
 
-  /**
-   * Abandon a prepared callback. Rejects the deferred promise so callers
-   * awaiting the code do not hang until the registry's own TTL fires.
-   */
+  close(): void {
+    this.credentialFence.close();
+    this.stopCallbackServer();
+  }
+
+  /** Reject the pending callback and remove its registry entry. */
   stopCallbackServer(): void {
+    this.cancelRegisteredCallback?.();
+    this.cancelRegisteredCallback = undefined;
     if (this._codeReject) {
       this._codeReject(new Error("MCP OAuth callback cancelled"));
       this._codeResolve = undefined;
@@ -630,7 +673,7 @@ export async function deleteMcpOAuthCredentials(
   serverId: string,
 ): Promise<{ ok: boolean; failedKeys: string[] }> {
   const [tokensResult, clientResult, bindingResult, discoveryResult] =
-    await Promise.all([
+    await Promise.allSettled([
       deleteSecureKeyAsync(tokensKey(serverId)),
       deleteSecureKeyAsync(clientInfoKey(serverId)),
       deleteSecureKeyAsync(clientBindingKey(serverId)),
@@ -643,7 +686,7 @@ export async function deleteMcpOAuthCredentials(
     { key: "discovery", result: discoveryResult },
   ];
   const failedKeys = results
-    .filter((r) => r.result === "error")
+    .filter((r) => r.result.status === "rejected" || r.result.value === "error")
     .map((r) => r.key);
   if (failedKeys.length > 0) {
     log.warn(

--- a/assistant/src/runtime/routes/__tests__/mcp-auth-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/mcp-auth-routes.test.ts
@@ -32,6 +32,14 @@ describe("mcp-auth route body validation", () => {
     ).rejects.toThrow(BadRequestError);
   });
 
+  test("internal_mcp_auth_cancel requires an attempt ID", async () => {
+    await expect(
+      routeFor("internal_mcp_auth_cancel").handler({
+        body: { serverId: "example" },
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
   test("internal_mcp_auth_revoke rejects a non-string serverId", async () => {
     await expect(
       routeFor("internal_mcp_auth_revoke").handler({

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -18,6 +18,14 @@ import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type { McpConfig, McpServerConfig } from "../../config/schemas/mcp.js";
 import { estimateToolDefinitionTokens } from "../../context/token-estimator.js";
 import { reloadMcpServers } from "../../daemon/mcp-reload-service.js";
+import {
+  beginMcpConnection,
+  cancelMcpConnectionAttempt,
+  McpTeardownError,
+  teardownMcpConnection,
+  withMcpConfigWrite,
+  withMcpServerOperation,
+} from "../../mcp/connection-lifecycle.js";
 import { getMcpServerManager } from "../../mcp/manager.js";
 import { orchestrateMcpOAuthConnect } from "../../mcp/mcp-auth-orchestrator.js";
 import { getMcpAuthState } from "../../mcp/mcp-auth-state.js";
@@ -26,10 +34,7 @@ import {
   getMcpHeaders,
   setMcpHeaders,
 } from "../../mcp/mcp-header-store.js";
-import {
-  deleteMcpOAuthCredentials,
-  hasMcpOAuthTokens,
-} from "../../mcp/mcp-oauth-provider.js";
+import { hasMcpOAuthTokens } from "../../mcp/mcp-oauth-provider.js";
 import { readPluginMcpServers } from "../../plugins/mcp-servers.js";
 import { getMcpToolsByServer } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
@@ -46,7 +51,11 @@ const log = getLogger("mcp-auth-routes");
 // `requestBody` (the OpenAPI/wire contract) and the handler's `parseBody`
 // call, so the advertised shape and the validated shape can't drift.
 
-const McpServerIdParams = z.object({ serverId: z.string() });
+const McpServerIdParams = z.object({ serverId: z.string().min(1) });
+const McpAuthCancelParams = z.object({
+  serverId: z.string().min(1),
+  attemptId: z.string().min(1),
+});
 
 const McpUpdateParams = z.object({
   name: z.string(),
@@ -71,44 +80,52 @@ async function handleMcpAuthStart({
 }): Promise<{
   auth_url: string;
   state: string;
+  attempt_id: string;
   already_authenticated?: boolean;
 }> {
   const { serverId } = parseBody(McpServerIdParams, body);
 
-  const raw = loadRawConfig();
-  const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
-  const serverConfig = servers[serverId];
+  return withMcpServerOperation(serverId, async () => {
+    const raw = loadRawConfig();
+    const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
+    const serverConfig = servers[serverId];
 
-  if (!serverConfig) {
-    throw new BadRequestError(`MCP server "${serverId}" not configured`);
-  }
+    if (!serverConfig) {
+      throw new BadRequestError(`MCP server "${serverId}" not configured`);
+    }
 
-  const transport = serverConfig.transport;
-  if (transport.type !== "sse" && transport.type !== "streamable-http") {
-    throw new BadRequestError(
-      `OAuth only supported for sse/streamable-http transports (server "${serverId}" uses ${transport.type})`,
-    );
-  }
+    const transport = serverConfig.transport;
+    if (transport.type !== "sse" && transport.type !== "streamable-http") {
+      throw new BadRequestError(
+        `OAuth only supported for sse/streamable-http transports (server "${serverId}" uses ${transport.type})`,
+      );
+    }
 
-  let result: { auth_url: string; already_authenticated?: boolean };
-  try {
-    result = await orchestrateMcpOAuthConnect({
-      serverId,
-      transport: {
-        url: transport.url,
-        type: transport.type,
-        headers: transport.headers,
-      },
-    });
-  } catch (err) {
-    throw new InternalError(err instanceof Error ? err.message : String(err));
-  }
+    let result: {
+      auth_url: string;
+      attempt_id: string;
+      already_authenticated?: boolean;
+    };
+    try {
+      result = await orchestrateMcpOAuthConnect({
+        serverId,
+        transport: {
+          url: transport.url,
+          type: transport.type,
+          headers: transport.headers,
+        },
+      });
+    } catch (err) {
+      throw new InternalError(err instanceof Error ? err.message : String(err));
+    }
 
-  return {
-    auth_url: result.auth_url,
-    state: serverId,
-    already_authenticated: result.already_authenticated,
-  };
+    return {
+      auth_url: result.auth_url,
+      state: serverId,
+      attempt_id: result.attempt_id,
+      already_authenticated: result.already_authenticated,
+    };
+  });
 }
 
 function handleMcpAuthStatus({
@@ -116,9 +133,9 @@ function handleMcpAuthStatus({
 }: {
   pathParams?: Record<string, string>;
 }):
-  | { status: "pending"; auth_url: string }
-  | { status: "complete" }
-  | { status: "error"; error: string } {
+  | { status: "pending"; auth_url: string; attempt_id: string }
+  | { status: "complete"; attempt_id: string }
+  | { status: "error"; error: string; attempt_id: string } {
   const { serverId } = pathParams as { serverId: string };
   const state = getMcpAuthState(serverId);
 
@@ -127,12 +144,16 @@ function handleMcpAuthStatus({
   }
 
   if (state.status === "pending") {
-    return { status: "pending", auth_url: state.authUrl };
+    return {
+      status: "pending",
+      auth_url: state.authUrl,
+      attempt_id: state.attemptId,
+    };
   }
   if (state.status === "complete") {
-    return { status: "complete" };
+    return { status: "complete", attempt_id: state.attemptId };
   }
-  return { status: "error", error: state.error };
+  return { status: "error", error: state.error, attempt_id: state.attemptId };
 }
 
 /**
@@ -394,50 +415,56 @@ async function handleMcpUpdate({
 }): Promise<{ updated: true }> {
   const { name, headers } = parseBody(McpUpdateParams, body);
 
-  const raw = loadRawConfig();
-  const mcpConfig = raw.mcp as Record<string, unknown> | undefined;
-  const serverMap = mcpConfig?.servers as
-    | Record<string, Record<string, unknown>>
-    | undefined;
+  return withMcpServerOperation(name, () =>
+    withMcpConfigWrite(async () => {
+      const raw = loadRawConfig();
+      const mcpConfig = raw.mcp as Record<string, unknown> | undefined;
+      const serverMap = mcpConfig?.servers as
+        | Record<string, Record<string, unknown>>
+        | undefined;
 
-  if (!serverMap || !serverMap[name]) {
-    throw new NotFoundError(`MCP server "${name}" not found.`);
-  }
+      if (!serverMap || !serverMap[name]) {
+        throw new NotFoundError(`MCP server "${name}" not found.`);
+      }
 
-  const server = serverMap[name];
+      const server = serverMap[name];
 
-  if (headers !== undefined) {
-    const transport = server.transport as Record<string, unknown> | undefined;
-    if (
-      transport &&
-      (transport.type === "sse" || transport.type === "streamable-http")
-    ) {
-      // Migrate any legacy config-level headers away
-      delete transport.headers;
+      if (headers !== undefined) {
+        const transport = server.transport as
+          | Record<string, unknown>
+          | undefined;
+        if (
+          transport &&
+          (transport.type === "sse" || transport.type === "streamable-http")
+        ) {
+          // Migrate any legacy config-level headers away
+          delete transport.headers;
 
-      // Store in credential store (or delete if clearing)
-      if (headers === null || Object.keys(headers).length === 0) {
-        const ok = await deleteMcpHeaders(name);
-        if (!ok) {
-          throw new InternalError(
-            "Failed to clear auth headers from credential store",
-          );
-        }
-      } else {
-        const ok = await setMcpHeaders(name, headers);
-        if (!ok) {
-          throw new InternalError(
-            "Failed to persist auth headers to credential store",
-          );
+          // Store in credential store (or delete if clearing)
+          if (headers === null || Object.keys(headers).length === 0) {
+            const ok = await deleteMcpHeaders(name);
+            if (!ok) {
+              throw new InternalError(
+                "Failed to clear auth headers from credential store",
+              );
+            }
+          } else {
+            const ok = await setMcpHeaders(name, headers);
+            if (!ok) {
+              throw new InternalError(
+                "Failed to persist auth headers to credential store",
+              );
+            }
+          }
         }
       }
-    }
-  }
 
-  saveRawConfig(raw);
-  triggerReload("internal_mcp_update");
+      saveRawConfig(raw);
+      triggerReload("internal_mcp_update");
 
-  return { updated: true };
+      return { updated: true };
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -477,40 +504,45 @@ async function handleMcpAdd({
       );
   }
 
-  const raw = loadRawConfig();
-  if (!raw.mcp) {
-    raw.mcp = { servers: {} };
-  }
-  const mcpConfig = raw.mcp as Record<string, unknown>;
-  if (!mcpConfig.servers) {
-    mcpConfig.servers = {};
-  }
-  const serverMap = mcpConfig.servers as Record<string, unknown>;
+  return withMcpServerOperation(name, () =>
+    withMcpConfigWrite(async () => {
+      const raw = loadRawConfig();
+      if (!raw.mcp) {
+        raw.mcp = { servers: {} };
+      }
+      const mcpConfig = raw.mcp as Record<string, unknown>;
+      if (!mcpConfig.servers) {
+        mcpConfig.servers = {};
+      }
+      const serverMap = mcpConfig.servers as Record<string, unknown>;
 
-  if (serverMap[name]) {
-    throw new BadRequestError(
-      `MCP server "${name}" already exists. Remove it first with: assistant mcp remove ${name}`,
-    );
-  }
+      if (serverMap[name]) {
+        throw new BadRequestError(
+          `MCP server "${name}" already exists. Remove it first with: assistant mcp remove ${name}`,
+        );
+      }
 
-  serverMap[name] = {
-    transport,
-  };
+      await beginMcpConnection(name);
+      serverMap[name] = {
+        transport,
+      };
 
-  // Store auth headers in credential store, not config
-  if (headers && Object.keys(headers).length > 0) {
-    const ok = await setMcpHeaders(name, headers);
-    if (!ok) {
-      throw new InternalError(
-        "Failed to persist auth headers to credential store",
-      );
-    }
-  }
+      // Store auth headers in credential store, not config
+      if (headers && Object.keys(headers).length > 0) {
+        const ok = await setMcpHeaders(name, headers);
+        if (!ok) {
+          throw new InternalError(
+            "Failed to persist auth headers to credential store",
+          );
+        }
+      }
 
-  saveRawConfig(raw);
-  triggerReload("internal_mcp_add");
+      saveRawConfig(raw);
+      triggerReload("internal_mcp_add");
 
-  return { added: true };
+      return { added: true };
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -523,37 +555,42 @@ async function handleMcpAuthRevoke({
   body?: Record<string, unknown>;
 }): Promise<{ revoked: true }> {
   const { serverId } = parseBody(McpServerIdParams, body);
-
-  const raw = loadRawConfig();
-  const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
-  const serverConfig = servers[serverId];
-
-  if (!serverConfig) {
-    throw new NotFoundError(`MCP server "${serverId}" not found`);
-  }
-
-  let result: { ok: boolean; failedKeys: string[] };
-  try {
-    result = await deleteMcpOAuthCredentials(serverId);
-  } catch (err) {
-    throw new InternalError(
-      `Failed to revoke OAuth credentials: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
-
-  if (!result.ok) {
-    throw new InternalError(
-      `Failed to delete OAuth credentials for keys: ${result.failedKeys.join(", ")}`,
-    );
-  }
-
-  triggerReload("internal_mcp_auth_revoke");
-  return { revoked: true };
+  return withMcpServerOperation(serverId, async () => {
+    const raw = loadRawConfig();
+    const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
+    if (!Object.hasOwn(servers, serverId)) {
+      throw new NotFoundError(`MCP server "${serverId}" not found`);
+    }
+    try {
+      await teardownMcpConnection(serverId, { removeConfig: false });
+    } catch (err) {
+      throw new InternalError(err instanceof Error ? err.message : String(err));
+    }
+    return { revoked: true };
+  });
 }
 
-// ---------------------------------------------------------------------------
-// Remove
-// ---------------------------------------------------------------------------
+async function handleMcpAuthCancel({
+  body,
+}: {
+  body?: Record<string, unknown>;
+}): Promise<{ cancelled: boolean }> {
+  const { serverId, attemptId } = parseBody(McpAuthCancelParams, body);
+  return withMcpServerOperation(serverId, async () => {
+    const raw = loadRawConfig();
+    const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
+    if (!Object.hasOwn(servers, serverId)) {
+      throw new NotFoundError(`MCP server "${serverId}" not found`);
+    }
+    try {
+      return {
+        cancelled: await cancelMcpConnectionAttempt(serverId, attemptId),
+      };
+    } catch (err) {
+      throw new InternalError(err instanceof Error ? err.message : String(err));
+    }
+  });
+}
 
 async function handleMcpRemove({
   body,
@@ -561,36 +598,39 @@ async function handleMcpRemove({
   body?: Record<string, unknown>;
 }): Promise<{ removed: true }> {
   const { name } = parseBody(McpRemoveParams, body);
-
-  const raw = loadRawConfig();
-  const mcpConfig = raw.mcp as Record<string, unknown> | undefined;
-  const serverMap = mcpConfig?.servers as Record<string, unknown> | undefined;
-
-  if (!serverMap || !serverMap[name]) {
-    throw new NotFoundError(`MCP server "${name}" not found.`);
-  }
-
-  // Best-effort cleanup of credentials stored for this server
-  const serverConfig = serverMap[name] as Record<string, unknown>;
-  const transport = serverConfig?.transport as
-    | Record<string, unknown>
-    | undefined;
-  if (transport?.type === "sse" || transport?.type === "streamable-http") {
-    try {
-      await Promise.all([
-        deleteMcpOAuthCredentials(name),
-        deleteMcpHeaders(name),
-      ]);
-    } catch {
-      // Ignore — credentials may not exist
+  return withMcpServerOperation(name, async () => {
+    const raw = loadRawConfig();
+    const servers = (raw.mcp as Partial<McpConfig> | undefined)?.servers ?? {};
+    if (!Object.hasOwn(servers, name)) {
+      if (
+        readPluginMcpServers().servers.some((server) => server.id === name) &&
+        !getMcpServerManager().hasWorkspaceConnection(name)
+      ) {
+        throw new NotFoundError(`Workspace MCP server "${name}" not found`);
+      }
+      try {
+        const reload = await reloadMcpServers({ requireCleanup: true });
+        if (!reload.success) {
+          throw new Error(reload.error);
+        }
+      } catch {
+        throw new InternalError(
+          "Removal was saved, but runtime cleanup failed; retry removing the integration",
+        );
+      }
+      return { removed: true };
     }
-  }
-
-  delete serverMap[name];
-  saveRawConfig(raw);
-  triggerReload("internal_mcp_remove");
-
-  return { removed: true };
+    try {
+      await teardownMcpConnection(name, { removeConfig: true });
+    } catch (err) {
+      const message =
+        err instanceof McpTeardownError
+          ? err.message
+          : "Credential cleanup failed; the integration was kept so you can retry disconnecting";
+      throw new InternalError(message);
+    }
+    return { removed: true };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -611,6 +651,12 @@ export const ROUTES: RouteDefinition[] = [
       "Starts a daemon-owned MCP OAuth flow and returns the authorization URL for the CLI to open in the browser.",
     tags: ["internal"],
     requestBody: McpServerIdParams,
+    responseBody: z.object({
+      auth_url: z.string(),
+      state: z.string(),
+      attempt_id: z.string(),
+      already_authenticated: z.boolean().optional(),
+    }),
     handler: handleMcpAuthStart,
   },
   {
@@ -629,7 +675,36 @@ export const ROUTES: RouteDefinition[] = [
     additionalResponses: {
       "404": { description: "No active OAuth flow for the given serverId" },
     },
+    responseBody: z.discriminatedUnion("status", [
+      z.object({
+        status: z.literal("pending"),
+        auth_url: z.string(),
+        attempt_id: z.string(),
+      }),
+      z.object({ status: z.literal("complete"), attempt_id: z.string() }),
+      z.object({
+        status: z.literal("error"),
+        error: z.string(),
+        attempt_id: z.string(),
+      }),
+    ]),
     handler: handleMcpAuthStatus,
+  },
+  {
+    operationId: "internal_mcp_auth_cancel",
+    endpoint: "internal/mcp/auth/cancel",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Cancel an MCP authorization attempt",
+    description:
+      "Cancels only the pending attempt matching the supplied attempt ID and clears its OAuth credentials.",
+    tags: ["internal"],
+    requestBody: McpAuthCancelParams,
+    responseBody: z.object({ cancelled: z.boolean() }),
+    handler: handleMcpAuthCancel,
   },
   {
     operationId: "internal_mcp_reload",

--- a/assistant/src/security/credential-completion.ts
+++ b/assistant/src/security/credential-completion.ts
@@ -1,0 +1,14 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const completionRequired = new AsyncLocalStorage<true>();
+
+/** A mutation lock must remain held until its credential operation settles. */
+export function withCredentialCompletion<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  return completionRequired.run(true, operation);
+}
+
+export function requiresCredentialCompletion(): boolean {
+  return completionRequired.getStore() === true;
+}

--- a/assistant/src/security/secure-keys.ts
+++ b/assistant/src/security/secure-keys.ts
@@ -54,6 +54,7 @@ import {
   createEncryptedStoreBackend,
   createUnavailableBackend,
 } from "./credential-backend.js";
+import { requiresCredentialCompletion } from "./credential-completion.js";
 import { credentialKey } from "./credential-key.js";
 
 export type {
@@ -164,9 +165,8 @@ async function attachCredentialRecordBackend(
   client: CesClient | undefined,
 ): Promise<void> {
   const { CesRpcRecordBackend } = await import("./ces-rpc-record-backend.js");
-  const { setCredentialRecordBackend } = await import(
-    "../tools/credentials/metadata-store.js"
-  );
+  const { setCredentialRecordBackend } =
+    await import("../tools/credentials/metadata-store.js");
   if (!client) {
     setCredentialRecordBackend(undefined);
     return;
@@ -596,6 +596,9 @@ async function withCredentialTimeout<T>(
   op: () => Promise<T>,
   fallback: T,
 ): Promise<T> {
+  if (requiresCredentialCompletion()) {
+    return op();
+  }
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
       log.warn(CREDENTIAL_TIMEOUT_MSG + " — returning fallback");


### PR DESCRIPTION
Disconnect removes workspace MCP configuration only after local OAuth/header cleanup succeeds, closes live transports with retryable failures, and prevents superseded authentication from restoring credentials. Authentication responses advertise an attempt ID and a scoped cancellation operation so an old dialog cannot cancel a newer connection attempt.

Credential writes and cleanup share a process-safe generation fence, while queued reloads converge on the latest config. Existing revoke/API/CLI interfaces remain compatible. Existing installed-plugin ownership and credential isolation are preserved.

Validation: 103 scoped tests across 16 isolated runs passed, followed by an independent review and a regression for failed tool discovery plus failed transport close. Typecheck, lint, and regenerated OpenAPI checks are included.

Review focus: credential fencing, callback cancellation, cleanup retries, and reload convergence. Risk is moderate because this changes connection lifecycle. Local cleanup does not revoke the provider-side grant. Worker shutdown uses the existing unacknowledged reload signal; an already-dispatched CES write whose acknowledgement is lost requires CES-side generation support for a fully atomic guarantee.

Part of #42552. PR 1 of 8 targeting `codex/integrations-qa`; earlier commits in this QA stack disappear from the diff as they merge.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->