### PR TITLE
chore(macos): per-channel log file and voice key registration/edge log lines (JARVIS-1796)

### DIFF
--- a/clients/macos/src/main/desktop-diagnostics.ts
+++ b/clients/macos/src/main/desktop-diagnostics.ts
@@ -19,6 +19,7 @@ import {
 } from "@vellumai/electron-desktop/settings";
 
 import { getVersionInfo } from "./about.client";
+import { getVoiceKeyDiagnostics } from "./hotkey-helper";
 import { getInstallLocation } from "./install-location";
 import { handle, on } from "./ipc";
 import { getLogFilePaths } from "./logger";
@@ -43,6 +44,7 @@ configureFeedback({
   getLogFilePaths,
   getFeatureFlags: () => readSetting("featureFlags"),
   hasSession: () => getSessionToken() !== null,
+  getHostDiagnostics: () => ({ voiceKey: getVoiceKeyDiagnostics() }),
 });
 
 configureSentryMain({

--- a/clients/macos/src/main/hotkey-helper.test.ts
+++ b/clients/macos/src/main/hotkey-helper.test.ts
@@ -103,11 +103,13 @@ mock.module("node:child_process", () => ({
   },
 }));
 
+const logMock = {
+  info: mock(() => undefined),
+  warn: mock(() => undefined),
+};
+
 mock.module("./logger", () => ({
-  default: {
-    info: mock(() => undefined),
-    warn: mock(() => undefined),
-  },
+  default: logMock,
 }));
 
 mock.module("./app-origin", () => ({
@@ -137,6 +139,7 @@ const {
   __resetForTesting,
   __setPlatformForTesting,
   __setSupervisorOptionsForTesting,
+  getVoiceKeyDiagnostics,
   installHotkeyHelper,
   queryFreshMacHelperPermission,
   requestMacHelperInputMonitoringPermission,
@@ -249,6 +252,8 @@ beforeEach(() => {
   nextWebContentsId = 1;
   defaultSender = makeWebContents();
   setPointerOnCompanion(false);
+  logMock.info.mockClear();
+  logMock.warn.mockClear();
 });
 
 afterEach(() => {
@@ -571,6 +576,67 @@ describe("installHotkeyHelper", () => {
       "vellum:helper:hotkey:event",
       { kind: "modifierHold", state: "down" },
     );
+  });
+
+  /**
+   * A working key and a dead one look the same in a log that only records
+   * failures, so the helper taking and dropping the binding each get a line.
+   */
+  test("logs the voice key registration and its clearing", async () => {
+    installHotkeyHelper();
+    expect(await registerHold()).toEqual({ ok: true, enabled: true });
+    expect(logMock.info).toHaveBeenCalledWith(
+      "[mac-helper] voice key registered: modifiers=control+option enabled=true",
+    );
+
+    const pending = invokeSetModifierHold({ kind: "off" });
+    await wait(5);
+    const request = lastChild?.stdin.writes.at(-1) ?? "";
+    const id = (JSON.parse(request) as { id: number }).id;
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(`{"jsonrpc":"2.0","id":${id},"result":{"enabled":false}}\n`),
+    );
+    expect(await pending).toEqual({ ok: true, enabled: false });
+    expect(logMock.info).toHaveBeenCalledWith("[mac-helper] voice key cleared");
+  });
+
+  test("reports the binding and the last hold edge for diagnostics", async () => {
+    installHotkeyHelper();
+    expect(getVoiceKeyDiagnostics()).toEqual({
+      binding: "off",
+      helperHoldsBinding: false,
+      lastEdge: null,
+    });
+
+    expect(await registerHold()).toEqual({ ok: true, enabled: true });
+    expect(getVoiceKeyDiagnostics()).toEqual({
+      binding: "control+option",
+      helperHoldsBinding: true,
+      lastEdge: null,
+    });
+
+    const before = Date.now();
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        '{"jsonrpc":"2.0","method":"hotkey.event","params":{"kind":"modifierHold","state":"down"}}\n',
+      ),
+    );
+    const down = getVoiceKeyDiagnostics().lastEdge;
+    expect(down?.state).toBe("down");
+    expect(Date.parse(down?.at ?? "")).toBeGreaterThanOrEqual(before);
+
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        '{"jsonrpc":"2.0","method":"hotkey.event","params":{"kind":"modifierHold","state":"up","reason":"released"}}\n',
+      ),
+    );
+    const up = getVoiceKeyDiagnostics().lastEdge;
+    expect(up?.state).toBe("up");
+    // The edge says the key moved and when, nothing about which key.
+    expect(Object.keys(up ?? {})).toEqual(["state", "at"]);
   });
 
   /**

--- a/clients/macos/src/main/hotkey-helper.ts
+++ b/clients/macos/src/main/hotkey-helper.ts
@@ -324,6 +324,13 @@ const sendModifierHold = async (
       return { ok: false, reason: "mac helper returned invalid hotkey result" };
     }
     helperHoldsBinding = hold.kind !== "off" && parsed.data.enabled;
+    if (hold.kind === "off") {
+      log.info("[mac-helper] voice key cleared");
+    } else {
+      log.info(
+        `[mac-helper] voice key registered: modifiers=${hold.modifiers.join("+")} enabled=${parsed.data.enabled}`,
+      );
+    }
     return { ok: true, enabled: parsed.data.enabled };
   } catch (err) {
     return {
@@ -754,6 +761,29 @@ let restoreHoldAfterRestart = false;
 let restoreHoldInFlight = false;
 let holdIsOpen = false;
 
+/**
+ * What a support bundle shows for the voice key: the binding main believes the
+ * helper holds, and when the hold last moved. The edge is recorded as it is
+ * forwarded to a window, so a key that registers but never reaches the app
+ * reads as never having moved. No key identity beyond the hold's own state.
+ */
+export interface VoiceKeyDiagnostics {
+  binding: string;
+  helperHoldsBinding: boolean;
+  lastEdge: { state: "down" | "up"; at: string } | null;
+}
+
+let lastVoiceKeyEdge: VoiceKeyDiagnostics["lastEdge"] = null;
+
+export const getVoiceKeyDiagnostics = (): VoiceKeyDiagnostics => ({
+  binding:
+    modifierHoldBinding.kind === "off"
+      ? "off"
+      : modifierHoldBinding.modifiers.join("+"),
+  helperHoldsBinding,
+  lastEdge: lastVoiceKeyEdge,
+});
+
 const newestOwnerId = (): number | null => {
   let id: number | null = null;
   for (const [ownerId, owner] of hotkeyOwners) {
@@ -834,6 +864,7 @@ const sendHotkeyEventToOwner = (event: HotkeyEvent): void => {
     return;
   }
   holdIsOpen = event.state === "down";
+  lastVoiceKeyEdge = { state: event.state, at: new Date().toISOString() };
   hotkeyOwnerTarget()?.send("vellum:helper:hotkey:event", event);
 };
 
@@ -1156,6 +1187,7 @@ export const __resetForTesting = (): void => {
   desiredModifierHold = { kind: "off" };
   modifierHoldInFlight = null;
   helperHoldsBinding = false;
+  lastVoiceKeyEdge = null;
   restoreHoldAfterRestart = false;
   releaseChordOwner?.();
   releaseChordOwner = null;

--- a/clients/macos/src/main/logger.test.ts
+++ b/clients/macos/src/main/logger.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const appState = { isPackaged: true };
+
+mock.module("electron", () => ({
+  app: {
+    get isPackaged() {
+      return appState.isPackaged;
+    },
+  },
+}));
+
+const STOCK_DIR = "/Users/someone/Library/Logs/@vellumai/macos";
+const pathVariables = { libraryDefaultDir: STOCK_DIR };
+
+const fileTransport = {
+  fileName: "vellum.log",
+  resolvePathFn: (vars: { libraryDefaultDir: string }): string =>
+    `${vars.libraryDefaultDir}/vellum.log`,
+  getFile: () => ({ path: fileTransport.resolvePathFn(pathVariables) }),
+};
+
+mock.module("@vellumai/electron-desktop/app-logger", () => ({
+  default: {
+    transports: { file: fileTransport },
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  },
+  getLogFilePaths: () => [fileTransport.getFile().path],
+}));
+
+// The build define is absent under bun test; a staging build is the case that
+// interleaved with production in the shared file.
+const globals = globalThis as { __VELLUM_ENVIRONMENT__?: string };
+globals.__VELLUM_ENVIRONMENT__ = "staging";
+
+const { getLogFilePaths, resolveLogDir } = await import("./logger");
+
+afterAll(() => {
+  delete globals.__VELLUM_ENVIRONMENT__;
+});
+
+beforeEach(() => {
+  appState.isPackaged = true;
+});
+
+describe("resolveLogDir", () => {
+  test("production keeps the stock directory", () => {
+    expect(resolveLogDir(STOCK_DIR, "production", true)).toBe(STOCK_DIR);
+  });
+
+  test("other packaged channels get the userData-style suffix", () => {
+    expect(resolveLogDir(STOCK_DIR, "dev", true)).toBe(`${STOCK_DIR}-dev`);
+    expect(resolveLogDir(STOCK_DIR, "staging", true)).toBe(
+      `${STOCK_DIR}-staging`,
+    );
+  });
+
+  test("an unpackaged build keeps the stock directory whatever its channel", () => {
+    expect(resolveLogDir(STOCK_DIR, "local", false)).toBe(STOCK_DIR);
+  });
+});
+
+describe("the file transport", () => {
+  test("writes the packaged channel's own file", () => {
+    expect(fileTransport.resolvePathFn(pathVariables)).toBe(
+      `${STOCK_DIR}-staging/vellum.log`,
+    );
+  });
+
+  test("the diagnostics reader follows the same resolution", () => {
+    expect(getLogFilePaths()).toEqual([`${STOCK_DIR}-staging/vellum.log`]);
+
+    appState.isPackaged = false;
+    expect(getLogFilePaths()).toEqual([`${STOCK_DIR}/vellum.log`]);
+  });
+});

--- a/clients/macos/src/main/logger.ts
+++ b/clients/macos/src/main/logger.ts
@@ -1,4 +1,41 @@
-export {
-  default,
-  getLogFilePaths,
-} from "@vellumai/electron-desktop/app-logger";
+import { app } from "electron";
+import path from "node:path";
+
+import log, { getLogFilePaths } from "@vellumai/electron-desktop/app-logger";
+
+declare const __VELLUM_ENVIRONMENT__: string;
+
+/**
+ * The directory a build's log file lives in.
+ *
+ * Packaged builds of every channel share one package.json `name`, so
+ * electron-log points them all at `~/Library/Logs/@vellumai/macos/`, and a
+ * support bundle from one build carries the lines of whichever other builds
+ * ran that day. Non-production channels get the same `-<channel>` suffix
+ * their userData directory already carries (`macos-dev`, `macos-staging`);
+ * production keeps the stock path so existing readers still find it.
+ */
+export const resolveLogDir = (
+  defaultDir: string,
+  channel: string,
+  isPackaged: boolean,
+): string =>
+  isPackaged && channel !== "production"
+    ? `${defaultDir}-${channel}`
+    : defaultDir;
+
+const channel =
+  typeof __VELLUM_ENVIRONMENT__ === "string"
+    ? __VELLUM_ENVIRONMENT__
+    : "production";
+
+// Consulted on every write and by `getLogFilePaths`, so the sink and the
+// diagnostics readers move together.
+log.transports.file.resolvePathFn = (vars) =>
+  path.join(
+    resolveLogDir(vars.libraryDefaultDir, channel, app.isPackaged),
+    log.transports.file.fileName,
+  );
+
+export default log;
+export { getLogFilePaths };

--- a/clients/macos/src/main/presence.test.ts
+++ b/clients/macos/src/main/presence.test.ts
@@ -41,6 +41,8 @@ const getSystemIdleStateMock = mock((_threshold: number): SystemIdleState => {
 });
 
 mock.module("electron", () => ({
+  // `./logger` reads `app.isPackaged` to place the log file.
+  app: { isPackaged: false },
   powerMonitor: {
     on: powerOnMock,
     off: powerOffMock,

--- a/packages/electron-desktop/src/diagnostics-contract.ts
+++ b/packages/electron-desktop/src/diagnostics-contract.ts
@@ -40,4 +40,9 @@ export interface FeedbackDependencies {
   getLogFilePaths: () => string[];
   getFeatureFlags: () => Record<string, boolean> | null;
   hasSession: () => boolean;
+  /**
+   * Facts only this shell can supply, keyed by feature (the macOS voice key,
+   * for one). They land under `host` in the diagnostics payload.
+   */
+  getHostDiagnostics?: () => Record<string, unknown>;
 }

--- a/packages/electron-desktop/src/feedback.test.ts
+++ b/packages/electron-desktop/src/feedback.test.ts
@@ -60,6 +60,22 @@ describe("collectDiagnostics", () => {
     expect(result.session).toEqual({ authenticated: true });
     expect(Object.keys(result.session)).toEqual(["authenticated"]);
   });
+
+  test("carries the shell's own facts under host only when supplied", () => {
+    configureFeedback(dependencies());
+    expect("host" in collectDiagnostics()).toBe(false);
+
+    configureFeedback(
+      dependencies({
+        getHostDiagnostics: () => ({
+          voiceKey: { binding: "function", lastEdge: null },
+        }),
+      }),
+    );
+    expect(collectDiagnostics().host).toEqual({
+      voiceKey: { binding: "function", lastEdge: null },
+    });
+  });
 });
 
 describe("collectRedactedLogs", () => {

--- a/packages/electron-desktop/src/feedback.ts
+++ b/packages/electron-desktop/src/feedback.ts
@@ -15,6 +15,7 @@ let getVersionInfo: FeedbackDependencies["getVersionInfo"];
 let getLogFilePaths: FeedbackDependencies["getLogFilePaths"];
 let readSetting: () => Record<string, boolean> | null;
 let hasSession: FeedbackDependencies["hasSession"];
+let getHostDiagnostics: FeedbackDependencies["getHostDiagnostics"];
 let handle: FeedbackIpc["handle"];
 
 export const configureFeedback = (dependencies: FeedbackDependencies): void => {
@@ -22,6 +23,7 @@ export const configureFeedback = (dependencies: FeedbackDependencies): void => {
     dependencies);
   fs = { readFile: dependencies.readFile };
   readSetting = dependencies.getFeatureFlags;
+  getHostDiagnostics = dependencies.getHostDiagnostics;
   handle = dependencies.ipc.handle;
 };
 
@@ -52,6 +54,8 @@ export interface ElectronDiagnostics {
   featureFlags: Record<string, boolean> | null;
   session: { authenticated: boolean };
   redactionVersion: number;
+  /** Shell-specific facts, present only when the shell supplies them. */
+  host?: Record<string, unknown>;
 }
 
 export function collectDiagnostics(): ElectronDiagnostics {
@@ -83,6 +87,7 @@ export function collectDiagnostics(): ElectronDiagnostics {
     featureFlags: readSetting(),
     session: { authenticated: hasSession() },
     redactionVersion: REDACTION_VERSION,
+    ...(getHostDiagnostics ? { host: getHostDiagnostics() } : {}),
   };
 }
 


### PR DESCRIPTION
Linear: JARVIS-1796

## What

Two small support-hygiene changes in the macOS Electron main process.

**1. Per-channel log file.** Packaged builds of every channel share the package.json `name`, so electron-log pointed Vellum.app, Vellum Dev.app and Vellum Staging.app at the same `~/Library/Logs/@vellumai/macos/vellum.log` (observed 11 Sep: lines from all three interleaved in one file). `clients/macos/src/main/logger.ts` now sets the file transport's `resolvePathFn` so non-production packaged channels get the same `-<channel>` suffix their userData directory already carries:

| Build | Log file |
| --- | --- |
| production (Vellum.app) | `~/Library/Logs/@vellumai/macos/vellum.log` (unchanged) |
| staging (Vellum Staging.app) | `~/Library/Logs/@vellumai/macos-staging/vellum.log` |
| dev (Vellum Dev.app) | `~/Library/Logs/@vellumai/macos-dev/vellum.log` |
| unpackaged `electron-vite dev` | unchanged (electron-log's default under the dev app name) |

`getLogFilePaths()` (what the feedback / support-bundle log export reads) goes through electron-log's `getFile()`, which consults the same `resolvePathFn`, so the sink and the diagnostics reader move together with no second copy of the path. The shared `packages/electron-desktop/app-logger` is untouched; Windows and Linux shells are unaffected.

**2. Voice key registration and last-edge lines.** A successful voice key registration logged nothing, so a working key and a dead one looked the same in a bundle. `hotkey-helper.ts` now logs, on `sendModifierHold` success:

- `[mac-helper] voice key registered: modifiers=<a+b> enabled=<true|false>`
- `[mac-helper] voice key cleared`

and records the timestamp of the last hold edge as it is forwarded to the owner window (`modifierHold` down/up only, no key identity, no transcript). `getVoiceKeyDiagnostics()` exposes `{ binding, helperHoldsBinding, lastEdge: { state, at } | null }`, and `desktop-diagnostics.ts` passes it into the existing feedback diagnostics payload under `host.voiceKey`. The shared `feedback.ts` gained one optional dependency (`getHostDiagnostics`) and one optional payload field (`host`), present only when a shell supplies it; no new IPC, the renderer already reads the payload through `feedback.diagnostics()` as `Record<string, unknown>`.

## How verified

From `clients/macos` in a fresh worktree (`bun install` first):

- `bun run typecheck` (clients/macos): clean
- `bun run typecheck` (packages/electron-desktop): clean
- `bun test src/main/logger.test.ts`: 5 pass
- `bun test src/main/hotkey-helper.test.ts`: 47 pass (two new cases: registration/clear log lines; binding + last edge diagnostics, including that the edge carries only `state` and `at`)
- `bun test src/main/presence.test.ts`: 26 pass (its per-file `electron` mock gained `app.isPackaged`, since `./logger` now reads it)
- `bun test src/feedback.test.ts` (packages/electron-desktop): 4 pass (new case: `host` present only when supplied)
- `bun scripts/run-tests.ts` (the isolating macOS runner, what `test:ci` runs): 38 passed, 0 failed (38 test files). An earlier run was 37/38 because `presence.test.ts`'s `electron` mock lacked the `app` export that `./logger` now imports; the stub above fixed it.

## Unverified

- No running-app check of the new log path. The per-channel paths above are what the resolution produces; a dev or staging build has not been launched to confirm the file appears there.
- The `host.voiceKey` object has not been eyeballed in the feedback modal of a running app, only in the unit test of `collectDiagnostics()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lmc2Cci1S3gWWvwXEyB5fK
