### PR TITLE
feat(web): ship message read-aloud without the internal-thread-actions gate

### DIFF
--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -1,21 +1,9 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
+import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
-
-let canUseInternalThreadActions = false;
-mock.module("@/lib/auth/internal-thread-actions", () => ({
-  useCanUseInternalThreadActions: () => canUseInternalThreadActions,
-}));
-
-const { MessageHoverActions } = await import(
-  "@/domains/chat/components/message-hover-actions/message-hover-actions"
-);
-
-afterEach(() => {
-  canUseInternalThreadActions = false;
-});
 
 describe("MessageHoverActions", () => {
   test("renders the timestamp even when no actions are available", () => {
@@ -120,25 +108,9 @@ describe("MessageHoverActions", () => {
     expect(html).not.toContain('title="Retry"');
   });
 
-  test("renders copy for a copyable message without read aloud when the internal gate is off", () => {
+  test("renders copy and read aloud for a copyable message", () => {
     const message: DisplayMessage = {
       id: "m7",
-      role: "assistant",
-      timestamp: Date.UTC(2026, 0, 2, 12, 34),
-      ...textBody("hello"),
-    };
-    const html = renderToStaticMarkup(
-      <MessageHoverActions message={message} />,
-    );
-
-    expect(html).toContain('title="Copy"');
-    expect(html).not.toContain('title="Read aloud"');
-  });
-
-  test("renders read aloud when the internal thread actions gate is on", () => {
-    canUseInternalThreadActions = true;
-    const message: DisplayMessage = {
-      id: "m7-read",
       role: "assistant",
       timestamp: Date.UTC(2026, 0, 2, 12, 34),
       ...textBody("hello"),
@@ -152,7 +124,6 @@ describe("MessageHoverActions", () => {
   });
 
   test("omits copy and read aloud when the message has no text", () => {
-    canUseInternalThreadActions = true;
     const message: DisplayMessage = {
       id: "m8",
       role: "assistant",

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -21,7 +21,6 @@ import {
   useCanBookmark,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
-import { useCanUseInternalThreadActions } from "@/lib/auth/internal-thread-actions";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { useTranslation } from "@/i18n";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -127,7 +126,6 @@ export function MessageHoverActions({
   // (and only touch TanStack Query) for bookmarkable rows; that keeps the
   // unsupported-assistant and no-conversation paths free of any query client.
   const canBookmark = useCanBookmark(message, conversationId);
-  const canReadAloud = useCanUseInternalThreadActions();
 
   // Flat plain-text body derived from the message's text blocks (empty for a
   // row deleted on its channel); this is the copy payload and mirrors the
@@ -211,7 +209,7 @@ export function MessageHoverActions({
         </button>
       )}
 
-      {hasCopyableText && message.id && canReadAloud && (
+      {hasCopyableText && message.id && (
         <MessageReadAloudButton
           messageId={message.id}
           text={content}

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-long-press-actions.tsx
@@ -21,7 +21,6 @@ import {
   useCanBookmark,
   useIsBookmarked,
 } from "@/hooks/use-bookmarks";
-import { useCanUseInternalThreadActions } from "@/lib/auth/internal-thread-actions";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { BottomSheet, PanelItem } from "@vellumai/design-library";
@@ -54,7 +53,6 @@ export function MessageLongPressActions({
 }: MessageLongPressActionsProps) {
   const { t } = useTranslation("chat");
   const canBookmark = useCanBookmark(message, conversationId);
-  const canReadAloud = useCanUseInternalThreadActions();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const readAloudMessageId = useMessageReadAloudStore.use.messageId();
   const readAloudStatus = useMessageReadAloudStore.use.status();
@@ -138,7 +136,7 @@ export function MessageLongPressActions({
     );
   }
 
-  if (hasCopyableText && message.id && canReadAloud) {
+  if (hasCopyableText && message.id) {
     items.push(
       buildItem({
         key: "read-aloud",

--- a/clients/web/src/lib/auth/internal-thread-actions.ts
+++ b/clients/web/src/lib/auth/internal-thread-actions.ts
@@ -4,10 +4,9 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  * Whether the viewer may use the internal thread affordances: fork ('Fork
  * from here' on a message, 'Fork Conversation' in the thread menu), 'Summarize
  * up to here', 'Analyze Conversation', 'Copy Full Conversation', 'Copy
- * conversation ID', 'Open in New Window', 'Refresh', message bookmarks, Read
- * aloud on messages, and the LLM inspector surfaces behind them. They all
- * read this one predicate, so widening or narrowing the audience moves them
- * together.
+ * conversation ID', 'Open in New Window', 'Refresh', message bookmarks, and
+ * the LLM inspector surfaces behind them. They all read this one predicate,
+ * so widening or narrowing the audience moves them together.
  *
  * The `internal-thread-actions` client flag is the sole gate. It defaults
  * off, so the affordances are opt-in for any session that enables it,

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -211,7 +211,7 @@
       "scope": "client",
       "key": "internal-thread-actions",
       "label": "Internal Thread Actions",
-      "description": "Show the internal thread affordances: 'Fork from here', 'Summarize up to here', and 'Read aloud' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. The flag is the sole gate: any session that enables it gets the affordances, including local sessions with no platform identity.",
+      "description": "Show the internal thread affordances: 'Fork from here' and 'Summarize up to here' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. The flag is the sole gate: any session that enables it gets the affordances, including local sessions with no platform identity.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -211,7 +211,7 @@
       "scope": "client",
       "key": "internal-thread-actions",
       "label": "Internal Thread Actions",
-      "description": "Show the internal thread affordances: 'Fork from here', 'Summarize up to here', and 'Read aloud' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. The flag is the sole gate: any session that enables it gets the affordances, including local sessions with no platform identity.",
+      "description": "Show the internal thread affordances: 'Fork from here' and 'Summarize up to here' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. The flag is the sole gate: any session that enables it gets the affordances, including local sessions with no platform identity.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Related to #42488

## Prompt / plan
Design approved shipping Read aloud to everyone. This PR removes the `internal-thread-actions` gate from the message hover and long-press actions so Copy and Read aloud both show on every copyable chat message.

`internal-thread-actions` stays in the registry and still defaults off. Fork, summarize, bookmarks, and inspect keep reading it. No new flag and no Terraform companion.

## Test plan
- Unit: `clients/web` `message-hover-actions.test.tsx` (9 pass): Copy + Read aloud on copyable rows without mocking the flag; both omitted for empty and deleted rows.
- ESLint on the touched hover-action and flag-doc files.
- `bun run meta/sync-bundled-copies.ts --check` confirms the web registry copy matches `meta/feature-flags/feature-flag-registry.json`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-914c43c9-8edb-4bce-bba8-5c3477bc9791?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-914c43c9-8edb-4bce-bba8-5c3477bc9791&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

