### PR TITLE
Polish streamed desktop window decorations

### DIFF
--- a/assistant/scripts/smoke-desktop-window-theme.ts
+++ b/assistant/scripts/smoke-desktop-window-theme.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeDesktopWindowTheme } from "../src/desktop/desktop-window-theme.js";
+
+if (process.platform !== "linux") {
+  throw new Error(
+    "Run in a disposable Linux environment with Xvfb, Openbox, xterm, xdotool, xwininfo and xmllint installed",
+  );
+}
+
+const directory = await mkdtemp(join(tmpdir(), "window-theme-smoke-"));
+const env = { ...process.env, DISPLAY: ":97" };
+const children: ReturnType<typeof Bun.spawn>[] = [];
+const start = (cmd: string[]) => {
+  const child = Bun.spawn(cmd, {
+    env,
+    stdout: "ignore",
+    stderr: "inherit",
+    windowsHide: true,
+  });
+  children.push(child);
+  return child;
+};
+const run = (...cmd: string[]) => {
+  const result = Bun.spawnSync(cmd, {
+    env,
+
+    windowsHide: true,
+  });
+  assert.equal(result.exitCode, 0, result.stderr.toString());
+  return result.stdout.toString();
+};
+const waitFor = async (predicate: () => boolean) => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      if (predicate()) {
+        return;
+      }
+    } catch {}
+    await Bun.sleep(50);
+  }
+  throw new Error("Window theme smoke condition timed out");
+};
+const pointer = async (...args: string[]) => {
+  run("xdotool", ...args);
+  await Bun.sleep(200);
+};
+const geometry = () => {
+  const info = run("xwininfo", "-name", "Theme smoke");
+  return [
+    "Absolute upper-left X",
+    "Absolute upper-left Y",
+    "Width",
+    "Height",
+  ].map((label) =>
+    Number(new RegExp(`${label}:\\s+(-?\\d+)`).exec(info)?.[1]),
+  ) as [number, number, number, number];
+};
+const state = () => run("xprop", "-name", "Theme smoke", "_NET_WM_STATE");
+const button = async (offset: number) => {
+  const [x, y, width] = geometry();
+  await pointer(
+    "mousemove",
+    String(x + width - offset),
+    String(y - 16),
+    "click",
+    "1",
+  );
+};
+
+try {
+  const home = join(directory, "home");
+  const sourceDir = join(home, ".config", "openbox");
+  await mkdir(sourceDir, { recursive: true });
+  const original = await readFile("/etc/xdg/openbox/rc.xml", "utf8");
+  const mouse = original.match(/<mouse>[^]*?<\/mouse>/)![0];
+  const keyboard = original.match(/<keyboard>[^]*?<\/keyboard>/)![0];
+  const source = original
+    .replace(
+      mouse,
+      `<xi:include href="bindings.xml" xpointer="xpointer(/*/*)"/>`,
+    )
+    .replace(keyboard, "");
+  const sourcePath = join(sourceDir, "rc.xml");
+  await writeFile(sourcePath, source);
+  await writeFile(
+    join(sourceDir, "bindings.xml"),
+    `<bindings xmlns="http://openbox.org/3.4/rc">${mouse}${keyboard}</bindings>`,
+  );
+  const configDir = join(directory, "managed & theme");
+  const config = writeDesktopWindowTheme(configDir, home, "#53b7aa");
+  const expanded = run("xmllint", "--xinclude", config);
+  assert(
+    expanded.includes("NextWindow") && expanded.includes("Move"),
+    "Relative includes must retain the actual keyboard and mouse bindings",
+  );
+  assert.equal(await readFile(sourcePath, "utf8"), source);
+  writeDesktopWindowTheme(configDir, home, "#bc7799");
+  writeDesktopWindowTheme(configDir, home, "#53b7aa");
+  assert.equal(await readFile(sourcePath, "utf8"), source);
+  const blocked = join(directory, "blocked");
+  await writeFile(blocked, "not a directory");
+  assert.throws(() => writeDesktopWindowTheme(blocked, home));
+  assert.equal(await readFile(sourcePath, "utf8"), source);
+  const customBase = source.replace(
+    "<openbox_config",
+    '<openbox_config xml:base="./custom/"',
+  );
+  await writeFile(sourcePath, customBase);
+  assert.throws(() => writeDesktopWindowTheme(configDir, home));
+  assert.equal(await readFile(sourcePath, "utf8"), customBase);
+  await writeFile(sourcePath, source);
+
+  start(["Xvfb", ":97", "-screen", "0", "1100x700x24"]);
+  await waitFor(
+    () => run("xdotool", "getdisplaygeometry").trim() === "1100 700",
+  );
+  start(["openbox", "--config-file", config]);
+  await waitFor(() =>
+    run("xprop", "-root", "_OB_THEME").includes("window-theme"),
+  );
+  start([
+    "xterm",
+    "-title",
+    "Theme smoke",
+    "-geometry",
+    "48x12+450+250",
+    "-e",
+    "sleep",
+    "60",
+  ]);
+  await waitFor(
+    () => run("xdotool", "search", "--name", "^Theme smoke$").trim().length > 0,
+  );
+  await Bun.sleep(300);
+  const id = run("xdotool", "search", "--name", "^Theme smoke$").trim();
+  await button(39);
+  assert(
+    state().includes("MAXIMIZED_HORZ") && state().includes("MAXIMIZED_VERT"),
+  );
+  await button(39);
+  assert(!state().includes("MAXIMIZED"));
+  await button(62);
+  assert(state().includes("HIDDEN"));
+  await pointer("windowactivate", id);
+  assert(!state().includes("HIDDEN"));
+  let [x, y, width, height] = geometry();
+  await pointer("mousemove", String(x + 100), String(y - 16), "mousedown", "1");
+  await pointer("mousemove", String(x + 90), String(y - 26));
+  await pointer("mousemove", String(x + 45), String(y - 65));
+  await pointer("mouseup", "1");
+  const [movedX, movedY] = geometry();
+  assert(Math.abs(movedX - x) >= 30 && Math.abs(movedY - y) >= 30);
+  [x, y, width, height] = geometry();
+  await pointer(
+    "mousemove",
+    String(x + width - 2),
+    String(y + height + 2),
+    "mousedown",
+    "1",
+  );
+  await pointer("mousemove", String(x + width + 10), String(y + height + 10));
+  await pointer("mousemove", String(x + width + 60), String(y + height + 40));
+  await pointer("mouseup", "1");
+  const [, , resizedWidth, resizedHeight] = geometry();
+  assert(resizedWidth > width && resizedHeight > height);
+  await pointer("key", "alt+F4");
+  await waitFor(
+    () =>
+      !run("xprop", "-root", "_NET_CLIENT_LIST").includes(
+        `0x${Number(id).toString(16)}`,
+      ),
+  );
+  console.log(
+    "PASS: relative includes, preserved source, repeated theme updates, maximize/restore, minimize/activation, dragging, resizing, and keyboard close",
+  );
+} finally {
+  for (const child of children.reverse()) {
+    child.kill();
+  }
+  await Promise.all(children.map((child) => child.exited));
+  await rm(directory, { recursive: true, force: true });
+}

--- a/assistant/src/desktop/desktop-session-manager.test.ts
+++ b/assistant/src/desktop/desktop-session-manager.test.ts
@@ -219,7 +219,7 @@ describe("DesktopSessionManager process tree", () => {
         DISPLAY: ":99",
       });
     }
-    expect(h.child("window-manager").request.cmd).toEqual(["/usr/bin/openbox"]);
+    expect(h.child("window-manager").request.cmd[0]).toBe("/usr/bin/openbox");
     // The compositor precedes the dock so it has an ARGB visual.
     expect(h.child("compositor").request.cmd).toEqual(["/usr/bin/xcompmgr"]);
     expect(h.child("panel").request.cmd).toEqual([

--- a/assistant/src/desktop/desktop-session-manager.ts
+++ b/assistant/src/desktop/desktop-session-manager.ts
@@ -9,6 +9,8 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { readAvatarState } from "../avatar/avatar-manifest.js";
+import { resolveNotificationAccentHex } from "../avatar/notification-avatar.js";
 import { getIsContainerized } from "../config/env-registry.js";
 import { terminateProcessTree } from "../util/host-process.js";
 import { getLogger } from "../util/logger.js";
@@ -335,7 +337,11 @@ export class DesktopSessionManager {
       try {
         windowManagerCommand.push(
           "--config-file",
-          writeDesktopWindowTheme(this.panelConfigDir, env.HOME),
+          writeDesktopWindowTheme(
+            this.panelConfigDir,
+            env.HOME,
+            resolveNotificationAccentHex(readAvatarState()),
+          ),
         );
       } catch (err) {
         log.warn({ err }, "Desktop window theme could not be applied");

--- a/assistant/src/desktop/desktop-session-manager.ts
+++ b/assistant/src/desktop/desktop-session-manager.ts
@@ -21,6 +21,7 @@ import {
 } from "./desktop-dependencies.js";
 import { writeDesktopPanelConfig } from "./desktop-panel-config.js";
 import { renderCurrentDesktopWallpaper } from "./desktop-wallpaper.js";
+import { writeDesktopWindowTheme } from "./desktop-window-theme.js";
 
 const log = getLogger("desktop-session");
 
@@ -330,7 +331,16 @@ export class DesktopSessionManager {
           `Desktop VNC server not ready on port ${DESKTOP_VNC_PORT} after ${this.readyDeadlineMs}ms`,
         );
       }
-      this.launch("window-manager", [this.binaries.windowManager], env);
+      const windowManagerCommand = [this.binaries.windowManager];
+      try {
+        windowManagerCommand.push(
+          "--config-file",
+          writeDesktopWindowTheme(this.panelConfigDir, env.HOME),
+        );
+      } catch (err) {
+        log.warn({ err }, "Desktop window theme could not be applied");
+      }
+      this.launch("window-manager", windowManagerCommand, env);
       // Before the dock, which only gets the ARGB visual its rounded corners
       // and translucency need if a compositor is already running.
       this.launchCosmetic("compositor", [this.binaries.compositor], env);

--- a/assistant/src/desktop/desktop-window-theme.ts
+++ b/assistant/src/desktop/desktop-window-theme.ts
@@ -1,7 +1,8 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
-import { escapeXmlContent } from "../util/xml.js";
+import { escapeXmlAttr, escapeXmlContent } from "../util/xml.js";
 
 const BUTTON_MASKS = {
   close: [0x201, 0x102, 0x084, 0x048, 0x030, 0x030, 0x048, 0x084, 0x102, 0x201],
@@ -12,7 +13,25 @@ const BUTTON_MASKS = {
   iconify: [0, 0, 0, 0, 0x3ff, 0x3ff, 0, 0, 0, 0],
 };
 
-const THEME = `
+function windowTheme(accentHex: string | null): string {
+  const tint = (base: string, amount: number): string => {
+    if (!accentHex || !/^#[\da-f]{6}$/i.test(accentHex)) {
+      return base;
+    }
+    return (
+      "#" +
+      [1, 3, 5]
+        .map((offset) => {
+          const from = parseInt(base.slice(offset, offset + 2), 16);
+          const to = parseInt(accentHex.slice(offset, offset + 2), 16);
+          return Math.round(from + (to - from) * amount)
+            .toString(16)
+            .padStart(2, "0");
+        })
+        .join("")
+    );
+  };
+  return `
 border.width: 1
 padding.width: 8
 padding.height: 7
@@ -27,15 +46,15 @@ window.*.handle.bg: Flat Solid
 window.*.grip.bg: Flat Solid
 window.*.button.*.bg: Flat Solid
 window.active.title.bg.color: #292930
-window.active.border.color: #4a4a54
-window.active.title.separator.color: #202026
+window.active.border.color: ${tint("#4a4a54", 0.4)}
+window.active.title.separator.color: ${tint("#202026", 0.4)}
 window.active.label.text.color: #f0f0f4
 window.active.handle.bg.color: #292930
 window.active.grip.bg.color: #292930
 window.active.button.*.bg.color: #292930
 window.active.button.*.image.color: #d4d4dc
-window.active.button.hover.bg.color: #45454f
-window.active.button.pressed.bg.color: #555561
+window.active.button.hover.bg.color: ${tint("#45454f", 0.22)}
+window.active.button.pressed.bg.color: ${tint("#555561", 0.18)}
 window.active.button.disabled.image.color: #62626e
 window.active.button.close.hover.bg.color: #b64150
 window.active.button.close.pressed.bg.color: #963442
@@ -70,13 +89,16 @@ osd.bg.color: #292930
 osd.border.color: #4a4a54
 osd.label.text.color: #f0f0f4
 `;
+}
 
 /** Keep Openbox bindings and placement rules while styling its decorations. */
 export function writeDesktopWindowTheme(
   configDir: string,
   home?: string,
+  accentHex: string | null = null,
 ): string {
   let source: string | undefined;
+  let sourcePath = "";
   const candidates = [
     ...(home ? [join(home, ".config", "openbox", "rc.xml")] : []),
     "/etc/xdg/openbox/rc.xml",
@@ -84,6 +106,7 @@ export function writeDesktopWindowTheme(
   for (const path of candidates) {
     try {
       source = readFileSync(path, "utf8");
+      sourcePath = path;
       break;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -94,9 +117,23 @@ export function writeDesktopWindowTheme(
   if (!source || !/<theme>[^]*?<\/theme>/.test(source)) {
     throw new Error("Openbox theme configuration is unavailable");
   }
+  const root = source.match(/<openbox_config\b[^>]*>/)?.[0];
+  if (!root || /\bxml:base\s*=/.test(root)) {
+    throw new Error("Openbox configuration requires its original base URI");
+  }
+  // Relative XIncludes keep resolving beside the source configuration.
+  source = source.replace(root, () =>
+    root.replace(
+      "<openbox_config",
+      `<openbox_config xml:base="${escapeXmlAttr(pathToFileURL(sourcePath).href)}"`,
+    ),
+  );
   const themeDir = join(configDir, "window-theme");
   mkdirSync(join(themeDir, "openbox-3"), { recursive: true });
-  writeFileSync(join(themeDir, "openbox-3", "themerc"), THEME.trimStart());
+  writeFileSync(
+    join(themeDir, "openbox-3", "themerc"),
+    windowTheme(accentHex).trimStart(),
+  );
   for (const [name, rows] of Object.entries(BUTTON_MASKS)) {
     const bytes = rows.flatMap((row) => [row & 0xff, row >> 8]);
     writeFileSync(

--- a/assistant/src/desktop/desktop-window-theme.ts
+++ b/assistant/src/desktop/desktop-window-theme.ts
@@ -44,18 +44,21 @@ window.*.title.bg: Flat Solid
 window.*.label.bg: Parentrelative
 window.*.handle.bg: Flat Solid
 window.*.grip.bg: Flat Solid
-window.*.button.*.bg: Flat Solid
-window.active.title.bg.color: #292930
-window.active.border.color: ${tint("#4a4a54", 0.4)}
-window.active.title.separator.color: ${tint("#202026", 0.4)}
+window.*.button.*.bg: Parentrelative
+window.*.button.*.hover.bg: Flat Solid
+window.*.button.*.pressed.bg: Flat Solid
+window.active.title.bg: Flat Gradient Horizontal
+window.active.title.bg.color: ${tint("#292930", 0.28)}
+window.active.title.bg.colorTo: #292930
+window.active.border.color: #4a4a54
+window.active.title.separator.color: #202026
 window.active.label.text.color: #f0f0f4
 window.active.handle.bg.color: #292930
 window.active.grip.bg.color: #292930
-window.active.button.*.bg.color: #292930
 window.active.button.*.image.color: #d4d4dc
-window.active.button.hover.bg.color: ${tint("#45454f", 0.22)}
-window.active.button.pressed.bg.color: ${tint("#555561", 0.18)}
-window.active.button.disabled.image.color: #62626e
+window.active.button.*.hover.bg.color: ${tint("#45454f", 0.22)}
+window.active.button.*.pressed.bg.color: ${tint("#555561", 0.18)}
+window.active.button.*.disabled.image.color: #62626e
 window.active.button.close.hover.bg.color: #b64150
 window.active.button.close.pressed.bg.color: #963442
 window.inactive.title.bg.color: #232329
@@ -64,11 +67,10 @@ window.inactive.title.separator.color: #202026
 window.inactive.label.text.color: #a6a6b2
 window.inactive.handle.bg.color: #232329
 window.inactive.grip.bg.color: #232329
-window.inactive.button.*.bg.color: #232329
 window.inactive.button.*.image.color: #858592
-window.inactive.button.hover.bg.color: #3b3b45
-window.inactive.button.pressed.bg.color: #4a4a54
-window.inactive.button.disabled.image.color: #565660
+window.inactive.button.*.hover.bg.color: #3b3b45
+window.inactive.button.*.pressed.bg.color: #4a4a54
+window.inactive.button.*.disabled.image.color: #565660
 menu.border.width: 1
 menu.border.color: #4a4a54
 menu.title.bg: Flat Solid

--- a/assistant/src/desktop/desktop-window-theme.ts
+++ b/assistant/src/desktop/desktop-window-theme.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { escapeXmlContent } from "../util/xml.js";
+
+const BUTTON_MASKS = {
+  close: [0x201, 0x102, 0x084, 0x048, 0x030, 0x030, 0x048, 0x084, 0x102, 0x201],
+  max: [0x3ff, 0x201, 0x201, 0x201, 0x201, 0x201, 0x201, 0x201, 0x201, 0x3ff],
+  max_toggled: [
+    0x3fc, 0x204, 0x27f, 0x241, 0x241, 0x241, 0x3c1, 0x041, 0x041, 0x07f,
+  ],
+  iconify: [0, 0, 0, 0, 0x3ff, 0x3ff, 0, 0, 0, 0],
+};
+
+const THEME = `
+border.width: 1
+padding.width: 8
+padding.height: 7
+window.client.padding.width: 0
+window.client.padding.height: 0
+window.handle.width: 3
+window.label.text.justify: Center
+window.*.label.text.font: shadow=n
+window.*.title.bg: Flat Solid
+window.*.label.bg: Parentrelative
+window.*.handle.bg: Flat Solid
+window.*.grip.bg: Flat Solid
+window.*.button.*.bg: Flat Solid
+window.active.title.bg.color: #292930
+window.active.border.color: #4a4a54
+window.active.title.separator.color: #202026
+window.active.label.text.color: #f0f0f4
+window.active.handle.bg.color: #292930
+window.active.grip.bg.color: #292930
+window.active.button.*.bg.color: #292930
+window.active.button.*.image.color: #d4d4dc
+window.active.button.hover.bg.color: #45454f
+window.active.button.pressed.bg.color: #555561
+window.active.button.disabled.image.color: #62626e
+window.active.button.close.hover.bg.color: #b64150
+window.active.button.close.pressed.bg.color: #963442
+window.inactive.title.bg.color: #232329
+window.inactive.border.color: #36363f
+window.inactive.title.separator.color: #202026
+window.inactive.label.text.color: #a6a6b2
+window.inactive.handle.bg.color: #232329
+window.inactive.grip.bg.color: #232329
+window.inactive.button.*.bg.color: #232329
+window.inactive.button.*.image.color: #858592
+window.inactive.button.hover.bg.color: #3b3b45
+window.inactive.button.pressed.bg.color: #4a4a54
+window.inactive.button.disabled.image.color: #565660
+menu.border.width: 1
+menu.border.color: #4a4a54
+menu.title.bg: Flat Solid
+menu.title.bg.color: #292930
+menu.title.text.color: #f0f0f4
+menu.title.text.font: shadow=n
+menu.items.bg: Flat Solid
+menu.items.bg.color: #232329
+menu.items.text.color: #e6e6ee
+menu.items.disabled.text.color: #858592
+menu.items.active.bg: Flat Solid
+menu.items.active.bg.color: #45454f
+menu.items.active.text.color: #ffffff
+menu.items.active.disabled.text.color: #a6a6b2
+menu.separator.color: #45454f
+osd.bg: Flat Solid
+osd.bg.color: #292930
+osd.border.color: #4a4a54
+osd.label.text.color: #f0f0f4
+`;
+
+/** Keep Openbox bindings and placement rules while styling its decorations. */
+export function writeDesktopWindowTheme(
+  configDir: string,
+  home?: string,
+): string {
+  let source: string | undefined;
+  const candidates = [
+    ...(home ? [join(home, ".config", "openbox", "rc.xml")] : []),
+    "/etc/xdg/openbox/rc.xml",
+  ];
+  for (const path of candidates) {
+    try {
+      source = readFileSync(path, "utf8");
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+    }
+  }
+  if (!source || !/<theme>[^]*?<\/theme>/.test(source)) {
+    throw new Error("Openbox theme configuration is unavailable");
+  }
+  const themeDir = join(configDir, "window-theme");
+  mkdirSync(join(themeDir, "openbox-3"), { recursive: true });
+  writeFileSync(join(themeDir, "openbox-3", "themerc"), THEME.trimStart());
+  for (const [name, rows] of Object.entries(BUTTON_MASKS)) {
+    const bytes = rows.flatMap((row) => [row & 0xff, row >> 8]);
+    writeFileSync(
+      join(themeDir, "openbox-3", `${name}.xbm`),
+      `#define button_width 10\n#define button_height 10\nstatic unsigned char button_bits[] = {\n${bytes.map((byte) => `0x${byte.toString(16)}`).join(",")}};\n`,
+    );
+  }
+  const fonts = [
+    "ActiveWindow",
+    "InactiveWindow",
+    "MenuHeader",
+    "MenuItem",
+    "ActiveOnScreenDisplay",
+    "InactiveOnScreenDisplay",
+  ].map(
+    (place) =>
+      `<font place="${place}"><name>sans</name><size>10</size><weight>normal</weight><slant>normal</slant></font>`,
+  );
+  const theme = `<theme>
+  <name>${escapeXmlContent(themeDir)}</name>
+  <titleLayout>LIMC</titleLayout>
+  <keepBorder>yes</keepBorder>
+  <animateIconify>yes</animateIconify>
+  ${fonts.join("\n  ")}
+</theme>`;
+  const configPath = join(configDir, "window-manager.xml");
+  writeFileSync(
+    configPath,
+    source.replace(/<theme>[^]*?<\/theme>/, () => theme),
+  );
+  return configPath;
+}


### PR DESCRIPTION
## Summary
- Replace the streamed desktop's default blue Openbox decorations with charcoal title bars with a soft horizontal avatar-color gradient on the active window, readable labels, larger minimize/maximize/close glyphs, and clear hover feedback. Use the same saved avatar accent as the desktop wallpaper. Keep borders neutral and let idle controls inherit the gradient; hover and pressed states have muted highlights. Match window menus and switcher colors to the theme.
- Generate the theme at desktop startup for new and existing installations. Preserve all non-theme Openbox settings, leave source configurations untouched, and fall back to the original window manager configuration if theme setup fails.
- Keep the existing default-off `assistant-desktop` gate and on-demand setup. No dependencies, host-desktop changes, or stored-data migrations are introduced.

## Original prompt
The Terminal title bar in the streamed desktop looked dated, with a blue gradient, tiny controls, and an oversized app icon. Improve the appearance consistently across windows using the desktop window manager while preserving normal window interactions. Incorporate a small amount of the assistant avatar color as a soft title-bar gradient, keeping the window border neutral. This PR targets the desktop feature branch in #42021.

## Validation
- Visually inspected the actual rendered Openbox theme on a disposable Linux X11 desktop with a subtle horizontal avatar-color gradient, neutral borders, clean button backgrounds, and neutral inactive windows. Reran the native window-control harness after the gradient change.
- Exercised the real title-bar controls: maximize, restore, minimize, activation, dragging, resizing, window menu, and close all passed.
- Parsed the generated and original Openbox XML and verified that non-theme settings are preserved. The generated document retains the source base URI so relative XIncludes continue resolving correctly.
- Added and ran `assistant/scripts/smoke-desktop-window-theme.ts` in a disposable Linux environment. It exercises real XML includes, source preservation, repeat generation, write failure, custom-base fallback, and window input through Openbox. The harness requires Xvfb, Openbox, xterm, xdotool, xwininfo and xmllint.
- Checked muted button tints against the lightest possible accent: icon contrast remains above 3:1 in hover and pressed states.
- All 26 existing desktop session-manager tests passed. Focused lint and formatting passed; assistant type checking passed through the commit and push hooks.

## Rollout
The theme and avatar accent are regenerated on the next desktop session start. Missing or invalid avatar accents retain the neutral appearance. Existing running sessions keep their current decorations until restarted. Applications drawing their own title bars, including Chrome's native tab strip, retain those controls. Cosmetic setup failures are logged and fall back to the existing appearance.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Custom Openbox configurations that already declare a root `xml:base` retain their original appearance through the fallback path. Source configuration files are never rewritten.

