### PR TITLE
fix(web): restore companion-surface after the v0.12.0 release merge

### DIFF
--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -529,34 +529,6 @@ export const InCallDrawingCardDown: Story = {
 };
 
 /**
- * Drawing on what is shared, with the box tool current: the strip of tools
- * stands off the Draw control on the card side of the pill.
- */
-export const InCallDrawing: Story = {
-  args: {
-    phase: "call",
-    shareEnabled: true,
-    sharing: true,
-    annotating: true,
-    annotationTool: "box",
-    call: DEMO_CALL,
-  },
-};
-
-/** The same strip where the card grows down, so it stands under the pill. */
-export const InCallDrawingCardDown: Story = {
-  args: {
-    phase: "call",
-    shareEnabled: true,
-    sharing: true,
-    annotating: true,
-    annotationTool: "circle",
-    cardGrowth: "down",
-    call: DEMO_CALL,
-  },
-};
-
-/**
  * Both held down at once, which is the widest row a call draws and what
  * `FALLBACK_WIDTHS.call` stands in for before the row has been measured.
  */

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -2341,19 +2341,7 @@ function ClearButton({
       onClick={() => {
         onClearMarks?.();
       }}
-    >
-      {tools.map((one) => (
-        <PillButton
-          key={one.tool}
-          icon={one.icon}
-          label={one.label}
-          pressed={tool === one.tool}
-          onClick={() => {
-            onTool?.(one.tool);
-          }}
-        />
-      ))}
-    </div>
+    />
   );
 }
 


### PR DESCRIPTION
Main fails `clients/web` type check on every PR since the Release v0.12.0 squash (#42554):

```
src/components/companion-surface.tsx(2356,7): error TS17002: Expected corresponding JSX closing tag for 'PillButton'.
```

The squash carried a bad conflict resolution: `ClearButton` opens a `PillButton` and closes a `div` (with a stray copy of the Draw tool strip inside), and `companion-surface.stories.tsx` declares `InCallDrawing` and `InCallDrawingCardDown` twice. This restores both files to their state after #42506, which is what main held before the release merge.

Unblocks web CI for every open PR, including #42548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUuRuR7FrkYcrT4WcbASbG
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->