### PR TITLE
Show current MCP lifecycle states in the CLI

### DIFF
--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -207,26 +207,63 @@ describe("assistant mcp list", () => {
     expect(stdout).toContain("https://example.com/mcp");
   });
 
-  test("prints the status string from the list response", async () => {
-    mockCliIpcCallFn = mock(() =>
-      Promise.resolve({
-        ok: true,
-        result: {
-          servers: [
-            {
-              id: "error-server",
-              status: "error",
-              transport: { type: "sse", url: "https://example.com/sse" },
-            },
-          ],
-        },
-      }),
-    );
+  test.each([undefined, "future-state"])(
+    "falls back to legacy status for lifecycle state %s",
+    async (lifecycleState) => {
+      mockCliIpcCallFn = mock(() =>
+        Promise.resolve({
+          ok: true,
+          result: {
+            servers: [
+              {
+                id: "error-server",
+                status: "error",
+                lifecycleState,
+                transport: { type: "sse", url: "https://example.com/sse" },
+              },
+            ],
+          },
+        }),
+      );
 
-    const { stdout, exitCode } = await runMcpList();
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("error");
-  });
+      const { stdout, exitCode } = await runMcpList();
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("Status:    error");
+    },
+  );
+
+  test.each([
+    "not-started",
+    "connecting",
+    "connected",
+    "needs-auth",
+    "error",
+    "declared",
+  ])(
+    "prefers known lifecycle state %s in human output",
+    async (lifecycleState) => {
+      mockCliIpcCallFn = mock(() =>
+        Promise.resolve({
+          ok: true,
+          result: {
+            servers: [
+              {
+                id: "test-server",
+                status: "legacy-status",
+                lifecycleState,
+                transport: { type: "sse", url: "https://example.com/sse" },
+              },
+            ],
+          },
+        }),
+      );
+
+      const { stdout, exitCode } = await runMcpList();
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain(`Status:    ${lifecycleState}`);
+      expect(stdout).not.toContain("legacy-status");
+    },
+  );
 
   test("shows stdio command info", async () => {
     mockCliIpcCallFn = mock(() =>
@@ -263,7 +300,8 @@ describe("assistant mcp list", () => {
           servers: [
             {
               id: "json-server",
-              status: "✓ Connected",
+              status: "error",
+              lifecycleState: "connecting",
               transport: {
                 type: "streamable-http",
                 url: "https://example.com/mcp",
@@ -280,6 +318,8 @@ describe("assistant mcp list", () => {
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toHaveLength(1);
     expect(parsed[0].id).toBe("json-server");
+    expect(parsed[0].status).toBe("error");
+    expect(parsed[0].lifecycleState).toBe("connecting");
     expect(parsed[0].transport.url).toBe("https://example.com/mcp");
   });
 

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -14,6 +14,7 @@ import { mcpHelp } from "./mcp.help.js";
 interface McpServerEntry {
   id: string;
   status: string;
+  lifecycleState?: string;
   transport: {
     type: string;
     url?: string;
@@ -89,9 +90,21 @@ async function pollMcpAuthStatus(
 // Display helper for list output
 // ---------------------------------------------------------------------------
 
+const MCP_LIFECYCLE_STATES = new Set([
+  "not-started",
+  "connecting",
+  "connected",
+  "needs-auth",
+  "error",
+  "declared",
+]);
+
 function printServerEntry(entry: McpServerEntry): void {
+  const status = MCP_LIFECYCLE_STATES.has(entry.lifecycleState ?? "")
+    ? entry.lifecycleState
+    : entry.status;
   log.info(`  ${entry.id}`);
-  log.info(`    Status:    ${entry.status}`);
+  log.info(`    Status:    ${status}`);
   // Only plugin-declared servers name a source. A workspace server is the
   // default case and printing "workspace" on every one of them is noise.
   if (entry.source === "plugin") {


### PR DESCRIPTION
MCP list output uses the detailed lifecycle state so starting connections are shown as connecting instead of the legacy error projection. Older assistants retain the existing status fallback, and JSON output is unchanged.

Validation: 13 focused CLI list tests, assistant typecheck, lint, and formatting passed.

Part of #42552; addresses feedback on #42560. Targets the temporary combined QA branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->