### PR TITLE
Enforce MCP catalog drift checks in CI

### DIFF
--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -12,6 +12,10 @@ on:
       - 'gateway/**'
       - 'packages/**'
       - 'scripts/skills/**'
+      - 'scripts/plugins/generate-mcp-catalog.ts'
+      - 'plugins/mcp-catalog.json'
+      - 'plugins/mcp-catalog/**'
+      - 'plugins/marketplace.json'
       - 'meta/feature-flags/**'
       - 'meta/sync-bundled-copies.ts'
       # The daemon LLM catalog parity test reads these files, so hand edits to
@@ -54,6 +58,9 @@ jobs:
 
       - name: Sync feature flag registry
         run: cd .. && bun run meta/sync-bundled-copies.ts
+
+      - name: Check MCP catalog bundle
+        run: bun ../scripts/plugins/generate-mcp-catalog.ts --check
 
       - name: Lint
         run: bun run lint

--- a/assistant/src/__tests__/workspace-migration-mcp-catalog-provenance.test.ts
+++ b/assistant/src/__tests__/workspace-migration-mcp-catalog-provenance.test.ts
@@ -10,7 +10,14 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import { McpConfigSchema } from "../config/schemas/mcp.js";
-import { mcpCatalogProvenanceMigration as migration } from "../workspace/migrations/155-mcp-catalog-provenance.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+
+const migration = WORKSPACE_MIGRATIONS.find(
+  (entry) => entry.id === "155-mcp-catalog-provenance",
+);
+if (!migration) {
+  throw new Error("MCP catalog provenance migration is not registered");
+}
 
 describe("catalog provenance migration", () => {
   test("preserves legacy IDs/transports and existing provenance on repeated runs", () => {


### PR DESCRIPTION
Canonical MCP package and catalog changes now trigger assistant CI, which checks that the bundled catalog matches its source documents. The provenance migration test selects the registered migration so registration is verified as part of its existing preservation checks.

Validation: generator --check, three migration tests, and workflow YAML/trigger checks passed. Existing action pins and dependency setup are reused.

Part of #42552. Addresses catalog drift and migration-test review feedback.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->