### PR TITLE
Connect catalog integrations with stable identity and sync

### DIFF
--- a/assistant/docs/architecture/integrations.md
+++ b/assistant/docs/architecture/integrations.md
@@ -1,6 +1,28 @@
 # Integrations Architecture
 
-OAuth, messaging adapters, script proxy, and conversation disk view architecture.
+OAuth, MCP connections, messaging adapters, script proxy, and conversation disk view architecture.
+
+## MCP catalog and connection identity
+
+The assistant serves a bundled, reviewed catalog through the existing gateway route table. `plugin.json` and `mcp.json` use the Agent Plugins 1.0.0 schemas; the supplemental index supplies display metadata and setup prerequisites. Listing catalog or configured entries performs no connection probes or package execution.
+
+```mermaid
+flowchart LR
+    Packages[Standard plugin.json and mcp.json] --> Bundle[Validated bundled catalog]
+    Bundle --> Read[GET internal/mcp/catalog]
+    Read --> UI[Integrations list]
+    UI --> Connect[POST internal/mcp/catalog/connect]
+    Connect --> Config[Workspace instance and provenance]
+    Config --> Runtime[MCP manager]
+    Runtime --> Sync[sync_changed mcp:list]
+    Sync --> UI
+```
+
+Connect accepts a reviewed catalog ID, server key, and definition digest. A serialized config write creates one stable instance with provenance or returns the existing instance for that catalog selection. A catalog refresh never substitutes the endpoint of an existing connection. Migration 155 marks existing workspace entries with null provenance without inferring provider identity or rewriting transports. A definition removed from the catalog leaves its saved connection configurable and removable.
+
+The catalog path is separate from installed plugins. Existing plugin loading, installation, update reconciliation, credentials, and storage retain their current behavior. Plugin-owned MCP rows remain managed by their owning plugin and do not borrow workspace credentials. [MCP lifecycle](mcp-lifecycle.md) describes cleanup, cancellation, ownership, and the limits of cross-process coordination.
+
+The `mcp:list` invalidation tag refreshes assistant-scoped rows and open tool details. Config/plugin changes and reconnect catch-up invalidate the same keys; unopened tool details are marked stale without fetching their schemas.
 
 ## Integrations — OAuth2 + Unified Messaging
 

--- a/assistant/docs/architecture/mcp-lifecycle.md
+++ b/assistant/docs/architecture/mcp-lifecycle.md
@@ -54,6 +54,18 @@ be reclaimed atomically; a live owner is never stolen on timeout. PID reuse can
 conservatively block an operation, which fails with a retryable error. Handles
 are closed after each operation.
 
+This is coordination among cooperating assistant processes, not an access-control
+boundary. Workspace writers can change or delete the file, defeating the ordering
+guarantee or blocking operations. Credential access remains subject to CES policy;
+the coordination metadata neither grants access nor protects against a malicious
+workspace writer. The repository's trusted host/pod process model applies here.
+
+The file is local runtime metadata and remains across ordinary restarts so live
+workers share the same generations. Workspace exports exclude `signals`, and a
+fresh instance creates fresh metadata. No existing user data or schema is
+converted. Do not delete or replace the file while the assistant or its workers
+are running; maintenance cleanup requires stopping all of them first.
+
 A scoped credential-completion context prevents the secure-key wrapper's outer
 deadline from releasing a mutation lock while its underlying promise still
 runs. Lock acquisition is bounded, so a blocked writer prevents a later remove
@@ -64,6 +76,8 @@ pending/complete/error vocabulary and also returns `attempt_id`. Cancel takes
 `{serverId, attemptId}` and only cancels a matching pending attempt. It closes
 the callback, fences writes, clears that attempt's OAuth records, and keeps
 configuration for retry. A stale cancellation returns `{cancelled: false}`.
+CLI polling requires a matching status ID when start advertised an attempt ID;
+older assistants that omit it retain their existing polling behavior.
 
 ## Acknowledgement boundaries
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18473,6 +18473,144 @@ paths:
                 type: object
         "404":
           description: No active OAuth flow for the given serverId
+  /v1/internal/mcp/catalog:
+    get:
+      operationId: internal_mcp_catalog_get
+      summary: List known MCP integrations
+      description: Reads bundled standard integration definitions without connecting servers or installing plugins.
+      tags:
+        - internal
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  supportsConnect:
+                    type: boolean
+                    const: true
+                  entries:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+                        serverKey:
+                          type: string
+                          minLength: 1
+                        displayName:
+                          type: string
+                          minLength: 1
+                        description:
+                          type: string
+                          minLength: 1
+                        documentationUrl:
+                          type: string
+                          format: uri
+                        verifiedAt:
+                          type: string
+                          format: date
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))$
+                        verification:
+                          type: string
+                          enum:
+                            - documentation-only
+                            - tested
+                        setup:
+                          type: object
+                          properties:
+                            mode:
+                              type: string
+                              enum:
+                                - oauth
+                                - manual
+                            instructions:
+                              type: string
+                          required:
+                            - mode
+                          additionalProperties: false
+                        oauthProvider:
+                          type: string
+                          minLength: 1
+                        icon:
+                          type: string
+                          pattern: ^[a-z0-9-]+$
+                        definitionDigest:
+                          type: string
+                        documents:
+                          type: object
+                          properties:
+                            plugin: {}
+                            mcp: {}
+                          required:
+                            - plugin
+                          additionalProperties: false
+                      required:
+                        - id
+                        - serverKey
+                        - displayName
+                        - description
+                        - documentationUrl
+                        - verifiedAt
+                        - verification
+                        - setup
+                        - definitionDigest
+                        - documents
+                      additionalProperties: false
+                required:
+                  - supportsConnect
+                  - entries
+                additionalProperties: false
+  /v1/internal/mcp/catalog/connect:
+    post:
+      operationId: internal_mcp_catalog_connect_post
+      summary: Create a connection from a known MCP definition
+      description: Reuses a saved catalog connection or creates one with stable identity and separate credentials.
+      tags:
+        - internal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                catalogId:
+                  type: string
+                  minLength: 1
+                serverKey:
+                  type: string
+                  minLength: 1
+                definitionDigest:
+                  type: string
+                  pattern: ^[0-9a-f]{64}$
+                setupAcknowledged:
+                  type: boolean
+              required:
+                - catalogId
+                - serverKey
+                - definitionDigest
+              additionalProperties: false
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  serverId:
+                    type: string
+                  created:
+                    type: boolean
+                required:
+                  - serverId
+                  - created
+                additionalProperties: false
   /v1/internal/mcp/list:
     get:
       operationId: internal_mcp_list_get
@@ -18546,6 +18684,25 @@ paths:
                           additionalProperties: {}
                         hasOAuth:
                           type: boolean
+                        catalog:
+                          anyOf:
+                            - type: object
+                              properties:
+                                id:
+                                  type: string
+                                  minLength: 1
+                                serverKey:
+                                  type: string
+                                  minLength: 1
+                                definitionDigest:
+                                  type: string
+                                  pattern: ^[0-9a-f]{64}$
+                              required:
+                                - id
+                                - serverKey
+                                - definitionDigest
+                              additionalProperties: false
+                            - type: "null"
                       required:
                         - id
                         - status

--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -516,7 +516,7 @@ describe("assistant mcp reload", () => {
   });
 });
 
-describe("assistant mcp auth — IPC path", () => {
+describe("assistant mcp auth - IPC path", () => {
   beforeAll(() => {
     testDataDir = join(
       tmpdir(),
@@ -636,6 +636,56 @@ describe("assistant mcp auth — IPC path", () => {
 
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Authentication successful");
+  });
+
+  test("polling completes when status matches the advertised attempt", async () => {
+    mockCliIpcCallFn = mock((method) =>
+      Promise.resolve({
+        ok: true,
+        result:
+          method === "internal_mcp_auth_start"
+            ? {
+                auth_url: "https://auth.example.com",
+                state: "srv",
+                attempt_id: "attempt-1",
+              }
+            : { status: "complete", attempt_id: "attempt-1" },
+      }),
+    );
+
+    const { exitCode, stdout } = await runMcp("auth", ["srv"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Authentication successful");
+  });
+
+  test.each([
+    { status: "pending", attempt_id: "attempt-2" },
+    { status: "complete", attempt_id: "attempt-2" },
+    { status: "error", attempt_id: "attempt-2", error: "access_denied" },
+    { status: "complete" },
+  ])("does not adopt status from an unverified attempt: %j", async (status) => {
+    mockCliIpcCallFn = mock((method) =>
+      Promise.resolve({
+        ok: true,
+        result:
+          method === "internal_mcp_auth_start"
+            ? {
+                auth_url: "https://auth.example.com",
+                state: "srv",
+                attempt_id: "attempt-1",
+              }
+            : status,
+      }),
+    );
+
+    const { exitCode, stdout, stderr } = await runMcp("auth", ["srv"]);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).not.toContain("Authentication successful");
+    expect(stderr).toContain("OAuth attempt changed or could not be verified");
+    expect(stderr).toContain("assistant mcp auth srv");
+    expect(mockCliIpcCallFn).toHaveBeenCalledTimes(2);
   });
 
   test("polling error → exits 1 with error message", async () => {

--- a/assistant/src/__tests__/mcp-client-auth.test.ts
+++ b/assistant/src/__tests__/mcp-client-auth.test.ts
@@ -25,6 +25,9 @@ mock.module("../config/env-registry.js", () => ({
   checkUnrecognizedEnvVars: () => [],
 }));
 
+const publishMcpChanged = mock(async () => {});
+mock.module("../mcp/sync.js", () => ({ publishMcpChanged }));
+
 const { McpClient } = await import("../mcp/client.js");
 const { McpOAuthProvider } = await import("../mcp/mcp-oauth-provider.js");
 
@@ -171,4 +174,26 @@ describe("McpClient cleanup failures", () => {
     fails = false;
     await client.disconnect({ requireCleanup: true });
   });
+});
+
+test("an unexpected SDK close invalidates the connected row and closes its credential fence", async () => {
+  const client = new McpClient("example");
+  const internal = client as unknown as {
+    client: { connect: () => Promise<void>; onclose: () => void };
+    createTransport: () => unknown;
+    oauthProvider?: { close: () => void };
+  };
+  internal.client.connect = async () => {};
+  internal.createTransport = () => ({});
+  await client.connect(httpTransport);
+  expect(client.isConnected).toBe(true);
+  const close = mock(() => {});
+  internal.oauthProvider = { close };
+  publishMcpChanged.mockClear();
+  internal.client.onclose();
+  expect(client.isConnected).toBe(false);
+  expect(close).toHaveBeenCalledTimes(1);
+  expect(publishMcpChanged).toHaveBeenCalledTimes(1);
+  internal.client.onclose();
+  expect(publishMcpChanged).toHaveBeenCalledTimes(1);
 });

--- a/assistant/src/__tests__/mcp-health-check.test.ts
+++ b/assistant/src/__tests__/mcp-health-check.test.ts
@@ -126,4 +126,28 @@ describe("passive runtime state (via internal_mcp_list route)", () => {
       lifecycleState: "connecting",
     });
   });
+  test("returns saved catalog provenance without inferring identity for custom entries", async () => {
+    const catalog = {
+      id: "example",
+      serverKey: "example",
+      definitionDigest: "a".repeat(64),
+    };
+    const transport = {
+      type: "streamable-http",
+      url: "https://example.com/mcp",
+    };
+    setConfig("mcp", {
+      servers: { saved: { transport, catalog }, custom: { transport } },
+    });
+    const result = (await listHandler({})) as {
+      servers: { id: string; catalog: unknown }[];
+    };
+    expect(
+      result.servers.find((server) => server.id === "saved")?.catalog,
+    ).toEqual(catalog);
+    expect(
+      result.servers.find((server) => server.id === "custom")?.catalog,
+    ).toBeNull();
+    expect(mockConnect).not.toHaveBeenCalled();
+  });
 });

--- a/assistant/src/__tests__/workspace-migration-mcp-catalog-provenance.test.ts
+++ b/assistant/src/__tests__/workspace-migration-mcp-catalog-provenance.test.ts
@@ -1,0 +1,96 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { McpConfigSchema } from "../config/schemas/mcp.js";
+import { mcpCatalogProvenanceMigration as migration } from "../workspace/migrations/155-mcp-catalog-provenance.js";
+
+describe("catalog provenance migration", () => {
+  test("preserves legacy IDs/transports and existing provenance on repeated runs", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "mcp-provenance-"));
+    const configPath = join(workspace, "config.json");
+    const legacy = {
+      transport: {
+        type: "sse" as const,
+        url: "https://example.com/mcp",
+        headers: { "X-Example": "example-value" },
+      },
+    };
+    const catalog = {
+      transport: {
+        type: "streamable-http" as const,
+        url: "https://example.org/mcp",
+      },
+      catalog: {
+        id: "example",
+        serverKey: "example",
+        definitionDigest: "a".repeat(64),
+      },
+    };
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcp: {
+          servers: { "existing-id": legacy, "catalog-instance": catalog },
+        },
+      }),
+    );
+    migration.run(workspace);
+    const once = readFileSync(configPath, "utf8");
+    migration.run(workspace);
+    expect(readFileSync(configPath, "utf8")).toBe(once);
+    const mcp = McpConfigSchema.parse(JSON.parse(once).mcp);
+    expect(mcp.servers["existing-id"]).toEqual({ ...legacy, catalog: null });
+    expect(mcp.servers["catalog-instance"]).toEqual(catalog);
+    expect(Object.keys(mcp.servers)).toEqual([
+      "existing-id",
+      "catalog-instance",
+    ]);
+  });
+
+  test("does not change an absent or malformed configuration", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "mcp-provenance-"));
+    expect(() => migration.run(workspace)).not.toThrow();
+    const configPath = join(workspace, "config.json");
+    writeFileSync(configPath, "{invalid");
+    migration.run(workspace);
+    expect(readFileSync(configPath, "utf8")).toBe("{invalid");
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "preserves config permissions when retrying an interrupted temporary write",
+    () => {
+      const workspace = mkdtempSync(join(tmpdir(), "mcp-provenance-mode-"));
+      const configPath = join(workspace, "config.json");
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          mcp: {
+            servers: {
+              example: {
+                transport: { type: "sse", url: "https://example.com/mcp" },
+              },
+            },
+          },
+        }),
+      );
+      chmodSync(configPath, 0o600);
+      const temporary = `${configPath}.migration-155.tmp`;
+      writeFileSync(temporary, "interrupted write");
+      chmodSync(temporary, 0o644);
+      migration.run(workspace);
+      expect(statSync(configPath).mode & 0o777).toBe(0o600);
+      expect(
+        JSON.parse(readFileSync(configPath, "utf8")).mcp.servers.example
+          .catalog,
+      ).toBeNull();
+    },
+  );
+});

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -32,17 +32,28 @@ interface McpServerEntry {
 
 async function pollMcpAuthStatus(
   serverId: string,
-  options: { intervalMs: number; timeoutMs: number },
+  options: { intervalMs: number; timeoutMs: number; attemptId?: string },
 ): Promise<{ status: "complete" | "error"; error?: string }> {
   const deadline = Date.now() + options.timeoutMs;
   while (Date.now() < deadline) {
     await new Promise<void>((resolve) =>
       setTimeout(resolve, options.intervalMs),
     );
-    const result = await cliIpcCall<{ status: string; error?: string }>(
-      "internal_mcp_auth_status",
-      { pathParams: { serverId } },
-    );
+    const result = await cliIpcCall<{
+      status: string;
+      error?: string;
+      attempt_id?: string;
+    }>("internal_mcp_auth_status", { pathParams: { serverId } });
+    if (
+      result.ok &&
+      options.attemptId !== undefined &&
+      result.result?.attempt_id !== options.attemptId
+    ) {
+      return {
+        status: "error",
+        error: `OAuth attempt changed or could not be verified. Run 'assistant mcp auth ${serverId}' to retry.`,
+      };
+    }
     if (result.ok && result.result?.status === "complete") {
       return { status: "complete" };
     }
@@ -229,10 +240,11 @@ export function registerMcpCommand(program: Command): void {
         );
 
       subcommand(mcp, "auth").action(async (name: string) => {
-        // IPC-first path — attempt daemon-orchestrated flow (works on hosted assistants)
+        // The assistant owns browser authorization, including on hosted instances.
         const startResult = await cliIpcCall<{
           auth_url: string;
           state: string;
+          attempt_id?: string;
           already_authenticated?: boolean;
         }>("internal_mcp_auth_start", { body: { serverId: name } });
 
@@ -252,6 +264,7 @@ export function registerMcpCommand(program: Command): void {
           );
 
           const finalStatus = await pollMcpAuthStatus(name, {
+            attemptId: startResult.result.attempt_id,
             intervalMs: 2_000,
             timeoutMs: 150_000, // matches existing OAUTH_TIMEOUT_MS
           });

--- a/assistant/src/config/schemas/mcp.ts
+++ b/assistant/src/config/schemas/mcp.ts
@@ -55,9 +55,7 @@ const McpSseTransportSchema = z
       .optional()
       .describe("Custom HTTP headers sent with SSE requests"),
   })
-  .describe(
-    "SSE transport: connects to an MCP server over Server-Sent Events",
-  );
+  .describe("SSE transport: connects to an MCP server over Server-Sent Events");
 
 const McpStreamableHttpTransportSchema = z
   .object({
@@ -83,6 +81,14 @@ export const McpTransportSchema = z.discriminatedUnion("type", [
 export const McpServerConfigSchema = z
   .object({
     transport: McpTransportSchema,
+    catalog: z
+      .object({
+        id: z.string().min(1),
+        serverKey: z.string().min(1),
+        definitionDigest: z.string().regex(/^[0-9a-f]{64}$/),
+      })
+      .nullable()
+      .optional(),
   })
   .describe("Configuration for an individual MCP server");
 

--- a/assistant/src/daemon/__tests__/mcp-reload-convergence.test.ts
+++ b/assistant/src/daemon/__tests__/mcp-reload-convergence.test.ts
@@ -32,6 +32,8 @@ mock.module("../../plugins/mcp-servers.js", () => ({
   readPluginMcpServers: () => ({ servers: [], issues: [] }),
 }));
 const signal = mock(() => {});
+const publishMcpChanged = mock(async () => {});
+mock.module("../../mcp/sync.js", () => ({ publishMcpChanged }));
 mock.module("../../mcp/reload-signal.js", () => ({
   signalMcpReloaded: signal,
 }));
@@ -58,6 +60,7 @@ beforeEach(() => {
   strictStops.length = 0;
   stopHook = undefined;
   signal.mockClear();
+  publishMcpChanged.mockClear();
 });
 
 describe("MCP reload convergence", () => {
@@ -99,6 +102,51 @@ describe("MCP reload convergence", () => {
     const result = await reloadMcpServers();
     expect(result.success).toBe(true);
     expect(signal).toHaveBeenCalledTimes(1);
+    expect(publishMcpChanged).toHaveBeenCalledTimes(1);
     expect(result).not.toHaveProperty("workersStopped");
+  });
+
+  test("failed strict cleanup invalidates rows after runtime teardown settles", async () => {
+    configure(["example"]);
+    const stopped = deferred();
+    const release = deferred();
+    stopHook = async () => {
+      stopped.resolve();
+      await release.promise;
+      throw new Error("connection close failed");
+    };
+    const reload = reloadMcpServers({ requireCleanup: true });
+    await stopped.promise;
+    expect(publishMcpChanged).not.toHaveBeenCalled();
+    release.resolve();
+    expect(await reload).toEqual({
+      success: false,
+      error: "connection close failed",
+    });
+    expect(publishMcpChanged).toHaveBeenCalledTimes(1);
+    expect(signal).not.toHaveBeenCalled();
+    expect(starts).toEqual([]);
+  });
+
+  test("a request during completion starts a reload for the latest configuration", async () => {
+    configure(["initial"]);
+    let queued: Promise<unknown> | undefined;
+    const requested = deferred();
+    publishMcpChanged.mockImplementationOnce(async () => {
+      // Arrive between the final loop check and a separately chained cleanup.
+      queueMicrotask(() =>
+        queueMicrotask(() =>
+          queueMicrotask(() => {
+            configure(["latest"]);
+            queued = reloadMcpServers();
+            requested.resolve();
+          }),
+        ),
+      );
+    });
+    const initial = reloadMcpServers();
+    await requested.promise;
+    await Promise.all([initial, queued]);
+    expect(starts).toEqual([["initial"], ["latest"]]);
   });
 });

--- a/assistant/src/daemon/mcp-reload-service.ts
+++ b/assistant/src/daemon/mcp-reload-service.ts
@@ -13,6 +13,7 @@ import {
 import { getMcpServerManager } from "../mcp/manager.js";
 import { migrateLegacyMcpHeaders } from "../mcp/mcp-header-store.js";
 import { signalMcpReloaded } from "../mcp/reload-signal.js";
+import { publishMcpChanged } from "../mcp/sync.js";
 import { createMcpToolsFromServer } from "../tools/mcp/mcp-tool-factory.js";
 import { registerMcpTools, unregisterAllMcpTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -54,16 +55,18 @@ export function reloadMcpServers(
     return reloadInProgress;
   }
   reloadInProgress = (async () => {
-    let result: McpReloadResult;
-    do {
-      reloadQueued = false;
-      result = await doReload(requireCleanup);
-    } while (reloadQueued);
-    return result;
-  })().finally(() => {
-    reloadInProgress = null;
-    requireCleanup = false;
-  });
+    try {
+      let result: McpReloadResult;
+      do {
+        reloadQueued = false;
+        result = await doReload(requireCleanup);
+      } while (reloadQueued);
+      return result;
+    } finally {
+      reloadInProgress = null;
+      requireCleanup = false;
+    }
+  })();
   return reloadInProgress;
 }
 
@@ -91,6 +94,7 @@ export async function reconcilePluginMcpServers(): Promise<void> {
 }
 
 async function doReload(requireCleanup: boolean): Promise<McpReloadResult> {
+  let teardownStarted = false;
   try {
     const manager = getMcpServerManager();
 
@@ -110,6 +114,7 @@ async function doReload(requireCleanup: boolean): Promise<McpReloadResult> {
     const config = getConfig();
 
     // 2. Stop existing MCP servers + unregister their tools
+    teardownStarted = true;
     try {
       await manager.stop({ requireCleanup });
     } finally {
@@ -175,5 +180,9 @@ async function doReload(requireCleanup: boolean): Promise<McpReloadResult> {
     const error = err instanceof Error ? err.message : String(err);
     log.error({ err }, "MCP reload failed");
     return { success: false, error };
+  } finally {
+    if (teardownStarted) {
+      await publishMcpChanged();
+    }
   }
 }

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -17,6 +17,7 @@ export const SYNC_TAGS = {
   appsList: "apps:list",
   documentsList: "documents:list",
   pluginsList: "plugins:list",
+  mcpList: "mcp:list",
   conversationsList: "conversations:list",
   /** Activation-checklist progress: task launches, step counts, completions. */
   activationProgress: "activation:progress",

--- a/assistant/src/mcp/__tests__/catalog-connections.test.ts
+++ b/assistant/src/mcp/__tests__/catalog-connections.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+import { loadRawConfig } from "../../config/loader.js";
+import {
+  STANDARD_MCP_SCHEMA_URL,
+  STANDARD_PLUGIN_SCHEMA_URL,
+  standardDefinitionDigest,
+  type StandardDocuments,
+} from "../standard-definitions.js";
+
+const documents = {
+  plugin: { $schema: STANDARD_PLUGIN_SCHEMA_URL, name: "example" },
+  mcp: {
+    $schema: STANDARD_MCP_SCHEMA_URL,
+    mcpServers: {
+      example: { type: "streamable-http", url: "https://example.com/mcp" },
+    },
+  },
+} satisfies StandardDocuments;
+const entry = {
+  id: "example",
+  serverKey: "example",
+  documents,
+  definitionDigest: standardDefinitionDigest(documents),
+  setup: { mode: "oauth" },
+};
+let entries = [entry];
+const reload = mock(async () => ({ success: true }));
+const publish = mock(async () => {});
+mock.module("../catalog.js", () => ({ getMcpCatalog: () => entries }));
+mock.module("../../daemon/mcp-reload-service.js", () => ({
+  reloadMcpServers: reload,
+}));
+mock.module("../sync.js", () => ({ publishMcpChanged: publish }));
+
+const { connectMcpCatalogEntry } = await import("../catalog-connections.js");
+const request = {
+  catalogId: entry.id,
+  serverKey: entry.serverKey,
+  definitionDigest: entry.definitionDigest,
+};
+
+describe("catalog connection identity", () => {
+  beforeEach(() => {
+    entries = [entry];
+    entry.setup.mode = "oauth";
+    reload.mockClear();
+    publish.mockClear();
+    setConfig("mcp", {
+      servers: {
+        custom: {
+          transport: {
+            type: "streamable-http",
+            url: "https://example.com/mcp",
+          },
+        },
+      },
+    });
+  });
+
+  test("concurrent clicks share one saved instance without merging matching custom URLs", async () => {
+    const [first, second] = await Promise.all([
+      connectMcpCatalogEntry(request),
+      connectMcpCatalogEntry(request),
+    ]);
+    expect(first.serverId).toBe(second.serverId);
+    expect([first.created, second.created]).toEqual([true, false]);
+    const mcp = loadRawConfig().mcp as { servers: Record<string, unknown> };
+    expect(Object.keys(mcp.servers)).toHaveLength(2);
+    expect(mcp.servers[first.serverId]).toEqual({
+      transport: documents.mcp.mcpServers.example,
+      catalog: {
+        id: "example",
+        serverKey: "example",
+        definitionDigest: entry.definitionDigest,
+      },
+    });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects stale definitions and unknown catalog identities before writing", async () => {
+    await expect(
+      connectMcpCatalogEntry({ ...request, definitionDigest: "0".repeat(64) }),
+    ).rejects.toThrow("changed");
+    await expect(
+      connectMcpCatalogEntry({ ...request, catalogId: "unknown" }),
+    ).rejects.toThrow("not available");
+    expect(
+      Object.keys((loadRawConfig().mcp as { servers: object }).servers),
+    ).toEqual(["custom"]);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test("catalog refresh never silently replaces an authorized instance's endpoint", async () => {
+    const first = await connectMcpCatalogEntry(request);
+    const nextDocuments = {
+      ...documents,
+      mcp: {
+        ...documents.mcp,
+        mcpServers: {
+          example: {
+            type: "streamable-http" as const,
+            url: "https://new.example.com/mcp",
+          },
+        },
+      },
+    };
+    const next = {
+      ...entry,
+      documents: nextDocuments,
+      definitionDigest: standardDefinitionDigest(nextDocuments),
+    };
+    entries = [next];
+    const retried = await connectMcpCatalogEntry({
+      ...request,
+      definitionDigest: next.definitionDigest,
+    });
+    expect(retried).toEqual({ serverId: first.serverId, created: false });
+    const saved = (
+      loadRawConfig().mcp as {
+        servers: Record<string, { transport: { url: string } }>;
+      }
+    ).servers[first.serverId];
+    expect(saved.transport.url).toBe("https://example.com/mcp");
+  });
+
+  test("manual setup must be acknowledged before creating a connection", async () => {
+    entry.setup.mode = "manual";
+    await expect(connectMcpCatalogEntry(request)).rejects.toThrow(
+      "setup requirements",
+    );
+    expect(
+      (await connectMcpCatalogEntry({ ...request, setupAcknowledged: true }))
+        .created,
+    ).toBe(true);
+  });
+});

--- a/assistant/src/mcp/__tests__/connection-lifecycle.test.ts
+++ b/assistant/src/mcp/__tests__/connection-lifecycle.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { setConfig } from "../../__tests__/helpers/set-config.js";
 
 const credentials = new Map<string, string>();
+const publishedCredentials: string[][] = [];
+mock.module("../sync.js", () => ({
+  publishMcpChanged: async () => {
+    publishedCredentials.push([...credentials.keys()].sort());
+  },
+}));
 let failedKeys = new Set<string>();
 let saveHook: (() => Promise<void>) | undefined;
 let deleteHook: ((key: string) => Promise<void>) | undefined;
@@ -107,6 +113,7 @@ beforeEach(() => {
   reloadResult = { success: true, error: undefined };
   reload.mockClear();
   seed();
+  publishedCredentials.length = 0;
 });
 
 describe("MCP connection teardown", () => {
@@ -258,6 +265,45 @@ describe("MCP connection teardown", () => {
     expect(savedServers()).toHaveProperty("example");
     expect([...credentials.keys()]).toEqual(["mcp:example:headers"]);
   });
+  test.each([false, true])(
+    "cancellation publishes settled credential cleanup, including partial failure: %s",
+    async (partialFailure) => {
+      const entered = deferred();
+      const release = deferred();
+      deleteHook = async (key) => {
+        if (key.endsWith(":tokens")) {
+          entered.resolve();
+          await release.promise;
+        }
+      };
+      if (partialFailure) {
+        failedKeys.add("mcp:example:client_binding");
+      }
+      setMcpAuthPending(
+        "example",
+        "https://auth.example.com",
+        "cancel-attempt",
+      );
+      publishedCredentials.length = 0;
+      const cancellation = handler("internal_mcp_auth_cancel", {
+        serverId: "example",
+        attemptId: "cancel-attempt",
+      });
+      await entered.promise;
+      expect(publishedCredentials.at(-1)).toContain("mcp:example:tokens");
+      release.resolve();
+      if (partialFailure) {
+        await expect(cancellation).rejects.toThrow("credential cleanup failed");
+      } else {
+        expect(await cancellation).toEqual({ cancelled: true });
+      }
+      expect(publishedCredentials.at(-1)).toEqual(
+        partialFailure
+          ? ["mcp:example:client_binding", "mcp:example:headers"]
+          : ["mcp:example:headers"],
+      );
+    },
+  );
   test("concurrent add and remove preserve unrelated configuration writes", async () => {
     const entered = deferred();
     const release = deferred();

--- a/assistant/src/mcp/catalog-connections.ts
+++ b/assistant/src/mcp/catalog-connections.ts
@@ -1,0 +1,92 @@
+import { randomUUID } from "node:crypto";
+
+import { loadRawConfig, saveRawConfig } from "../config/loader.js";
+import type { McpConfig } from "../config/schemas/mcp.js";
+import { reloadMcpServers } from "../daemon/mcp-reload-service.js";
+import {
+  BadRequestError,
+  InternalError,
+  NotFoundError,
+} from "../runtime/routes/errors.js";
+import { getLogger } from "../util/logger.js";
+import { getMcpCatalog } from "./catalog.js";
+import { withMcpConfigWrite } from "./connection-lifecycle.js";
+import { parseStandardDefinitions } from "./standard-definitions.js";
+import { publishMcpChanged } from "./sync.js";
+
+const log = getLogger("mcp-catalog-connections");
+
+export interface CatalogConnectRequest {
+  catalogId: string;
+  serverKey: string;
+  definitionDigest: string;
+  setupAcknowledged?: boolean;
+}
+
+export async function connectMcpCatalogEntry(
+  request: CatalogConnectRequest,
+): Promise<{
+  serverId: string;
+  created: boolean;
+}> {
+  const entry = getMcpCatalog().find(
+    (candidate) =>
+      candidate.id === request.catalogId &&
+      candidate.serverKey === request.serverKey,
+  );
+  if (!entry) {
+    throw new NotFoundError("This integration is not available in the catalog");
+  }
+  if (entry.definitionDigest !== request.definitionDigest) {
+    throw new BadRequestError(
+      "This integration definition changed; refresh the catalog and try again",
+    );
+  }
+  if (entry.setup.mode === "manual" && !request.setupAcknowledged) {
+    throw new BadRequestError(
+      "Complete this integration's setup requirements before connecting",
+    );
+  }
+  const definition = parseStandardDefinitions(
+    entry.documents.plugin,
+    entry.documents.mcp,
+  );
+  if (!definition.ok || !definition.servers[entry.serverKey]) {
+    throw new InternalError(
+      "This integration's server definition is unavailable",
+    );
+  }
+
+  const result = await withMcpConfigWrite(async () => {
+    const raw = loadRawConfig();
+    const mcp = (raw.mcp ??= { servers: {} }) as Partial<McpConfig>;
+    const servers = (mcp.servers ??= {});
+    const existing = Object.entries(servers).find(
+      ([, server]) =>
+        server.catalog?.id === entry.id &&
+        server.catalog.serverKey === entry.serverKey,
+    );
+    if (existing) {
+      return { serverId: existing[0], created: false };
+    }
+    const serverId = `catalog-${entry.id}-${randomUUID()}`;
+    servers[serverId] = {
+      transport: definition.servers[entry.serverKey],
+      catalog: {
+        id: entry.id,
+        serverKey: entry.serverKey,
+        definitionDigest: entry.definitionDigest,
+      },
+    };
+    saveRawConfig(raw);
+    return { serverId, created: true };
+  });
+
+  if (result.created) {
+    await publishMcpChanged();
+    void reloadMcpServers().catch((error) => {
+      log.warn({ error }, "Catalog connection reload failed");
+    });
+  }
+  return result;
+}

--- a/assistant/src/mcp/catalog.ts
+++ b/assistant/src/mcp/catalog.ts
@@ -1,0 +1,53 @@
+import { getLogger } from "../util/logger.js";
+import bundled from "./bundled-catalog.json" with { type: "json" };
+import {
+  type BundledMcpCatalogEntry,
+  mcpCatalogEntrySchema,
+} from "./catalog-schema.js";
+import {
+  parseStandardDefinitions,
+  standardDefinitionDigest,
+} from "./standard-definitions.js";
+
+const log = getLogger("mcp-catalog");
+
+export type PublicMcpCatalogEntry = Omit<
+  BundledMcpCatalogEntry,
+  "packagePath" | "source" | "resolvedSource"
+>;
+
+export function getMcpCatalog(): PublicMcpCatalogEntry[] {
+  return bundled.entries.flatMap((value: unknown) => {
+    const entry = value as BundledMcpCatalogEntry;
+    try {
+      const {
+        documents,
+        definitionDigest,
+        resolvedSource: _resolved,
+        ...index
+      } = entry;
+      const {
+        packagePath: _path,
+        source: _source,
+        ...metadata
+      } = mcpCatalogEntrySchema.parse(index);
+      const parsed = parseStandardDefinitions(documents.plugin, documents.mcp);
+      if (
+        !parsed.ok ||
+        !Object.hasOwn(parsed.servers, metadata.serverKey) ||
+        standardDefinitionDigest(parsed.documents) !== definitionDigest
+      ) {
+        throw new Error(
+          "Bundled definition does not match its catalog identity",
+        );
+      }
+      return [{ ...metadata, documents: parsed.documents, definitionDigest }];
+    } catch (error) {
+      log.warn(
+        { catalogId: entry?.id, error },
+        "Ignoring invalid MCP catalog entry",
+      );
+      return [];
+    }
+  });
+}

--- a/assistant/src/mcp/client.ts
+++ b/assistant/src/mcp/client.ts
@@ -10,6 +10,7 @@ import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import { getMcpHeaders } from "./mcp-header-store.js";
 import { McpOAuthProvider } from "./mcp-oauth-provider.js";
+import { publishMcpChanged } from "./sync.js";
 
 const log = getLogger("mcp-client");
 
@@ -97,8 +98,12 @@ export class McpClient {
       );
     };
     this.client.onclose = () => {
+      const wasConnected = this.connected;
       this.connected = false;
       this.oauthProvider?.close();
+      if (wasConnected) {
+        void publishMcpChanged();
+      }
     };
   }
 

--- a/assistant/src/mcp/connection-lifecycle.ts
+++ b/assistant/src/mcp/connection-lifecycle.ts
@@ -6,6 +6,7 @@ import { withMcpConfigWrite } from "./config-write-lock.js";
 import { withMcpCredentialLock } from "./credential-coordination.js";
 import { cancelCurrentMcpAuth, getMcpAuthState } from "./mcp-auth-state.js";
 import { deleteMcpHeaders } from "./mcp-header-store.js";
+import { publishMcpChanged } from "./sync.js";
 
 export { withMcpConfigWrite } from "./config-write-lock.js";
 
@@ -69,6 +70,7 @@ export async function cancelMcpConnectionAttempt(
       return true;
     } finally {
       lease.advance();
+      await publishMcpChanged();
     }
   });
 }
@@ -126,6 +128,8 @@ export async function teardownMcpConnection(
       );
     }
     throw err;
+  } finally {
+    await publishMcpChanged();
   }
   try {
     const result = await reloadMcpServers({ requireCleanup: true });

--- a/assistant/src/mcp/mcp-auth-state.ts
+++ b/assistant/src/mcp/mcp-auth-state.ts
@@ -14,6 +14,8 @@
  * the polling CLI can render progress without holding a long-lived IPC
  * connection.
  */
+import { publishMcpChanged } from "./sync.js";
+
 type McpAuthState =
   | { status: "pending"; authUrl: string; attemptId: string; expiresAt: number }
   | {
@@ -79,6 +81,7 @@ export function setMcpAuthPending(
     attemptId,
     expiresAt: Date.now() + PENDING_TTL_MS,
   });
+  void publishMcpChanged();
 }
 
 /**
@@ -101,6 +104,7 @@ export function setMcpAuthComplete(
     attemptId,
     completedAt: Date.now(),
   });
+  void publishMcpChanged();
   return true;
 }
 
@@ -123,6 +127,7 @@ export function setMcpAuthError(
     attemptId,
     failedAt: Date.now(),
   });
+  void publishMcpChanged();
   return true;
 }
 

--- a/assistant/src/mcp/sync.ts
+++ b/assistant/src/mcp/sync.ts
@@ -1,0 +1,6 @@
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
+
+export async function publishMcpChanged(): Promise<void> {
+  await publishSyncInvalidation([SYNC_TAGS.mcpList]);
+}

--- a/assistant/src/runtime/routes/__tests__/mcp-catalog-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/mcp-catalog-routes.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const entries = [{ id: "example", serverKey: "primary" }];
+const list = mock(() => entries);
+const connect = mock(async (_request: unknown) => ({
+  serverId: "catalog-instance",
+  created: true,
+}));
+mock.module("../../../mcp/catalog.js", () => ({ getMcpCatalog: list }));
+mock.module("../../../mcp/catalog-connections.js", () => ({
+  connectMcpCatalogEntry: connect,
+}));
+const { ROUTES } = await import("../mcp-catalog-routes.js");
+const { BadRequestError } = await import("../errors.js");
+const readRoute = ROUTES.find(
+  (route) => route.operationId === "internal_mcp_catalog",
+)!;
+const connectRoute = ROUTES.find(
+  (route) => route.operationId === "internal_mcp_catalog_connect",
+)!;
+const request = {
+  catalogId: "example",
+  serverKey: "primary",
+  definitionDigest: "a".repeat(64),
+};
+
+beforeEach(() => {
+  list.mockClear();
+  connect.mockClear();
+});
+
+describe("MCP catalog route contracts", () => {
+  test("catalog reads expose capability without creating connections", async () => {
+    expect(readRoute.method).toBe("GET");
+    expect(await readRoute.handler({})).toEqual({
+      supportsConnect: true,
+      entries,
+    });
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(connect).not.toHaveBeenCalled();
+    expect(readRoute.policy?.requiredScopes).toEqual(["settings.read"]);
+  });
+
+  test("connecting requires settings-write policy and forwards only declared request fields", async () => {
+    expect(connectRoute.method).toBe("POST");
+    expect(connectRoute.policy?.requiredScopes).toEqual(["settings.write"]);
+    expect(
+      await connectRoute.handler({
+        body: { ...request, setupAcknowledged: true },
+      }),
+    ).toEqual({
+      serverId: "catalog-instance",
+      created: true,
+    });
+    expect(connect).toHaveBeenCalledWith({
+      ...request,
+      setupAcknowledged: true,
+    });
+  });
+
+  test.each([
+    { url: "https://replacement.example.com/mcp" },
+    { transport: { type: "stdio", command: "example-command" } },
+    { source: "plugin" },
+    { serverId: "existing-user-connection" },
+  ])(
+    "rejects identity or endpoint overrides before calling connect: %j",
+    async (override) => {
+      await expect(
+        Promise.resolve().then(() =>
+          connectRoute.handler({ body: { ...request, ...override } }),
+        ),
+      ).rejects.toThrow(BadRequestError);
+      expect(connect).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    { ...request, definitionDigest: "stale" },
+    { ...request, catalogId: "" },
+    { ...request, serverKey: "" },
+  ])("rejects malformed catalog selections before writes: %j", async (body) => {
+    await expect(
+      Promise.resolve().then(() => connectRoute.handler({ body })),
+    ).rejects.toThrow(BadRequestError);
+    expect(connect).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -112,6 +112,7 @@ import { ROUTES as LIVE_VOICE_ROUTES } from "./live-voice-routes.js";
 import { ROUTES as LLM_CALL_SITES_ROUTES } from "./llm-call-sites-routes.js";
 import { ROUTES as LOG_EXPORT_ROUTES } from "./log-export-routes.js";
 import { ROUTES as MCP_AUTH_ROUTES } from "./mcp-auth-routes.js";
+import { ROUTES as MCP_CATALOG_ROUTES } from "./mcp-catalog-routes.js";
 import { ROUTES as MESSAGES_LEXICAL_ROUTES } from "./messages-lexical-routes.js";
 import { ROUTES as MIGRATION_ROLLBACK_ROUTES } from "./migration-rollback-routes.js";
 import { ROUTES as MIGRATION_ROUTES } from "./migration-routes.js";
@@ -255,6 +256,7 @@ export const ROUTES: RouteDefinition[] = [
   ...INTERNAL_OAUTH_ROUTES,
   ...INTERNAL_TELEMETRY_ROUTES,
   ...MCP_AUTH_ROUTES,
+  ...MCP_CATALOG_ROUTES,
   ...OAUTH_CONNECT_ROUTES,
   ...INTERNAL_TWILIO_ROUTES,
   ...LIFECYCLE_ROUTES,

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -15,7 +15,11 @@
 import { z } from "zod";
 
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
-import type { McpConfig, McpServerConfig } from "../../config/schemas/mcp.js";
+import {
+  type McpConfig,
+  type McpServerConfig,
+  McpServerConfigSchema,
+} from "../../config/schemas/mcp.js";
 import { estimateToolDefinitionTokens } from "../../context/token-estimator.js";
 import { reloadMcpServers } from "../../daemon/mcp-reload-service.js";
 import {
@@ -35,6 +39,7 @@ import {
   setMcpHeaders,
 } from "../../mcp/mcp-header-store.js";
 import { hasMcpOAuthTokens } from "../../mcp/mcp-oauth-provider.js";
+import { publishMcpChanged } from "../../mcp/sync.js";
 import { readPluginMcpServers } from "../../plugins/mcp-servers.js";
 import { getMcpToolsByServer } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
@@ -195,6 +200,7 @@ interface McpServerEntry {
   >;
   transport: Omit<McpServerConfig["transport"], "headers"> & { type: string };
   hasOAuth: boolean;
+  catalog?: McpServerConfig["catalog"];
   hasStaticAuth: boolean;
   authType: "none" | "bearer" | "api-key";
   authHeaderName?: string;
@@ -279,6 +285,7 @@ async function handleMcpList(_args: {
         authType,
         ...(authHeaderName && { authHeaderName }),
         source: "workspace" as const,
+        catalog: config.catalog ?? null,
       };
     }),
   );
@@ -460,6 +467,7 @@ async function handleMcpUpdate({
       }
 
       saveRawConfig(raw);
+      await publishMcpChanged();
       triggerReload("internal_mcp_update");
 
       return { updated: true };
@@ -538,6 +546,7 @@ async function handleMcpAdd({
       }
 
       saveRawConfig(raw);
+      await publishMcpChanged();
       triggerReload("internal_mcp_add");
 
       return { added: true };
@@ -759,6 +768,7 @@ export const ROUTES: RouteDefinition[] = [
             })
             .passthrough(),
           hasOAuth: z.boolean(),
+          catalog: McpServerConfigSchema.shape.catalog,
         }),
       ),
     }),

--- a/assistant/src/runtime/routes/mcp-catalog-routes.ts
+++ b/assistant/src/runtime/routes/mcp-catalog-routes.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+import { getMcpCatalog } from "../../mcp/catalog.js";
+import { connectMcpCatalogEntry } from "../../mcp/catalog-connections.js";
+import { mcpCatalogEntrySchema } from "../../mcp/catalog-schema.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { parseBody } from "./parse-body.js";
+import type { RouteDefinition } from "./types.js";
+
+const connectSchema = z.strictObject({
+  catalogId: z.string().min(1),
+  serverKey: z.string().min(1),
+  definitionDigest: z.string().regex(/^[0-9a-f]{64}$/),
+  setupAcknowledged: z.boolean().optional(),
+});
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "internal_mcp_catalog",
+    endpoint: "internal/mcp/catalog",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List known MCP integrations",
+    description:
+      "Reads bundled standard integration definitions without connecting servers or installing plugins.",
+    tags: ["internal"],
+    responseBody: z.object({
+      supportsConnect: z.literal(true),
+      entries: z.array(
+        mcpCatalogEntrySchema.omit({ packagePath: true, source: true }).extend({
+          definitionDigest: z.string(),
+          documents: z.object({
+            plugin: z.unknown(),
+            mcp: z.unknown().optional(),
+          }),
+        }),
+      ),
+    }),
+    handler: () => ({ supportsConnect: true, entries: getMcpCatalog() }),
+  },
+  {
+    operationId: "internal_mcp_catalog_connect",
+    endpoint: "internal/mcp/catalog/connect",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Create a connection from a known MCP definition",
+    description:
+      "Reuses a saved catalog connection or creates one with stable identity and separate credentials.",
+    tags: ["internal"],
+    requestBody: connectSchema,
+    responseBody: z.object({ serverId: z.string(), created: z.boolean() }),
+    handler: ({ body }) =>
+      connectMcpCatalogEntry(parseBody(connectSchema, body)),
+  },
+];

--- a/assistant/src/workspace/migrations/155-mcp-catalog-provenance.ts
+++ b/assistant/src/workspace/migrations/155-mcp-catalog-provenance.ts
@@ -1,0 +1,66 @@
+import {
+  closeSync,
+  fchmodSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+export const mcpCatalogProvenanceMigration: WorkspaceMigration = {
+  id: "155-mcp-catalog-provenance",
+  description: "Preserve existing MCP connections as custom integrations",
+  run(workspaceDir) {
+    const path = join(workspaceDir, "config.json");
+    let raw: Record<string, unknown>;
+    try {
+      raw = JSON.parse(readFileSync(path, "utf8"));
+    } catch (error) {
+      if (
+        error instanceof SyntaxError ||
+        (error as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        return;
+      }
+      throw error;
+    }
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return;
+    }
+    const mcp = raw.mcp as { servers?: unknown } | null | undefined;
+    const servers = mcp?.servers;
+    if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+      return;
+    }
+    let changed = false;
+    for (const server of Object.values(servers)) {
+      if (
+        server &&
+        typeof server === "object" &&
+        !Array.isArray(server) &&
+        !Object.hasOwn(server, "catalog")
+      ) {
+        server.catalog = null;
+        changed = true;
+      }
+    }
+    if (changed) {
+      const temporary = `${path}.migration-155.tmp`;
+      const mode = statSync(path).mode & 0o777;
+      const fd = openSync(temporary, "w", mode);
+      try {
+        fchmodSync(fd, mode);
+        writeFileSync(fd, `${JSON.stringify(raw, null, 2)}\n`);
+      } finally {
+        closeSync(fd);
+      }
+      renameSync(temporary, path);
+    }
+  },
+  retryFailedCheckpoint: true,
+  down() {},
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -152,6 +152,7 @@ import { repairRenamedFireworksDeepseekProModelIdMigration } from "./151-repair-
 import { repairRetiredFireworksMinimaxM2p7ModelIdMigration } from "./152-repair-retired-fireworks-minimax-m2p7-model-id.js";
 import { stripMcpPolicyFieldsMigration } from "./153-strip-mcp-policy-fields.js";
 import { repairRetiredCodexGpt54ModelIdsMigration } from "./154-repair-retired-codex-gpt-5-4-model-ids.js";
+import { mcpCatalogProvenanceMigration } from "./155-mcp-catalog-provenance.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -319,4 +320,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairRetiredFireworksMinimaxM2p7ModelIdMigration,
   stripMcpPolicyFieldsMigration,
   repairRetiredCodexGpt54ModelIdsMigration,
+  mcpCatalogProvenanceMigration,
 ];

--- a/clients/web/src/domains/settings/mcp/mcp-catalog-api.test.ts
+++ b/clients/web/src/domains/settings/mcp/mcp-catalog-api.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+let result: { data?: unknown; response: Response };
+const get = mock(async (_args: unknown) => result);
+const post = mock(async (_args: unknown) => result);
+mock.module("@/generated/daemon/client.gen", () => ({ client: { get, post } }));
+const { fetchMcpCatalog, connectMcpCatalogEntry } = await import("./mcp-catalog-api");
+
+beforeEach(() => {
+  get.mockClear();
+  post.mockClear();
+});
+
+test("old assistants expose no catalog write capability", async () => {
+  result = { response: new Response(null, { status: 404 }) };
+  expect(await fetchMcpCatalog("assistant-1")).toEqual({ supportsConnect: false, entries: [] });
+  expect(post).not.toHaveBeenCalled();
+});
+
+test("capability must be explicitly advertised and outages stay errors", async () => {
+  result = { data: { entries: [] }, response: new Response() };
+  expect((await fetchMcpCatalog("assistant-1")).supportsConnect).toBe(false);
+  result = { data: { entries: [], supportsConnect: true }, response: new Response() };
+  expect((await fetchMcpCatalog("assistant-1")).supportsConnect).toBe(true);
+  result = { response: new Response(null, { status: 503 }) };
+  await expect(fetchMcpCatalog("assistant-1")).rejects.toThrow("503");
+});
+
+test("connect passes reviewed identity and returns the saved instance", async () => {
+  result = { data: { serverId: "saved-instance", created: false }, response: new Response() };
+  const body = { catalogId: "example", serverKey: "example", definitionDigest: "a".repeat(64) };
+  expect(await connectMcpCatalogEntry("assistant-1", body)).toEqual({ serverId: "saved-instance", created: false });
+  expect(post).toHaveBeenCalledWith({
+    url: "/v1/assistants/{assistant_id}/internal/mcp/catalog/connect",
+    path: { assistant_id: "assistant-1" },
+    body,
+  });
+});

--- a/clients/web/src/domains/settings/mcp/mcp-catalog-api.ts
+++ b/clients/web/src/domains/settings/mcp/mcp-catalog-api.ts
@@ -1,0 +1,71 @@
+import { client } from "@/generated/daemon/client.gen";
+
+export interface McpCatalogEntry {
+  id: string;
+  serverKey: string;
+  definitionDigest: string;
+  displayName: string;
+  description: string;
+  documentationUrl: string;
+  verifiedAt: string;
+  verification: "documentation-only" | "tested";
+  setup: { mode: "oauth" | "manual"; instructions?: string };
+  oauthProvider?: string;
+  icon?: string;
+  documents: {
+    plugin: Record<string, unknown>;
+    mcp?: {
+      mcpServers?: Record<string, { type?: string; url?: string }>;
+      [key: string]: unknown;
+    };
+  };
+}
+
+export interface McpCatalogResponse {
+  supportsConnect: boolean;
+  entries: McpCatalogEntry[];
+}
+
+export async function fetchMcpCatalog(assistantId: string): Promise<McpCatalogResponse> {
+  const { data, response } = await client.get({
+    url: "/v1/assistants/{assistant_id}/internal/mcp/catalog" as "/v1/assistants/{assistant_id}/config",
+    path: { assistant_id: assistantId },
+  });
+  if (response?.status === 404) {
+    return { supportsConnect: false, entries: [] };
+  }
+  if (!response?.ok) {
+    throw new Error(`Failed to fetch integrations: ${response?.status}`);
+  }
+  const catalog = data as unknown as Partial<McpCatalogResponse>;
+  if (!catalog || !Array.isArray(catalog.entries)) {
+    throw new Error("Invalid integration catalog response");
+  }
+  return { supportsConnect: catalog.supportsConnect === true, entries: catalog.entries };
+}
+
+export interface McpCatalogConnectRequest {
+  catalogId: string;
+  serverKey: string;
+  definitionDigest: string;
+  setupAcknowledged?: boolean;
+}
+
+export async function connectMcpCatalogEntry(
+  assistantId: string,
+  body: McpCatalogConnectRequest,
+): Promise<{ serverId: string; created: boolean }> {
+  const { data, response } = await client.post({
+    url: "/v1/assistants/{assistant_id}/internal/mcp/catalog/connect" as "/v1/assistants/{assistant_id}/config",
+    path: { assistant_id: assistantId },
+    body: { ...body },
+  });
+  if (!response?.ok) {
+    throw new Error(`Failed to connect integration: ${response?.status}`);
+  }
+  const result = data as unknown as { serverId?: unknown; created?: unknown };
+  if (!result || typeof result.serverId !== "string" || typeof result.created !== "boolean") {
+    throw new Error("Invalid integration connection response");
+  }
+  return { serverId: result.serverId, created: result.created };
+}

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -31,6 +31,7 @@ import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { platformAvatarUrlsQueryKey } from "@/hooks/use-platform-avatar-urls";
+import { mcpQueryKeys } from "@/domains/settings/mcp/mcp-query-keys";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import type { SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
@@ -388,6 +389,43 @@ describe("useAssistantResourceSync", () => {
         ]) as never,
       );
     });
+  });
+
+  for (const tag of [SYNC_TAGS.mcpList, SYNC_TAGS.assistantConfig, SYNC_TAGS.pluginsList]) {
+    test(`invalidates only the active assistant MCP caches for ${tag}`, async () => {
+      const queryClient = freshQueryClient();
+      for (const assistantId of ["asst-1", "asst-2"]) {
+        queryClient.setQueryData(mcpQueryKeys.list(assistantId), []);
+        queryClient.setQueryData(mcpQueryKeys.details(assistantId), []);
+      }
+      renderHook(() => useAssistantResourceSync("asst-1", true), { wrapper: createWrapper(queryClient) });
+      emit(syncEvent([tag]) as unknown as AssistantEvent);
+      await waitFor(() => {
+        expect(queryClient.getQueryState(mcpQueryKeys.list("asst-1"))?.isInvalidated).toBe(true);
+        expect(queryClient.getQueryState(mcpQueryKeys.details("asst-1"))?.isInvalidated).toBe(true);
+      });
+      expect(queryClient.getQueryState(mcpQueryKeys.list("asst-2"))?.isInvalidated).toBe(false);
+      expect(queryClient.getQueryState(mcpQueryKeys.details("asst-2"))?.isInvalidated).toBe(false);
+    });
+  }
+
+  test("reconnect refetches mounted MCP rows without fetching unopened tool details", async () => {
+    const queryClient = freshQueryClient();
+    const fetchRows = mock(async () => []);
+    const observer = new QueryObserver(queryClient, { queryKey: mcpQueryKeys.list("asst-1"), queryFn: fetchRows, staleTime: Infinity });
+    queryClient.setQueryData(mcpQueryKeys.details("asst-1"), []);
+    const unsubscribe = observer.subscribe(() => {});
+    try {
+      await waitFor(() => expect(fetchRows).toHaveBeenCalledTimes(1));
+      renderHook(() => useAssistantResourceSync("asst-1", true), { wrapper: createWrapper(queryClient) });
+      publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+      await flushReconnectSweep();
+      await waitFor(() => expect(fetchRows).toHaveBeenCalledTimes(2));
+      expect(queryClient.getQueryState(mcpQueryKeys.details("asst-1"))?.isInvalidated).toBe(true);
+      expect(queryClient.getQueryState(mcpQueryKeys.details("asst-1"))?.fetchStatus).toBe("idle");
+    } finally {
+      unsubscribe();
+    }
   });
 
   test("invalidates plugin list / catalog / open-detail queries on plugins:list sync tag", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -32,6 +32,7 @@
 import { useEffect, useRef } from "react";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 
+import { mcpQueryKeys } from "@/domains/settings/mcp/mcp-query-keys";
 import { invalidateMemoryQueries } from "@/domains/intelligence/memory-graph/invalidate-memory-queries";
 import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalidate-plugin-queries";
 import {
@@ -141,6 +142,7 @@ export function useAssistantResourceSync(
               // `memory.v3.live`), so a config write on any client can change
               // what the Memory surface must render.
               invalidateMemoryQueries(queryClient, assistantId);
+              invalidateMcpQueries(queryClient, assistantId);
               break;
             case SYNC_TAGS.assistantSounds:
               void queryClient.invalidateQueries({
@@ -188,6 +190,10 @@ export function useAssistantResourceSync(
               break;
             case SYNC_TAGS.pluginsList:
               invalidatePluginQueries(queryClient, assistantId);
+              invalidateMcpQueries(queryClient, assistantId);
+              break;
+            case SYNC_TAGS.mcpList:
+              invalidateMcpQueries(queryClient, assistantId);
               break;
             case SYNC_TAGS.activationProgress:
               void queryClient.invalidateQueries({
@@ -313,6 +319,7 @@ function refreshAssistantResources(
     queryKey: configGetQueryKey(pathOpts),
     refetchType,
   });
+  invalidateMcpQueries(queryClient, assistantId, refetchType);
   invalidateAvatarQueries(queryClient, assistantId, refetchType);
   invalidateMemoryQueries(queryClient, assistantId, refetchType);
   void queryClient.invalidateQueries({
@@ -372,4 +379,10 @@ function isGeneratedQueryKey(
     typeof firstKeyPart === "object" &&
     (firstKeyPart as { _id?: unknown })._id === id
   );
+}
+
+function invalidateMcpQueries(queryClient: QueryClient, assistantId: string, refetchType: "active" | "none" = "active"): void {
+  for (const queryKey of [mcpQueryKeys.list(assistantId), mcpQueryKeys.details(assistantId)]) {
+    void queryClient.invalidateQueries({queryKey, refetchType});
+  }
 }

--- a/clients/web/src/lib/sync/types.ts
+++ b/clients/web/src/lib/sync/types.ts
@@ -8,6 +8,7 @@ export const SYNC_TAGS = {
   appsList: "apps:list",
   documentsList: "documents:list",
   pluginsList: "plugins:list",
+  mcpList: "mcp:list",
   conversationsList: "conversations:list",
   /** Activation checklist progress: which tasks are started or done, their
    *  live step counts, and which surfaces have been dismissed. Emitted on

--- a/gateway/src/__tests__/runtime-proxy.test.ts
+++ b/gateway/src/__tests__/runtime-proxy.test.ts
@@ -51,6 +51,68 @@ afterEach(() => {
 });
 
 describe("runtime proxy handler", () => {
+  test.each([
+    ["GET", "/v1/internal/mcp/catalog", "/v1/internal/mcp/catalog"],
+    [
+      "GET",
+      "/v1/assistants/test-assistant/internal/mcp/catalog",
+      "/v1/internal/mcp/catalog",
+    ],
+    [
+      "POST",
+      "/v1/internal/mcp/catalog/connect",
+      "/v1/internal/mcp/catalog/connect",
+    ],
+    [
+      "POST",
+      "/v1/assistants/test-assistant/internal/mcp/catalog/connect",
+      "/v1/internal/mcp/catalog/connect",
+    ],
+  ])(
+    "forwards catalog %s %s through the HTTP catch-all",
+    async (method, path, upstreamPath) => {
+      const payload =
+        method === "POST"
+          ? JSON.stringify({
+              catalogId: "example",
+              serverKey: "primary",
+              definitionDigest: "a".repeat(64),
+            })
+          : undefined;
+      let captured:
+        | { url: string; method: string; body: string | undefined }
+        | undefined;
+      fetchMock = mock(
+        async (input: string | URL | Request, init?: RequestInit) => {
+          captured = {
+            url: String(input),
+            method: init?.method ?? "GET",
+            body: init?.body
+              ? new TextDecoder().decode(init.body as ArrayBuffer)
+              : undefined,
+          };
+          return Response.json({ ok: true });
+        },
+      );
+
+      const response = await createRuntimeProxyHandler(makeConfig())(
+        new Request(`http://localhost:7830${path}`, {
+          method,
+          headers: { "content-type": "application/json" },
+          body: payload,
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(captured).toEqual({
+        url: `http://localhost:7821${upstreamPath}`,
+        method,
+        body: payload,
+      });
+      expect(await response.json()).toEqual({ ok: true });
+    },
+  );
+
   test("rewrites legacy /v1/assistants/:assistantId/... to flat /v1/... for upstream", async () => {
     const captured: { url: string }[] = [];
     fetchMock = mock(async (input: string | URL | Request) => {

--- a/gateway/src/http/routes/ipc-runtime-proxy.test.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.test.ts
@@ -64,6 +64,24 @@ const ROUTE_SCHEMA = [
     },
   },
   {
+    operationId: "internal_mcp_catalog",
+    endpoint: "internal/mcp/catalog",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
+    },
+  },
+  {
+    operationId: "internal_mcp_catalog_connect",
+    endpoint: "internal/mcp/catalog/connect",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ["actor", "svc_gateway", "svc_daemon", "local"],
+    },
+  },
+  {
     operationId: "calls_start",
     endpoint: "calls/start",
     method: "POST",
@@ -323,6 +341,73 @@ describe("tryIpcProxy", () => {
     expect(opId).toBe("acp_steer");
     expect(params.pathParams).toEqual({ id: "test-id" });
     expect(params.body).toEqual({ message: "hello" });
+  });
+
+  test.each([
+    ["GET", "internal/mcp/catalog", "internal_mcp_catalog"],
+    ["POST", "internal/mcp/catalog/connect", "internal_mcp_catalog_connect"],
+  ])(
+    "proxies %s %s through the catalog IPC schema",
+    async (method, endpoint, operationId) => {
+      const body =
+        method === "POST"
+          ? {
+              catalogId: "example",
+              serverKey: "primary",
+              definitionDigest: "a".repeat(64),
+            }
+          : undefined;
+      const handler = createRuntimeProxyHandler(
+        makeConfig({ runtimeProxyRequireAuth: true }),
+      );
+      const response = await handler(
+        makeRequest(`/v1/${endpoint}`, {
+          method,
+          headers: {
+            authorization: "Bearer valid",
+            "content-type": "application/json",
+          },
+          body: body ? JSON.stringify(body) : undefined,
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(ipcCallAssistantMock).toHaveBeenCalledTimes(1);
+      const [actualOperation, params] = ipcCallAssistantMock.mock.calls[0];
+      expect(actualOperation).toBe(operationId);
+      expect(params?.body).toEqual(body);
+      expect(params?.pathParams).toEqual({});
+    },
+  );
+
+  test("a read-only client can browse the catalog but cannot connect", async () => {
+    validateEdgeTokenMock.mockImplementation(() => ({
+      ok: true,
+      claims: { sub: "actor:asst_1:user_1", scope_profile: "ui_page_v1" },
+    }));
+    const handler = createRuntimeProxyHandler(
+      makeConfig({ runtimeProxyRequireAuth: true }),
+    );
+    const headers = { authorization: "Bearer valid" };
+    const readResponse = await handler(
+      makeRequest("/v1/internal/mcp/catalog", { headers }),
+    );
+    expect(readResponse.status).toBe(200);
+    ipcCallAssistantMock.mockClear();
+
+    const writeResponse = await handler(
+      makeRequest("/v1/internal/mcp/catalog/connect", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          catalogId: "example",
+          serverKey: "primary",
+          definitionDigest: "a".repeat(64),
+        }),
+      }),
+    );
+    expect(writeResponse.status).toBe(403);
+    expect(ipcCallAssistantMock).not.toHaveBeenCalled();
   });
 
   test("falls back to HTTP (returns null) on BINARY_UNSUPPORTED_OVER_IPC", async () => {


### PR DESCRIPTION
Known MCP definitions can be browsed and connected through the existing gateway/IPC routes. Connect accepts a reviewed catalog identity and digest, creates a stable workspace instance, and reuses it on retries; later catalog changes never silently replace its saved endpoint.

An append-only migration records null catalog provenance for existing custom connections while preserving IDs, transports, credentials, and config permissions. Existing installed-plugin loaders and storage are unchanged. The web wrapper exposes explicit catalog capability and falls back on older assistants. CLI polling verifies advertised authentication attempt IDs and preserves legacy responses.

A shared mcp:list invalidation refreshes assistant-scoped rows and open details after writes and runtime changes, including reload completion/failure, settled cancellation cleanup, and unexpected transport closure. A regression reproduces and fixes a reload request arriving at the completion microtask boundary. Reconnect catches up missed updates without eagerly fetching unopened tool details.

Validation: catalog/route/migration tests, 80 gateway forwarding and scope tests, 41 web sync tests, wrapper compatibility tests, lifecycle regressions, and an unexpected-close regression passed. Assistant, web, and gateway typechecks passed; OpenAPI is regenerated from route definitions.

Part of #42552. PR 6 of 8 targeting `codex/integrations-qa`; earlier commits in the QA stack disappear from the diff as they merge.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->