### PR TITLE
refactor(skills): drop conversation-scoped skill catalog cache

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -545,6 +545,33 @@ describe("projectSkillTools", () => {
     expect(mockRegisteredTools.has("deploy")).toBe(true);
   });
 
+  test("catalog membership changes are visible on the next projection with a persistent cache", () => {
+    const cache = {};
+    mockCatalog = [];
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    const result1 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      cache,
+    });
+    expect(result1.allowedToolNames.size).toBe(0);
+    expect(sessionState.has("deploy")).toBe(false);
+
+    mockCatalog = [makeSkill("deploy")];
+
+    const result2 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      cache,
+    });
+    expect(result2.allowedToolNames).toEqual(new Set(["deploy_run"]));
+    expect(sessionState.has("deploy")).toBe(true);
+    expect(mockRegisteredTools.has("deploy")).toBe(true);
+  });
+
   test("skill with manifest failure on turn 1 is registered when manifest is available on turn 2", () => {
     mockCatalog = [makeSkill("deploy")];
     // No manifest — will fail to load

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -3447,8 +3447,9 @@ describe("Subagent advisor-role consult", () => {
   });
 
   test("advisor consults still run when the parent conversation is gone", async () => {
-    // The parent is looked up only for its warm skill catalog, so an evicted
-    // conversation costs a section of the context pack, not the consult.
+    // Advisor consults do not look up the parent conversation for a skill
+    // catalog snapshot. An evicted parent still gets a consult; the context
+    // pack loads the catalog from disk independently.
     mockFindConversation = () => undefined;
     const { captured, restore } = stubSpawn();
     try {

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -75,11 +75,13 @@ export interface SkillToolProjection {
 }
 
 /**
- * Conversation-scoped cache for skill projection. Avoids re-scanning the entire
- * conversation history and re-reading the filesystem on every agent turn.
+ * Conversation-scoped cache for skill projection. Avoids re-scanning the
+ * conversation history on every agent turn. Catalog membership is not stored
+ * here: each projection reads a fresh `loadSkillCatalog()` so newly
+ * installed or removed skills are visible on the next turn.
  *
- * Each conversation should own its own cache instance to prevent cross-conversation
- * state bleed.
+ * Each conversation should own its own cache instance to prevent
+ * cross-conversation state bleed.
  */
 export interface SkillProjectionCache {
   /** Cached deriveActiveSkills result. */
@@ -95,9 +97,6 @@ export interface SkillProjectionCache {
     /** The accumulated active skill entries. */
     entries: ActiveSkillEntry[];
   };
-  /** Cached skill catalog. Invalidated when the conversation is marked stale
-   *  (e.g. config or prompt files changed on disk while a run is in progress). */
-  catalog?: SkillSummary[];
 }
 
 export interface ProjectSkillToolsOptions {
@@ -113,9 +112,9 @@ export interface ProjectSkillToolsOptions {
    */
   previouslyActiveSkillIds?: Map<string, string>;
   /**
-   * Conversation-scoped projection cache. When provided, projectSkillTools will
-   * avoid redundant deriveActiveSkills scans and loadSkillCatalog filesystem
-   * reads across agent turns.
+   * Conversation-scoped projection cache. When provided, projectSkillTools
+   * avoids redundant deriveActiveSkills scans across agent turns. Catalog
+   * membership is always a fresh `loadSkillCatalog()` read.
    */
   cache?: SkillProjectionCache;
   /**
@@ -310,23 +309,6 @@ function getCachedActiveSkills(
   return entries;
 }
 
-/**
- * Return the skill catalog, caching it across agent turns.
- *
- * The cache is invalidated when the conversation is marked stale (e.g. config
- * or prompt files changed on disk while the conversation is still processing).
- */
-function getCachedCatalog(cache?: SkillProjectionCache): SkillSummary[] {
-  if (!cache) {
-    return loadSkillCatalog();
-  }
-
-  if (!cache.catalog) {
-    cache.catalog = loadSkillCatalog();
-  }
-  return cache.catalog;
-}
-
 // ---------------------------------------------------------------------------
 // Main export
 // ---------------------------------------------------------------------------
@@ -363,11 +345,11 @@ export function projectSkillTools(
   const contextIds = contextEntries.map((e) => e.id);
   const allCandidateIds = new Set<string>([...contextIds, ...preactivated]);
 
-  // Load the catalog (cached for conversation lifetime), then scope it to the
-  // conversation's per-chat plugin selection so plugin-contributed skills from
-  // unselected plugins are not resolvable for this run (null = no restriction).
+  // Load the catalog, then scope it to the conversation's per-chat plugin
+  // selection so plugin-contributed skills from unselected plugins are not
+  // resolvable for this run (null = no restriction).
   const catalog = filterSkillsByEnabledPlugins(
-    getCachedCatalog(options?.cache),
+    loadSkillCatalog(),
     options?.effectiveEnabledPluginSet ?? null,
   );
   const catalogById = new Map<string, SkillSummary>();

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2366,10 +2366,6 @@ export class Conversation {
 
   markStale(): void {
     this.stale = true;
-    // Invalidate the cached skill catalog so the next projection picks up
-    // catalog membership changes after a config/prompt reload marked this
-    // conversation stale.
-    this.skillProjectionCache.catalog = undefined;
   }
 
   isStale(): boolean {

--- a/assistant/src/subagent/consult-context.ts
+++ b/assistant/src/subagent/consult-context.ts
@@ -33,7 +33,6 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 
-import type { SkillSummary } from "../config/skills.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { truncate as truncateText } from "../util/truncate.js";
@@ -56,15 +55,6 @@ export interface AdvisorContextSources {
    * from the catalog section, mirroring the `skill_load` gate.
    */
   enabledPluginSet?: ReadonlySet<string> | null;
-  /**
-   * Pre-resolved skill catalog, typically the parent conversation's warm
-   * `skillProjectionCache.catalog`. Passing it keeps the synchronous on-disk
-   * catalog scan out of the consult path (and matches the catalog view the
-   * parent turn's tool projection used). When absent, the section falls back
-   * to a fresh `loadSkillCatalog()` scan, the same call every agent turn's
-   * projection already makes.
-   */
-  skillCatalog?: readonly SkillSummary[];
 }
 
 /** Cap a block so the assembled context never balloons the consult prompt. */
@@ -114,7 +104,6 @@ async function buildToolsSection(
  */
 async function buildSkillsSection(
   enabledPluginSet: ReadonlySet<string> | null | undefined,
-  preResolvedCatalog: readonly SkillSummary[] | undefined,
 ): Promise<string | null> {
   try {
     const [
@@ -130,19 +119,17 @@ async function buildSkillsSection(
     ]);
     const config = getConfig();
     const pluginScope = enabledPluginSet ?? null;
-    const catalog = (preResolvedCatalog ?? loadSkillCatalog()).filter(
-      (skill) => {
-        if (
-          pluginScope !== null &&
-          skill.owner?.kind === "plugin" &&
-          !pluginScope.has(skill.owner.id)
-        ) {
-          return false;
-        }
-        const flagKey = skillFlagKey(skill);
-        return !flagKey || isAssistantFeatureFlagEnabled(flagKey, config);
-      },
-    );
+    const catalog = loadSkillCatalog().filter((skill) => {
+      if (
+        pluginScope !== null &&
+        skill.owner?.kind === "plugin" &&
+        !pluginScope.has(skill.owner.id)
+      ) {
+        return false;
+      }
+      const flagKey = skillFlagKey(skill);
+      return !flagKey || isAssistantFeatureFlagEnabled(flagKey, config);
+    });
     if (catalog.length === 0) {
       return null;
     }
@@ -384,7 +371,7 @@ export async function buildAdvisorContext(
   const sections = await Promise.all(
     [
       buildToolsSection(sources.allowedToolNames),
-      buildSkillsSection(sources.enabledPluginSet, sources.skillCatalog),
+      buildSkillsSection(sources.enabledPluginSet),
       buildWorkspaceSection(sources),
     ].map((section) => withSectionTimeout(section, sectionTimeoutMs)),
   );

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -484,9 +484,9 @@ function spawnCancelledResult(label: string): ToolExecutionResult {
  * repeat-spawn guard folds, so a consult has to record it the same way every
  * other spawn does or the guard could never match one consult against another.
  *
- * The context pack is best effort: the parent conversation is looked up only
- * for its warm skill catalog, so an unresolvable one (e.g. evicted) costs the
- * skills section of the pack and nothing else.
+ * The context pack is best effort: each section independently falls back to
+ * null on failure, so a missing workspace or empty catalog costs only that
+ * section, never the consult.
  *
  * The budget is the advisor's alone. It is the only spawn the agent may issue
  * unprompted and the only one that runs on the premium profile, so it is the
@@ -502,21 +502,18 @@ async function buildAdvisorFields(
   maxRuntimeMs: number;
   maxToolCalls: number;
 }> {
-  const parentConversation = findConversation(context.conversationId);
   // Situational awareness for the advisor: the parent's live tool set, the
   // full skill catalog, and its workspace. Assembled off the per-turn
   // ToolContext snapshot (trust, channel) so the personal-memory sections are
   // gated exactly like the runtime injectors. A null pack just means the
-  // consult runs on the brief alone.
+  // consult runs on the brief alone. Skills come from a fresh
+  // `loadSkillCatalog()` inside the context pack, not a conversation snapshot.
   const situationalContext = await buildAdvisorContext({
     conversationId: context.conversationId,
     workingDir: context.workingDir,
     allowedToolNames: context.allowedToolNames,
     trustClass: context.trustClass,
     enabledPluginSet: context.enabledPluginSet,
-    // The parent's warm per-turn catalog keeps the synchronous on-disk catalog
-    // scan out of the spawn path.
-    skillCatalog: parentConversation?.skillProjectionCache?.catalog,
   });
   return {
     requestText: advisorRequestText(objective, situationalContext),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

The skills directory watcher that evicted conversations on file change is gone (`feat(skills): reseed capability cards from SKILL.md mtimes`, #42550). Interrogate and delete the leftover conversation-scoped skill catalog on `Conversation`.

`SkillProjectionCache.catalog` existed because PR #5354 cached `loadSkillCatalog()` for the conversation lifetime, which was safe only while the watcher evicted conversations whenever a skill directory changed. With that invariant gone, the snapshot froze catalog membership until an unrelated `markStale()` (config/prompt reload) cleared it. Newly installed or removed skills stayed invisible for the rest of the conversation.

This change:
- Removes `catalog` from `SkillProjectionCache` and deletes `getCachedCatalog()`.
- Calls `loadSkillCatalog()` on every `projectSkillTools` projection.
- Drops the advisor `skillCatalog` pass-through so consults also scan live.
- Leaves `SkillProjectionCache.derived` (incremental history scan) in place.

This is not the remote/local merged Vellum catalog in `skills/catalog-cache.ts` (`getCachedCatalogSync`). That cache is unchanged.

## Test plan

- Unit: `assistant/src/__tests__/conversation-skill-tools.test.ts` (new case: catalog membership change is visible on the next projection with a persistent `SkillProjectionCache`)
- Unit: `assistant/src/__tests__/subagent-tools.test.ts` (advisor consult still runs without a parent conversation)
- Unit: `assistant/src/subagent/__tests__/consult-context-skills.test.ts`
- Benchmark: `skill-projection.benchmark.test.ts` still green. It mocks `loadSkillCatalog` and measures the `derived` cache, not catalog FS cost.

Verified locally:
- `conversation-skill-tools.test.ts` including the new persistent-cache membership test
- `consult-context-skills.test.ts` and `consult-context.test.ts`
- `consult-context-gating.test.ts`
- `subagent-tools.test.ts` (184 pass)
- `skill-projection.benchmark.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24534214-9be1-4d37-bcbc-f8b9d12e1ec7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24534214-9be1-4d37-bcbc-f8b9d12e1ec7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

