### PR TITLE
fix(prompts): hold the volatile system-prompt block for a conversation's life (JARVIS-1684)

### DIFF
--- a/assistant/src/__tests__/conversation-system-prompt-pin.test.ts
+++ b/assistant/src/__tests__/conversation-system-prompt-pin.test.ts
@@ -1,0 +1,230 @@
+/**
+ * A conversation keeps the volatile system-prompt block it started with.
+ *
+ * The prompt is rebuilt from the workspace before every turn, and the
+ * sections behind the cache boundary (first-run ritual, voice markers,
+ * connected services) change while a conversation runs. The system prompt
+ * heads every request, so a rebuild that differs anywhere re-writes the
+ * provider's cache for the entire history behind it. `buildCurrentSystemPrompt`
+ * holds a rebuild that differs only behind the boundary, and only a head change
+ * reaches the agent loop.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import { CompactionCircuit } from "../agent/compaction-circuit.js";
+import type { AgentEvent } from "../agent/loop.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Mocks — must precede Conversation import
+// ---------------------------------------------------------------------------
+
+mock.module("../providers/registry.js", () => ({
+  getProvider: () => ({ name: "mock-provider" }),
+  initializeProviders: async () => {},
+}));
+
+// The "workspace": whatever a rebuild renders right now.
+let workspacePrompt = "";
+
+mock.module("../prompts/system-prompt.js", () => ({
+  buildSystemPrompt: () => workspacePrompt,
+  applyBootstrapTemplate: () => {},
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => [],
+  loadSkillBySelector: () => ({ skill: null }),
+  ensureSkillIcon: async () => null,
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: () => [],
+}));
+
+mock.module("../permissions/trust-store.js", () => ({
+  addRule: () => {},
+  findHighestPriorityRule: () => null,
+  clearCache: () => {},
+}));
+
+mock.module("../security/secret-allowlist.js", () => ({
+  resetAllowlist: () => {},
+}));
+
+mock.module("../persistence/conversation-crud.js", () => ({
+  setConversationProcessingStartedAt: () => {},
+  isConversationProcessing: () => false,
+  setConversationOriginChannelIfUnset: () => {},
+  updateConversationContextWindow: () => {},
+  deleteMessageById: () => {},
+  provenanceFromTrustContext: () => ({
+    source: "user",
+    trustContext: undefined,
+  }),
+  getConversationOriginInterface: () => null,
+  getConversationOriginChannel: () => null,
+  getMessages: () => [],
+  getConversation: () => ({
+    id: "conv-1",
+    contextSummary: null,
+    contextCompactedMessageCount: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalEstimatedCost: 0,
+  }),
+  createConversation: () => ({ id: "conv-1" }),
+  addMessage: () => ({ id: `msg-${Date.now()}` }),
+  updateConversationUsage: () => {},
+  updateConversationTitle: () => {},
+  reserveMessage: mock(async () => ({ id: "msg-reserve" })),
+}));
+
+mock.module("../persistence/conversation-queries.js", () => ({
+  listConversations: () => [],
+}));
+
+mock.module("../persistence/attachments-store.js", () => ({
+  uploadAttachment: () => ({ id: `att-${Date.now()}` }),
+  linkAttachmentToMessage: () => {},
+}));
+
+mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
+  ContextWindowManager: class {
+    estimateInputTokens() {
+      return 0;
+    }
+    get tokenCountInputs() {
+      return { systemPrompt: "", tools: undefined };
+    }
+    constructor() {}
+    updateConfig() {}
+    shouldCompact() {
+      return { needed: false, estimatedTokens: 0 };
+    }
+    async maybeCompact() {
+      return { compacted: false };
+    }
+    resetOverflowRecovery() {}
+  },
+  createContextSummaryMessage: () => ({
+    role: "user",
+    content: [{ type: "text", text: "summary" }],
+  }),
+  getSummaryFromContextMessage: () => null,
+}));
+
+mock.module("../persistence/llm-usage-store.js", () => ({
+  recordUsageEvent: () => ({ id: "mock-id", createdAt: Date.now() }),
+  listUsageEvents: () => [],
+}));
+
+// What the agent loop was last told to send.
+const loopPrompts: string[] = [];
+
+mock.module("../agent/loop.js", () => ({
+  AgentLoop: class {
+    compactionCircuit = new CompactionCircuit("test-conv");
+    constructor() {}
+    setSystemPrompt(prompt: string) {
+      loopPrompts.push(prompt);
+    }
+    getToolTokenBudget() {
+      return 0;
+    }
+    getResolvedTools() {
+      return [];
+    }
+    getActiveModel() {
+      return undefined;
+    }
+    async run(_options: {
+      messages: Message[];
+      onEvent: (event: AgentEvent) => void;
+    }): Promise<Message[]> {
+      return [];
+    }
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import Conversation AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { Conversation } from "../daemon/conversation.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../prompts/cache-boundary.js";
+
+const HEAD = "# Instructions\n\nBe helpful.";
+const RITUAL = "# First-Run Ritual\n\nThis is your first conversation.";
+const SERVICES = "# Connected Services\n\n- **google**: Connected";
+
+function prompt(head: string, ...suffix: string[]): string {
+  return suffix.length === 0
+    ? head
+    : [head, suffix.join("\n\n")].join(SYSTEM_PROMPT_CACHE_BOUNDARY);
+}
+
+function makeConversation(initialPrompt: string): Conversation {
+  workspacePrompt = initialPrompt;
+  loopPrompts.length = 0;
+  const provider = {
+    name: "mock",
+    async sendMessage(): Promise<ProviderResponse> {
+      return {
+        content: [],
+        model: "mock",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        stopReason: "end_turn",
+      };
+    },
+  };
+  return new Conversation("conv-1", provider, initialPrompt, () => {}, "/tmp", {
+    maxTokens: 4096,
+  });
+}
+
+describe("the volatile system-prompt block is held for the conversation's life", () => {
+  test("deleting BOOTSTRAP.md mid-conversation does not change the prompt in flight", () => {
+    const conversation = makeConversation(prompt(HEAD, RITUAL));
+
+    // The model completes the ritual and deletes BOOTSTRAP.md; the next
+    // rebuild has no ritual section and no boundary at all.
+    workspacePrompt = prompt(HEAD);
+    conversation.syncLoopSystemPrompt();
+
+    expect(conversation.systemPrompt).toBe(prompt(HEAD, RITUAL));
+    expect(loopPrompts).toEqual([]);
+  });
+
+  test("a service connected mid-conversation waits for the next conversation", () => {
+    const conversation = makeConversation(prompt(HEAD, RITUAL));
+
+    workspacePrompt = prompt(HEAD, RITUAL, SERVICES);
+    conversation.syncLoopSystemPrompt();
+
+    expect(conversation.systemPrompt).toBe(prompt(HEAD, RITUAL));
+    expect(loopPrompts).toEqual([]);
+  });
+
+  test("a head change is pushed whole, carrying the volatile block as it stands", () => {
+    const conversation = makeConversation(prompt(HEAD, RITUAL));
+
+    // A voice call resolves the caller after construction: a persona section
+    // lands in the head, and the ritual is gone from the workspace by now.
+    const rescoped = prompt(`${HEAD}\n\n## Persona\n\nThe caller.`, SERVICES);
+    workspacePrompt = rescoped;
+    conversation.syncLoopSystemPrompt();
+
+    expect(conversation.systemPrompt).toBe(rescoped);
+    expect(loopPrompts).toEqual([rescoped]);
+  });
+
+  test("a new conversation starts from the workspace as it is now", () => {
+    const conversation = makeConversation(prompt(HEAD));
+
+    conversation.syncLoopSystemPrompt();
+
+    expect(conversation.systemPrompt).toBe(prompt(HEAD));
+    expect(loopPrompts).toEqual([]);
+  });
+});

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -92,6 +92,7 @@ import {
   markV3LiveBlock,
   MEMORY_V3_POINTER_BLOCK_METADATA_KEY,
 } from "../plugins/defaults/memory/v3/types.js";
+import { stabilizeSystemPrompt } from "../prompts/cache-boundary.js";
 import {
   applyBootstrapTemplate,
   buildSystemPrompt,
@@ -998,7 +999,8 @@ export class Conversation {
 
     const configuredMaxTokens = maxTokens;
     // When a systemPromptOverride was provided, use it as-is; otherwise
-    // rebuild the full prompt each turn (picks up any workspace file changes).
+    // rebuild the prompt each turn (see `buildCurrentSystemPrompt` for what a
+    // rebuild is allowed to change mid-conversation).
     const hasSystemPromptOverride = systemPrompt !== buildSystemPrompt();
     this.hasSystemPromptOverride = hasSystemPromptOverride;
 
@@ -1124,31 +1126,43 @@ export class Conversation {
   /**
    * Build the system prompt for the current conversation state. When a
    * system-prompt override was supplied at construction, use it as-is;
-   * otherwise rebuild the full prompt (picks up workspace file changes,
-   * live trust/channel context, persona overrides, onboarding context).
+   * otherwise rebuild the prompt under the live trust/channel context,
+   * persona overrides, onboarding context, and the turn's tool surface.
+   *
+   * The rebuild is then held against the prompt this conversation last sent
+   * ({@link stabilizeSystemPrompt}): a difference confined to the volatile
+   * block behind the cache boundary (the first-run ritual after the model
+   * deletes BOOTSTRAP.md, a voice marker it appended, a service connected
+   * mid-chat) keeps the prompt already in flight, because any change to the
+   * system prompt re-writes the provider's cache for the whole history behind
+   * it. Those workspace changes reach the next conversation. Only a change to
+   * the stable head, which is always a deliberate re-scoping of the turn,
+   * produces a new prompt.
    *
    * Called by the caller before invoking `agentLoop.run()` — the loop
    * itself never re-resolves the prompt mid-loop (re-resolving would bust
    * the provider's prefix cache).
    */
   buildCurrentSystemPrompt(): string {
-    return this.hasSystemPromptOverride
-      ? this.systemPrompt
-      : buildSystemPrompt({
-          hasNoClient: this.hasNoClient,
-          trustContext: this.currentTurnTrustContext,
-          channelCapabilities: this.currentTurnChannelCapabilities,
-          personaOverride: this.wakePersonaOverride,
-          onboardingContext: this.getOnboardingContext(),
-          conversationId: this.conversationId,
-          sendUserMessageTool: resolveSendUserMessageActive(this),
-          // Read off this turn's resolved tool surface: a workspace
-          // `tools.exclude` entry, a background run's `allowedTools` scope, a
-          // read-only subagent pass, or tools disabled all answer no, and the
-          // delegation section renders off rather than pointing at a tool the
-          // turn cannot call.
-          canSpawnSubagents: canSpawnSubagentsForTurn(this),
-        });
+    if (this.hasSystemPromptOverride) {
+      return this.systemPrompt;
+    }
+    const rebuilt = buildSystemPrompt({
+      hasNoClient: this.hasNoClient,
+      trustContext: this.currentTurnTrustContext,
+      channelCapabilities: this.currentTurnChannelCapabilities,
+      personaOverride: this.wakePersonaOverride,
+      onboardingContext: this.getOnboardingContext(),
+      conversationId: this.conversationId,
+      sendUserMessageTool: resolveSendUserMessageActive(this),
+      // Read off this turn's resolved tool surface: a workspace
+      // `tools.exclude` entry, a background run's `allowedTools` scope, a
+      // read-only subagent pass, or tools disabled all answer no, and the
+      // delegation section renders off rather than pointing at a tool the
+      // turn cannot call.
+      canSpawnSubagents: canSpawnSubagentsForTurn(this),
+    });
+    return stabilizeSystemPrompt(this.systemPrompt, rebuilt);
   }
 
   /**
@@ -1160,11 +1174,13 @@ export class Conversation {
    * construction-time persona (the guardian, or `users/default.md`) for the
    * whole conversation.
    *
-   * Pushing only when the rebuilt prompt actually differs keeps the provider's
+   * Pushing only when the resolved prompt actually differs keeps the provider's
    * prefix cache intact for the common case (a stable-identity conversation
-   * rebuilds to the same bytes, so no update is sent). A system-prompt override
-   * resolves verbatim via {@link buildCurrentSystemPrompt}, so override
-   * conversations (subagent forks, stored overrides) are inherently a no-op.
+   * resolves to the same bytes, so no update is sent), and
+   * {@link buildCurrentSystemPrompt} already holds a rebuild that differs only
+   * behind the cache boundary. A system-prompt override resolves verbatim, so
+   * override conversations (subagent forks, stored overrides) are inherently a
+   * no-op.
    *
    * Called by the turn runner before `agentLoop.run()`, once the turn's
    * persona snapshots ({@link currentTurnTrustContext},

--- a/assistant/src/prompts/__tests__/cache-boundary.test.ts
+++ b/assistant/src/prompts/__tests__/cache-boundary.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  stabilizeSystemPrompt,
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+} from "../cache-boundary.js";
+
+const HEAD = "# Instructions\n\nBe helpful.";
+const RITUAL = "# First-Run Ritual\n\nThis is your first conversation.";
+const SERVICES = "# Connected Services\n\n- **google**: Connected";
+
+function prompt(head: string, ...suffix: string[]): string {
+  return suffix.length === 0
+    ? head
+    : [head, suffix.join("\n\n")].join(SYSTEM_PROMPT_CACHE_BOUNDARY);
+}
+
+describe("stabilizeSystemPrompt", () => {
+  test("an identical rebuild is returned as-is", () => {
+    const current = prompt(HEAD, RITUAL);
+    expect(stabilizeSystemPrompt(current, current)).toBe(current);
+  });
+
+  test("a rebuild that only lost the volatile block keeps the current prompt", () => {
+    // The model deleted BOOTSTRAP.md mid-conversation: the ritual section
+    // vanishes from the rebuild and, with it, the boundary itself.
+    const current = prompt(HEAD, RITUAL);
+    expect(stabilizeSystemPrompt(current, prompt(HEAD))).toBe(current);
+  });
+
+  test("a rebuild that only gained a volatile block keeps the current prompt", () => {
+    // A service connected mid-conversation reaches the next conversation.
+    const current = prompt(HEAD);
+    expect(stabilizeSystemPrompt(current, prompt(HEAD, SERVICES))).toBe(
+      current,
+    );
+  });
+
+  test("a rebuild that only changed the volatile block keeps the current prompt", () => {
+    const current = prompt(HEAD, RITUAL);
+    expect(stabilizeSystemPrompt(current, prompt(HEAD, RITUAL, SERVICES))).toBe(
+      current,
+    );
+  });
+
+  test("a rebuild whose head changed is taken whole, volatile block included", () => {
+    const current = prompt(HEAD, RITUAL);
+    const next = prompt(`${HEAD}\n\n## Persona\n\nA new caller.`, SERVICES);
+    expect(stabilizeSystemPrompt(current, next)).toBe(next);
+  });
+
+  test("prompts without a boundary compare in full", () => {
+    expect(stabilizeSystemPrompt(HEAD, `${HEAD} more`)).toBe(`${HEAD} more`);
+  });
+
+  test("an empty current prompt never pins", () => {
+    const next = prompt("", RITUAL);
+    expect(stabilizeSystemPrompt("", next)).toBe(next);
+  });
+});

--- a/assistant/src/prompts/cache-boundary.ts
+++ b/assistant/src/prompts/cache-boundary.ts
@@ -15,3 +15,35 @@
  */
 export const SYSTEM_PROMPT_CACHE_BOUNDARY =
   "\n<!-- SYSTEM_PROMPT_CACHE_BOUNDARY -->\n";
+
+/**
+ * The stable head of a system prompt: everything before its first cache
+ * boundary, or the whole prompt when it carries none.
+ */
+function stableHead(prompt: string): string {
+  const boundary = prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
+  return boundary === -1 ? prompt : prompt.slice(0, boundary);
+}
+
+/**
+ * Pick the system prompt a conversation sends this turn, given the prompt it
+ * sent last (`current`) and a fresh rebuild from the workspace (`next`).
+ *
+ * A provider's prompt cache is prefix-based, and the system prompt is the
+ * head of every request, so any byte that changes in it, in either block,
+ * re-writes the whole conversation history behind it. On a long voice call
+ * that is a six-figure token write to answer one utterance. The sections
+ * behind the cache boundary (the first-run ritual, voice markers, connected
+ * services) are the ones that change while a conversation is running, so a
+ * rebuild that differs only there returns `current`: the conversation keeps
+ * the suffix it started with for its whole life, and what changed on disk
+ * reaches the next conversation. A change to the stable head (persona, trust
+ * class, channel, the turn's tool surface) is deliberate and returns `next`,
+ * refreshing the suffix with it.
+ */
+export function stabilizeSystemPrompt(current: string, next: string): string {
+  if (current.length === 0 || next === current) {
+    return next;
+  }
+  return stableHead(next) === stableHead(current) ? current : next;
+}

--- a/assistant/src/prompts/sections.ts
+++ b/assistant/src/prompts/sections.ts
@@ -64,7 +64,9 @@ export type SectionRenderContext = Record<string, unknown>;
  * declaring section itself gates off, so a disabled section doesn't
  * silently merge the blocks around it.  Only the first breakpoint is
  * honored (the provider-side cache budget allows exactly two system
- * blocks); extras are logged and ignored.
+ * blocks); extras are logged and ignored.  The block before the boundary
+ * is the head shared by every conversation on the workspace; the block
+ * after it is held fixed per conversation (see `stabilizeSystemPrompt`).
  *
  * The numeric prefix on each id is load-bearing inside its render phase; pick
  * a number that places the section where it should appear in the final prompt.

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -231,8 +231,13 @@ export interface BundledSection {
   /**
    * When true, a system-prompt cache breakpoint falls *after* this
    * section: the renderer ends the current cache block here, so
-   * everything up to and including this section forms a stable cached
-   * prefix and later (more volatile) sections form their own block.
+   * everything up to and including this section forms the stable head
+   * and later sections form their own block. The head's cache is shared
+   * by every conversation on the workspace; the block behind it holds
+   * what differs between conversations, and a conversation keeps sending
+   * the copy it started with (`Conversation.buildCurrentSystemPrompt`),
+   * because a change anywhere in the system prompt re-writes the cache
+   * for the whole history behind it.
    *
    * Workspace overrides control this via frontmatter
    * `cache_breakpoint: true` — an override file without the field
@@ -500,10 +505,11 @@ You can still be genuinely helpful — answer general questions, do research, an
     body: "",
     workspacePath: "channels/{{channelSlug}}.md",
     // Default cache breakpoint: sections 00–11 (instructions, identity,
-    // soul, personas) are stable within a conversation; 12+ (voice
-    // markers, bootstrap, connected services) change mid-session.
-    // Splitting here keeps the large stable prefix cached when a
-    // volatile section busts.
+    // soul, personas) are the stable head every conversation on the
+    // workspace shares; 12+ (voice markers, bootstrap, connected
+    // services) differ between conversations. A conversation holds the
+    // 12+ block fixed for its own life, so a workspace change there is
+    // seen by the next conversation, never re-written into a running one.
     cacheBreakpoint: true,
   },
   {
@@ -549,7 +555,7 @@ You can still be genuinely helpful — answer general questions, do research, an
         | OnboardingContext
         | undefined;
       const parts: string[] = [
-        "# First-Run Ritual\n\nBOOTSTRAP.md is present — this is your first conversation. Follow its instructions.",
+        "# First-Run Ritual\n\nThis is your first conversation. Follow the instructions below.",
       ];
       const voiceBlock = onboarding?.tone
         ? BOOTSTRAP_VOICE_BLOCKS[onboarding.tone]

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1104,9 +1104,9 @@ export class AnthropicProvider implements Provider {
       if (systemPrompt) {
         // The system prompt may carry a cache boundary (placed by the
         // section pipeline — see `prompts/sections.ts`) splitting it into
-        // a stable-prefix block and a volatile-suffix block, each with
-        // its own breakpoint so a volatile-section change doesn't
-        // re-create the stable prefix.  A 1-hour cache TTL is used (when
+        // a head every conversation shares and a per-conversation block,
+        // each with its own breakpoint so a different per-conversation
+        // block still reads the shared head.  A 1-hour cache TTL is used (when
         // supported by the model) so the breakpoints survive turn gaps
         // that exceed the default 5-minute window.
         params.system = systemPrompt


### PR DESCRIPTION
Fixes JARVIS-1684

## What

A conversation keeps sending the system-prompt block behind the cache boundary that it started with. Only a change to the stable head (persona, trust class, channel, the turn's tool surface) pushes a rebuilt prompt to the agent loop, and that push carries the volatile block as it stands at that moment.

## Why

The prompt is rebuilt from the workspace before every turn and pushed whenever its bytes differ. The two-block split already keeps the head's cache readable when the second block changes, but the system prompt heads every request, so any change in either block re-writes the provider's cache for the entire conversation history behind it. On the traced voice call, the model deleting `BOOTSTRAP.md` dropped the `# First-Run Ritual` section and re-wrote a 113k-token prefix to emit 31 output tokens, on the voice front door first and then again on the text lane. Voice re-ships the whole conversation every utterance, so a workspace edit the assistant makes on the user's behalf was a six-figure token re-write.

## How

- `stabilizeSystemPrompt(current, next)` in `prompts/cache-boundary.ts`: returns `current` when the two prompts share the text before the first boundary, `next` otherwise.
- `Conversation.buildCurrentSystemPrompt` runs the rebuild through it against the prompt the conversation last sent. `syncLoopSystemPrompt`, the wake paths, and `warmPromptCache` all go through that method, so the voice front door and the text lane resolve the same pinned prompt.
- The ritual header reads "This is your first conversation. Follow the instructions below." instead of asserting `BOOTSTRAP.md` is present, since the section now outlives the file within the first conversation.
- Comments on the breakpoint, the section pipeline, and the Anthropic client describe the split as a head shared across conversations plus a per-conversation block.

## Behaviour change to be aware of

Within a running conversation the model no longer sees a service connected mid-chat in `# Connected Services`, a voice marker it appended in `# Voice Profile`, or the ritual disappearing after it deletes `BOOTSTRAP.md`. The model has each of those in its own history (the tool result, the file write, the delete), the `03a-verify-live-state` section already tells it to check connection state live rather than from prompt text, and the fresh values render in the next conversation. Live per-turn state that must not be pinned belongs in the message tail, not the system prompt; nothing in the volatile block needs that today.

## Not in this PR

The ticket also asks whether the front-door triage leg needs the full conversation or could run against a bounded recent window. That is a separate change to `voiceFrontDoor` request assembly and is left for a follow-up.

## Tests

- `prompts/__tests__/cache-boundary.test.ts`: the helper across identical, suffix-only (lost, gained, changed), head-changed, boundary-less, and empty-current cases.
- `__tests__/conversation-system-prompt-pin.test.ts`: a real `Conversation` with a mutable prompt builder, asserting the loop receives no push for a suffix-only change and the whole rebuild for a head change.
- Existing prompt, provider, cross-turn cache stability, agent-wake, and conversation-loop suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhskE1jzzsEUr1i1pMCeMn
