### PR TITLE
Retry incomplete MCP cancellation cleanup safely

### DIFF
--- a/assistant/src/__tests__/mcp-auth-routes.test.ts
+++ b/assistant/src/__tests__/mcp-auth-routes.test.ts
@@ -24,6 +24,7 @@ const mockGetMcpAuthState = mock((_serverId: string) => null as unknown);
 mock.module("../mcp/mcp-auth-state.js", () => ({
   cancelCurrentMcpAuth: () => {},
   getMcpAuthState: mockGetMcpAuthState,
+  setMcpAuthCancellationCleanupPending: () => {},
 }));
 
 import { setConfig } from "./helpers/set-config.js";

--- a/assistant/src/mcp/__tests__/connection-lifecycle.test.ts
+++ b/assistant/src/mcp/__tests__/connection-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 import { setConfig } from "../../__tests__/helpers/set-config.js";
 
@@ -302,6 +302,119 @@ describe("MCP connection teardown", () => {
           ? ["mcp:example:client_binding", "mcp:example:headers"]
           : ["mcp:example:headers"],
       );
+    },
+  );
+  test("failed cancellation retries the same attempt after the status grace period", async () => {
+    setMcpAuthPending("example", "https://auth.example.com", "retry-attempt");
+    const close = mock(() => {});
+    registerMcpAuthCancellation("example", "retry-attempt", close);
+    failedKeys.add("mcp:example:client_binding");
+    const request = { serverId: "example", attemptId: "retry-attempt" };
+    await expect(handler("internal_mcp_auth_cancel", request)).rejects.toThrow(
+      "retry cancelling",
+    );
+
+    const clock = spyOn(Date, "now").mockReturnValue(Date.now() + 120_000);
+    try {
+      expect(getMcpAuthState("example")).toMatchObject({
+        status: "error",
+        attemptId: "retry-attempt",
+        cancellationCleanupPending: true,
+      });
+      const entered = deferred();
+      const release = deferred();
+      failedKeys.clear();
+      deleteHook = async (key) => {
+        if (key.endsWith(":client_binding")) {
+          entered.resolve();
+          await release.promise;
+        }
+      };
+      publishedCredentials.length = 0;
+      const retry = handler("internal_mcp_auth_cancel", request);
+      await entered.promise;
+      expect(credentials.has("mcp:example:client_binding")).toBe(true);
+      expect(publishedCredentials).toHaveLength(0);
+      release.resolve();
+
+      expect(await retry).toEqual({ cancelled: true });
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(publishedCredentials.at(-1)).toEqual(["mcp:example:headers"]);
+      expect(savedServers()).toHaveProperty("example");
+      expect(getMcpAuthState("example")).toMatchObject({
+        cancellationCleanupPending: false,
+      });
+      expect(await handler("internal_mcp_auth_cancel", request)).toEqual({
+        cancelled: false,
+      });
+    } finally {
+      clock.mockRestore();
+    }
+  });
+  test("a stale cleanup retry cannot cancel or clear a newer attempt", async () => {
+    setMcpAuthPending("example", "https://auth.example.com", "failed-attempt");
+    failedKeys.add("mcp:example:tokens");
+    const request = { serverId: "example", attemptId: "failed-attempt" };
+    await expect(handler("internal_mcp_auth_cancel", request)).rejects.toThrow(
+      "credential cleanup failed",
+    );
+    failedKeys.clear();
+    setMcpAuthPending("example", "https://auth.example.com", "new-attempt");
+    const closeNew = mock(() => {});
+    registerMcpAuthCancellation("example", "new-attempt", closeNew);
+    credentials.set("mcp:example:tokens", "new-attempt-token");
+    publishedCredentials.length = 0;
+
+    expect(await handler("internal_mcp_auth_cancel", request)).toEqual({
+      cancelled: false,
+    });
+    expect(closeNew).not.toHaveBeenCalled();
+    expect(credentials.get("mcp:example:tokens")).toBe("new-attempt-token");
+    expect(getMcpAuthState("example")).toMatchObject({
+      status: "pending",
+      attemptId: "new-attempt",
+    });
+    expect(publishedCredentials).toHaveLength(0);
+  });
+  test("an ordinary OAuth error does not authorize cancellation cleanup", async () => {
+    setMcpAuthPending("example", "https://auth.example.com", "error-attempt");
+    setMcpAuthError("example", "Connection cancelled", "error-attempt");
+    const before = [...credentials.entries()];
+    expect(
+      await handler("internal_mcp_auth_cancel", {
+        serverId: "example",
+        attemptId: "error-attempt",
+      }),
+    ).toEqual({ cancelled: false });
+    expect([...credentials.entries()]).toEqual(before);
+  });
+  test.each(["internal_mcp_remove", "internal_mcp_auth_revoke"])(
+    "%s also settles a failed cancellation's cleanup state",
+    async (operation) => {
+      setMcpAuthPending(
+        "example",
+        "https://auth.example.com",
+        "cleanup-attempt",
+      );
+      failedKeys.add("mcp:example:tokens");
+      await expect(
+        handler("internal_mcp_auth_cancel", {
+          serverId: "example",
+          attemptId: "cleanup-attempt",
+        }),
+      ).rejects.toThrow("credential cleanup failed");
+      failedKeys.clear();
+
+      await handler(
+        operation,
+        operation === "internal_mcp_remove"
+          ? { name: "example" }
+          : { serverId: "example" },
+      );
+
+      expect(getMcpAuthState("example")).toMatchObject({
+        cancellationCleanupPending: false,
+      });
     },
   );
   test("concurrent add and remove preserve unrelated configuration writes", async () => {

--- a/assistant/src/mcp/connection-lifecycle.ts
+++ b/assistant/src/mcp/connection-lifecycle.ts
@@ -4,7 +4,11 @@ import { reloadMcpServers } from "../daemon/mcp-reload-service.js";
 import { Mutex } from "../util/mutex.js";
 import { withMcpConfigWrite } from "./config-write-lock.js";
 import { withMcpCredentialLock } from "./credential-coordination.js";
-import { cancelCurrentMcpAuth, getMcpAuthState } from "./mcp-auth-state.js";
+import {
+  cancelCurrentMcpAuth,
+  getMcpAuthState,
+  setMcpAuthCancellationCleanupPending,
+} from "./mcp-auth-state.js";
 import { deleteMcpHeaders } from "./mcp-header-store.js";
 import { publishMcpChanged } from "./sync.js";
 
@@ -55,18 +59,26 @@ export async function cancelMcpConnectionAttempt(
   const { deleteMcpOAuthCredentials } = await import("./mcp-oauth-provider.js");
   return withMcpCredentialLock(serverId, async (lease) => {
     const state = getMcpAuthState(serverId);
-    if (state?.status !== "pending" || state.attemptId !== attemptId) {
+    if (
+      state?.attemptId !== attemptId ||
+      !(
+        state.status === "pending" ||
+        (state.status === "error" && state.cancellationCleanupPending)
+      )
+    ) {
       return false;
     }
     cancelCurrentMcpAuth(serverId);
+    setMcpAuthCancellationCleanupPending(serverId, attemptId, true);
     lease.advance();
     try {
       const result = await deleteMcpOAuthCredentials(serverId);
       if (!result.ok) {
         throw new Error(
-          "Authorization cancelled, but credential cleanup failed; retry disconnecting",
+          "Authorization cancelled, but credential cleanup failed; retry cancelling",
         );
       }
+      setMcpAuthCancellationCleanupPending(serverId, attemptId, false);
       return true;
     } finally {
       lease.advance();
@@ -101,6 +113,17 @@ export async function teardownMcpConnection(
               `Credential cleanup failed (${failed.join(
                 ", ",
               )}); retry disconnecting`,
+              false,
+            );
+          }
+          const authState = getMcpAuthState(serverId);
+          if (
+            authState?.status === "error" &&
+            authState.cancellationCleanupPending
+          ) {
+            setMcpAuthCancellationCleanupPending(
+              serverId,
+              authState.attemptId,
               false,
             );
           }

--- a/assistant/src/mcp/mcp-auth-state.ts
+++ b/assistant/src/mcp/mcp-auth-state.ts
@@ -24,7 +24,13 @@ type McpAuthState =
       attemptId: string;
       completedAt: number;
     }
-  | { status: "error"; error: string; attemptId: string; failedAt: number };
+  | {
+      status: "error";
+      error: string;
+      attemptId: string;
+      failedAt: number;
+      cancellationCleanupPending?: boolean;
+    };
 
 const activeMcpAuthFlows = new Map<string, McpAuthState>();
 const cancellations = new Map<
@@ -57,6 +63,21 @@ export function cancelCurrentMcpAuth(serverId: string): void {
   setMcpAuthError(serverId, "Connection cancelled", current.attemptId);
   cancellations.get(serverId)?.cancel();
   cancellations.delete(serverId);
+}
+
+export function setMcpAuthCancellationCleanupPending(
+  serverId: string,
+  attemptId: string,
+  pending: boolean,
+): void {
+  const current = activeMcpAuthFlows.get(serverId);
+  if (current?.status === "error" && current.attemptId === attemptId) {
+    activeMcpAuthFlows.set(serverId, {
+      ...current,
+      cancellationCleanupPending: pending,
+      failedAt: Date.now(),
+    });
+  }
 }
 
 const PENDING_TTL_MS = 5 * 60 * 1000; // 5 min — matches oauth-callback-registry.ts
@@ -132,9 +153,8 @@ export function setMcpAuthError(
 }
 
 /**
- * Get the current state of an OAuth flow, or null if none exists. Sweeps
- * expired entries on every read so a long-polling CLI can never observe
- * a stale flow past its TTL.
+ * Get the current OAuth flow and sweep expired entries. Failed cancellation
+ * cleanup remains retryable until settled or superseded.
  */
 export function getMcpAuthState(serverId: string): McpAuthState | null {
   const now = Date.now();
@@ -150,6 +170,7 @@ export function getMcpAuthState(serverId: string): McpAuthState | null {
       activeMcpAuthFlows.delete(id);
     } else if (
       state.status === "error" &&
+      !state.cancellationCleanupPending &&
       now > state.failedAt + COMPLETION_GRACE_MS
     ) {
       activeMcpAuthFlows.delete(id);


### PR DESCRIPTION
If credential cleanup fails during cancellation, the same authorization attempt can retry cleanup until it succeeds. A pending-cleanup marker retains exact attempt ownership through the normal status grace period; newer attempts and unrelated errors remain protected. Remove and legacy revoke also clear the marker only after successful cleanup.

Validation: 34 focused lifecycle, route, and orchestrator tests passed, including deferred failed deletion, retry after the status grace period, and newer-attempt isolation; assistant typecheck and lint passed.

Part of #42552. Addresses the cancellation retry finding on #42560; targets the combined QA branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->