### PR TITLE
Verify MCP authorization status identity in the web client

### DIFF
--- a/clients/web/src/domains/settings/mcp/use-mcp-connect.test.tsx
+++ b/clients/web/src/domains/settings/mcp/use-mcp-connect.test.tsx
@@ -288,6 +288,32 @@ describe("useMcpConnect", () => {
     expect(result.current.attempt?.error).toBeTruthy();
   });
 
+  test("completion without an attempt ID cannot complete a verified UI attempt", async () => {
+    status = { status: "complete" };
+    const { result } = renderConnect();
+    act(() => result.current.connect("example-integration"));
+    await waitFor(() => expect(result.current.attempt?.phase).toBe("error"));
+    expect(list).not.toHaveBeenCalled();
+    expect(result.current.attempt?.error).toBeTruthy();
+  });
+
+  test("legacy authorization without attempt IDs still waits for runtime readiness", async () => {
+    start.mockImplementationOnce(async () => ({
+      state: "oauth-state",
+      auth_url: "https://example.com/authorize",
+    }));
+    status = { status: "complete" };
+    const { result } = renderConnect();
+    act(() => result.current.connect("example-integration"));
+    await waitFor(() =>
+      expect(result.current.attempt?.phase).toBe("connecting"),
+    );
+    expect(result.current.canCancel).toBe(false);
+    servers = [mcpServer({ lifecycleState: "connected" })];
+    act(() => browserFinished?.());
+    await waitFor(() => expect(result.current.attempt).toBeNull());
+  });
+
   test("unmount closes the blank popup and ignores a late start response", async () => {
     const pending = deferred<StartResult>();
     start.mockImplementationOnce(() => pending.promise);

--- a/clients/web/src/domains/settings/mcp/use-mcp-connect.ts
+++ b/clients/web/src/domains/settings/mcp/use-mcp-connect.ts
@@ -88,11 +88,7 @@ export function useMcpConnect(assistantId: string) {
       return;
     }
     const status = authStatus.data;
-    if (
-      attempt.attemptId &&
-      status.attempt_id &&
-      status.attempt_id !== attempt.attemptId
-    ) {
+    if (attempt.attemptId && status.attempt_id !== attempt.attemptId) {
       setAttempt({
         ...attempt,
         phase: "error",


### PR DESCRIPTION
When authorization start advertises an attempt ID, the web client requires the same ID on every status response before accepting completion. A missing ID is treated as supersession instead of accidentally accepting another flow. Older assistants that never advertise an ID retain their existing behavior.

Validation: 14 auth-hook tests, including omitted-ID and legacy-completion regressions, web typecheck, and scoped lint passed.

Part of #42552. Focused follow-up to #42564 on the combined QA branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->