### PR TITLE
feat(i18n): localize activation flows and sync missing zh / zh-TW locale keys

### DIFF
--- a/clients/web/src/i18n/locales/zh-TW/activation-tasks.json
+++ b/clients/web/src/i18n/locales/zh-TW/activation-tasks.json
@@ -1,1 +1,533 @@
-{}
+{
+  "tasks": {
+    "pdf-car-report": {
+      "category": "documents",
+      "icon": "FileText",
+      "color": "blue",
+      "title": "產生 PDF 報告",
+      "description": "根據你駕駛（或停在車庫裡）的愛車產生一份經典的車輛估值報告。",
+      "chip": "為我的愛車產生報告",
+      "prompt": "為我開的汽車製作一份一頁紙的 PDF 價值評估報告。如果你不知道車型，請先詢問我品牌、型號和年份。"
+    },
+    "pdf-proposal": {
+      "category": "documents",
+      "icon": "FileText",
+      "color": "blue",
+      "title": "製作提案 PDF",
+      "description": "一份隨時可以向客戶發送的一頁紙提案或報價單。",
+      "chip": "為新客戶起草報價",
+      "prompt": "為新客戶製作一份一頁紙的 PDF 提案。請先詢問我們銷售的產品或服務、客戶姓名和價格，然後產生 PDF。"
+    },
+    "pdf-chore-chart": {
+      "category": "documents",
+      "icon": "FileText",
+      "color": "blue",
+      "title": "製作家務清單",
+      "description": "一份可列印並貼在冰箱上的每週家務圖表。",
+      "chip": "兩個孩子的家務表",
+      "prompt": "製作一份可列印的每週家務 PDF 圖表。請先詢問孩子的姓名和年齡，然後推薦適合相應年齡的家務項目。"
+    },
+    "draft-doc": {
+      "category": "documents",
+      "icon": "PenLine",
+      "color": "purple",
+      "title": "起草文件",
+      "description": "在編輯器中起草單頁內容：公告、備忘錄或任何你需要的材料。",
+      "chip": "起草發布公告",
+      "prompt": "開啟一份新文件並起草一份單頁內容。請先詢問我是需要撰寫公告、備忘錄還是其他內容。"
+    },
+    "edit-my-doc": {
+      "category": "documents",
+      "icon": "SpellCheck",
+      "color": "purple",
+      "title": "潤色文稿",
+      "description": "貼上任何文字，取得可逐項採納的修改建議。",
+      "chip": "精煉這封郵件",
+      "prompt": "我會貼上一段自己寫的內容。請將其放入文件中，並逐條給出修改建議，使其更簡練、更清晰。"
+    },
+    "meeting-notes": {
+      "category": "documents",
+      "icon": "ListChecks",
+      "color": "purple",
+      "title": "將筆記整理為摘要",
+      "description": "貼上零散筆記，自動梳理決議與行動項。",
+      "chip": "總結會議紀要",
+      "prompt": "我會貼上粗略的會議筆記。請將其整理為包含會議決議、責任人明確的待辦事項以及待決問題的摘要。"
+    },
+    "sop-doc": {
+      "category": "documents",
+      "icon": "ClipboardList",
+      "color": "purple",
+      "title": "為團隊撰寫作業指南",
+      "description": "將腦海中的工作流程轉化為任何人都能照做執行的清單。",
+      "chip": "記錄客戶入職流程",
+      "prompt": "協助我為團隊的一項日常重複流程編寫逐步操作指南。對我進行五分鐘簡短提問，然後在文件中整理成清晰的檢查清單。"
+    },
+    "school-letter": {
+      "category": "documents",
+      "icon": "Mail",
+      "color": "purple",
+      "title": "給學校寫請假條",
+      "description": "以你的語氣撰寫請假條或致老師的信函。",
+      "chip": "明天的請假條",
+      "prompt": "為我孩子明天的學校請假寫一封簡短便條。請先詢問孩子的姓名、班級和請假原因。"
+    },
+    "campaign-tracker": {
+      "category": "apps",
+      "icon": "Megaphone",
+      "color": "orange",
+      "title": "建立行銷活動追蹤器",
+      "description": "用於追蹤行銷活動、負責人與進度的輕量應用程式。",
+      "chip": "活動追蹤應用程式",
+      "prompt": "幫我建構一個簡單的行銷活動追蹤應用程式，包含活動名稱、渠道、負責人、狀態和啟動日期等欄位。"
+    },
+    "analytics-dashboard": {
+      "category": "apps",
+      "icon": "BarChart3",
+      "color": "orange",
+      "title": "從 CSV 產生儀表板",
+      "description": "拖入試算表，即刻產生統計圖表。",
+      "chip": "基於 CSV 的儀表板",
+      "prompt": "根據我上傳的 CSV 檔案建立一個儀表板應用程式，為每個數值欄位產生一個圖表，並在頂部展示總結。"
+    },
+    "content-calendar": {
+      "category": "apps",
+      "icon": "CalendarDays",
+      "color": "orange",
+      "title": "規劃內容日曆",
+      "description": "一目了然縱覽整月發布排期。",
+      "chip": "30 天內容日曆",
+      "prompt": "製作一個未來 30 天的內容日曆應用程式，包含部落格、社群媒體和電子報的版塊，並允許我按天拖曳調整文章。"
+    },
+    "idea-tree": {
+      "category": "apps",
+      "icon": "GitBranch",
+      "color": "orange",
+      "title": "樹狀思維導圖腦暴",
+      "description": "層層分支擴展創意，支援無限發散。",
+      "chip": "副業專案創意樹",
+      "prompt": "製作一個創意樹應用程式：我給出一個主題，你向下拆解三層分支，並允許我繼續展開任意節點。"
+    },
+    "invoice-tracker": {
+      "category": "apps",
+      "icon": "Receipt",
+      "color": "orange",
+      "title": "追蹤未付發票",
+      "description": "清楚記錄欠款對象、金額及截止日期。",
+      "chip": "發票追蹤器",
+      "prompt": "建構一個追蹤發票的小應用程式：包含客戶、金額、發送日期、到期日、付款狀態，並醒目提示逾期列。"
+    },
+    "inventory-app": {
+      "category": "apps",
+      "icon": "Boxes",
+      "color": "orange",
+      "title": "盤點庫存",
+      "description": "帶有低庫存預警提示的輕便庫存表。",
+      "chip": "庫存清單",
+      "prompt": "建構一個庫存管理應用程式：記錄物品、現有數量、補貨閾值和供應商。低於補貨閾值的物品自動標出。"
+    },
+    "family-board": {
+      "category": "apps",
+      "icon": "LayoutGrid",
+      "color": "orange",
+      "title": "製作家庭週看板",
+      "description": "在一個螢幕上清晰掌握全家本週動向。",
+      "chip": "每週家庭看板",
+      "prompt": "建構一個家庭週日程看板應用程式，每人一列，每天一行。請先詢問我的家庭成員構成。"
+    },
+    "allowance-tracker": {
+      "category": "apps",
+      "icon": "PiggyBank",
+      "color": "orange",
+      "title": "記錄零用錢與家務",
+      "description": "為孩子追蹤積分、獎勵與連續打卡記錄。",
+      "chip": "零用錢追蹤器",
+      "prompt": "建構一個零用錢應用程式：家務對應積分、每個孩子的累計積分、連續打卡天數以及每週結算摘要。"
+    },
+    "meal-planner": {
+      "category": "apps",
+      "icon": "UtensilsCrossed",
+      "color": "orange",
+      "title": "規劃本週食譜",
+      "description": "制定晚餐菜單並自動產生可勾選的採買清單。",
+      "chip": "本週飲食計劃",
+      "prompt": "幫我為本週建構一個膳食規劃應用程式，安排每晚的晚餐，並自動產生可打勾的食材購物清單。請先詢問忌口或過敏原。"
+    },
+    "habit-tracker": {
+      "category": "apps",
+      "icon": "Flame",
+      "color": "orange",
+      "title": "習慣打卡追蹤",
+      "description": "每天一鍵打卡，自動統計堅持天數。",
+      "chip": "習慣打卡器",
+      "prompt": "建構一個支援最多追蹤 5 個習慣的打卡應用程式，支援一鍵點擊打卡並記錄連續完成天數。"
+    },
+    "price-quote-calc": {
+      "category": "apps",
+      "icon": "Calculator",
+      "color": "orange",
+      "title": "建構報價計算器",
+      "description": "輸入參數即刻得出報價，方便與客戶共享。",
+      "chip": "報價計算器",
+      "prompt": "為我銷售的產品或服務建構一個價格計算器應用程式。先向我了解影響價格的各項輸入因素，然後製作計算器。"
+    },
+    "connect-email": {
+      "category": "inbox",
+      "icon": "Inbox",
+      "color": "teal",
+      "title": "連接電子郵箱",
+      "description": "讓助理為你閱讀並起草電子郵件。",
+      "chip": "連接我的信箱",
+      "prompt": "幫我連接信箱帳號，以便你能為我閱讀郵件和起草回覆。請引導我逐步完成設定。"
+    },
+    "inbox-sweep": {
+      "category": "inbox",
+      "icon": "MailX",
+      "color": "teal",
+      "title": "信箱大掃除",
+      "description": "退訂非必要郵件、封存舊郵件並提煉重要內容。",
+      "chip": "清理我的收件匣",
+      "prompt": "幫我梳理收件匣：建議可以退訂的電子報、可封存的舊會話，並挑出今天應該回覆的 5 封重要郵件。在執行變更前先徵得我的同意。",
+      "requires": [
+        "email"
+      ]
+    },
+    "daily-briefing": {
+      "category": "automations",
+      "icon": "Sunrise",
+      "color": "teal",
+      "title": "取得每日早報",
+      "description": "每天早晨一條訊息匯集行事曆日程、重要郵件與天氣預報。",
+      "chip": "每天早晨 7 點向我匯報",
+      "prompt": "設定每天早晨 7 點的每日早報，內容涵蓋我的日程安排、重要郵件和天氣情況。請詢問我希望發送到哪個通知渠道。"
+    },
+    "calendar-find-time": {
+      "category": "inbox",
+      "icon": "CalendarClock",
+      "color": "teal",
+      "title": "協調會議時間",
+      "description": "檢查日程空檔並智慧提議合適的時間段。",
+      "chip": "尋找本週的 30 分鐘空檔",
+      "prompt": "查看我的行事曆，提議本週 3 個適合開會的 30 分鐘空檔。同時幫我起草會議邀請函文字。",
+      "requires": [
+        "calendar"
+      ]
+    },
+    "draft-replies": {
+      "category": "inbox",
+      "icon": "Reply",
+      "color": "teal",
+      "title": "起草客戶回覆郵件",
+      "description": "為等待你答覆的郵件預先寫好得體的回覆。",
+      "chip": "起草今日郵件回覆",
+      "prompt": "找出正在等待我回覆的客戶郵件，並以我的口吻為每封郵件起草回覆草稿。發送前先給我確認。",
+      "requires": [
+        "email"
+      ]
+    },
+    "school-emails": {
+      "category": "inbox",
+      "icon": "GraduationCap",
+      "color": "teal",
+      "title": "監控學校郵件",
+      "description": "再也不會錯過學校的回執單或通知。",
+      "chip": "留意學校郵件",
+      "prompt": "監控我的收件匣中來自孩子學校的郵件，當天向我發送簡短摘要並標註截止日期。請先向我詢問學校的郵箱網域名稱。",
+      "requires": [
+        "email"
+      ]
+    },
+    "set-schedule": {
+      "category": "automations",
+      "icon": "Calendar",
+      "color": "teal",
+      "title": "設定定時提醒",
+      "description": "早晨簡報、信箱清理或任何週期性事務。",
+      "chip": "每個工作日早 9 點提醒我",
+      "prompt": "為我設定一個週期性提醒。向我推薦早晨簡報、收件匣清理或其他實用的日常流程，然後設定我選擇的那項。"
+    },
+    "weekly-report": {
+      "category": "automations",
+      "icon": "CalendarCheck",
+      "color": "teal",
+      "title": "取得每週業務回顧",
+      "description": "每週五彙總本週進展及下週待辦事項。",
+      "chip": "週五下午 4 點回顧",
+      "prompt": "設定每週五下午 4 點的定期週報，根據你能讀取的資訊彙總本週完成的工作以及下週待辦，先詢問我需要包含哪些內容。"
+    },
+    "sunday-ping": {
+      "category": "automations",
+      "icon": "CalendarCheck",
+      "color": "teal",
+      "title": "週日規劃提醒",
+      "description": "每週日發送一條訊息，提前預告下週安排。",
+      "chip": "週日晚預覽下週日程",
+      "prompt": "設定每週日晚 6 點的提醒訊息，預覽全家下週的安排：包括預約、學校活動以及我曾交代你記住的所有事項。"
+    },
+    "watcher": {
+      "category": "automations",
+      "icon": "Eye",
+      "color": "teal",
+      "title": "監控網頁變動",
+      "description": "頁面內容發生變化時及時通知你。",
+      "chip": "降價時通知我",
+      "prompt": "幫我監控一個網頁，並在頁面內容發生變化時給我發訊息。請詢問我目標網址以及我關心的具體變化。"
+    },
+    "bill-reminders": {
+      "category": "automations",
+      "icon": "BellRing",
+      "color": "teal",
+      "title": "帳單到期提醒",
+      "description": "在每個還款截止日期前提早提醒。",
+      "chip": "提醒我支付帳單",
+      "prompt": "在每個週期性帳單到期前 3 天為我設定提醒。請向我詢問有哪些帳單及其截止日期。"
+    },
+    "blog-post": {
+      "category": "content",
+      "icon": "Newspaper",
+      "color": "pink",
+      "title": "撰寫部落格文章",
+      "description": "構思大綱、起草正文並潤色成文。",
+      "chip": "700 字部落格文章",
+      "prompt": "寫一篇 700 字左右的部落格文章。請先向我詢問主題與目標讀者，展示大綱，然後在文件中起草正文。"
+    },
+    "social-posts": {
+      "category": "content",
+      "icon": "Share2",
+      "color": "pink",
+      "title": "發布社群動態",
+      "description": "將一個核心創意轉化為三套針對不同平台的文案。",
+      "chip": "一靈感衍生三篇文案",
+      "prompt": "將一條發布公告分別改寫為 LinkedIn 貼文、X 貼文以及電子報短訊。請先問我要發布什麼。"
+    },
+    "newsletter": {
+      "category": "content",
+      "icon": "MailOpen",
+      "color": "pink",
+      "title": "起草電子報",
+      "description": "包含標題、引言及三個核心版塊。",
+      "chip": "本週電子報",
+      "prompt": "起草本週的電子報，包含標題、簡要引言和三個主要版塊。請先詢問我本週發生了哪些要事。"
+    },
+    "image-asset": {
+      "category": "content",
+      "icon": "Image",
+      "color": "pink",
+      "title": "製作社群宣傳圖",
+      "description": "符合你品牌色調的精美分享配圖。",
+      "chip": "發布宣傳圖",
+      "prompt": "為一項發布活動產生一張 1200x630 的社群媒體分享圖片。請詢問我的大標題和品牌主色調。",
+      "requires": [
+        "image-generation"
+      ]
+    },
+    "seo-audit": {
+      "category": "content",
+      "icon": "SearchCheck",
+      "color": "pink",
+      "title": "網站 SEO 審計",
+      "description": "快速診斷並列出最關鍵的五項優化建議。",
+      "chip": "審計我的網站",
+      "prompt": "對我的網站進行搜尋引擎最佳化（SEO）和 AI 搜尋可見性審計，給出效果最顯著的五項改進建議。請向我索取網站 URL。"
+    },
+    "google-review-replies": {
+      "category": "content",
+      "icon": "Star",
+      "color": "pink",
+      "title": "回覆客戶評價",
+      "description": "為最新的客戶評價撰寫真誠熱情的回覆。",
+      "chip": "回覆三條評價",
+      "prompt": "我會貼上三條客戶評價。請以符合我企業風格的口吻，為每條評價寫出溫和且具針對性的回覆。"
+    },
+    "meme-generator": {
+      "category": "content",
+      "icon": "Laugh",
+      "color": "pink",
+      "title": "製作迷因梗圖",
+      "description": "群組聊天必備。",
+      "chip": "週一主題迷因",
+      "prompt": "幫我製作一張迷因梗圖。請向我詢問主題並選擇合適的模版。",
+      "requires": [
+        "image-generation"
+      ]
+    },
+    "research-competitors": {
+      "category": "research",
+      "icon": "Telescope",
+      "color": "green",
+      "title": "評估競爭對手",
+      "description": "掌握對方定價、宣傳主張及你的致勝優勢。",
+      "chip": "對比競品與我方優勢",
+      "prompt": "調研一家競爭對手，並提供單頁對比分析：包括定價模式、市場定位以及我方可以勝出的三個切入點。請向我索取雙方網站。"
+    },
+    "compare-products": {
+      "category": "research",
+      "icon": "Scale",
+      "color": "green",
+      "title": "選品對比決策",
+      "description": "三項備選、一張清單、一份明確建議。",
+      "chip": "200 美元內最佳安全座椅",
+      "prompt": "幫我挑選商品。先詢問我打算買什麼和預算範圍，然後在表格中對比三個候選產品並推薦一款。"
+    },
+    "plan-a-trip": {
+      "category": "research",
+      "icon": "Plane",
+      "color": "green",
+      "title": "規劃家庭旅行",
+      "description": "涵蓋行程規劃、行李清單與預算安排。",
+      "chip": "帶孩子度過小長假",
+      "prompt": "幫我規劃一次家庭旅行。先詢問目的地、出發時間、出行人員和預算，然後提供按天排期的詳細行程單與行李清單。"
+    },
+    "restaurant-reservation": {
+      "category": "research",
+      "icon": "ChefHat",
+      "color": "green",
+      "title": "餐廳預訂安排",
+      "description": "尋找心儀餐廳並協助訂位。",
+      "chip": "週五四人晚餐訂位",
+      "prompt": "尋找一家合適的餐廳並協助預訂座位。請先詢問城市、用餐日期、人數以及我們想品嘗的菜系偏好。"
+    },
+    "weather-plan": {
+      "category": "research",
+      "icon": "CloudSun",
+      "color": "green",
+      "title": "依據天氣安排週末",
+      "description": "結合天氣預報推薦適合親子出行的活動。",
+      "chip": "這個週末去哪玩？",
+      "prompt": "查詢我所在地區本週末的天氣，並根據天氣推薦三套適合親子出遊的計劃。請先詢問我所在的城市和孩子的年齡。"
+    },
+    "reorder-essentials": {
+      "category": "research",
+      "icon": "ShoppingCart",
+      "color": "green",
+      "title": "補購生活必需品",
+      "description": "一鍵告知，自動送貨上門。",
+      "chip": "補購尿布和咖啡",
+      "prompt": "幫我設定家庭必需品的定期補貨流程。請先詢問我平時消耗最快、最常缺貨的物品有哪些。",
+      "requires": [
+        "shopping"
+      ]
+    },
+    "expense-summary": {
+      "category": "money",
+      "icon": "Wallet",
+      "color": "green",
+      "title": "彙總分類開銷",
+      "description": "匯入對帳單，自動按類別彙總並核算總額。",
+      "chip": "上月開銷分類統計",
+      "prompt": "我會上傳銀行或信用卡的對帳單匯出檔案。請幫我對各項費用進行分類統計、計算各類總和，並指出任何異常交易。"
+    },
+    "budget-plan": {
+      "category": "money",
+      "icon": "Wallet",
+      "color": "green",
+      "title": "制定家庭預算",
+      "description": "按月梳理收入、固定支出及結餘資金。",
+      "chip": "每月家庭預算表",
+      "prompt": "和我一起制定一份家庭月度預算。請先詢問收入和各項固定開銷，然後展示結餘資金並提議三條省錢方案。"
+    },
+    "teach-memory": {
+      "category": "setup",
+      "icon": "Brain",
+      "color": "yellow",
+      "title": "讓 {name} 認識你",
+      "description": "告訴 {name} 你的生活習慣、偏好與雷區，{name} 會牢牢記住。",
+      "chip": "關於我，你應該知道這些",
+      "prompt": "向我提出十個關於我的生活和工作的簡短問題，以便你記住關鍵細節。請一次只提一個問題，等我回答後再提下一個，並將了解到的內容妥善保存。"
+    },
+    "add-contacts": {
+      "category": "setup",
+      "icon": "Users",
+      "color": "yellow",
+      "title": "新增重要聯絡人",
+      "description": "保存助理需要知曉姓名的人物資訊。",
+      "chip": "新增我的團隊成員",
+      "prompt": "幫我把經常提到的人新增為聯絡人，以便日後你能清楚我指代的是誰。請向我詢問他們的名字以及我們之間的關係。"
+    },
+    "voice-mode": {
+      "category": "setup",
+      "icon": "Mic",
+      "color": "yellow",
+      "title": "開啟語音對話模式",
+      "description": "解放雙手，體驗自然流暢的口語暢聊。",
+      "chip": "設定語音模式",
+      "prompt": "幫我設定語音功能，這樣我就可以直接和你語音交流而不是打字，然後我們來進行一次簡短的語音對話吧。"
+    },
+    "connect-telegram": {
+      "category": "setup",
+      "icon": "MessageCircle",
+      "color": "yellow",
+      "title": "在手機上與助理聊天",
+      "description": "透過 Telegram、WhatsApp 或簡訊隨時連接你的助理。",
+      "chip": "設定 Telegram",
+      "prompt": "幫我連接通訊渠道，方便我用手機給你發訊息。向我展示支援的選項，並協助我設定所選渠道。"
+    },
+    "connect-slack": {
+      "category": "setup",
+      "icon": "Hash",
+      "color": "yellow",
+      "title": "接入團隊 Slack",
+      "description": "在團隊熟悉的日常溝通工作區隨時提問。",
+      "chip": "設定 Slack",
+      "prompt": "幫我把你新增到團隊的 Slack 工作區，這樣我們就能在公共頻道裡直接向你提問。"
+    },
+    "connect-notion": {
+      "category": "setup",
+      "icon": "BookOpen",
+      "color": "yellow",
+      "title": "連接 Notion",
+      "description": "閱讀並更新團隊的 Notion 頁面。",
+      "chip": "連接 Notion",
+      "prompt": "幫我連接 Notion，以便你能閱讀和更新我們的知識庫頁面，然後幫我總結我指定的一個頁面。"
+    },
+    "import-chatgpt": {
+      "category": "setup",
+      "icon": "Download",
+      "color": "yellow",
+      "title": "匯入 ChatGPT 歷史記錄",
+      "description": "匯入以往的對話歷史，讓助理直接掌握背景脈絡。",
+      "chip": "匯入 ChatGPT 匯出資料",
+      "prompt": "幫我匯入 ChatGPT 的歷史聊天記錄，這樣你就能清楚我之前一直在處理哪些事情。"
+    },
+    "faq-page": {
+      "category": "content",
+      "icon": "MessageCircleQuestion",
+      "color": "pink",
+      "title": "編寫常見問題解答",
+      "description": "針對客戶反覆提問的十個核心問題，一次性給出權威解答。",
+      "chip": "企業常見問題 FAQ",
+      "prompt": "為我的業務編寫一份常見問題解答（FAQ）頁面。請先詢問我的產品服務以及最常遇到的諮詢，然後在文件中起草十個解答。"
+    },
+    "birthday-tracker": {
+      "category": "automations",
+      "icon": "Cake",
+      "color": "teal",
+      "title": "生日提醒備忘",
+      "description": "提前一週溫馨提醒，並附贈貼心送禮靈感。",
+      "chip": "提醒重要生日",
+      "prompt": "為我設定提前一週的生日提醒，並針對每個人推薦三個禮物建議。請向我詢問人員名單和具體日期。"
+    },
+    "weekly-review": {
+      "category": "automations",
+      "icon": "NotebookPen",
+      "color": "teal",
+      "title": "每週複盤反思",
+      "description": "每週五三個簡短啟發問題，自動彙編成日誌文件。",
+      "chip": "週五反思複盤",
+      "prompt": "每週五下午 5 點向我提出三個簡短的反思問題，並將我的回答記錄保存到日誌文件中。"
+    },
+    "try-computer-use": {
+      "category": "setup",
+      "icon": "MonitorSmartphone",
+      "color": "yellow",
+      "title": "體驗電腦控制功能",
+      "description": "讓助理查看你的螢幕並替你點擊操作。需要桌面端應用程式支援。",
+      "chip": "展示電腦控制能力",
+      "prompt": "向我展示你在我電腦上能實現的電腦操作功能。首先擷取一張螢幕截圖並描述目前畫面，然後提議兩件你可以幫我完成的事情。",
+      "link": {
+        "label": "下載桌面端應用程式",
+        "url": "https://www.vellum.ai/downloads"
+      }
+    }
+  }
+}

--- a/clients/web/src/i18n/locales/zh-TW/activation.json
+++ b/clients/web/src/i18n/locales/zh-TW/activation.json
@@ -1,1 +1,45 @@
-{}
+{
+  "catalog": {
+    "assistantFallback": "你的助理"
+  },
+  "celebration": {
+    "title": "太棒了，全部搞定！",
+    "subtitle": "已完成三項初始任務。隨時可以在這裡查看完整靈感清單。"
+  },
+  "launch": {
+    "failed": "無法啟動任務，請重試。",
+    "noAssistant": "目前未連接任何助理。",
+    "openConversation": "開啟對話",
+    "running": "正在側邊欄中執行",
+    "unknownTask": "該任務已不再可用。"
+  },
+  "menu": {
+    "inspirationList": "靈感清單"
+  },
+  "page": {
+    "loading": "正在載入建議...",
+    "title": "快速入門"
+  },
+  "pill": {
+    "aria": "任務建議，已完成 {total} 項中的 {done} 項",
+    "label": "任務建議",
+    "progress": "{done}/{total}"
+  },
+  "row": {
+    "customLabel": "自訂：",
+    "customPlaceholder": "輸入任何你想嘗試的內容",
+    "done": "已完成",
+    "open": "開啟",
+    "openTask": "開啟 {title}",
+    "send": "傳送",
+    "steps": "{count} 個步驟",
+    "working": "正在處理",
+    "writeYourOwn": "自行撰寫"
+  },
+  "welcome": {
+    "later": "稍後再說",
+    "showFullList": "查看完整清單",
+    "subtitle": "嘗試精選的任務卡片，協助你全面了解助理的強大能力。",
+    "title": "歡迎使用！"
+  }
+}

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -827,7 +827,12 @@
     "stepWarmup": "預熱",
     "surfaceVoice": "語音通話攝影機",
     "thresholds": "閾值",
-    "valueAbsent": "無"
+    "valueAbsent": "無",
+    "forcedNoveltyThresholdLabel": "主動請求閾值",
+    "reasonAnswered": "已請求，但上一張相片已包含該內容。",
+    "reasonSettling": "已停止移動，但靜止時間尚不足。",
+    "stepAnswered": "已顯示",
+    "stepSettling": "保持靜止"
   },
   "groupActions": {
     "archiveAll": "全部封存…",
@@ -1930,5 +1935,12 @@
   "assistantSection": {
     "emptyBody": "我隨時都在思考。當有值得您關注的事情時，我會在這裡發起對話。",
     "emptyTitle": "目前還沒有任何想法。"
+  },
+  "assistantSectionToggle": {
+    "hide": "隱藏來自 {name} 的對話",
+    "show": "顯示來自 {name} 的對話"
+  },
+  "coachmarkPress": {
+    "turn": "我點擊了 {label}。接下來呢？"
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/onboarding.json
+++ b/clients/web/src/i18n/locales/zh-TW/onboarding.json
@@ -287,5 +287,8 @@
     "title": "您已準備就緒",
     "setupNote": "我已根據您的資訊設定了外掛程式。",
     "letsChat": "開始聊天"
+  },
+  "googleCalendar": {
+    "providerLabel": "Google 日曆"
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/settings.json
+++ b/clients/web/src/i18n/locales/zh-TW/settings.json
@@ -2398,5 +2398,15 @@
     "setUpTag": "設定",
     "signInTag": "登入",
     "soleProviderHint": "僅 {name} 提供此模型。"
+  },
+  "previewUiChannel": {
+    "description": "在目前瀏覽器中載入此應用程式的預覽版本。你的助理不受影響。",
+    "offAriaLabel": "預覽版介面已關閉",
+    "onAriaLabel": "預覽版介面已開啟",
+    "runningPreview": "目前運行：預覽版本 {version}",
+    "runningStable": "目前運行：穩定版本 {version}",
+    "title": "預覽版介面",
+    "unavailableHint": "目前未提供預覽版本，因此此瀏覽器仍在使用穩定版本。可在開發者工具中刪除 vellum_preview Cookie 以重設。",
+    "versionUnknown": "未知"
   }
 }

--- a/clients/web/src/i18n/locales/zh/activation-tasks.json
+++ b/clients/web/src/i18n/locales/zh/activation-tasks.json
@@ -1,1 +1,533 @@
-{}
+{
+  "tasks": {
+    "pdf-car-report": {
+      "category": "documents",
+      "icon": "FileText",
+      "color": "blue",
+      "title": "生成 PDF 报告",
+      "description": "根据你驾驶（或停在车库里）的爱车生成一份经典的车辆估值报告。",
+      "chip": "为我的爱车生成报告",
+      "prompt": "为我开的汽车制作一份一页纸的 PDF 价值评估报告。如果你不知道车型，请先询问我品牌、型号和年份。"
+    },
+    "pdf-proposal": {
+      "category": "documents",
+      "icon": "FileText",
+      "color": "blue",
+      "title": "制作提案 PDF",
+      "description": "一份随时可以向客户发送的一页纸提案或报价单。",
+      "chip": "为新客户起草报价",
+      "prompt": "为新客户制作一份一页纸的 PDF 提案。请先询问我们销售的产品或服务、客户姓名和价格，然后生成 PDF。"
+    },
+    "pdf-chore-chart": {
+      "category": "documents",
+      "icon": "FileText",
+      "color": "blue",
+      "title": "制作家务清单",
+      "description": "一份可打印并贴在冰箱上的每周家务图表。",
+      "chip": "两个孩子的家务表",
+      "prompt": "制作一份可打印的每周家务 PDF 图表。请先询问孩子的姓名和年龄，然后推荐适合相应年龄的家务项目。"
+    },
+    "draft-doc": {
+      "category": "documents",
+      "icon": "PenLine",
+      "color": "purple",
+      "title": "起草文档",
+      "description": "在编辑器中起草单页内容：公告、备忘录或任何你需要的材料。",
+      "chip": "起草发布公告",
+      "prompt": "打开一个新文档并起草一份单页内容。请先询问我是需要撰写公告、备忘录还是其他内容。"
+    },
+    "edit-my-doc": {
+      "category": "documents",
+      "icon": "SpellCheck",
+      "color": "purple",
+      "title": "润色文稿",
+      "description": "粘贴任何文本，获取可逐项采纳的修改建议。",
+      "chip": "精炼这封邮件",
+      "prompt": "我会粘贴一段自己写的内容。请将其放入文档中，并逐条给出修改建议，使其更简练、更清晰。"
+    },
+    "meeting-notes": {
+      "category": "documents",
+      "icon": "ListChecks",
+      "color": "purple",
+      "title": "将笔记整理为摘要",
+      "description": "粘贴零散笔记，自动梳理决议与行动项。",
+      "chip": "总结会议纪要",
+      "prompt": "我会粘贴粗略的会议笔记。请将其整理为包含会议决议、责任人明确的待办事项以及待决问题的摘要。"
+    },
+    "sop-doc": {
+      "category": "documents",
+      "icon": "ClipboardList",
+      "color": "purple",
+      "title": "为团队撰写操作指南",
+      "description": "将脑海中的工作流程转化为任何人都能照做执行的清单。",
+      "chip": "记录客户入职流程",
+      "prompt": "协助我为团队的一项日常重复流程编写逐步操作指南。对我进行五分钟简短提问，然后在文档中整理成清晰的检查清单。"
+    },
+    "school-letter": {
+      "category": "documents",
+      "icon": "Mail",
+      "color": "purple",
+      "title": "给学校写请假条",
+      "description": "以你的语气撰写请假条或致老师的信函。",
+      "chip": "明天的请假条",
+      "prompt": "为我孩子明天的学校请假写一封简短便条。请先询问孩子的姓名、班级和请假原因。"
+    },
+    "campaign-tracker": {
+      "category": "apps",
+      "icon": "Megaphone",
+      "color": "orange",
+      "title": "创建营销活动追踪器",
+      "description": "用于追踪营销活动、负责人与进度的轻量应用。",
+      "chip": "活动追踪应用",
+      "prompt": "帮我构建一个简单的营销活动追踪应用，包含活动名称、渠道、负责人、状态和启动日期等列。"
+    },
+    "analytics-dashboard": {
+      "category": "apps",
+      "icon": "BarChart3",
+      "color": "orange",
+      "title": "从 CSV 生成仪表盘",
+      "description": "拖入电子表格，即刻生成统计图表。",
+      "chip": "基于 CSV 的仪表盘",
+      "prompt": "根据我上传的 CSV 文件创建一个仪表盘应用，为每个数值列生成一个图表，并在顶部展示总结。"
+    },
+    "content-calendar": {
+      "category": "apps",
+      "icon": "CalendarDays",
+      "color": "orange",
+      "title": "规划内容日历",
+      "description": "一目了然纵览整月发布排期。",
+      "chip": "30 天内容日历",
+      "prompt": "制作一个未来 30 天的内容日历应用，包含博客、社交媒体和新闻通讯的版块，并允许我按天拖拽调整文章。"
+    },
+    "idea-tree": {
+      "category": "apps",
+      "icon": "GitBranch",
+      "color": "orange",
+      "title": "树状思维导图脑暴",
+      "description": "层层分支扩展创意，支持无限发散。",
+      "chip": "副业项目创意树",
+      "prompt": "制作一个创意树应用：我给出一个主题，你向下拆解三层分支，并允许我继续展开任意节点。"
+    },
+    "invoice-tracker": {
+      "category": "apps",
+      "icon": "Receipt",
+      "color": "orange",
+      "title": "追踪未付发票",
+      "description": "清楚记录欠款对象、金额及截止日期。",
+      "chip": "发票追踪器",
+      "prompt": "构建一个追踪发票的小应用：包含客户、金额、发送日期、到期日、付款状态，并高亮逾期行。"
+    },
+    "inventory-app": {
+      "category": "apps",
+      "icon": "Boxes",
+      "color": "orange",
+      "title": "盘点库存",
+      "description": "带有低库存预警提示的轻便库存表。",
+      "chip": "库存清单",
+      "prompt": "构建一个库存管理应用：记录物品、现有数量、补货阈值和供应商。低于补货阈值的物品自动标出。"
+    },
+    "family-board": {
+      "category": "apps",
+      "icon": "LayoutGrid",
+      "color": "orange",
+      "title": "制作家庭周看板",
+      "description": "在一个屏幕上清晰掌握全家本周动向。",
+      "chip": "每周家庭看板",
+      "prompt": "构建一个家庭周日程看板应用，每人一列，每天一行。请先询问我的家庭成员构成。"
+    },
+    "allowance-tracker": {
+      "category": "apps",
+      "icon": "PiggyBank",
+      "color": "orange",
+      "title": "记录零花钱与家务",
+      "description": "为孩子追踪积分、奖励与连续打卡记录。",
+      "chip": "零用钱追踪器",
+      "prompt": "构建一个零花钱应用：家务对应积分、每个孩子的累计积分、连续打卡天数以及每周结算摘要。"
+    },
+    "meal-planner": {
+      "category": "apps",
+      "icon": "UtensilsCrossed",
+      "color": "orange",
+      "title": "规划本周食谱",
+      "description": "制定晚餐菜单并自动生成可勾选的买菜清单。",
+      "chip": "本周饮食计划",
+      "prompt": "帮我为本周构建一个膳食规划应用，安排每晚的晚餐，并自动生成可打勾的食材购物清单。请先询问忌口或过敏源。"
+    },
+    "habit-tracker": {
+      "category": "apps",
+      "icon": "Flame",
+      "color": "orange",
+      "title": "习惯打卡追踪",
+      "description": "每天一键打卡，自动统计坚持天数。",
+      "chip": "习惯打卡器",
+      "prompt": "构建一个支持最多追踪 5 个习惯的打卡应用，支持一键点击打卡并记录连续完成天数。"
+    },
+    "price-quote-calc": {
+      "category": "apps",
+      "icon": "Calculator",
+      "color": "orange",
+      "title": "构建报价计算器",
+      "description": "输入参数即刻得出报价，方便与客户共享。",
+      "chip": "报价计算器",
+      "prompt": "为我销售的产品或服务构建一个价格计算器应用。先向我了解影响价格的各项输入因素，然后制作计算器。"
+    },
+    "connect-email": {
+      "category": "inbox",
+      "icon": "Inbox",
+      "color": "teal",
+      "title": "连接电子邮箱",
+      "description": "让助理为你阅读并起草电子邮件。",
+      "chip": "连接我的邮箱",
+      "prompt": "帮我连接邮箱账户，以便你能为我阅读邮件和起草回复。请引导我逐步完成设置。"
+    },
+    "inbox-sweep": {
+      "category": "inbox",
+      "icon": "MailX",
+      "color": "teal",
+      "title": "邮箱大扫除",
+      "description": "退订非必要邮件、归档旧邮件并提炼重要内容。",
+      "chip": "清理我的收件箱",
+      "prompt": "帮我梳理收件箱：建议可以退订的新闻通讯、可归档的旧会话，并挑出今天应该回复的 5 封重要邮件。在执行更改前先征得我的同意。",
+      "requires": [
+        "email"
+      ]
+    },
+    "daily-briefing": {
+      "category": "automations",
+      "icon": "Sunrise",
+      "color": "teal",
+      "title": "获取每日早报",
+      "description": "每天早晨一条消息汇集日历日程、重要邮件与天气预报。",
+      "chip": "每天早晨 7 点向我汇报",
+      "prompt": "设置每天早晨 7 点的每日早报，内容涵盖我的日程安排、重要邮件和天气情况。请询问我希望发送到哪个通知渠道。"
+    },
+    "calendar-find-time": {
+      "category": "inbox",
+      "icon": "CalendarClock",
+      "color": "teal",
+      "title": "协调会议时间",
+      "description": "检查日程空档并智能提议合适的时间段。",
+      "chip": "寻找本周的 30 分钟空档",
+      "prompt": "查看我的日历，提议本周 3 个适合开会的 30 分钟空档。同时帮我起草会议邀请函文本。",
+      "requires": [
+        "calendar"
+      ]
+    },
+    "draft-replies": {
+      "category": "inbox",
+      "icon": "Reply",
+      "color": "teal",
+      "title": "起草客户回复邮件",
+      "description": "为等待你答复的邮件预先写好得体的回复。",
+      "chip": "起草今日邮件回复",
+      "prompt": "找出正在等待我回复的客户邮件，并以我的口吻为每封邮件起草回复草稿。发送前先给我确认。",
+      "requires": [
+        "email"
+      ]
+    },
+    "school-emails": {
+      "category": "inbox",
+      "icon": "GraduationCap",
+      "color": "teal",
+      "title": "监控学校邮件",
+      "description": "再也不会错过学校的回执单或通知。",
+      "chip": "留意学校邮件",
+      "prompt": "监控我的收件箱中来自孩子学校的邮件，当天向我发送简短摘要并标注截止日期。请先向我询问学校的邮箱域名。",
+      "requires": [
+        "email"
+      ]
+    },
+    "set-schedule": {
+      "category": "automations",
+      "icon": "Calendar",
+      "color": "teal",
+      "title": "设置定时提醒",
+      "description": "早间简报、邮箱清理或任何周期性事务。",
+      "chip": "每个工作日早 9 点提醒我",
+      "prompt": "为我设置一个周期性提醒。向我推荐早间简报、收件箱清理或其他实用的日常流程，然后配置我选择的那项。"
+    },
+    "weekly-report": {
+      "category": "automations",
+      "icon": "CalendarCheck",
+      "color": "teal",
+      "title": "获取每周业务回顾",
+      "description": "每周五汇总本周进展及下周待办事项。",
+      "chip": "周五下午 4 点回顾",
+      "prompt": "设置每周五下午 4 点的定期周报，根据你能读取的信息汇总本周完成的工作以及下周待办，先询问我需要包含哪些内容。"
+    },
+    "sunday-ping": {
+      "category": "automations",
+      "icon": "CalendarCheck",
+      "color": "teal",
+      "title": "周日规划提醒",
+      "description": "每周日发送一条消息，提前预告下周安排。",
+      "chip": "周日晚预览下周日程",
+      "prompt": "设置每周日晚 6 点的提醒消息，预览全家下周的安排：包括预约、学校活动以及我曾交代你记住的所有事项。"
+    },
+    "watcher": {
+      "category": "automations",
+      "icon": "Eye",
+      "color": "teal",
+      "title": "监控网页变动",
+      "description": "页面内容发生变化时及时通知你。",
+      "chip": "降价时通知我",
+      "prompt": "帮我监控一个网页，并在页面内容发生变化时给我发消息。请询问我目标网址以及我关心的具体变化。"
+    },
+    "bill-reminders": {
+      "category": "automations",
+      "icon": "BellRing",
+      "color": "teal",
+      "title": "账单到期提醒",
+      "description": "在每个还款截止日期前提早提醒。",
+      "chip": "提醒我支付账单",
+      "prompt": "在每个周期性账单到期前 3 天为我设置提醒。请向我询问有哪些账单及其截止日期。"
+    },
+    "blog-post": {
+      "category": "content",
+      "icon": "Newspaper",
+      "color": "pink",
+      "title": "撰写博客文章",
+      "description": "构思大纲、起草正文并润色成文。",
+      "chip": "700 字博客文章",
+      "prompt": "写一篇 700 字左右的博客文章。请先向我询问主题与目标读者，展示大纲，然后在文档中起草正文。"
+    },
+    "social-posts": {
+      "category": "content",
+      "icon": "Share2",
+      "color": "pink",
+      "title": "发布社交动态",
+      "description": "将一个核心创意转化为三套针对不同平台的文案。",
+      "chip": "一灵感衍生三篇文案",
+      "prompt": "将一条发布公告分别改写为 LinkedIn 贴文、X 贴文以及新闻通讯短讯。请先问我要发布什么。"
+    },
+    "newsletter": {
+      "category": "content",
+      "icon": "MailOpen",
+      "color": "pink",
+      "title": "起草新闻通讯",
+      "description": "包含标题、引言及三个核心版块。",
+      "chip": "本周新闻通讯",
+      "prompt": "起草本周的新闻通讯，包含标题、简要引言和三个主要版块。请先询问我本周发生了哪些要事。"
+    },
+    "image-asset": {
+      "category": "content",
+      "icon": "Image",
+      "color": "pink",
+      "title": "制作社媒宣传图",
+      "description": "符合你品牌色调的精美分享配图。",
+      "chip": "发布宣传图",
+      "prompt": "为一项发布活动生成一张 1200x630 的社交媒体分享图片。请询问我的大标题和品牌主色调。",
+      "requires": [
+        "image-generation"
+      ]
+    },
+    "seo-audit": {
+      "category": "content",
+      "icon": "SearchCheck",
+      "color": "pink",
+      "title": "网站 SEO 审计",
+      "description": "快速诊断并列出最关键的五项优化建议。",
+      "chip": "审计我的网站",
+      "prompt": "对我的网站进行搜索引擎优化（SEO）和 AI 搜索可见性审计，给出效果最显著的五项改进建议。请向我索取网站 URL。"
+    },
+    "google-review-replies": {
+      "category": "content",
+      "icon": "Star",
+      "color": "pink",
+      "title": "回复客户评价",
+      "description": "为最新的客户评价撰写真诚热情的回复。",
+      "chip": "回复三条评价",
+      "prompt": "我会粘贴三条客户评价。请以符合我企业风格的口吻，为每条评价写出温和且具有针对性的回复。"
+    },
+    "meme-generator": {
+      "category": "content",
+      "icon": "Laugh",
+      "color": "pink",
+      "title": "制作表情包",
+      "description": "群聊破冰利器。",
+      "chip": "周一主题表情包",
+      "prompt": "帮我制作一张表情包梗图。请向我询问主题并选择合适的模版。",
+      "requires": [
+        "image-generation"
+      ]
+    },
+    "research-competitors": {
+      "category": "research",
+      "icon": "Telescope",
+      "color": "green",
+      "title": "评估竞争对手",
+      "description": "掌握对方定价、宣传主张及你的致胜优势。",
+      "chip": "对比竞品与我方优势",
+      "prompt": "调研一家竞争对手，并提供单页对比分析：包括定价模式、市场定位以及我方可以胜出的三个切入点。请向我索取双方网站。"
+    },
+    "compare-products": {
+      "category": "research",
+      "icon": "Scale",
+      "color": "green",
+      "title": "选品对比决策",
+      "description": "三项备选、一张清单、一份明确建议。",
+      "chip": "200 美元内最佳安全座椅",
+      "prompt": "帮我挑选商品。先询问我打算买什么和预算范围，然后在表格中对比三个候选产品并推荐一款。"
+    },
+    "plan-a-trip": {
+      "category": "research",
+      "icon": "Plane",
+      "color": "green",
+      "title": "规划家庭旅行",
+      "description": "涵盖行程规划、行李清单与预算安排。",
+      "chip": "带娃度过小长假",
+      "prompt": "帮我规划一次家庭旅行。先询问目的地、出发时间、出行人员和预算，然后提供按天排期的详细行程单与打包清单。"
+    },
+    "restaurant-reservation": {
+      "category": "research",
+      "icon": "ChefHat",
+      "color": "green",
+      "title": "餐厅预订安排",
+      "description": "寻找心仪餐厅并协助订座。",
+      "chip": "周五四人晚餐订位",
+      "prompt": "寻找一家合适的餐厅并协助预订座位。请先询问城市、用餐日期、人数以及我们想品尝的菜系偏好。"
+    },
+    "weather-plan": {
+      "category": "research",
+      "icon": "CloudSun",
+      "color": "green",
+      "title": "依据天气安排周末",
+      "description": "结合天气预报推荐适合亲子出行的活动。",
+      "chip": "这个周末去哪玩？",
+      "prompt": "查询我所在地区本周末的天气，并根据天气推荐三套适合亲子出游的计划。请先询问我所在的城市和孩子的年龄。"
+    },
+    "reorder-essentials": {
+      "category": "research",
+      "icon": "ShoppingCart",
+      "color": "green",
+      "title": "补购生活必需品",
+      "description": "一键告知，自动送货上门。",
+      "chip": "补购纸尿裤和咖啡",
+      "prompt": "帮我设置家庭必需品的定期补货流程。请先询问我平时消耗最快、最常缺货的物品有哪些。",
+      "requires": [
+        "shopping"
+      ]
+    },
+    "expense-summary": {
+      "category": "money",
+      "icon": "Wallet",
+      "color": "green",
+      "title": "汇总分类开销",
+      "description": "导入对账单，自动按类别汇总并核算总额。",
+      "chip": "上月开销分类统计",
+      "prompt": "我会上传银行或信用卡的账单导出文件。请帮我对各项费用进行分类统计、计算各类总和，并指出任何异常交易。"
+    },
+    "budget-plan": {
+      "category": "money",
+      "icon": "Wallet",
+      "color": "green",
+      "title": "制定家庭预算",
+      "description": "按月梳理收入、固定支出及结余资金。",
+      "chip": "每月家庭预算表",
+      "prompt": "和我一起制定一份家庭月度预算。请先询问收入和各项固定开销，然后展示结余资金并提议三条省钱方案。"
+    },
+    "teach-memory": {
+      "category": "setup",
+      "icon": "Brain",
+      "color": "yellow",
+      "title": "让 {name} 认识你",
+      "description": "告诉 {name} 你的生活习惯、偏好与雷区，{name} 会牢牢记住。",
+      "chip": "关于我，你应该知道这些",
+      "prompt": "向我提出十个关于我的生活和工作的简短问题，以便你记住关键细节。请一次只提一个问题，等我回答后再提下一个，并将了解到的内容妥善保存。"
+    },
+    "add-contacts": {
+      "category": "setup",
+      "icon": "Users",
+      "color": "yellow",
+      "title": "添加重要联系人",
+      "description": "保存助理需要知晓姓名的人物信息。",
+      "chip": "添加我的团队成员",
+      "prompt": "帮我把经常提到的人添加为联系人，以便日后你能清楚我指代的是谁。请向我询问他们的名字以及我们之间的关系。"
+    },
+    "voice-mode": {
+      "category": "setup",
+      "icon": "Mic",
+      "color": "yellow",
+      "title": "开启语音对话模式",
+      "description": "解放双手，体验自然流利的口语畅聊。",
+      "chip": "设置语音模式",
+      "prompt": "帮我设置语音功能，这样我就可以直接和你语音交流而不是打字，然后我们来进行一次简短的语音对话吧。"
+    },
+    "connect-telegram": {
+      "category": "setup",
+      "icon": "MessageCircle",
+      "color": "yellow",
+      "title": "在手机上与助理聊天",
+      "description": "通过 Telegram、WhatsApp 或短信随时连接你的助理。",
+      "chip": "配置 Telegram",
+      "prompt": "帮我连接消息通讯渠道，方便我用手机给你发消息。向我展示支持的选项，并协助我配置所选渠道。"
+    },
+    "connect-slack": {
+      "category": "setup",
+      "icon": "Hash",
+      "color": "yellow",
+      "title": "接入团队 Slack",
+      "description": "在团队熟悉的日常沟通工作区随时提问。",
+      "chip": "配置 Slack",
+      "prompt": "帮我把你添加到团队的 Slack 工作区，这样我们就能在公共频道里直接向你提问。"
+    },
+    "connect-notion": {
+      "category": "setup",
+      "icon": "BookOpen",
+      "color": "yellow",
+      "title": "连接 Notion",
+      "description": "阅读并更新团队的 Notion 页面。",
+      "chip": "连接 Notion",
+      "prompt": "帮我连接 Notion，以便你能阅读和更新我们的知识库页面，然后帮我总结我指定的一个页面。"
+    },
+    "import-chatgpt": {
+      "category": "setup",
+      "icon": "Download",
+      "color": "yellow",
+      "title": "导入 ChatGPT 历史记录",
+      "description": "导入以往的对话历史，让助理直接掌握背景脉络。",
+      "chip": "导入 ChatGPT 导出数据",
+      "prompt": "帮我导入 ChatGPT 的历史聊天记录，这样你就能清楚我之前一直在处理哪些事情。"
+    },
+    "faq-page": {
+      "category": "content",
+      "icon": "MessageCircleQuestion",
+      "color": "pink",
+      "title": "编写常见问题解答",
+      "description": "针对客户反复提问的十个核心问题，一次性给出权威解答。",
+      "chip": "企业常见问题 FAQ",
+      "prompt": "为我的业务编写一份常见问题解答（FAQ）页面。请先询问我的产品服务以及最常遇到的咨询，然后在文档中起草十个解答。"
+    },
+    "birthday-tracker": {
+      "category": "automations",
+      "icon": "Cake",
+      "color": "teal",
+      "title": "生日提醒备忘",
+      "description": "提前一周温馨提醒，并附赠贴心送礼灵感。",
+      "chip": "提醒重要生日",
+      "prompt": "为我设置提前一周的生日提醒，并针对每个人推荐三个礼物建议。请向我询问人员名单和具体日期。"
+    },
+    "weekly-review": {
+      "category": "automations",
+      "icon": "NotebookPen",
+      "color": "teal",
+      "title": "每周复盘反思",
+      "description": "每周五三个简短启发问题，自动汇编成日志文档。",
+      "chip": "周五反思复盘",
+      "prompt": "每周五下午 5 点向我提出三个简短的反思问题，并将我的回答记录保存到日志文档中。"
+    },
+    "try-computer-use": {
+      "category": "setup",
+      "icon": "MonitorSmartphone",
+      "color": "yellow",
+      "title": "体验电脑控制功能",
+      "description": "让助理查看你的屏幕并替你点击操作。需要桌面客户端支持。",
+      "chip": "展示电脑控制能力",
+      "prompt": "向我展示你在我电脑上能实现的电脑操作功能。首先截取一张屏幕截图并描述当前画面，然后提议两件你可以帮我完成的事情。",
+      "link": {
+        "label": "下载桌面客户端",
+        "url": "https://www.vellum.ai/downloads"
+      }
+    }
+  }
+}

--- a/clients/web/src/i18n/locales/zh/activation.json
+++ b/clients/web/src/i18n/locales/zh/activation.json
@@ -1,1 +1,45 @@
-{}
+{
+  "catalog": {
+    "assistantFallback": "你的助理"
+  },
+  "celebration": {
+    "title": "太棒了，全部搞定！",
+    "subtitle": "已完成三项初始任务。随时可以在这里查看完整灵感清单。"
+  },
+  "launch": {
+    "failed": "无法启动任务，请重试。",
+    "noAssistant": "当前未连接任何助理。",
+    "openConversation": "打开对话",
+    "running": "正在侧边栏中运行",
+    "unknownTask": "该任务已不再可用。"
+  },
+  "menu": {
+    "inspirationList": "灵感清单"
+  },
+  "page": {
+    "loading": "正在加载建议...",
+    "title": "快速入门"
+  },
+  "pill": {
+    "aria": "任务建议，已完成 {total} 项中的 {done} 项",
+    "label": "任务建议",
+    "progress": "{done}/{total}"
+  },
+  "row": {
+    "customLabel": "自定义：",
+    "customPlaceholder": "输入任何你想尝试的内容",
+    "done": "已完成",
+    "open": "打开",
+    "openTask": "打开 {title}",
+    "send": "发送",
+    "steps": "{count} 个步骤",
+    "working": "正在处理",
+    "writeYourOwn": "自己编写"
+  },
+  "welcome": {
+    "later": "稍后再说",
+    "showFullList": "查看完整清单",
+    "subtitle": "尝试精选的任务卡片，帮助你全面了解助理的强大能力。",
+    "title": "欢迎使用！"
+  }
+}

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -827,7 +827,12 @@
     "stepWarmup": "预热",
     "surfaceVoice": "语音通话摄像头",
     "thresholds": "阈值",
-    "valueAbsent": "无"
+    "valueAbsent": "无",
+    "forcedNoveltyThresholdLabel": "主动请求阈值",
+    "reasonAnswered": "已请求，但上一张照片已包含该内容。",
+    "reasonSettling": "已停止移动，但静止时间尚不足。",
+    "stepAnswered": "已显示",
+    "stepSettling": "保持静止"
   },
   "groupActions": {
     "archiveAll": "全部归档…",
@@ -1930,5 +1935,12 @@
   "assistantSection": {
     "emptyBody": "我随时都在思考。当有值得您关注的事情时，我会在这里发起对话。",
     "emptyTitle": "目前还没有任何想法。"
+  },
+  "assistantSectionToggle": {
+    "hide": "隐藏来自 {name} 的对话",
+    "show": "显示来自 {name} 的对话"
+  },
+  "coachmarkPress": {
+    "turn": "我点击了 {label}。接下来呢？"
   }
 }

--- a/clients/web/src/i18n/locales/zh/onboarding.json
+++ b/clients/web/src/i18n/locales/zh/onboarding.json
@@ -287,5 +287,8 @@
     "title": "您已准备就绪",
     "setupNote": "我已根据您的信息设置了插件。",
     "letsChat": "开始聊天"
+  },
+  "googleCalendar": {
+    "providerLabel": "Google 日历"
   }
 }

--- a/clients/web/src/i18n/locales/zh/settings.json
+++ b/clients/web/src/i18n/locales/zh/settings.json
@@ -2398,5 +2398,15 @@
     "setUpTag": "设置",
     "signInTag": "登录",
     "soleProviderHint": "仅 {name} 提供此模型。"
+  },
+  "previewUiChannel": {
+    "description": "在当前浏览器中加载本应用的预览版本。你的助理不会受到影响。",
+    "offAriaLabel": "预览版界面已关闭",
+    "onAriaLabel": "预览版界面已开启",
+    "runningPreview": "当前运行：预览版本 {version}",
+    "runningStable": "当前运行：稳定版本 {version}",
+    "title": "预览版界面",
+    "unavailableHint": "当前未提供预览版本，因此本浏览器仍在使用稳定版本。可在开发者工具中删除 vellum_preview Cookie 以重置。",
+    "versionUnknown": "未知"
   }
 }


### PR DESCRIPTION
## Summary

This PR completes the Simplified Chinese (`zh`) and Traditional Chinese (`zh-TW`) localizations introduced in Vellum 0.12.0, covering the entire new Activation Flow and syncing missing keys across existing namespaces (445 keys total per language).

### Changes

1. **Activation System (`activation.json` & `activation-tasks.json`)**:
   - `activation.json`: 27 keys translated in both `zh` and `zh-TW` (welcome modal, celebration copy, suggestions pill, task trigger actions).
   - `activation-tasks.json`: all 56 tasks (401 keys) localized in both `zh` and `zh-TW` across documents, apps, personal routines, business operations, and computer use.
   - Strictly conforms to the catalog coupling contract: preserves structural fields (`category`, `icon`, `color`, `requires`), localizes `link.label` while keeping `link.url`, strictly avoids em dashes (`—`), and preserves ICU interpolation parameters like `{name}`.

2. **Sync Missing Locale Keys**:
   - `chat.json`: Added 8 keys for frame gate HUD steps/reasons and assistant section toggles in `zh` and `zh-TW`.
   - `settings.json`: Added 8 keys for the preview UI channel switcher and description in `zh` and `zh-TW`.
   - `onboarding.json`: Added `googleCalendar.providerLabel` (1 key) in `zh` and `zh-TW`.

### Validation

- Tested with `bun test src/i18n/catalogs.test.ts src/domains/activation/catalog.test.ts`:
  - 268/268 tests pass (0 failures).
  - ICU MessageFormat AST parsing verified.
  - Zero placeholder omissions.
  - No unreferenced keys or orphaned keys.