### PR TITLE
fix(web): keep the sleep stage dark in light mode and redraw its lid line

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -145,11 +145,15 @@ describe("AssistantSleepStage", () => {
     const view = renderAt("/assistant/conversations/c1");
     const svg = view.container.querySelector("[data-slot=sleep-stage-eyes]");
     expect(svg).not.toBeNull();
-    // The lid is the avatar's own color, clipped to the eyes' silhouette.
+    // The lid is the avatar's own color, clipped to the eyes' silhouette,
+    // with an edge line per eye.
     expect(svg!.querySelector("clipPath")).not.toBeNull();
-    expect(svg!.querySelector("rect")?.getAttribute("fill")).toBe(
-      catalog.colors[1]!.hex,
-    );
+    expect(
+      svg!.querySelector("[data-slot=sleep-stage-lid]")?.getAttribute("fill"),
+    ).toBe(catalog.colors[1]!.hex);
+    expect(
+      svg!.querySelectorAll("[data-slot=sleep-stage-lid-edge]").length,
+    ).toBe(2);
   });
 
   test("is a dark surface whatever the app's theme", () => {

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -152,6 +152,15 @@ describe("AssistantSleepStage", () => {
     );
   });
 
+  test("is a dark surface whatever the app's theme", () => {
+    const { container } = renderAt("/assistant/conversations/c1");
+    // The eyes' whites are a near-white, as is the light surface: the stage
+    // re-declares the tokens dark so they never share a color.
+    expect(
+      container.querySelector("[data-scene]")?.getAttribute("data-theme"),
+    ).toBe("dark");
+  });
+
   test("falls back to unnamed copy before the identity resolves", () => {
     useAssistantIdentityStore.setState({ name: null, version: null });
 

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
@@ -5,7 +5,10 @@
  * and only on an arrival, so this is where the animation itself gets watched:
  * pick an eye style and a color, switch scenes, and see the lids move. The
  * `Waking up` story runs the real sequence end to end on a loop, which is the
- * one thing a static scene cannot show.
+ * one thing a static scene cannot show. `Light and dark` puts the two themes
+ * side by side: the stage is dark in both, since the eyes' whites are a
+ * near-white and so is the light surface, and this is where that holds or
+ * does not. `Every color` runs the palette against that ground.
  *
  * The eye art comes from the bundled character catalog through the same
  * `resolveSleepStageEyes` the app uses, so what renders here is what ships.
@@ -48,6 +51,24 @@ interface StoryArgs {
   eyeStyle: string;
   color: string;
   line: string;
+}
+
+/** A frame pinned to one theme, for the stories that show more than one. */
+function ThemedStage({
+  theme,
+  children,
+}: {
+  theme: "light" | "dark";
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      data-theme={theme}
+      className="relative h-[560px] min-w-0 flex-1 overflow-hidden rounded-xl bg-[var(--surface-base)] p-6"
+    >
+      {children}
+    </div>
+  );
 }
 
 /** The stage is an inset layer, so the frame stands in for the chat `<main>`. */
@@ -122,6 +143,56 @@ export const EveryEyeStyle: Story = {
             scene={scene}
             eyes={eyesFor(eyeStyle, color)}
             line={eyeStyle}
+            dismissLabel="Hide the sleep screen"
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * The same scene in both themes at once. The app's surface is near-white in
+ * light and near-black in dark, and the eyes' whites are near-white in both,
+ * so the stage keeps its own dark ground in either: this is where that is
+ * checked, with the frame around the stage showing the theme it sits in.
+ */
+export const LightAndDark: Story = {
+  name: "Light and dark",
+  render: ({ scene, eyeStyle, color, line }) => (
+    <div className="flex flex-col gap-4 p-4 md:flex-row">
+      {(["light", "dark"] as const).map((theme) => (
+        <ThemedStage key={theme} theme={theme}>
+          <SleepStageView
+            scene={scene}
+            eyes={eyesFor(eyeStyle, color)}
+            line={line}
+            dismissLabel="Hide the sleep screen"
+          />
+        </ThemedStage>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * Every palette color asleep at once. The lid is the avatar's color and the
+ * whites of the eyes are fixed, so the lightest color (yellow) is the one to
+ * watch against the stage's dark ground.
+ */
+export const EveryColor: Story = {
+  name: "Every color",
+  render: ({ eyeStyle, scene }) => (
+    <div className="grid grid-cols-3 gap-4 bg-[var(--surface-base)] p-4">
+      {COLORS.map((color) => (
+        <div
+          key={color}
+          className="relative h-[320px] overflow-hidden rounded-xl border border-[var(--border-base)]"
+        >
+          <SleepStageView
+            scene={scene}
+            eyes={eyesFor(eyeStyle, color)}
+            line={color}
             dismissLabel="Hide the sleep screen"
           />
         </div>

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
@@ -22,24 +22,37 @@
  * ground they were drawn for and the copy and the close button take light
  * values with it. In dark mode nothing changes.
  *
- * The lid is a slab wearing the eyes' own silhouette (a `clipPath` of the eye
- * paths), so it closes each eye over its top and leaves the gap between them
- * empty. It is painted in the avatar's own color, with its lower edge banded
- * in a darker shade of that same color: the band is what reads as an eyelid
- * rather than as a color fill stopping halfway down the eye. Lid and band
- * slide as one group, so the edge stays welded to the lid through every
- * drift and the whole way open.
+ * The lid is a slab per eye wearing the eyes' own silhouette (a `clipPath`
+ * of the eye paths), so it closes each eye over its top and leaves the gap
+ * between them empty. Its lower edge is a shallow arch, higher in the middle
+ * than at the ends, the way a lid sits across an eye. It is painted in the
+ * avatar's own color, with that edge drawn as a line in a darker shade of the
+ * same color: the line is what reads as an eyelid rather than as a color
+ * fill stopping halfway down the eye. The line has round ends and runs a few
+ * pixels past the eye's outline on each side, a lash line rather than the
+ * edge of the fill. It is sized to the eye's width at the height the lid
+ * rests (see `pathSpanAt`) so those ends are its own, and it is not clipped
+ * with the lid: each eye's line is masked to that eye's outline grown a
+ * little past the overhang, which keeps it off the gap between the eyes and
+ * takes it away once the lid has slid clear. Lid and lines share one motion,
+ * so the edge stays welded to the lid through every drift and the whole way
+ * open.
  */
 
 import { X } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
-import { useId } from "react";
+import { useId, useMemo } from "react";
 
 import { resolveVoiceRoomLook } from "@/domains/chat/voice/voice-room/voice-room-eyes";
 import type { SleepStageScene } from "@/stores/assistant-sleep-stage-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { darkenHex } from "@/utils/avatar-tone";
-import { tightPathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
+import {
+  pathSpanAt,
+  tightPathBBox,
+  unionBBox,
+  type BBox,
+} from "@/utils/eye-bbox";
 
 export type { SleepStageScene };
 
@@ -47,6 +60,11 @@ export type { SleepStageScene };
 export interface SleepStageEyes {
   paths: { svgPath: string; color: string }[];
   bbox: BBox;
+  /**
+   * One per eye: the path that outlines it, which the lid's edge is drawn
+   * across. A pupil sits inside its sclera and is not an eye of its own.
+   */
+  outlines: { svgPath: string; bbox: BBox }[];
   lidColor: string;
 }
 
@@ -62,8 +80,25 @@ const LID_REST: Record<SleepStageScene, number> = {
 };
 /** How much further the lids sink at the bottom of a sleeping drift. */
 const LID_DRIFT = 0.12;
-/** The lid's own edge, as a share of the eye's height. */
-const LID_EDGE = 0.035;
+/** The lid's edge line, as a share of the eye's height: thick enough for its
+ *  round ends to read at the size the stage draws the eyes. */
+const LID_EDGE = 0.05;
+/**
+ * How far the edge line runs past the eye's outline on each side, as a share
+ * of the eye's height: a couple of pixels at the size the stage draws the eyes.
+ */
+const LID_EDGE_SPILL = 0.02;
+/**
+ * How much higher the lid's edge sits at the middle of the eye than at its
+ * ends, as a share of the eye's height: a slight arch, not a curve.
+ */
+const LID_SAG = 0.05;
+/**
+ * The line's mask is the outline grown by this much more than the overhang,
+ * so the line's round ends survive the drift, which carries the lid to where
+ * the eye is a little narrower than where the line was measured.
+ */
+const LID_EDGE_MASK_SLACK = 1.5;
 /** How far the edge band is darkened from the lid's color: enough to read as
  *  an edge, not so much that it cuts the face in two. */
 const LID_EDGE_DARKEN = 0.72;
@@ -108,13 +143,40 @@ export function resolveSleepStageEyes(
   if (!look?.art) {
     return null;
   }
-  const bbox = unionBBox(
-    look.art.paths.map((path) => tightPathBBox(path.svgPath)),
-  );
+  const boxes = look.art.paths.map((path) => tightPathBBox(path.svgPath));
+  const bbox = unionBBox(boxes);
   if (bbox.w <= 0 || bbox.h <= 0) {
     return null;
   }
-  return { paths: look.art.paths, bbox, lidColor: look.bgHex };
+  // An eye is a path no larger path's box contains: the sclera, not the
+  // pupil drawn inside it. Two paths sharing one box count once.
+  const outlines = look.art.paths.flatMap((path, i) => {
+    const box = boxes[i]!;
+    const inner = boxes.some(
+      (other, j) =>
+        j !== i &&
+        contains(other, box) &&
+        (area(other) > area(box) || (area(other) === area(box) && j < i)),
+    );
+    return inner ? [] : [{ svgPath: path.svgPath, bbox: box }];
+  });
+  return { paths: look.art.paths, bbox, outlines, lidColor: look.bgHex };
+}
+
+/** Slack for boxes measured off curves that share an edge. */
+const CONTAINS_EPSILON = 0.5;
+
+function contains(outer: BBox, inner: BBox): boolean {
+  return (
+    outer.x <= inner.x + CONTAINS_EPSILON &&
+    outer.y <= inner.y + CONTAINS_EPSILON &&
+    outer.x + outer.w >= inner.x + inner.w - CONTAINS_EPSILON &&
+    outer.y + outer.h >= inner.y + inner.h - CONTAINS_EPSILON
+  );
+}
+
+function area(box: BBox): number {
+  return box.w * box.h;
 }
 
 export interface SleepStageViewProps {
@@ -221,6 +283,7 @@ function StageEyes({
   reduce: boolean;
 }) {
   const clipId = useId();
+  const maskId = useId();
   const { bbox } = eyes;
   // How far the lid has slid down over the eye. The slab hangs above the box
   // with its lower edge at the top of the eye at rest, so one translated
@@ -228,16 +291,70 @@ function StageEyes({
   // Art much wider than it is tall keeps more of itself: see
   // `SHALLOW_EYE_ASPECT`.
   const shallow = Math.min(1, SHALLOW_EYE_ASPECT / (bbox.w / bbox.h));
-  const closed = LID_REST[scene] * shallow * bbox.h;
-  const deep = (LID_REST[scene] + LID_DRIFT) * shallow * bbox.h;
   const edge = LID_EDGE * bbox.h;
+  const spill = LID_EDGE_SPILL * bbox.h;
+  const sag = LID_SAG * bbox.h;
+  const maskGrow = spill * (1 + LID_EDGE_MASK_SLACK);
+  // The lid rests where the scene says; a woken one is measured as if still
+  // waking, so its lines are the shape they had a moment before they left.
+  const rest = LID_REST[scene === "woke" ? "waking" : scene] * shallow * bbox.h;
+  // Open, the lid clears the eye and the edge line clears its mask, so the
+  // clip and the masks take all of it.
+  const open = -(maskGrow + edge);
+  const closed = scene === "woke" ? open : rest;
+  const deep = (LID_REST[scene] + LID_DRIFT) * shallow * bbox.h;
   const drifts = scene !== "woke" && !reduce;
+  // The overhang and the line's round ends have to fit in the frame.
+  const pad = spill + edge / 2;
+  const frame: BBox = {
+    x: bbox.x - pad,
+    y: bbox.y - pad,
+    w: bbox.w + pad * 2,
+    h: bbox.h + pad * 2,
+  };
+  const lidMotion = {
+    initial: { y: closed },
+    animate: drifts ? { y: [closed, deep, closed] } : { y: closed },
+    transition: drifts
+      ? {
+          duration: LID_DRIFT_SECONDS,
+          repeat: Infinity,
+          ease: "easeInOut" as const,
+        }
+      : { duration: reduce ? 0 : WOKE_OPEN_SECONDS, ease: "easeOut" as const },
+  };
+
+  // Each eye's lid and line, drawn in place over the eye and slid up from
+  // there. The line spans the eye where the lid rests, plus its overhang;
+  // the lid is that arch with the rest of the slab above it, and reaches
+  // past the line's ends so the eye's wider parts above the line are still
+  // covered (the clip takes the excess).
+  const lids = useMemo(
+    () =>
+      eyes.outlines.map((outline) => {
+        const span = pathSpanAt(outline.svgPath, bbox.y + rest) ?? {
+          x0: outline.bbox.x,
+          x1: outline.bbox.x + outline.bbox.w,
+        };
+        const xa = span.x0 - spill;
+        const xb = span.x1 + spill;
+        const xm = (xa + xb) / 2;
+        const yb = bbox.y;
+        const yc = yb - sag * 2;
+        const far = spill * 4;
+        return {
+          line: `M${xa} ${yb} Q${xm} ${yc} ${xb} ${yb}`,
+          fill: `M${outline.bbox.x - far} ${yb - bbox.h - sag} H${outline.bbox.x + outline.bbox.w + far} V${yb} H${xb} Q${xm} ${yc} ${xa} ${yb} H${outline.bbox.x - far} Z`,
+        };
+      }),
+    [eyes.outlines, bbox, rest, spill, sag],
+  );
 
   return (
     <svg
       aria-hidden="true"
       data-slot="sleep-stage-eyes"
-      viewBox={`${bbox.x} ${bbox.y} ${bbox.w} ${bbox.h}`}
+      viewBox={`${frame.x} ${frame.y} ${frame.w} ${frame.h}`}
       className="h-auto w-[clamp(140px,26vw,240px)] shrink-0"
     >
       <defs>
@@ -246,42 +363,60 @@ function StageEyes({
             <path key={i} d={path.svgPath} />
           ))}
         </clipPath>
+        {/* Masks rather than clips for the edge lines: a clip cannot wear a
+            stroke, and the stroke is what grows the outline. */}
+        {eyes.outlines.map((outline, i) => (
+          <mask
+            key={i}
+            id={`${maskId}-${i}`}
+            maskUnits="userSpaceOnUse"
+            x={frame.x - maskGrow}
+            y={frame.y - maskGrow}
+            width={frame.w + maskGrow * 2}
+            height={frame.h + maskGrow * 2}
+          >
+            <path
+              d={outline.svgPath}
+              fill="white"
+              stroke="white"
+              strokeWidth={maskGrow * 2}
+              strokeLinejoin="round"
+            />
+          </mask>
+        ))}
       </defs>
       {eyes.paths.map((path, i) => (
         <path key={i} d={path.svgPath} fill={path.color} />
       ))}
-      {/* The clip sits on a group of its own: on the moving group it would
-          travel with the transform and stop following the eye. */}
+      {/* The clip and the masks sit on groups of their own: on the moving
+          group they would travel with the transform and stop following the
+          eye. */}
       <g clipPath={`url(#${clipId})`}>
-        <motion.g
-          initial={{ y: closed }}
-          animate={drifts ? { y: [closed, deep, closed] } : { y: closed }}
-          transition={
-            drifts
-              ? {
-                  duration: LID_DRIFT_SECONDS,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }
-              : { duration: reduce ? 0 : WOKE_OPEN_SECONDS, ease: "easeOut" }
-          }
-        >
-          <rect
-            x={bbox.x}
-            y={bbox.y - bbox.h}
-            width={bbox.w}
-            height={bbox.h}
-            fill={eyes.lidColor}
-          />
-          <rect
-            x={bbox.x}
-            y={bbox.y - edge}
-            width={bbox.w}
-            height={edge}
-            fill={darkenHex(eyes.lidColor, LID_EDGE_DARKEN)}
-          />
+        <motion.g {...lidMotion}>
+          {lids.map((lid, i) => (
+            <path
+              key={i}
+              data-slot="sleep-stage-lid"
+              d={lid.fill}
+              fill={eyes.lidColor}
+            />
+          ))}
         </motion.g>
       </g>
+      {lids.map((lid, i) => (
+        <g key={i} mask={`url(#${maskId}-${i})`}>
+          <motion.g {...lidMotion}>
+            <path
+              data-slot="sleep-stage-lid-edge"
+              d={lid.line}
+              fill="none"
+              stroke={darkenHex(eyes.lidColor, LID_EDGE_DARKEN)}
+              strokeWidth={edge}
+              strokeLinecap="round"
+            />
+          </motion.g>
+        </g>
+      ))}
     </svg>
   );
 }

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
@@ -14,6 +14,14 @@
  *   lids from wherever they were, so the open is one movement out of the
  *   sleep rather than a cut to a new picture.
  *
+ * The stage is always dark. The catalog's sclera is a near-white and so is
+ * the light theme's surface, so eyes laid on the light page lose their whites
+ * and the pupils float on nothing. The stage re-declares the design tokens
+ * under `data-theme="dark"`, the treatment the voice room and the research
+ * overlay give their own surfaces, so in light mode the eyes sit on the dark
+ * ground they were drawn for and the copy and the close button take light
+ * values with it. In dark mode nothing changes.
+ *
  * The lid is a slab wearing the eyes' own silhouette (a `clipPath` of the eye
  * paths), so it closes each eye over its top and leaves the gap between them
  * empty. It is painted in the avatar's own color, with its lower edge banded
@@ -136,6 +144,7 @@ export function SleepStageView({
   return (
     <motion.div
       data-scene={scene}
+      data-theme="dark"
       className="group absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
       initial={reduce ? false : { opacity: 0 }}
       // Waking runs the whole exit here: the eyes hold open for a beat and

--- a/clients/web/src/utils/eye-bbox.test.ts
+++ b/clients/web/src/utils/eye-bbox.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, test } from "bun:test";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import {
   pathBBox,
+  pathSpanAt,
   tightPathBBox,
   unionBBox,
   type BBox,
@@ -125,5 +126,28 @@ describe("tightPathBBox", () => {
     // control-point box is the one that disagrees with the sampled truth.
     expect(control.h / tight.h).toBeGreaterThan(1.5);
     expect(Math.abs(control.h - SAMPLED_BOUNDS.angry.h)).toBeGreaterThan(1);
+  });
+});
+
+describe("pathSpanAt", () => {
+  test("spans a square across its full width at any interior height", () => {
+    expect(pathSpanAt("M0 0 H10 V10 H0 Z", 5)).toEqual({ x0: 0, x1: 10 });
+  });
+
+  test("narrows a circle away from its middle", () => {
+    // A unit circle of radius 10 about (10, 10), as four cubic arcs.
+    const k = 5.5228;
+    const circle = `M20 10 C20 ${10 + k} ${10 + k} 20 10 20 C${10 - k} 20 0 ${10 + k} 0 10 C0 ${10 - k} ${10 - k} 0 10 0 C${10 + k} 0 20 ${10 - k} 20 10 Z`;
+    const middle = pathSpanAt(circle, 10)!;
+    expect(middle.x0).toBeCloseTo(0, 1);
+    expect(middle.x1).toBeCloseTo(20, 1);
+    const low = pathSpanAt(circle, 16)!;
+    expect(low.x0).toBeGreaterThan(1);
+    expect(low.x1).toBeLessThan(19);
+    expect(low.x1 - low.x0).toBeCloseTo(16, 0);
+  });
+
+  test("is null where the line misses the path", () => {
+    expect(pathSpanAt("M0 0 H10 V10 H0 Z", 12)).toBeNull();
   });
 });

--- a/clients/web/src/utils/eye-bbox.ts
+++ b/clients/web/src/utils/eye-bbox.ts
@@ -362,3 +362,174 @@ export function unionBBox(boxes: BBox[]): BBox {
   const maxY = Math.max(...boxes.map((b) => b.y + b.h));
   return { x: minX, y: minY, w: maxX - minX, h: maxY - minY };
 }
+
+/** How many straight pieces a curve is cut into when it is flattened. */
+const FLATTEN_STEPS = 16;
+
+/**
+ * The horizontal extent of a path where the line `y` crosses it: the leftmost
+ * and rightmost points of its outline at that height, or null where the line
+ * misses it. Curves are flattened into short straight pieces, so the answer
+ * is close rather than exact; `A` (arc) is treated as a straight line to its
+ * endpoint, as elsewhere in this module.
+ *
+ * The sleep stage draws each eye's lid line across the eye at the height the
+ * lid rests, and needs the eye's width there rather than its widest.
+ */
+export function pathSpanAt(
+  d: string,
+  y: number,
+): { x0: number; x1: number } | null {
+  let x0 = Infinity;
+  let x1 = -Infinity;
+  let cx = 0;
+  let cy = 0;
+  let startX = 0;
+  let startY = 0;
+  let cubicControl: Point | null = null;
+  let quadControl: Point | null = null;
+
+  const cross = (ax: number, ay: number, bx: number, by: number) => {
+    if (ay === by || (ay - y) * (by - y) > 0) {
+      return;
+    }
+    const x = ax + ((y - ay) * (bx - ax)) / (by - ay);
+    if (x < x0) {
+      x0 = x;
+    }
+    if (x > x1) {
+      x1 = x;
+    }
+  };
+  const lineTo = (x: number, yy: number) => {
+    cross(cx, cy, x, yy);
+    cx = x;
+    cy = yy;
+  };
+  const cubicTo = (c1: Point, c2: Point, end: Point) => {
+    const p0: Point = { x: cx, y: cy };
+    for (let i = 1; i <= FLATTEN_STEPS; i++) {
+      const t = i / FLATTEN_STEPS;
+      const u = 1 - t;
+      lineTo(
+        u * u * u * p0.x +
+          3 * u * u * t * c1.x +
+          3 * u * t * t * c2.x +
+          t * t * t * end.x,
+        u * u * u * p0.y +
+          3 * u * u * t * c1.y +
+          3 * u * t * t * c2.y +
+          t * t * t * end.y,
+      );
+    }
+  };
+  const quadraticTo = (c1: Point, end: Point) => {
+    const p0: Point = { x: cx, y: cy };
+    for (let i = 1; i <= FLATTEN_STEPS; i++) {
+      const t = i / FLATTEN_STEPS;
+      const u = 1 - t;
+      lineTo(
+        u * u * p0.x + 2 * u * t * c1.x + t * t * end.x,
+        u * u * p0.y + 2 * u * t * c1.y + t * t * end.y,
+      );
+    }
+  };
+
+  const segments = d.match(SEGMENTS) ?? [];
+  for (const seg of segments) {
+    const code = seg[0]!;
+    const upper = code.toUpperCase();
+    const relative = code !== upper;
+    const nums = (seg.slice(1).match(NUM) ?? []).map(Number);
+    const absX = (value: number) => (relative ? cx + value : value);
+    const absY = (value: number) => (relative ? cy + value : value);
+
+    if (upper === "Z") {
+      lineTo(startX, startY);
+      cubicControl = null;
+      quadControl = null;
+      continue;
+    }
+
+    if (upper === "M") {
+      for (let i = 0; i + 2 <= nums.length; i += 2) {
+        if (i === 0) {
+          cx = absX(nums[i]!);
+          cy = absY(nums[i + 1]!);
+          startX = cx;
+          startY = cy;
+        } else {
+          lineTo(absX(nums[i]!), absY(nums[i + 1]!));
+        }
+      }
+      cubicControl = null;
+      quadControl = null;
+    } else if (upper === "L") {
+      for (let i = 0; i + 2 <= nums.length; i += 2) {
+        lineTo(absX(nums[i]!), absY(nums[i + 1]!));
+      }
+      cubicControl = null;
+      quadControl = null;
+    } else if (upper === "H") {
+      for (const n of nums) {
+        lineTo(relative ? cx + n : n, cy);
+      }
+      cubicControl = null;
+      quadControl = null;
+    } else if (upper === "V") {
+      for (const n of nums) {
+        lineTo(cx, relative ? cy + n : n);
+      }
+      cubicControl = null;
+      quadControl = null;
+    } else if (upper === "C") {
+      for (let i = 0; i + 6 <= nums.length; i += 6) {
+        const c1: Point = { x: absX(nums[i]!), y: absY(nums[i + 1]!) };
+        const c2: Point = { x: absX(nums[i + 2]!), y: absY(nums[i + 3]!) };
+        const end: Point = { x: absX(nums[i + 4]!), y: absY(nums[i + 5]!) };
+        cubicTo(c1, c2, end);
+        cubicControl = c2;
+      }
+      quadControl = null;
+    } else if (upper === "S") {
+      for (let i = 0; i + 4 <= nums.length; i += 4) {
+        const c1: Point = {
+          x: 2 * cx - (cubicControl?.x ?? cx),
+          y: 2 * cy - (cubicControl?.y ?? cy),
+        };
+        const c2: Point = { x: absX(nums[i]!), y: absY(nums[i + 1]!) };
+        const end: Point = { x: absX(nums[i + 2]!), y: absY(nums[i + 3]!) };
+        cubicTo(c1, c2, end);
+        cubicControl = c2;
+      }
+      quadControl = null;
+    } else if (upper === "Q") {
+      for (let i = 0; i + 4 <= nums.length; i += 4) {
+        const c1: Point = { x: absX(nums[i]!), y: absY(nums[i + 1]!) };
+        const end: Point = { x: absX(nums[i + 2]!), y: absY(nums[i + 3]!) };
+        quadraticTo(c1, end);
+        quadControl = c1;
+      }
+      cubicControl = null;
+    } else if (upper === "T") {
+      for (let i = 0; i + 2 <= nums.length; i += 2) {
+        const c1: Point = {
+          x: 2 * cx - (quadControl?.x ?? cx),
+          y: 2 * cy - (quadControl?.y ?? cy),
+        };
+        const end: Point = { x: absX(nums[i]!), y: absY(nums[i + 1]!) };
+        quadraticTo(c1, end);
+        quadControl = c1;
+      }
+      cubicControl = null;
+    } else if (upper === "A") {
+      for (let i = 0; i + 7 <= nums.length; i += 7) {
+        lineTo(absX(nums[i + 5]!), absY(nums[i + 6]!));
+      }
+      cubicControl = null;
+      quadControl = null;
+    }
+  }
+
+  return x0 === Infinity ? null : { x0, x1 };
+}


### PR DESCRIPTION
## Summary

- **The sleep stage is always dark.** The catalog's eye white is `#F2F2F2` and the light theme's surface is `#F6F5F4`, so on a light page the eyes of a sleeping assistant lost their whites and the pupils floated on nothing. The stage now re-declares the design tokens under `data-theme="dark"`, the same treatment the voice room, signup shell, and research overlay give their surfaces, so the copy and close button take light values with it. Dark mode is unchanged.
- **The lid's edge is a lash line.** The lid's lower edge is now a shallow arch, and the darker edge is a line of its own per eye with round ends that runs a couple of pixels past the eye's outline. It is sized to the eye's width at the height the lid rests (new `pathSpanAt` in the eye-bbox utils) so its round ends are its own, and masked to the outline grown a little past the overhang so it stays off the gap between the eyes and leaves with the lid when the eyes open.
- **Stories.** `Light and dark` renders both themes side by side and `Every color` runs the palette, so the whites can be checked where they were lost.

## Test plan

- [x] `bun test` on `assistant-sleep-stage.test.tsx` and `eye-bbox.test.ts` (new tests for the dark stage, the per-eye lid line, and `pathSpanAt`)
- [x] `eslint`, `prettier`, and `tsc` clean on the touched files
- [x] Visually QA'd in Storybook (`Chat/SleepStage`) across every eye style, every palette color, and both themes

Note: `companion-surface.stories.tsx` on `main` fails to parse and blocks the Storybook index, and `companion-surface.tsx` has an unclosed JSX tag that fails `tsc`. Neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRgFQZt3Dhw4FF6gkNrKnX