### PR TITLE
fix(assistant): keep assistant-initiated threads out of the notifications bell

### DIFF
--- a/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
+++ b/assistant/src/notifications/__tests__/home-feed-side-effect.test.ts
@@ -26,6 +26,15 @@ const messageRewrites: Array<{ messageId: string; content: string }> = [];
 /** messageId -> the conversation it belongs to, for the scoped lookup. */
 const messageOwners = new Map<string, string>();
 let conversationRow: { conversationType: string } | null = null;
+/**
+ * Rows for specific ids, consulted before the catch-all `conversationRow`,
+ * so a test can hand the signal's source and the delivery's paired
+ * conversation different shapes.
+ */
+const conversationRowsById = new Map<
+  string,
+  { conversationType: string; source?: string }
+>();
 let conversationLookupShouldThrow = false;
 let messageAppendShouldThrow = false;
 let messageRewriteShouldThrow = false;
@@ -71,7 +80,7 @@ mock.module("../../persistence/conversation-crud.js", () => ({
     if (conversationLookupShouldThrow) {
       throw new Error("simulated conversation lookup failure");
     }
-    return conversationRow;
+    return conversationRowsById.get(id) ?? conversationRow;
   },
   addMessage: async (
     conversationId: string,
@@ -164,6 +173,7 @@ beforeEach(() => {
   messageRewrites.length = 0;
   messageOwners.clear();
   conversationRow = null;
+  conversationRowsById.clear();
   conversationLookupShouldThrow = false;
   messageAppendShouldThrow = false;
   messageRewriteShouldThrow = false;
@@ -400,6 +410,139 @@ describe("writeHomeFeedItemForSignal", () => {
     expect(item).not.toBeNull();
     expect(appendCalls).toHaveLength(1);
     expect(appendCalls[0]!.conversationId).toBe("paired-delivery-conv-id");
+  });
+
+  describe("assistant-initiated thread deliveries", () => {
+    // Under the assistant-initiated-threads flag, conversation pairing
+    // promotes a background assistant.share into a standard conversation
+    // stamped `assistant_initiated`, which the sidebar's assistant section
+    // renders. That thread is the share's surface; a feed item for the
+    // same signal put it in the bell a second time.
+    const assistantThreadDelivery = () =>
+      makeVellumDelivery({ conversationId: "assistant-thread-1" });
+
+    function stampAssistantThread(): void {
+      conversationRowsById.set("assistant-thread-1", {
+        conversationType: "standard",
+        source: "assistant_initiated",
+      });
+    }
+
+    function shareFromHeartbeat(): NotificationSignal {
+      return makeSignal({
+        sourceChannel: "assistant_tool",
+        sourceEventName: "assistant.share",
+        sourceContextId: "conv-source-1",
+        contextPayload: { title: "Doctor checklist built" },
+      });
+    }
+
+    const shareDecision = () =>
+      makeDecision({
+        selectedChannels: ["vellum"],
+        renderedCopy: {
+          vellum: {
+            title: "Doctor checklist built",
+            body: "Your doctor-visit one-pager is ready.",
+          },
+        },
+      });
+
+    test("a background share promoted into an assistant thread does not mirror", async () => {
+      conversationRow = { conversationType: "background" };
+      stampAssistantThread();
+
+      const item = await writeHomeFeedItemForSignal(
+        shareFromHeartbeat(),
+        shareDecision(),
+        assistantThreadDelivery(),
+      );
+
+      expect(item).toBeNull();
+      expect(appendCalls).toHaveLength(0);
+      expect(messageAppends).toHaveLength(0);
+    });
+
+    test("the async-background hint does not override the assistant-thread suppression", async () => {
+      conversationRow = null;
+      stampAssistantThread();
+      const signal = makeSignal({
+        sourceChannel: "assistant_tool",
+        sourceEventName: "assistant.share",
+        sourceContextId: "heartbeat",
+        contextPayload: { title: "Bilbao solo trip is planned" },
+        attentionHints: {
+          requiresAction: false,
+          urgency: "medium",
+          isAsyncBackground: true,
+          visibleInSourceNow: false,
+        },
+      });
+
+      const item = await writeHomeFeedItemForSignal(
+        signal,
+        shareDecision(),
+        assistantThreadDelivery(),
+      );
+
+      expect(item).toBeNull();
+      expect(appendCalls).toHaveLength(0);
+    });
+
+    test("a share paired with an ordinary notification thread still mirrors", async () => {
+      // Flag off, or any producer that did not promote: pairing writes a
+      // `notification`-sourced row, which stays in Chats and the bell.
+      conversationRow = { conversationType: "background" };
+      conversationRowsById.set("assistant-thread-1", {
+        conversationType: "standard",
+        source: "notification",
+      });
+
+      const item = await writeHomeFeedItemForSignal(
+        shareFromHeartbeat(),
+        shareDecision(),
+        assistantThreadDelivery(),
+      );
+
+      expect(item).not.toBeNull();
+      expect(appendCalls).toHaveLength(1);
+    });
+
+    test("a guardian request keeps its bell item even when paired with an assistant thread", async () => {
+      // The bell is the request's canonical home: nothing else renders the
+      // pending card, so the assistant-thread suppression must not reach it.
+      conversationRow = { conversationType: "standard" };
+      stampAssistantThread();
+      const signal = makeSignal({
+        sourceChannel: "assistant_tool",
+        sourceEventName: "guardian.question",
+        contextPayload: {
+          title: "Approve this?",
+          questionText: "May I send the email?",
+          requestId: "req-1",
+        },
+        attentionHints: {
+          requiresAction: true,
+          urgency: "medium",
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+      });
+
+      const item = await writeHomeFeedItemForSignal(
+        signal,
+        makeDecision({
+          selectedChannels: ["vellum"],
+          renderedCopy: {
+            vellum: { title: "Approve this?", body: "May I send the email?" },
+          },
+        }),
+        assistantThreadDelivery(),
+      );
+
+      expect(item).not.toBeNull();
+      expect(appendCalls).toHaveLength(1);
+    });
   });
 
   test("source conversation id wins over the paired delivery fallback when both are available", async () => {

--- a/assistant/src/notifications/home-feed-side-effect.ts
+++ b/assistant/src/notifications/home-feed-side-effect.ts
@@ -23,7 +23,10 @@ import {
   getMessageById,
   updateMessageContent,
 } from "../persistence/conversation-crud.js";
-import { isBackgroundConversationType } from "../persistence/conversation-types.js";
+import {
+  ASSISTANT_INITIATED_SOURCE,
+  isBackgroundConversationType,
+} from "../persistence/conversation-types.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import { normalizeTitle, stripMarkdown } from "../util/short-title.js";
@@ -495,6 +498,18 @@ function deriveDetailPanelKind(
  * `isAsyncBackground` hint. `chat.assistant_reply` also mirrors: it is the
  * durable in-app record for the push sent after a user leaves a chat, while
  * retaining the normal interactive conversation as its navigation target.
+ *
+ * A delivery that materialized an assistant-initiated thread never mirrors.
+ * Under the `assistant-initiated-threads` flag, `conversation-pairing.ts`
+ * promotes a background `assistant.share` into a standard conversation
+ * stamped {@link ASSISTANT_INITIATED_SOURCE}, and that thread's row in the
+ * sidebar's assistant section is the share's one surface. Mirroring it here
+ * as well put the same share in the bell a second time, labeled by its
+ * source channel ("Heartbeat"). The check reads the paired conversation's
+ * `source` rather than re-deriving the promotion rule, so it holds however
+ * that rule narrows or widens. Guardian requests are checked first on
+ * purpose: the bell is their canonical home whatever conversation they pair
+ * with.
  */
 function resolveHomeFeedMirror(
   signal: NotificationSignal,
@@ -525,6 +540,15 @@ function resolveHomeFeedMirror(
     : fallbackConversationId;
   const sourceScheduleJobId = sourceRow?.scheduleJobId ?? undefined;
 
+  // Guardian requests always project into the feed: the "Needs
+  // attention" item is the request's canonical home, and the request
+  // blocks on the guardian whatever kind of conversation raised it.
+  if (isGuardianRequestSignalEvent(signal.sourceEventName)) {
+    return { mirror: true, sourceConversationId, sourceScheduleJobId };
+  }
+  if (isAssistantInitiatedThreadDelivery(fallbackConversationId)) {
+    return { mirror: false };
+  }
   if (
     signal.sourceChannel === "assistant_tool" ||
     signal.sourceEventName === "chat.assistant_reply"
@@ -534,16 +558,35 @@ function resolveHomeFeedMirror(
   if (signal.attentionHints.isAsyncBackground) {
     return { mirror: true, sourceConversationId, sourceScheduleJobId };
   }
-  // Guardian requests always project into the feed: the "Needs
-  // attention" item is the request's canonical home, and the request
-  // blocks on the guardian whatever kind of conversation raised it.
-  if (isGuardianRequestSignalEvent(signal.sourceEventName)) {
-    return { mirror: true, sourceConversationId, sourceScheduleJobId };
-  }
   if (isBackgroundConversationType(sourceRow?.conversationType)) {
     return { mirror: true, sourceConversationId, sourceScheduleJobId };
   }
   return { mirror: false };
+}
+
+/**
+ * Whether the vellum delivery this signal produced landed in a thread the
+ * sidebar's assistant section already shows.
+ *
+ * Best-effort like the source lookup above: a missing id, a missing row, or
+ * a lookup failure all read as "not an assistant thread", so a storage
+ * hiccup degrades to the pre-existing behavior (a bell row) rather than
+ * dropping the notification everywhere.
+ */
+function isAssistantInitiatedThreadDelivery(
+  deliveryConversationId: string | undefined,
+): boolean {
+  if (!deliveryConversationId) {
+    return false;
+  }
+  try {
+    return (
+      getConversation(deliveryConversationId)?.source ===
+      ASSISTANT_INITIATED_SOURCE
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Threads in the sidebar's "From me" section were also showing up as rows in the notifications bell, labeled "Heartbeat". Same title, same body, two surfaces.

A heartbeat `assistant.share` signal runs the full notification pipeline. Under the `assistant-initiated-threads` flag, conversation pairing promotes it into a standard conversation stamped `assistant_initiated`, which is the section's membership mark (`conversation-pairing.ts`, added in #41943). Nothing then told the home-feed mirror about the promotion: `resolveHomeFeedMirror` saw a background-typed producing conversation and wrote a feed item too, and the bell reads that feed.

## Fix

`resolveHomeFeedMirror` now looks up the paired vellum delivery's conversation and returns no mirror when its `source` is `assistant_initiated`. The sidebar thread becomes the share's only surface.

- Reads the row's `source` rather than re-deriving the promotion rule, so it stays correct however that rule narrows or widens.
- Guardian requests are checked first: the bell is their canonical home whatever conversation they pair with.
- A missing id, missing row, or lookup failure degrades to the previous behavior (a bell row), never to dropping the notification everywhere.
- Flag off, pairing writes a `notification`-sourced row, which still mirrors. Transactional items are unchanged.

## Tests

The test mock's `getConversation` is now id-aware so a case can give the signal's source and the delivery's paired conversation different shapes. Four new cases pin: the suppression, the async-background-hint arm, the `notification`-sourced pass-through, and the guardian exemption.

Ran in isolation (multi-file `bun test` cross-contaminates module mocks):
- `home-feed-side-effect.test.ts`: 62 pass
- `conversation-pairing.test.ts`: 51 pass
- `emit-signal-pipeline-failure.test.ts`: 5 pass
- `tsc --noEmit`, eslint, prettier: clean

## Not in scope

Whether the vellum delivery also fires a banner or OS push for these shares was not changed here. This PR only removes the bell duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PLTPz6MoDfiP2xEU9Nh38
