### PR TITLE
fix(web): paint the active assistant-section row in its hover wash

### DIFF
--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -529,34 +529,6 @@ export const InCallDrawingCardDown: Story = {
 };
 
 /**
- * Drawing on what is shared, with the box tool current: the strip of tools
- * stands off the Draw control on the card side of the pill.
- */
-export const InCallDrawing: Story = {
-  args: {
-    phase: "call",
-    shareEnabled: true,
-    sharing: true,
-    annotating: true,
-    annotationTool: "box",
-    call: DEMO_CALL,
-  },
-};
-
-/** The same strip where the card grows down, so it stands under the pill. */
-export const InCallDrawingCardDown: Story = {
-  args: {
-    phase: "call",
-    shareEnabled: true,
-    sharing: true,
-    annotating: true,
-    annotationTool: "circle",
-    cardGrowth: "down",
-    call: DEMO_CALL,
-  },
-};
-
-/**
  * Both held down at once, which is the widest row a call draws and what
  * `FALLBACK_WIDTHS.call` stands in for before the row has been measured.
  */

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -2341,19 +2341,7 @@ function ClearButton({
       onClick={() => {
         onClearMarks?.();
       }}
-    >
-      {tools.map((one) => (
-        <PillButton
-          key={one.tool}
-          icon={one.icon}
-          label={one.label}
-          pressed={tool === one.tool}
-          onClick={() => {
-            onTool?.(one.tool);
-          }}
-        />
-      ))}
-    </div>
+    />
   );
 }
 

--- a/clients/web/src/domains/chat/components/assistant-initiated-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-initiated-section.stories.tsx
@@ -190,6 +190,7 @@ function Scene({
   assistantName,
   withNeighbour = true,
   withCharacterAvatar = true,
+  activeConversationId,
 }: {
   threads: Conversation[];
   assistantName: string | null;
@@ -199,11 +200,15 @@ function Scene({
    * and no published accent var, exactly as `useAvatarAccentVar` leaves it.
    */
   withCharacterAvatar?: boolean;
+  /** The open thread, painted in the card's raised wash like a hovered row. */
+  activeConversationId?: string;
 }) {
   openGate(assistantName);
   return (
     <QueryClientProvider client={seededClient(threads, withCharacterAvatar)}>
-      <ConversationListProvider value={LIST_CONTEXT}>
+      <ConversationListProvider
+        value={{ ...LIST_CONTEXT, activeConversationId }}
+      >
         {/* The rail's real width, so title truncation reads truthfully. */}
         <div
           style={{
@@ -258,6 +263,19 @@ export const InContext: Story = {
 /** Named assistant, alone, for a closer look at the tint and header. */
 export const Alone: Story = {
   args: { threads: THREADS, assistantName: "Ada", withNeighbour: false },
+};
+
+/**
+ * One of her threads open. The current row wears the same raised wash a
+ * hovered row does, not the neutral active surface, so it stays part of the
+ * tinted card rather than punching a white cell through it.
+ */
+export const WithOpenThread: Story = {
+  args: {
+    threads: THREADS,
+    assistantName: "Ada",
+    activeConversationId: THREADS[1]!.conversationId,
+  },
 };
 
 /**

--- a/clients/web/src/domains/chat/components/assistant-initiated-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-initiated-section.stories.tsx
@@ -32,7 +32,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
-import { ConversationListProvider } from "@/domains/chat/components/conversation-list-context";
+import {
+  ConversationListProvider,
+  type ConversationListContextValue,
+} from "@/domains/chat/components/conversation-list-context";
 import { SidebarSectionItem } from "@/domains/chat/components/sidebar-section-item";
 import type { SidebarSection } from "@/domains/chat/use-sidebar-state";
 import { avatarQueryKey, type AvatarData } from "@/hooks/use-assistant-avatar";
@@ -176,9 +179,10 @@ function openGate(name: string | null): void {
   });
 }
 
-const LIST_CONTEXT: React.ComponentProps<
-  typeof ConversationListProvider
->["value"] = {
+/* Typed as the value itself rather than the provider's `value` prop, which
+   admits `null`: spreading that union would make every property optional and
+   lose `onSelect`. */
+const LIST_CONTEXT: ConversationListContextValue = {
   overlayCards: false,
   processingConversationIds: new Set<string>(),
   attentionConversationIds: new Set<string>(),

--- a/clients/web/src/domains/chat/components/assistant-initiated-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-initiated-section.stories.tsx
@@ -279,6 +279,21 @@ export const WithOpenThread: Story = {
 };
 
 /**
+ * The open thread under a custom-image avatar, where no accent is published.
+ * The raised wash is unset there, so the current row keeps the neutral
+ * `--surface-active` every other card's rows open in rather than dissolving
+ * into the card.
+ */
+export const WithOpenThreadCustomImageAvatar: Story = {
+  args: {
+    threads: THREADS,
+    assistantName: "Ada",
+    withCharacterAvatar: false,
+    activeConversationId: THREADS[1]!.conversationId,
+  },
+};
+
+/**
  * Before the assistant has a name. "From Your Assistant" reads as a settings
  * row rather than a byline, so the unnamed case falls back to a neutral
  * header.

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -275,9 +275,12 @@ export function ConversationRow({
           // The wash belongs to the row rather than the panel: declared on the
           // menu it would reach every active PanelItem in the drawer, and a
           // tinted pill that publishes `--panel-item-bg` and no active value
-          // of its own would lose its colour to it.
+          // of its own would lose its colour to it. It reads through the
+          // row's hover property first so the active row matches whatever
+          // its card hovers in: the assistant card publishes an accent wash
+          // for hover, and a value stated on the row itself would beat it.
           ctx.overlayCards
-            ? "min-h-[var(--side-menu-tile-size)] [--panel-item-active:var(--surface-hover)]"
+            ? "min-h-[var(--side-menu-tile-size)] [--panel-item-active:var(--panel-item-hover,var(--surface-hover))]"
             : "h-[30px]",
         )}
       />

--- a/clients/web/src/domains/chat/components/sidebar-section-item.test.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.test.tsx
@@ -176,28 +176,25 @@ describe("SidebarSectionItem — the assistant-initiated section", () => {
     );
   });
 
-  /* Its rows hover in the accent's raised wash, the New Chat pill's own
-     hover, rather than the neutral gray the other cards' rows hover in. */
-  test("raises a hovered row to the New Chat pill's wash", () => {
+  /* Its rows hover and open in the accent's raised wash, the New Chat
+     pill's own hover, rather than the neutral gray the other cards' rows use.
+     The wash is derived from `--avatar-accent` without a fallback, so where no
+     accent is published it is unset and each state's own neutral fallback
+     stands: an open thread under a custom-image avatar keeps the visible
+     `--surface-active` rather than dissolving into the card. */
+  test("raises a hovered or open row to the New Chat pill's wash, with neutral fallbacks", () => {
     const { container } = renderSection(assistantSection());
     const card = container.querySelector<HTMLElement>(
       "[class*='--sidebar-card-surface:']",
     );
     expect(card!.className).toContain(
-      "[--panel-item-hover:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_24%,var(--surface-lift))]",
-    );
-  });
-
-  /* The open thread sits in the same wash as a hovered one. Without an
-     active value the row falls back to `--surface-active`, a white cell on
-     the tinted card. */
-  test("paints the active row in the same wash as a hovered one", () => {
-    const { container } = renderSection(assistantSection());
-    const card = container.querySelector<HTMLElement>(
-      "[class*='--sidebar-card-surface:']",
+      "[--assistant-row-raised:color-mix(in_srgb,var(--avatar-accent)_24%,var(--surface-lift))]",
     );
     expect(card!.className).toContain(
-      "[--panel-item-active:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_24%,var(--surface-lift))]",
+      "[--panel-item-hover:var(--assistant-row-raised,var(--surface-hover))]",
+    );
+    expect(card!.className).toContain(
+      "[--panel-item-active:var(--assistant-row-raised,var(--surface-active))]",
     );
   });
 

--- a/clients/web/src/domains/chat/components/sidebar-section-item.test.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.test.tsx
@@ -188,6 +188,19 @@ describe("SidebarSectionItem — the assistant-initiated section", () => {
     );
   });
 
+  /* The open thread sits in the same wash as a hovered one. Without an
+     active value the row falls back to `--surface-active`, a white cell on
+     the tinted card. */
+  test("paints the active row in the same wash as a hovered one", () => {
+    const { container } = renderSection(assistantSection());
+    const card = container.querySelector<HTMLElement>(
+      "[class*='--sidebar-card-surface:']",
+    );
+    expect(card!.className).toContain(
+      "[--panel-item-active:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_24%,var(--surface-lift))]",
+    );
+  });
+
   test("shows the empty state in place of the rows when it has none", () => {
     renderSection(assistantSection());
 

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -178,12 +178,22 @@ export function SidebarSectionItem({
                  one tinted object under the pointer and around the open
                  thread as well as at rest. Every row is a `PanelItem`, and
                  these are the properties its hover and current-page states
-                 read. Active is stated alongside hover, as
+                 read; active is stated alongside hover, as
                  `panelItemWashStyle` does, because without it the current
                  row falls back to `--surface-active` and sits as a white
-                 cell on the tint. */
-              "[--panel-item-hover:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_24%,var(--surface-lift))]",
-              "[--panel-item-active:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_24%,var(--surface-lift))]",
+                 cell on the tint.
+
+                 The raised wash is derived from `--avatar-accent` with NO
+                 fallback, on purpose: when the accent is absent (custom
+                 image, still loading) the derived property is invalid at
+                 computed-value time and so counts as unset, and each
+                 consumer's own fallback stands - the neutral hover and
+                 active surfaces every other card's rows use. Mixing a
+                 fallback surface into itself would instead paint both
+                 states in the card's own colour and hide them. */
+              "[--assistant-row-raised:color-mix(in_srgb,var(--avatar-accent)_24%,var(--surface-lift))]",
+              "[--panel-item-hover:var(--assistant-row-raised,var(--surface-hover))]",
+              "[--panel-item-active:var(--assistant-row-raised,var(--surface-active))]",
             )
           : undefined
       }

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -171,13 +171,19 @@ export function SidebarSectionItem({
         isAssistantSection
           ? cn(
               "mt-auto [--sidebar-card-surface:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_15%,var(--surface-lift))]",
-              /* A row hovered on this card raises to the same wash the New
-                 Chat pill raises to (`PANEL_ITEM_WASH.raised`, 24% of the
-                 accent into the lift), rather than the neutral gray every
-                 other card's rows hover in, so the card reads as one tinted
-                 object under the pointer as well as at rest. Every row is a
-                 `PanelItem`, and this is the property its hover reads. */
+              /* A row hovered or selected on this card raises to the same
+                 wash the New Chat pill raises to (`PANEL_ITEM_WASH.raised`,
+                 24% of the accent into the lift), rather than the neutral
+                 gray every other card's rows hover in, so the card reads as
+                 one tinted object under the pointer and around the open
+                 thread as well as at rest. Every row is a `PanelItem`, and
+                 these are the properties its hover and current-page states
+                 read. Active is stated alongside hover, as
+                 `panelItemWashStyle` does, because without it the current
+                 row falls back to `--surface-active` and sits as a white
+                 cell on the tint. */
               "[--panel-item-hover:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_24%,var(--surface-lift))]",
+              "[--panel-item-active:color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_24%,var(--surface-lift))]",
             )
           : undefined
       }


### PR DESCRIPTION
## Summary

The assistant-initiated section card publishes an accent wash for a hovered row (`--panel-item-hover`) but no active value, so the open thread fell back to `--surface-active` and sat as a white cell on the tinted card.

- The card derives a raised wash (`--assistant-row-raised`, 24% of `--avatar-accent` into `--surface-lift`) and publishes it as both `--panel-item-hover` and `--panel-item-active`, matching what `panelItemWashStyle` already does for tinted pills.
- The wash is derived with no fallback on purpose: when no accent is published (custom-image avatar, still loading) the property is invalid at computed-value time, so each state keeps its own neutral fallback, `--surface-hover` for hover and `--surface-active` for the open thread. Previously the hover wash mixed `--surface-lift` into itself there and was invisible.
- On the overlay the row states its own active value, which would beat the card's; it now reads through `--panel-item-hover` first, so it matches whatever its card hovers in and stays `--surface-hover` everywhere else.
- Test asserting the card's fallback chain; `WithOpenThread` and `WithOpenThreadCustomImageAvatar` stories on Chat/AssistantInitiatedSection.

## Verification

- `sidebar-section-item` and `conversation-row` tests pass.
- Storybook + headless Chrome (forced `:hover` via CDP): with an accent, the open thread and a hovered row compute to the identical wash. Under the custom-image avatar, the open thread computes to `--surface-active` and the hovered row to `--surface-hover`. An ordinary active row in the overlay drawer still computes to `--surface-hover`.

## CI

Lint, Type Check and Build fail on the base with the pre-existing `companion-surface.tsx:2356` JSX error from the v0.12.0 release merge, which #42583 repairs. This PR touches none of that; it goes green once that lands and main is merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsoPwtHcMRN2YrY8e95dS1
