### PR TITLE
feat(voice-key): ask for Input Monitoring in onboarding instead of at launch (JARVIS-1794)

### DIFF
--- a/clients/web/src/domains/chat/voice/input-monitoring-ask.test.ts
+++ b/clients/web/src/domains/chat/voice/input-monitoring-ask.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type * as SystemPermissions from "@/runtime/system-permissions";
+
+let inputMonitoringStatus: string | null = "not-determined";
+let answer: string = "granted";
+const requestSystemPermission = mock(async (_kind: string) => ({
+  status: answer,
+}));
+mock.module(
+  "@/runtime/system-permissions",
+  (): Partial<typeof SystemPermissions> => ({
+    getSystemPermissionsState: async () =>
+      (inputMonitoringStatus === null
+        ? null
+        : {
+            inputMonitoring: { status: inputMonitoringStatus },
+          }) as unknown as Awaited<
+        ReturnType<typeof SystemPermissions.getSystemPermissionsState>
+      >,
+    requestSystemPermission:
+      requestSystemPermission as unknown as typeof SystemPermissions.requestSystemPermission,
+  }),
+);
+
+const { askForInputMonitoring, __resetInputMonitoringAskForTests } =
+  await import("@/domains/chat/voice/input-monitoring-ask");
+
+describe("asking for Input Monitoring", () => {
+  beforeEach(() => {
+    inputMonitoringStatus = "not-determined";
+    answer = "granted";
+    requestSystemPermission.mockClear();
+    __resetInputMonitoringAskForTests();
+  });
+
+  test("asks when the grant is not given, and answers with the outcome", async () => {
+    answer = "denied";
+    expect(await askForInputMonitoring()).toBe("denied");
+    expect(requestSystemPermission).toHaveBeenCalledWith("inputMonitoring");
+  });
+
+  test("asks nothing of a user who already said yes", async () => {
+    inputMonitoringStatus = "granted";
+    expect(await askForInputMonitoring()).toBe("granted");
+    expect(requestSystemPermission).not.toHaveBeenCalled();
+  });
+
+  /** A refusal is the user's answer for the session. */
+  test("asks once per launch", async () => {
+    answer = "denied";
+    await askForInputMonitoring();
+    inputMonitoringStatus = "denied";
+    expect(await askForInputMonitoring()).toBe("denied");
+    expect(requestSystemPermission).toHaveBeenCalledTimes(1);
+  });
+
+  test("has nothing to ask on a host without system permissions", async () => {
+    inputMonitoringStatus = null;
+    expect(await askForInputMonitoring()).toBeNull();
+    expect(requestSystemPermission).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/domains/chat/voice/input-monitoring-ask.ts
+++ b/clients/web/src/domains/chat/voice/input-monitoring-ask.ts
@@ -1,0 +1,44 @@
+import {
+  getSystemPermissionsState,
+  requestSystemPermission,
+  type SystemPermissionStatus,
+} from "@/runtime/system-permissions";
+
+/**
+ * Whether this launch has asked for Input Monitoring on the voice key's
+ * behalf. Once per launch: a refusal is the user's answer for the session,
+ * and the settings card offers the question again.
+ */
+let askedThisLaunch = false;
+
+/**
+ * Ask macOS for Input Monitoring on the voice key's behalf.
+ *
+ * The helper cannot see the key without the grant, and the system prompt
+ * names the app and nothing else, so the ask belongs where the user is about
+ * to try the key and has just read why (`InputMonitoringReason`). Nothing
+ * asks on its own: registering the key never prompts, and the settings card
+ * carries the question for the user who said no.
+ *
+ * Resolves to the grant's status once the ask is over: `granted` when it was
+ * already given, the answer when it was asked here, the standing status when
+ * this launch has asked already, and `null` on a host with no system
+ * permissions to ask for.
+ */
+export async function askForInputMonitoring(): Promise<SystemPermissionStatus | null> {
+  const state = await getSystemPermissionsState();
+  if (state === null) {
+    return null;
+  }
+  const status = state.inputMonitoring.status;
+  if (status === "granted" || askedThisLaunch) {
+    return status;
+  }
+  askedThisLaunch = true;
+  const item = await requestSystemPermission("inputMonitoring");
+  return item?.status ?? status;
+}
+
+export function __resetInputMonitoringAskForTests(): void {
+  askedThisLaunch = false;
+}

--- a/clients/web/src/domains/chat/voice/input-monitoring-reason.test.tsx
+++ b/clients/web/src/domains/chat/voice/input-monitoring-reason.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import type * as SystemPermissions from "@/runtime/system-permissions";
+
+let inputMonitoringStatus: string | null = "not-determined";
+mock.module(
+  "@/runtime/system-permissions",
+  (): Partial<typeof SystemPermissions> => ({
+    useSystemPermissionsState: () =>
+      ({
+        state:
+          inputMonitoringStatus === null
+            ? null
+            : { inputMonitoring: { status: inputMonitoringStatus } },
+        loading: false,
+        error: null,
+        supported: inputMonitoringStatus !== null,
+        refresh: async () => null,
+      }) as unknown as ReturnType<
+        typeof SystemPermissions.useSystemPermissionsState
+      >,
+  }),
+);
+
+const { InputMonitoringReason } =
+  await import("@/domains/chat/voice/input-monitoring-reason");
+
+describe("the Input Monitoring reason", () => {
+  beforeEach(() => {
+    inputMonitoringStatus = "not-determined";
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("says what the grant is for while it is not given", () => {
+    render(<InputMonitoringReason />);
+    expect(screen.getByText(/Input Monitoring/)).toBeTruthy();
+  });
+
+  test("draws nothing once the grant is given", () => {
+    inputMonitoringStatus = "granted";
+    const { container } = render(<InputMonitoringReason />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("draws nothing on a host with no system permissions", () => {
+    inputMonitoringStatus = null;
+    const { container } = render(<InputMonitoringReason />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/clients/web/src/domains/chat/voice/input-monitoring-reason.tsx
+++ b/clients/web/src/domains/chat/voice/input-monitoring-reason.tsx
@@ -1,0 +1,42 @@
+import { Info } from "lucide-react";
+
+import { cn } from "@vellumai/design-library/utils/cn";
+
+import { useTranslation } from "@/i18n";
+import { useSystemPermissionsState } from "@/runtime/system-permissions";
+
+interface InputMonitoringReasonProps {
+  className?: string;
+}
+
+/**
+ * The one line that says why macOS is about to ask for Input Monitoring.
+ *
+ * Dropped in beside the invitation to try the voice key, ahead of
+ * `askForInputMonitoring()`: the system prompt names the app and nothing
+ * else, so this is where the user learns what the grant is for. Draws nothing
+ * once the grant is given, and on a host with no system permissions to ask
+ * for, so a user who already said yes never reads about a prompt that is
+ * not coming.
+ */
+export function InputMonitoringReason({
+  className,
+}: InputMonitoringReasonProps) {
+  const { t } = useTranslation("chat");
+  const { state } = useSystemPermissionsState();
+  const status = state?.inputMonitoring.status ?? null;
+  if (status === null || status === "granted") {
+    return null;
+  }
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-1 text-body-small-lighter text-[var(--content-quiet)]",
+        className,
+      )}
+    >
+      <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+      <span>{t("inputMonitoringReason.body")}</span>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/use-voice-key.test.tsx
+++ b/clients/web/src/domains/chat/voice/use-voice-key.test.tsx
@@ -278,22 +278,22 @@ describe("the voice key", () => {
   });
 
   /**
-   * Arming the key is what asks for Input Monitoring, once per launch: the
-   * grant is for noticing the press, so the press itself can never be the
-   * moment to ask.
+   * The grant is asked for by the step that introduces the key, never by the
+   * binding: a system prompt at launch reaches a user who has not met the key
+   * yet, and has no idea what it is for.
    */
-  test("asks for Input Monitoring when the key is armed without it", async () => {
+  test("never asks for Input Monitoring on its own", async () => {
     inputMonitoringStatus = "not-determined";
-    const { view } = renderKey();
+    const { onRegistered, view } = renderKey();
     await settle(0);
-    expect(requestSystemPermission).toHaveBeenCalledWith("inputMonitoring");
+    expect(requestSystemPermission).not.toHaveBeenCalled();
+    expect(onRegistered).toHaveBeenLastCalledWith(true);
 
-    // Once. A second registration in the same launch asks nothing more.
     view.rerender({
       key: { kind: "modifierOnly", modifiers: ["control", "option"] },
     });
     await settle(0);
-    expect(requestSystemPermission).toHaveBeenCalledTimes(1);
+    expect(requestSystemPermission).not.toHaveBeenCalled();
   });
 
   /** Edges from the other bindings are other features' business. */

--- a/clients/web/src/domains/chat/voice/use-voice-key.ts
+++ b/clients/web/src/domains/chat/voice/use-voice-key.ts
@@ -8,10 +8,6 @@ import {
   subscribeToHotkeyEvents,
   supportsModifierHold,
 } from "@/runtime/hotkey";
-import {
-  getSystemPermissionsState,
-  requestSystemPermission,
-} from "@/runtime/system-permissions";
 import { createVoiceKeyGestureClassifier } from "@/domains/chat/voice/voice-key-gestures";
 import type { VoiceKey } from "@/utils/voice-key";
 
@@ -51,27 +47,6 @@ export interface VoiceKeyHandlers {
 }
 
 /**
- * Whether this launch has asked for Input Monitoring on the key's behalf.
- *
- * The grant is asked for when the key is armed and not yet granted, which on a
- * fresh install is the first launch. Once per launch: a refusal is the user's
- * answer for the session, and the settings card offers the question again.
- */
-let inputMonitoringAskedThisLaunch = false;
-
-async function askForInputMonitoringOnce(): Promise<void> {
-  if (inputMonitoringAskedThisLaunch) {
-    return;
-  }
-  const state = await getSystemPermissionsState();
-  if (state?.inputMonitoring.status === "granted") {
-    return;
-  }
-  inputMonitoringAskedThisLaunch = true;
-  await requestSystemPermission("inputMonitoring");
-}
-
-/**
  * The voice key, from whatever app the user is in: a hold dictates, a double
  * tap starts or ends a call.
  *
@@ -79,6 +54,11 @@ async function askForInputMonitoringOnce(): Promise<void> {
  * key only reaches a focused window and the point of this binding is that the
  * user is somewhere else entirely. The helper reports the key as a hold span,
  * and the gestures are read off the span here (see `voice-key-gestures`).
+ *
+ * Registering never asks for Input Monitoring. The helper needs the grant to
+ * see the key, but a system prompt at launch reaches a user who has not yet
+ * met the key; `askForInputMonitoring` is called from the step that
+ * introduces it, and `onRegistered` reports `false` until then.
  *
  * **A hold is a microphone.** Every `onHoldStart` is closed exactly once, so
  * the effect's teardown closes an open hold too: a binding that goes away
@@ -153,7 +133,6 @@ export function useVoiceKey({
         }
       },
     );
-    void askForInputMonitoringOnce();
 
     return () => {
       disposed = true;

--- a/clients/web/src/domains/settings/pages/voice-key-card.tsx
+++ b/clients/web/src/domains/settings/pages/voice-key-card.tsx
@@ -3,8 +3,8 @@
  *
  * One key, held to dictate and double-tapped for a call. Fn out of the box, a
  * modifier set of the user's own, or nothing. The card is also where the
- * Input Monitoring grant is asked for again: the key is armed on launch and
- * asks then, so this is for the user who said no and has come back.
+ * Input Monitoring grant is asked for again: onboarding asks as it introduces
+ * the key, so this is for the user who said no and has come back.
  *
  * Absent on hosts with no helper to watch the raw keyboard, since there is
  * nothing there to choose.

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -881,6 +881,9 @@
   "inlineProcessCard": {
     "stop": "Stop"
   },
+  "inputMonitoringReason": {
+    "body": "macOS will ask to allow Input Monitoring, which is how Vellum notices the key from any app."
+  },
   "inspectPage": {
     "accessDenied": "Inspector is available when the Internal Thread Actions feature flag is enabled.",
     "allMessages": "All messages",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -833,6 +833,9 @@
   "inlineProcessCard": {
     "stop": "Detener"
   },
+  "inputMonitoringReason": {
+    "body": "macOS pedirá permitir la Monitorización de entrada, que es como Vellum detecta la tecla desde cualquier app."
+  },
   "inspectPage": {
     "accessDenied": "El inspector está disponible cuando la marca Internal Thread Actions está habilitada.",
     "allMessages": "Todos los mensajes",


### PR DESCRIPTION
Part of JARVIS-1794.

## What

A fresh install got the macOS Input Monitoring prompt the first time the voice key armed after launch, before the user had met the key. The key's registration no longer prompts on its own. The ask is now explicit:

- `askForInputMonitoring()` in `clients/web/src/domains/chat/voice/input-monitoring-ask.ts`. Keeps the once-per-launch guard (a refusal is the answer for the session), returns `granted` without asking when the grant already exists, `null` on a host with no system permissions, and otherwise the status macOS answered with.
- `<InputMonitoringReason />` in `clients/web/src/domains/chat/voice/input-monitoring-reason.tsx`. The one-line reason ("macOS will ask to allow Input Monitoring, which is how Vellum notices the key from any app."). Draws nothing once the grant is given or where there is nothing to ask for, so a user who already said yes never reads about a prompt that is not coming. Catalog keys `chat:inputMonitoringReason.body` in `en` and `es`.
- `useVoiceKey` drops `askForInputMonitoringOnce`; the settings card's "Allow Input Monitoring" recovery in `voice-key-card.tsx` is unchanged apart from one docstring line that described the launch-time ask.

## Where the ask happens now

Nowhere on its own. There is no existing first-run surface that introduces the voice key today: the onboarding funnel is pre-hatch, `VoiceFirstRunCard` is about the first call, and the in-chat tour is a spike. JARVIS-1792 is building exactly that step, so this PR wires nothing and ships the function plus the affordance for it.

Consequences, as the ticket asks:
- Upgrading with the grant already given: no change. Nothing asked, the note renders nothing, the key registers as before.
- Without the grant and never reaching the onboarding step: the key registers as refused (`onRegistered(false)`), and Settings > Voice shows the existing "The key cannot be watched until Input Monitoring is allowed" notice with the Allow button.

## How JARVIS-1792 should call it

```tsx
import { askForInputMonitoring } from "@/domains/chat/voice/input-monitoring-ask";
import { InputMonitoringReason } from "@/domains/chat/voice/input-monitoring-reason";

// In the "hold Fn now" step, before inviting the hold:
<InputMonitoringReason />
...
const status = await askForInputMonitoring();
// "granted": invite the hold and wait for the edge.
// anything else: the edge cannot arrive; go straight to the troubleshooting state
// (it names "no Input Monitoring" already).
// null: no helper here; skip the step.
```

The Electron main polls after a request and pushes state, so the note clears by itself once the user allows it in System Settings. Both exports live in `domains/chat/voice/`; a step under `components/` or `domains/chat/` can import them directly. If the step ends up under `domains/onboarding/`, the two files need lifting to a top-level dir first (`local/no-cross-domain-imports`).

## Verified

From `clients/web/` in a fresh worktree after `bun install`:

- `bun test src/domains/chat/voice/use-voice-key.test.tsx`: 15 pass (the launch-time ask test is replaced by "never asks for Input Monitoring on its own")
- `bun test src/domains/chat/voice/input-monitoring-ask.test.ts`: 4 pass
- `bun test src/domains/chat/voice/input-monitoring-reason.test.tsx`: 3 pass
- `bun test src/domains/settings/pages/voice-page.desktop.test.tsx`: 6 pass (the card's own ask on choosing a key still fires)
- `bun test src/i18n/catalogs.test.ts`: 236 pass
- `bun run typecheck`: exit 0
- `bun run lint`: 0 errors, 15 pre-existing warnings

## Unverified

- Not run in the real desktop app: that a fresh install no longer sees the prompt at launch, and the note's appearance. No prettier binary is installed in the workspace, so formatting was checked by eslint only.
- The step that calls this does not exist yet (JARVIS-1792).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lmc2Cci1S3gWWvwXEyB5fK
