### PR TITLE
feat(companion): dock the call bar to any edge of the display (JARVIS-1791)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -1385,13 +1385,18 @@ describe("the edge a call's bar docks to", () => {
     expect(state().dock).toBe("top");
   });
 
+  /**
+   * The window is built with the call and kept hidden, so the drag has a
+   * window to show rather than one to build and load.
+   */
   test("a drag mid-call shows the edges and names the one it is heading for", () => {
-    send("vellum:companion:startVoice");
     expect(zonesWindow()).toBeNull();
+    send("vellum:companion:startVoice");
+    expect(zonesWindow()?.visible).toBe(false);
+    expect(zonesWindow()?.bounds).toEqual(SCREEN);
     dragTo({ x: 100, y: 450 });
     const zones = zonesWindow();
-    expect(zones).not.toBeNull();
-    expect(zones?.bounds).toEqual(SCREEN);
+    expect(zones?.visible).toBe(true);
     expect(zones?.level).toEqual(["floating", -1]);
     expect(state().docking).toBe("left");
     dragTo({ x: 700, y: 60 });
@@ -1406,7 +1411,7 @@ describe("the edge a call's bar docks to", () => {
     send("vellum:companion:startVoice");
     const docked = centre();
     send("vellum:companion:moveBy", 1, -1);
-    expect(zonesWindow()).toBeNull();
+    expect(zonesWindow()?.visible).toBe(false);
     expect(state().docking).toBeUndefined();
     release();
     expect(centre()).toEqual({ x: docked.x + 1, y: docked.y - 1 });
@@ -1425,7 +1430,7 @@ describe("the edge a call's bar docks to", () => {
     send("vellum:companion:startVoice");
     dragTo({ x: 100, y: 450 });
     release();
-    expect(zonesWindow()).toBeNull();
+    expect(zonesWindow()?.visible).toBe(false);
     expect(state().docking).toBeUndefined();
     expect(state().dock).toBe("left");
     expect(storedDock).toBe("left");
@@ -1466,7 +1471,7 @@ describe("the edge a call's bar docks to", () => {
   test("a call ending under a drag takes the edges down with it", () => {
     send("vellum:companion:startVoice");
     dragTo({ x: 100, y: 450 });
-    expect(zonesWindow()).not.toBeNull();
+    expect(zonesWindow()?.visible).toBe(true);
     send("vellum:voiceActivity:end");
     expect(zonesWindow()).toBeNull();
     expect(state().docking).toBeUndefined();

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -16,6 +16,7 @@ import {
   companionCardSideFor,
   companionNearEdgeFor,
   companionScaleFor,
+  type CompanionDock,
   type CompanionSize,
   type CompanionSizeAxis,
   type CompanionSurfaceState,
@@ -396,17 +397,27 @@ type GlowWindow = {
   focus: () => void;
 };
 let glow: GlowWindow | null = null;
+/**
+ * Every other window main has opened, by kind: the frame, and the edges a
+ * call's drag can drop the bar on. `glow` is the frame's own alias, since most
+ * cases about a second window are about that one.
+ */
+const others = new Map<string, GlowWindow>();
 const glowPushes: CompanionSurfaceState[] = [];
 /** The BrowserWindow options the frame was last opened with. */
 let glowOptions: Record<string, unknown> | undefined;
 
 const openGlow = (options: {
+  kind: string;
   position?: { x: number; y: number } | (() => { x: number; y: number });
   width: number;
   height: number;
   browserWindow?: Record<string, unknown>;
 }): GlowWindow => {
-  glowOptions = options.browserWindow;
+  const frame = options.kind === "companion-watch-frame";
+  if (frame) {
+    glowOptions = options.browserWindow;
+  }
   const at =
     typeof options.position === "function"
       ? options.position()
@@ -429,7 +440,10 @@ const openGlow = (options: {
     },
     close: () => {
       window.closed = true;
-      glow = null;
+      others.delete(options.kind);
+      if (frame) {
+        glow = null;
+      }
     },
     isDestroyed: () => false,
     on: () => {},
@@ -460,9 +474,16 @@ const openGlow = (options: {
       }
     },
   };
-  glow = window;
+  others.set(options.kind, window);
+  if (frame) {
+    glow = window;
+  }
   return window;
 };
+
+/** The edges a call's drag can drop the bar on, while a drag is in flight. */
+const zonesWindow = (): GlowWindow | null =>
+  others.get("companion-dock-zones") ?? null;
 
 mock.module("@vellumai/electron-desktop/floating-window", () => ({
   createFloatingWindow: (options: {
@@ -480,7 +501,11 @@ mock.module("@vellumai/electron-desktop/floating-window", () => ({
     return surface;
   },
   getFloatingWindow: (kind: string) =>
-    kind === "companion" ? (companionOpen ? surface : null) : glow,
+    kind === "companion"
+      ? companionOpen
+        ? surface
+        : null
+      : (others.get(kind) ?? null),
 }));
 
 mock.module("@vellumai/electron-desktop/avatar", () => ({
@@ -521,11 +546,21 @@ const sizes: Record<CompanionSizeAxis, CompanionSize> = {
   options: "small",
 };
 
+/**
+ * The edge the store holds for the call bar, which is what the next call reads
+ * and what a drop writes.
+ */
+let storedDock: CompanionDock = "bottom";
+
 mock.module("@vellumai/electron-desktop/window-state", () => ({
   readCompanionSize: (axis: CompanionSizeAxis) => sizes[axis],
   readCompanionHidden: () => false,
   writeCompanionSize: (axis: CompanionSizeAxis, size: CompanionSize) => {
     sizes[axis] = size;
+  },
+  readCompanionCallDock: () => storedDock,
+  writeCompanionCallDock: (dock: CompanionDock) => {
+    storedDock = dock;
   },
   writeCompanionHidden: () => {},
   // Stubbed rather than omitted, like every other export here: the module
@@ -543,7 +578,9 @@ const {
   avatarOffsetFor,
   companionContextMenuTemplate,
   defaultAvatarCentre,
+  dockedAvatarCentre,
   geometryFor,
+  nearestDock,
   placeCanvas,
   callOnUpdate,
   callSurfaceFor,
@@ -587,6 +624,7 @@ beforeEach(() => {
   nearestDisplay = NEAREST_DISPLAY;
   boundsSet.length = 0;
   glow = null;
+  others.clear();
   glowPushes.length = 0;
   displays = [
     {
@@ -1199,6 +1237,268 @@ describe("the surface a call takes", () => {
     send("vellum:voiceActivity:start", START);
     expect(centre()).toEqual(bottomCentre);
     send("vellum:voiceActivity:end");
+  });
+});
+
+/**
+ * The edge a call's bar rests on. The bottom by default, and any of the four
+ * once the user has dragged the bar there mid-call and let go: the drag moves
+ * the surface as freely as an idle drag does, the edges are shown for as long
+ * as it is in flight, and the release docks the bar to the nearest one. The
+ * sides stand the bar up, which is a canvas of another shape.
+ *
+ * Under "Reduce motion", as the call's cases are, so each move lands in the
+ * beat it is asked for.
+ */
+describe("the edge a call's bar docks to", () => {
+  const SCREEN = { x: 0, y: 0, width: 1440, height: 900 };
+  const SIDE = geometryFor("small", "small", "left");
+  /** The canvas main is drawing in, read off the last bounds it asked for. */
+  const canvas = (): typeof GEOMETRY =>
+    boundsSet.at(-1)?.height === SIDE.canvasHeight ? SIDE : GEOMETRY;
+  const centre = (): { x: number; y: number } => ({
+    x: origin.x + canvas().canvasWidth / 2,
+    y: origin.y + avatarOffsetFor(state().cardGrowth, canvas()),
+  });
+  /** Where a dock lands the avatar, read back the way `avatarCentre` reads it. */
+  const landing = (
+    dock: CompanionDock,
+    geometry: typeof GEOMETRY = GEOMETRY,
+  ): { x: number; y: number } => {
+    const placed = placeCanvas(
+      dockedAvatarCentre(dock, SCREEN, geometry),
+      SCREEN,
+      geometry,
+    );
+    return {
+      x: placed.origin.x + geometry.canvasWidth / 2,
+      y: placed.origin.y + avatarOffsetFor(placed.cardGrowth, geometry),
+    };
+  };
+  /** Drag the bar so the avatar rests on a point, mid-call or not. */
+  const dragTo = (point: { x: number; y: number }): void => {
+    send("vellum:companion:moveBy", point.x - centre().x, point.y - centre().y);
+  };
+  const release = (): void => {
+    send("vellum:companion:release");
+  };
+
+  beforeEach(() => {
+    mainWindowOpen = true;
+    storedDock = "bottom";
+  });
+
+  /**
+   * Leave the bar docked to the bottom for the next case, the way a fresh
+   * install has it. The module holds the dock it was last dropped on, and a
+   * reset mid-call is the one way back that goes through the store.
+   */
+  afterEach(() => {
+    send("vellum:voiceActivity:end");
+    send("vellum:voiceActivity:control", { action: "endSession" });
+    send("vellum:companion:startVoice");
+    resetCompanionSurfacePosition();
+    send("vellum:voiceActivity:control", { action: "endSession" });
+    storedDock = "bottom";
+  });
+
+  describe("geometryFor", () => {
+    test("builds the ordinary canvas for the top and bottom", () => {
+      expect(geometryFor("small", "small", "top")).toEqual(GEOMETRY);
+      expect(geometryFor("small", "small", "bottom")).toEqual(GEOMETRY);
+    });
+
+    /**
+     * The column is centred on the avatar, so the canvas has to reach as far
+     * below it as above; and it has to hold half the column, the gap and the
+     * whole creature standing at its end.
+     */
+    test("builds a canvas symmetric about the avatar for a side", () => {
+      for (const dock of ["left", "right"] as const) {
+        const side = geometryFor("small", "small", dock);
+        expect(side.riseAbove).toBe(side.dropBelow);
+        expect(side.canvasHeight).toBe(side.riseAbove * 2);
+        expect(side.canvasWidth).toBe(GEOMETRY.canvasWidth);
+        const scale = companionScaleFor(side.optionsBox);
+        expect(side.riseAbove).toBeGreaterThanOrEqual(
+          (COMPANION_BASE_MAX_PILL_WIDTH * scale) / 2 + side.avatarBox,
+        );
+      }
+    });
+  });
+
+  describe("dockedAvatarCentre", () => {
+    test("is the bottom centre for the bottom", () => {
+      expect(dockedAvatarCentre("bottom", SCREEN, GEOMETRY)).toEqual(
+        defaultAvatarCentre(SCREEN, GEOMETRY),
+      );
+    });
+
+    /** As high as the canvas above the avatar lets the window server go. */
+    test("settles as high as the work area allows for the top", () => {
+      const top = landing("top");
+      expect(top.x).toBe(SCREEN.width / 2);
+      expect(top.y).toBe(SCREEN.y + DROP_BELOW);
+    });
+
+    test("stands the sides at the display's vertical centre, a margin in", () => {
+      const reach = companionLowerReachFor(SIDE.avatarBox, SIDE.optionsBox);
+      expect(dockedAvatarCentre("left", SCREEN, SIDE)).toEqual({
+        x: 2 + reach,
+        y: SCREEN.height / 2,
+      });
+      expect(dockedAvatarCentre("right", SCREEN, SIDE)).toEqual({
+        x: SCREEN.width - 2 - reach,
+        y: SCREEN.height / 2,
+      });
+    });
+  });
+
+  describe("nearestDock", () => {
+    test("is the edge the point is closest to", () => {
+      expect(nearestDock({ x: 700, y: 850 }, SCREEN)).toBe("bottom");
+      expect(nearestDock({ x: 700, y: 40 }, SCREEN)).toBe("top");
+      expect(nearestDock({ x: 30, y: 450 }, SCREEN)).toBe("left");
+      expect(nearestDock({ x: 1400, y: 450 }, SCREEN)).toBe("right");
+    });
+
+    test("resolves a tie to the bottom, the shape the bar is designed around", () => {
+      expect(nearestDock({ x: 720, y: 450 }, SCREEN)).toBe("bottom");
+    });
+
+    test("measures against the work area it is given, not the origin", () => {
+      const second = { x: 1440, y: 0, width: 1920, height: 1080 };
+      expect(nearestDock({ x: 1460, y: 500 }, second)).toBe("left");
+    });
+  });
+
+  test("a call goes to the remembered edge rather than the bottom", () => {
+    storedDock = "top";
+    // The dock is read once at load, so this case reaches it the way a drop
+    // does; the store's read is `window-state.test.ts`'s subject.
+    send("vellum:voiceActivity:start", START);
+    dragTo({ x: 700, y: 30 });
+    release();
+    send("vellum:voiceActivity:end");
+    send("vellum:companion:startVoice");
+    expect(centre()).toEqual(landing("top"));
+    expect(state().dock).toBe("top");
+  });
+
+  test("a drag mid-call shows the edges and names the one it is heading for", () => {
+    send("vellum:companion:startVoice");
+    expect(zonesWindow()).toBeNull();
+    dragTo({ x: 100, y: 450 });
+    const zones = zonesWindow();
+    expect(zones).not.toBeNull();
+    expect(zones?.bounds).toEqual(SCREEN);
+    expect(zones?.level).toEqual(["floating", -1]);
+    expect(state().docking).toBe("left");
+    dragTo({ x: 700, y: 60 });
+    expect(state().docking).toBe("top");
+  });
+
+  /**
+   * A click on the creature mid-call is a press the renderer reports moves
+   * for, jitter and all, and it must not flash the edges or move the bar.
+   */
+  test("a press that barely moves is a click, not a drag", () => {
+    send("vellum:companion:startVoice");
+    const docked = centre();
+    send("vellum:companion:moveBy", 1, -1);
+    expect(zonesWindow()).toBeNull();
+    expect(state().docking).toBeUndefined();
+    release();
+    expect(centre()).toEqual({ x: docked.x + 1, y: docked.y - 1 });
+    expect(state().dock).toBe("bottom");
+  });
+
+  test("an idle drag shows no edges", () => {
+    dragTo({ x: 100, y: 450 });
+    expect(zonesWindow()).toBeNull();
+    expect(state().docking).toBeUndefined();
+    release();
+    expect(state().dock).toBe("bottom");
+  });
+
+  test("the release docks the bar to the edge it was heading for and remembers it", () => {
+    send("vellum:companion:startVoice");
+    dragTo({ x: 100, y: 450 });
+    release();
+    expect(zonesWindow()).toBeNull();
+    expect(state().docking).toBeUndefined();
+    expect(state().dock).toBe("left");
+    expect(storedDock).toBe("left");
+    expect(centre()).toEqual(landing("left", SIDE));
+  });
+
+  /** The column needs a canvas of its own shape, and the row wants the old one back. */
+  test("a side dock stands the canvas up for the call and lays it back down after", () => {
+    send("vellum:companion:startVoice");
+    dragTo({ x: 1400, y: 450 });
+    release();
+    expect(boundsSet.at(-1)?.height).toBe(SIDE.canvasHeight);
+    expect(state().avatarBox).toBe(SIDE.avatarBox);
+    send("vellum:voiceActivity:end");
+    expect(boundsSet.at(-1)?.height).toBe(GEOMETRY.canvasHeight);
+  });
+
+  test("goes home after a call docked to a side", () => {
+    dragTo({ x: 300, y: 200 });
+    const home = centre();
+    send("vellum:companion:startVoice");
+    dragTo({ x: 1400, y: 450 });
+    release();
+    send("vellum:voiceActivity:end");
+    expect(centre()).toEqual(home);
+  });
+
+  test("the next call stands the bar up on the side it was left on", () => {
+    send("vellum:companion:startVoice");
+    dragTo({ x: 1400, y: 450 });
+    release();
+    send("vellum:voiceActivity:end");
+    send("vellum:companion:startVoice");
+    expect(centre()).toEqual(landing("right", SIDE));
+    expect(boundsSet.at(-1)?.height).toBe(SIDE.canvasHeight);
+  });
+
+  test("a call ending under a drag takes the edges down with it", () => {
+    send("vellum:companion:startVoice");
+    dragTo({ x: 100, y: 450 });
+    expect(zonesWindow()).not.toBeNull();
+    send("vellum:voiceActivity:end");
+    expect(zonesWindow()).toBeNull();
+    expect(state().docking).toBeUndefined();
+    // A release arriving after the call has nothing left to dock.
+    release();
+    expect(state().dock).toBe("bottom");
+  });
+
+  test("a reset mid-call puts the bar back on the bottom for this call and the next", () => {
+    send("vellum:companion:startVoice");
+    dragTo({ x: 100, y: 450 });
+    release();
+    expect(state().dock).toBe("left");
+    resetCompanionSurfacePosition();
+    expect(state().dock).toBe("bottom");
+    expect(storedDock).toBe("bottom");
+    expect(centre()).toEqual(landing("bottom"));
+    send("vellum:voiceActivity:end");
+    expect(centre()).toEqual(landing("bottom"));
+  });
+
+  test("the edges follow a drag onto another display", () => {
+    send("vellum:companion:startVoice");
+    const second = displays[1];
+    if (second === undefined) {
+      throw new Error("Expected a second display");
+    }
+    dragTo({ x: 100, y: 450 });
+    nearestDisplay = second;
+    dragTo({ x: 1500, y: 500 });
+    expect(zonesWindow()?.bounds).toEqual(second.workArea);
+    expect(state().docking).toBe("left");
   });
 });
 

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -29,6 +29,7 @@ import {
   COMPANION_INTRO_BEATS,
   companionBoxFor,
   companionCardSideFor,
+  companionDockIsSide,
   companionGapFor,
   companionNearEdgeFor,
   companionPadFor,
@@ -44,6 +45,7 @@ import {
   type CompanionAnnotationTool,
   type CompanionCardGrowth,
   type CompanionCoachmark,
+  type CompanionDock,
   type CompanionGrowth,
   type CompanionContext,
   type CompanionIntroAction,
@@ -61,9 +63,11 @@ import {
   readSetting,
 } from "@vellumai/electron-desktop/settings";
 import {
+  readCompanionCallDock,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
+  writeCompanionCallDock,
   writeCompanionIntroSeen,
   writeCompanionSize,
   writeCompanionHidden,
@@ -231,10 +235,21 @@ export interface CompanionGeometry {
  * process, which is what the fixed canvas exists to avoid. It *is* resized when
  * the user picks a different size on either axis, which is a deliberate,
  * one-off event rather than something that happens mid-gesture.
+ *
+ * A call docked to a side of the display is the other such event. The bar
+ * stands up as a column centred on the avatar, and a column reaches as far
+ * below the avatar as above it, where the canvas above keeps only the near
+ * edge below. So for a side dock the canvas is symmetric about the avatar
+ * instead: as tall each way as the column's half length, the gap, the creature
+ * standing at the column's end and the pad. Taller below than the ordinary
+ * canvas, which the window server allows (the canvas may hang off the bottom
+ * of a display), and shorter above, which is what keeps the avatar reachable
+ * near the top on a display shorter than the ordinary canvas is wide.
  */
 export const geometryFor = (
   avatar: CompanionSize,
   options: CompanionSize,
+  dock: CompanionDock = "bottom",
 ): CompanionGeometry => {
   const avatarBox = companionBoxFor("avatar", avatar);
   const optionsBox = companionBoxFor("options", options);
@@ -266,13 +281,30 @@ export const geometryFor = (
   // drawing the creature on another, and a card side is a ceiling with slack in
   // it where a near edge is the line itself.
   const riseAbove = canvasHeight - dropBelow;
+  // Twice a whole half rather than a whole total. The renderer puts the
+  // avatar on the canvas's centre line, so an odd width would stand the
+  // creature on a half point and a resize would not land back on it.
+  const canvasWidth = Math.round(maxReach + pad) * 2;
+  if (companionDockIsSide(dock)) {
+    // Half the column's greatest length, then the gap and the whole of the
+    // creature standing at its end, then the pad: the same reach the width
+    // holds for the row, read up from the avatar's centre. Whole for the
+    // reason the width is twice a whole half.
+    const sideHalf = Math.round(maxPillWidth / 2 + gap + avatarBox + pad);
+    return {
+      avatarBox,
+      optionsBox,
+      canvasWidth,
+      canvasHeight: sideHalf * 2,
+      riseAbove: sideHalf,
+      dropBelow: sideHalf,
+      maxReach,
+    };
+  }
   return {
     avatarBox,
     optionsBox,
-    // Twice a whole half rather than a whole total. The renderer puts the
-    // avatar on the canvas's centre line, so an odd width would stand the
-    // creature on a half point and a resize would not land back on it.
-    canvasWidth: Math.round(maxReach + pad) * 2,
+    canvasWidth,
     canvasHeight,
     riseAbove,
     dropBelow,
@@ -317,12 +349,49 @@ let growth: CompanionGrowth = "right";
 let cardGrowth: CompanionCardGrowth = "up";
 
 /**
+ * Which edge of the display a call takes the bar to. See `CompanionDock`.
+ *
+ * Read from the store at startup and replaced when the user drops the bar on
+ * another edge mid-call. Held beside {@link growth} for the same reason: it is
+ * a fact about where the window is put, and the renderer has to be told it to
+ * draw the bar the way the window was placed for.
+ */
+let dock: CompanionDock = readCompanionCallDock();
+
+/**
+ * The edge a call's drag would drop the bar on if the hand let go now, or
+ * `null` while no such drag is in flight.
+ *
+ * Set on each move of a drag during a call and cleared by the release. The
+ * window showing the four edges reads it off the pushed state to light one,
+ * and the release reads it to know where to send the bar.
+ */
+let docking: CompanionDock | null = null;
+
+/**
+ * How far a press has carried the bar since it began, in points, while a
+ * call has the surface.
+ *
+ * A press is a drag once it has travelled this far and a click until then,
+ * the same slop the renderer keeps for its own click. The renderer reports
+ * every move of a held button, jitter included, so without this a click on
+ * the creature mid-call would flash the four edges for a frame and glide the
+ * bar a point back to its dock.
+ */
+const DOCK_DRAG_SLOP = 3;
+let dockDragTravel = 0;
+
+/**
  * The canvas the surface is currently drawn in.
  *
  * Read from the store at startup and replaced when the user picks a different
- * size. Held rather than derived per call because it is what every position
+ * size, and when a call docks the bar to a side of the display or ends there.
+ * Held rather than derived per call because it is what every position
  * computed here is measured in, and reading the store on each mouse-move of a
  * drag would be a file read per frame.
+ *
+ * Built for the bottom at startup whatever the remembered dock: no call is
+ * running, and the canvas a side dock needs is the call's alone.
  */
 let geometry: CompanionGeometry = geometryFor(
   readCompanionSize("avatar"),
@@ -460,6 +529,15 @@ const WATCH_FRAME_KIND = "companion-watch-frame";
 const WATCH_FRAME_ROUTE = "/floating/companion-watch-frame";
 
 /**
+ * The edges a call's drag can drop the bar on, drawn over the display the
+ * drag is on for as long as it is in flight. Its own click-through window the
+ * size of the work area, like the frame and for the same reason: the surface's
+ * canvas is sized for the pill, and the edges are the display's.
+ */
+const DOCK_ZONES_KIND = "companion-dock-zones";
+const DOCK_ZONES_ROUTE = "/floating/companion-dock-zones";
+
+/**
  * How often the frame asks where a picked window is.
  *
  * A window the user is dragging moves every frame, and nothing tells this
@@ -582,6 +660,9 @@ const currentState = (): CompanionSurfaceState => {
   return {
     growth,
     cardGrowth,
+    dock,
+    // Absent rather than null between drags, as the contract has it.
+    docking: docking ?? undefined,
     avatarBox: geometry.avatarBox,
     optionsBox: geometry.optionsBox,
     character: character === null ? undefined : character,
@@ -818,6 +899,85 @@ export const defaultAvatarCentre = (
 });
 
 /**
+ * Where the avatar's centre goes for a call docked to an edge of the display.
+ *
+ * The bottom is {@link defaultAvatarCentre}, which is where every call has
+ * ever put the bar. The top is asked for at the work area's own top line and
+ * left to {@link placeCanvas} to settle as high as the window server allows,
+ * since the canvas above the avatar is what decides that and the clamp already
+ * knows it. The sides stand the bar up as a column centred on the avatar, so
+ * the avatar goes to the display's vertical centre and the same margin in from
+ * the edge the bottom keeps up from its own: the column's cross reach is the
+ * bar's half box and its lit edge, which is the same number the bottom
+ * measures its margin from (see `companionLowerReachFor`).
+ *
+ * Exported for its tests and pure for the same reason as {@link placeCanvas}.
+ */
+export const dockedAvatarCentre = (
+  dock: CompanionDock,
+  workArea: { x: number; y: number; width: number; height: number },
+  geometry: CompanionGeometry,
+): { x: number; y: number } => {
+  const reach = companionLowerReachFor(geometry.avatarBox, geometry.optionsBox);
+  switch (dock) {
+    case "bottom":
+      return defaultAvatarCentre(workArea, geometry);
+    case "top":
+      return { x: workArea.x + workArea.width / 2, y: workArea.y };
+    case "left":
+      return {
+        x: workArea.x + DEFAULT_MARGIN + reach,
+        y: workArea.y + workArea.height / 2,
+      };
+    case "right":
+      return {
+        x: workArea.x + workArea.width - DEFAULT_MARGIN - reach,
+        y: workArea.y + workArea.height / 2,
+      };
+  }
+};
+
+/**
+ * The edge a bar dropped at a point would dock to: whichever of the four is
+ * closest to it.
+ *
+ * Plain distance rather than a fraction of the display's size, so the answer
+ * is the edge the hand is nearest, which is the edge it was dragging toward.
+ * A point equally far from two edges goes to the earlier of the two in the
+ * order the docks are named, which puts the bottom first: it is the edge the
+ * bar is designed around, so a tie resolves to the shape the user already
+ * knows.
+ *
+ * Exported for its tests, as {@link growthFor} is.
+ */
+export const nearestDock = (
+  point: { x: number; y: number },
+  workArea: { x: number; y: number; width: number; height: number },
+): CompanionDock => {
+  const distances: [CompanionDock, number][] = [
+    ["bottom", workArea.y + workArea.height - point.y],
+    ["top", point.y - workArea.y],
+    ["left", point.x - workArea.x],
+    ["right", workArea.x + workArea.width - point.x],
+  ];
+  return distances.reduce((nearest, candidate) =>
+    candidate[1] < nearest[1] ? candidate : nearest,
+  )[0];
+};
+
+/**
+ * Which dock the canvas is currently built for: the remembered one while a
+ * call has the surface, and the bottom otherwise.
+ *
+ * The bottom outside a call whatever the user last dropped the bar on, because
+ * the side dock's canvas is the column's and the idle pill is a row hanging
+ * off the creature with the introduction's card above it, which is the shape
+ * the ordinary canvas is sized for.
+ */
+const canvasDock = (): CompanionDock =>
+  callSurfaceFor(call, dialing) ? dock : "bottom";
+
+/**
  * Where the surface opens with no remembered position: the bottom centre of
  * the display under the cursor.
  *
@@ -841,8 +1001,9 @@ const pushState = (): void => {
   const state = currentState();
   // The glow reads the same state the surface does, for the same reason the
   // surface holds none of it: one push, two windows, no second idea of which
-  // call is running or what colour it is.
-  for (const kind of [COMPANION_KIND, WATCH_FRAME_KIND]) {
+  // call is running or what colour it is. The edges a call's drag can drop
+  // the bar on read it the same way, for which of them to light.
+  for (const kind of [COMPANION_KIND, WATCH_FRAME_KIND, DOCK_ZONES_KIND]) {
     const win = getFloatingWindow(kind);
     if (win) {
       win.webContents.send("vellum:companion:state", state);
@@ -2019,10 +2180,13 @@ const syncCallSurface = (): void => {
     // arrives on the way home must send the pill back to that home when it
     // ends, not to wherever it was passing through when the call came.
     callHome = glide === null ? avatarCentre(win) : glide.to;
+    // The column's canvas before the glide to a side, so the bar arrives
+    // already standing in a canvas that can hold it.
+    syncCanvas();
     const display = displayUnder(callHome);
     glideAvatarTo(
       win,
-      defaultAvatarCentre(display.workArea, geometry),
+      dockedAvatarCentre(dock, display.workArea, geometry),
       display.workArea,
     );
     return;
@@ -2032,10 +2196,110 @@ const syncCallSurface = (): void => {
   }
   const home = callHome;
   callHome = null;
+  // A drag the call ends under has nothing left to dock.
+  docking = null;
+  dockDragTravel = 0;
+  closeDockZones();
   if (win === null) {
     return;
   }
+  syncCanvas();
   glideAvatarTo(win, home, displayUnder(home).workArea);
+};
+
+/**
+ * Show the edges over a display, or move them to it.
+ *
+ * Opened by the first move of a drag during a call, moved with the drag from
+ * display to display, and closed by the release or by the call ending under
+ * it.
+ */
+const placeDockZones = (bounds: Rectangle): void => {
+  const existing = getFloatingWindow(DOCK_ZONES_KIND);
+  if (existing !== null) {
+    const current = existing.getBounds();
+    if (
+      current.x !== bounds.x ||
+      current.y !== bounds.y ||
+      current.width !== bounds.width ||
+      current.height !== bounds.height
+    ) {
+      existing.setBounds(bounds);
+    }
+    return;
+  }
+  const win = createFloatingWindow({
+    kind: DOCK_ZONES_KIND,
+    route: DOCK_ZONES_ROUTE,
+    width: bounds.width,
+    height: bounds.height,
+    ignoreMouseEvents: true,
+    position: { x: bounds.x, y: bounds.y },
+    browserWindow: {
+      hasShadow: false,
+      focusable: false,
+      movable: false,
+      minimizable: false,
+      maximizable: false,
+      backgroundColor: "#00000000",
+    },
+  });
+  // Under the surface being dragged over it, so the bar is never hidden by
+  // the edge it is about to land on.
+  win.setAlwaysOnTop(true, "floating", -1);
+};
+
+const closeDockZones = (): void => {
+  getFloatingWindow(DOCK_ZONES_KIND)?.close();
+};
+
+/**
+ * Note where a drag during a call would drop the bar, and show the edges.
+ *
+ * Run after each move of such a drag, against the display the avatar is now
+ * over: a drag across displays docks to an edge of the display it ends on.
+ * Pushed only when the answer changes, since the surface is pushed the same
+ * state and a drag is a message per pixel.
+ */
+const armDock = (centre: { x: number; y: number }): void => {
+  const { workArea } = displayUnder(centre);
+  placeDockZones(workArea);
+  const next = nearestDock(centre, workArea);
+  if (next === docking) {
+    return;
+  }
+  docking = next;
+  pushState();
+};
+
+/**
+ * Drop the bar on an edge: remember it, and glide the bar there in a canvas
+ * that fits it.
+ *
+ * The release of a drag during a call, and the mid-call reset. The edge is
+ * the user's stated placement of the call's bar, so it is written to the store
+ * the way a size pick is and every call after this one takes the bar there.
+ */
+const dropOnDock = (next: CompanionDock): void => {
+  docking = null;
+  closeDockZones();
+  writeCompanionCallDock(next);
+  dock = next;
+  const win = getFloatingWindow(COMPANION_KIND);
+  if (win === null || win.isDestroyed()) {
+    pushState();
+    return;
+  }
+  const resting = glide === null ? avatarCentre(win) : glide.to;
+  // Before the glide, as on the way into a call: the canvas is rebuilt
+  // around where the bar rests now, and the glide then crosses to the edge
+  // in the canvas the edge needs. A rebuild pushes the surface itself; the
+  // push is owed either way, since the dock and the drag both moved.
+  if (!syncCanvas()) {
+    pushState();
+  }
+  const { workArea } = displayUnder(resting);
+  glideAvatarTo(win, dockedAvatarCentre(dock, workArea, geometry), workArea);
 };
 
 /**
@@ -2282,8 +2546,29 @@ export const installCompanionWindow = (): void => {
       // clamped to that display's edges instead of being held back at the
       // first one's.
       moveAvatarTo(win, wanted, displayUnder(wanted).workArea);
+      // A drag during a call is a drag toward an edge: the bar moves as
+      // freely as the idle pill does, and the release docks it to whichever
+      // edge it is nearest. Read back off the window rather than from
+      // `wanted`, since the clamp is what decided where the avatar is.
+      if (callSurfaceFor(call, dialing)) {
+        dockDragTravel += Math.abs(dx) + Math.abs(dy);
+        if (dockDragTravel > DOCK_DRAG_SLOP) {
+          armDock(avatarCentre(win));
+        }
+      }
     },
   );
+
+  // The hand letting go. Sent after every press, and what it settles is
+  // main's to know: a drag during a call docks the bar to the edge it was
+  // heading for, and every other release has nothing to do.
+  on("vellum:companion:release", z.tuple([]), () => {
+    dockDragTravel = 0;
+    if (docking === null) {
+      return;
+    }
+    dropOnDock(docking);
+  });
 
   /**
    * Talk, delivered to the renderer that can act on it.
@@ -2979,6 +3264,9 @@ export const openCompanionWindow = (): void => {
   win.on("closed", () => {
     cancelGlide();
     callHome = null;
+    // A drag on a window that no longer exists has nothing left to drop.
+    docking = null;
+    closeDockZones();
   });
   // `createFloatingWindow` has already shown it. A surface opened while the
   // app is in front, which is where a sign-in opens it from, goes straight back
@@ -3049,10 +3337,48 @@ export const setCompanionSurfaceSize = (
   size: CompanionSize,
 ): void => {
   writeCompanionSize(axis, size);
+  applyGeometry(
+    geometryFor(
+      readCompanionSize("avatar"),
+      readCompanionSize("options"),
+      canvasDock(),
+    ),
+  );
+};
+
+/**
+ * Rebuild the canvas for the dock the surface is on, if it is not already
+ * built for it.
+ *
+ * The call's way in and out and a drop on another edge all go through here:
+ * each can change which dock the canvas answers for, and only a change that
+ * moves an edge of the canvas is worth a window resize. Answers whether the
+ * canvas was rebuilt, since a rebuild pushes the surface and a caller with a
+ * push of its own to make can then leave it at that.
+ */
+const syncCanvas = (): boolean => {
   const next = geometryFor(
     readCompanionSize("avatar"),
     readCompanionSize("options"),
+    canvasDock(),
   );
+  if (
+    next.canvasHeight === geometry.canvasHeight &&
+    next.riseAbove === geometry.riseAbove
+  ) {
+    return false;
+  }
+  applyGeometry(next);
+  return true;
+};
+
+/**
+ * Swap the canvas for another one built around the same avatar point.
+ *
+ * The surface is not moved by it: the avatar rests exactly where it was, and
+ * the window is placed in the new canvas around that point.
+ */
+const applyGeometry = (next: CompanionGeometry): void => {
   const win = getFloatingWindow(COMPANION_KIND);
   if (!win || win.isDestroyed()) {
     geometry = next;
@@ -3096,11 +3422,13 @@ export const setCompanionSurfaceSize = (
  * pointer. Where the pill rests, for a glide in flight, is where the glide is
  * headed, as every other reader of its resting place has it.
  *
- * During a call the surface is already at this point unless the user dragged
- * it away, and the call is holding the place the pill goes back to when the
- * call ends. A reset asked for mid-call makes the default that place too:
- * the user has just said where the surface belongs, and a call ending by
- * sending it back to wherever it was before would undo that.
+ * During a call the surface is at the edge the bar is docked to unless the
+ * user dragged it away, and the call is holding the place the pill goes back
+ * to when the call ends. A reset asked for mid-call makes the default that
+ * place too, and the bottom the bar's dock again: the user has just said
+ * where the surface belongs, and a call ending by sending it back to wherever
+ * it was before, or the next call standing the bar up on a side, would undo
+ * that.
  *
  * A glide rather than a jump, the way the call moves it, and instant under
  * "Reduce motion" for the same reason.
@@ -3112,11 +3440,15 @@ export const resetCompanionSurfacePosition = (): void => {
   }
   const resting = glide === null ? avatarCentre(win) : glide.to;
   const { workArea } = displayUnder(resting);
-  const home = defaultAvatarCentre(workArea, geometry);
   if (callHome !== null) {
-    callHome = home;
+    // In the ordinary canvas, which the drop on the bottom rebuilds before
+    // it measures the home: the bottom's margin is the same in both, so the
+    // point is the same either way.
+    callHome = defaultAvatarCentre(workArea, geometry);
+    dropOnDock("bottom");
+    return;
   }
-  glideAvatarTo(win, home, workArea);
+  glideAvatarTo(win, defaultAvatarCentre(workArea, geometry), workArea);
 };
 
 /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -2184,6 +2184,9 @@ const syncCallSurface = (): void => {
     // already standing in a canvas that can hold it.
     syncCanvas();
     const display = displayUnder(callHome);
+    // The edges, loaded now and kept hidden, so the first drag of the call
+    // has a window to show rather than one to build.
+    readyDockZones(display.workArea);
     glideAvatarTo(
       win,
       dockedAvatarCentre(dock, display.workArea, geometry),
@@ -2208,13 +2211,15 @@ const syncCallSurface = (): void => {
 };
 
 /**
- * Show the edges over a display, or move them to it.
+ * Have the edges' window built and hidden over a display, ready to show.
  *
- * Opened by the first move of a drag during a call, moved with the drag from
- * display to display, and closed by the release or by the call ending under
- * it.
+ * Built when the call takes the surface rather than on the first move of a
+ * drag: a window has to load its page before it can draw, and a drag that
+ * had to wait for that would be halfway to the edge before the edges
+ * appeared. Hidden straight after it is built; its page draws nothing until
+ * a drag is in flight anyway, so nothing is seen either way.
  */
-const placeDockZones = (bounds: Rectangle): void => {
+const readyDockZones = (bounds: Rectangle): BrowserWindow => {
   const existing = getFloatingWindow(DOCK_ZONES_KIND);
   if (existing !== null) {
     const current = existing.getBounds();
@@ -2226,7 +2231,7 @@ const placeDockZones = (bounds: Rectangle): void => {
     ) {
       existing.setBounds(bounds);
     }
-    return;
+    return existing;
   }
   const win = createFloatingWindow({
     kind: DOCK_ZONES_KIND,
@@ -2247,6 +2252,26 @@ const placeDockZones = (bounds: Rectangle): void => {
   // Under the surface being dragged over it, so the bar is never hidden by
   // the edge it is about to land on.
   win.setAlwaysOnTop(true, "floating", -1);
+  win.hide();
+  return win;
+};
+
+/**
+ * Show the edges over a display, or move them to it.
+ *
+ * On each move of a drag during a call, so the edges follow the drag from
+ * display to display. Hidden again by the release, and closed by the call
+ * ending.
+ */
+const placeDockZones = (bounds: Rectangle): void => {
+  const win = readyDockZones(bounds);
+  if (!win.isVisible()) {
+    win.showInactive();
+  }
+};
+
+const hideDockZones = (): void => {
+  getFloatingWindow(DOCK_ZONES_KIND)?.hide();
 };
 
 const closeDockZones = (): void => {
@@ -2282,7 +2307,7 @@ const armDock = (centre: { x: number; y: number }): void => {
  */
 const dropOnDock = (next: CompanionDock): void => {
   docking = null;
-  closeDockZones();
+  hideDockZones();
   writeCompanionCallDock(next);
   dock = next;
   const win = getFloatingWindow(COMPANION_KIND);

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -549,6 +549,9 @@ const bridge: VellumBridge = {
     moveBy: (dx: number, dy: number): void => {
       ipcRenderer.send("vellum:companion:moveBy", dx, dy);
     },
+    release: (): void => {
+      ipcRenderer.send("vellum:companion:release");
+    },
     startVoice: (): void => {
       ipcRenderer.send("vellum:companion:startVoice");
     },

--- a/clients/web/src/components/companion-dock-zones-page.test.tsx
+++ b/clients/web/src/components/companion-dock-zones-page.test.tsx
@@ -114,6 +114,22 @@ describe("the edges a call's bar can dock to", () => {
     );
   });
 
+  /**
+   * The middle of each edge, not the whole of it: the bar lands at the
+   * centre of the edge, and the zone is the size of what lands there.
+   */
+  test("sits at the centre of its edge rather than corner to corner", () => {
+    const { container } = render(<CompanionDockZonesPage />);
+    pushState({ ...STATE, call: LISTENING_CALL, docking: "top" });
+    const [bottom, top, left, right] = zonesOf(container);
+    expect(top?.style.left).toBe("50%");
+    expect(top?.style.width).toBe("360px");
+    expect(bottom?.style.left).toBe("50%");
+    expect(left?.style.top).toBe("50%");
+    expect(left?.style.height).toBe("360px");
+    expect(right?.style.top).toBe("50%");
+  });
+
   test("takes no pointer, so the drag underneath it goes on", () => {
     const { container } = render(<CompanionDockZonesPage />);
     pushState({ ...STATE, call: LISTENING_CALL, docking: "right" });

--- a/clients/web/src/components/companion-dock-zones-page.test.tsx
+++ b/clients/web/src/components/companion-dock-zones-page.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render } from "@testing-library/react";
+import type { CompanionSurfaceState } from "@vellumai/ipc-contract";
+
+const STATE: CompanionSurfaceState = {
+  growth: "right",
+  cardGrowth: "up",
+  avatarBox: 44,
+  optionsBox: 44,
+  call: null,
+  assistantName: "Ziggy",
+  working: false,
+  intro: null,
+};
+
+const listeners = new Set<(state: CompanionSurfaceState) => void>();
+
+const pushState = (state: CompanionSurfaceState) => {
+  act(() => {
+    for (const listener of listeners) {
+      listener(state);
+    }
+  });
+};
+
+mock.module("@/runtime/companion-surface", () => ({
+  getCompanionState: async () => STATE,
+  subscribeCompanionState: (
+    listener: (state: CompanionSurfaceState) => void,
+  ) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+}));
+
+const { CompanionDockZonesPage } = await import("./companion-dock-zones-page");
+
+afterEach(() => {
+  cleanup();
+  listeners.clear();
+});
+
+const zonesOf = (container: HTMLElement): HTMLElement[] =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(
+      "[data-testid='companion-dock-zone']",
+    ),
+  );
+
+const armedOf = (container: HTMLElement): string[] =>
+  zonesOf(container)
+    .filter((zone) => zone.dataset.armed === "true")
+    .map((zone) => zone.dataset.dock ?? "");
+
+const LISTENING_CALL = {
+  phase: "listening" as const,
+  label: "Listening",
+  accentHex: "#ff9f45",
+  muted: false,
+  outputMuted: false,
+  detail: "",
+  approvalRequestId: "",
+  assistantName: "Ziggy",
+};
+
+/**
+ * The edges a call's bar can be dropped on. The window exists only while a
+ * drag is in flight, so what these pin is that the page draws off the state
+ * the shell pushes rather than off its own existence, and lights the edge the
+ * shell says the drop would land on.
+ */
+describe("the edges a call's bar can dock to", () => {
+  test("draws nothing while no drag is in flight", () => {
+    const { container } = render(<CompanionDockZonesPage />);
+    pushState({ ...STATE, call: LISTENING_CALL, dock: "bottom" });
+    expect(zonesOf(container)).toHaveLength(0);
+  });
+
+  test("shows all four edges once a drag is in flight", () => {
+    const { container } = render(<CompanionDockZonesPage />);
+    pushState({ ...STATE, call: LISTENING_CALL, docking: "bottom" });
+    expect(zonesOf(container).map((zone) => zone.dataset.dock)).toEqual([
+      "bottom",
+      "top",
+      "left",
+      "right",
+    ]);
+  });
+
+  test("lights the one the drop would land on, and follows it", () => {
+    const { container } = render(<CompanionDockZonesPage />);
+    pushState({ ...STATE, call: LISTENING_CALL, docking: "left" });
+    expect(armedOf(container)).toEqual(["left"]);
+    pushState({ ...STATE, call: LISTENING_CALL, docking: "top" });
+    expect(armedOf(container)).toEqual(["top"]);
+  });
+
+  test("takes the edges down on the release", () => {
+    const { container } = render(<CompanionDockZonesPage />);
+    pushState({ ...STATE, call: LISTENING_CALL, docking: "right" });
+    expect(zonesOf(container)).toHaveLength(4);
+    pushState({ ...STATE, call: LISTENING_CALL, dock: "right" });
+    expect(zonesOf(container)).toHaveLength(0);
+  });
+
+  test("lights the edge in the running call's accent", () => {
+    const { container } = render(<CompanionDockZonesPage />);
+    pushState({ ...STATE, call: LISTENING_CALL, docking: "right" });
+    const page = container.querySelector<HTMLElement>(
+      "[data-testid='companion-dock-zones']",
+    );
+    expect(page?.style.getPropertyValue("--companion-ring-accent")).toBe(
+      "#ff9f45",
+    );
+  });
+
+  test("takes no pointer, so the drag underneath it goes on", () => {
+    const { container } = render(<CompanionDockZonesPage />);
+    pushState({ ...STATE, call: LISTENING_CALL, docking: "right" });
+    const page = container.querySelector<HTMLElement>(
+      "[data-testid='companion-dock-zones']",
+    );
+    expect(page?.className).toContain("pointer-events-none");
+  });
+});

--- a/clients/web/src/components/companion-dock-zones-page.tsx
+++ b/clients/web/src/components/companion-dock-zones-page.tsx
@@ -1,0 +1,138 @@
+/**
+ * The four edges a call's bar can be dropped on, shown while the bar is being
+ * dragged mid-call.
+ *
+ * Drawn in its own click-through window the size of the display's work area,
+ * which the macOS shell opens on the first move of such a drag, moves with
+ * the drag from display to display, and closes on the release
+ * (`clients/macos/src/main/companion-window.ts`). The bar itself is a window
+ * the size of a pill; the edges are the display's, so they need a window the
+ * display's size.
+ *
+ * All four are shown at once, because the drag is a choice between them and
+ * a choice is shown whole. The one the release would land on is lit, so the
+ * hand knows where the bar is going before it lets go. Which one that is
+ * arrives on the pushed state (`docking`), decided by main from where the bar
+ * actually is, so the edge that lights and the edge the bar lands on cannot
+ * come apart.
+ *
+ * **It draws the choice and holds none of it.** Nothing here takes the
+ * pointer: the page has no way to know where the hand is and does not need
+ * one. Decoration on a desktop it does not own, like the watch frame.
+ */
+
+import { useEffect, useState } from "react";
+
+import {
+  companionAccentHexFor,
+  COMPANION_DEFAULT_ACCENT,
+} from "@/components/companion-accent";
+import {
+  getCompanionState,
+  subscribeCompanionState,
+} from "@/runtime/companion-surface";
+import {
+  COMPANION_DOCKS,
+  type CompanionDock,
+  type CompanionSurfaceState,
+} from "@vellumai/ipc-contract";
+
+/**
+ * How far in from the display's edge a zone reaches, in points.
+ *
+ * Deep enough to read as a place rather than a line, and shallow enough that
+ * the four never meet in the middle of a small display: a zone is where the
+ * bar is going, not where the drag is allowed.
+ */
+export const DOCK_ZONE_DEPTH = 88;
+
+/** The room a zone keeps from the display's edge and from its neighbours. */
+const DOCK_ZONE_INSET = 10;
+
+/** Where one edge's zone sits, as the CSS edges it is pinned to. */
+const zoneEdges = (dock: CompanionDock): Record<string, number> => {
+  const inset = DOCK_ZONE_INSET;
+  const depth = DOCK_ZONE_DEPTH;
+  switch (dock) {
+    case "top":
+      return { top: inset, left: inset, right: inset, height: depth };
+    case "bottom":
+      return { bottom: inset, left: inset, right: inset, height: depth };
+    case "left":
+      return { left: inset, top: inset, bottom: inset, width: depth };
+    case "right":
+      return { right: inset, top: inset, bottom: inset, width: depth };
+  }
+};
+
+export function CompanionDockZonesPage() {
+  const [state, setState] = useState<CompanionSurfaceState | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeCompanionState(setState);
+    // The route chunk loads lazily after the window is created, so a state
+    // pushed before this subscription registered was dropped. Catch up.
+    void getCompanionState().then((initial) => {
+      if (initial) {
+        setState(initial);
+      }
+    });
+    return unsubscribe;
+  }, []);
+
+  // The window exists only while a drag is in flight, but the state it is
+  // pushed is the surface's whole state, and one between drags says nothing
+  // is being dragged. Drawn only on a positive answer, so a window main has
+  // not closed yet shows nothing rather than four dark edges.
+  const docking = state?.docking;
+  if (docking === undefined) {
+    return null;
+  }
+
+  // The assistant's colour, resolved exactly as the surface resolves it, so
+  // the edge the bar lands on is lit in the colour the bar itself is ringed
+  // in.
+  const accentHex = companionAccentHexFor(
+    state?.call ?? null,
+    state?.accentHex,
+    state?.character,
+  );
+  const accent = accentHex ?? COMPANION_DEFAULT_ACCENT;
+
+  return (
+    <div
+      className="pointer-events-none relative h-screen w-screen bg-transparent select-none"
+      data-testid="companion-dock-zones"
+      // The one place the colour is stated, so a test can read it and the
+      // four zones cannot disagree about it.
+      style={{ ["--companion-ring-accent" as string]: accent }}
+      aria-hidden
+    >
+      {COMPANION_DOCKS.map((dock) => {
+        const armed = dock === docking;
+        return (
+          <div
+            key={dock}
+            className="absolute rounded-2xl transition-[background-color,border-color,box-shadow] duration-150"
+            data-testid="companion-dock-zone"
+            data-dock={dock}
+            data-armed={armed ? "true" : "false"}
+            style={{
+              ...zoneEdges(dock),
+              // Lit against a wallpaper of any colour: a tint of the accent
+              // for the place, and the accent itself for its edge. The armed
+              // one is the same shape with the light turned up, so the eye
+              // reads four places and one answer rather than four different
+              // things.
+              backgroundColor: `color-mix(in srgb, var(--companion-ring-accent) ${armed ? 26 : 9}%, transparent)`,
+              border: `1.5px ${armed ? "solid" : "dashed"} color-mix(in srgb, var(--companion-ring-accent) ${armed ? 90 : 45}%, transparent)`,
+              boxShadow: armed
+                ? "0 0 24px color-mix(in srgb, var(--companion-ring-accent) 45%, transparent), inset 0 0 24px color-mix(in srgb, var(--companion-ring-accent) 25%, transparent)"
+                : undefined,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/clients/web/src/components/companion-dock-zones-page.tsx
+++ b/clients/web/src/components/companion-dock-zones-page.tsx
@@ -21,7 +21,7 @@
  * one. Decoration on a desktop it does not own, like the watch frame.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 
 import {
   companionAccentHexFor,
@@ -40,28 +40,65 @@ import {
 /**
  * How far in from the display's edge a zone reaches, in points.
  *
- * Deep enough to read as a place rather than a line, and shallow enough that
- * the four never meet in the middle of a small display: a zone is where the
- * bar is going, not where the drag is allowed.
+ * About the bar's own thickness: deep enough to read as a place rather than
+ * a line, and shallow enough to stay a rim of the display rather than a band
+ * across it. A zone is where the bar is going, not where the drag is
+ * allowed, and the drop snaps to the nearest edge from anywhere.
  */
-export const DOCK_ZONE_DEPTH = 88;
+export const DOCK_ZONE_DEPTH = 44;
 
-/** The room a zone keeps from the display's edge and from its neighbours. */
+/**
+ * How far a zone runs along its edge, in points.
+ *
+ * The middle of the edge and not the whole of it, because the middle is
+ * where the bar lands: a drop docks the bar to the centre of the nearest
+ * edge, and a zone running corner to corner would promise a whole side the
+ * bar never uses. About the length of the bar with the creature beside it,
+ * so the lit zone is the size of the thing about to land in it.
+ */
+export const DOCK_ZONE_LENGTH = 360;
+
+/** The room a zone keeps from the display's edge. */
 const DOCK_ZONE_INSET = 10;
 
-/** Where one edge's zone sits, as the CSS edges it is pinned to. */
-const zoneEdges = (dock: CompanionDock): Record<string, number> => {
+/** Where one edge's zone sits: centred on its edge, a rim's depth in. */
+const zoneEdges = (dock: CompanionDock): CSSProperties => {
   const inset = DOCK_ZONE_INSET;
   const depth = DOCK_ZONE_DEPTH;
+  const length = DOCK_ZONE_LENGTH;
   switch (dock) {
     case "top":
-      return { top: inset, left: inset, right: inset, height: depth };
+      return {
+        top: inset,
+        left: "50%",
+        translate: "-50% 0",
+        width: length,
+        height: depth,
+      };
     case "bottom":
-      return { bottom: inset, left: inset, right: inset, height: depth };
+      return {
+        bottom: inset,
+        left: "50%",
+        translate: "-50% 0",
+        width: length,
+        height: depth,
+      };
     case "left":
-      return { left: inset, top: inset, bottom: inset, width: depth };
+      return {
+        left: inset,
+        top: "50%",
+        translate: "0 -50%",
+        height: length,
+        width: depth,
+      };
     case "right":
-      return { right: inset, top: inset, bottom: inset, width: depth };
+      return {
+        right: inset,
+        top: "50%",
+        translate: "0 -50%",
+        height: length,
+        width: depth,
+      };
   }
 };
 

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -196,6 +196,20 @@ describe("bridgeRect", () => {
     const bridge = bridgeRect(AVATAR, overlapping);
     expect(bridge.left).toBeGreaterThan(bridge.right);
   });
+
+  /**
+   * A call docked to a side stands the pill up under the creature, and the
+   * strip turns with it: the pill's column wide, the gap between them tall.
+   */
+  test("stands up between a creature and a pill below it", () => {
+    const column = { left: 100, right: 144, top: 156, bottom: 356 };
+    expect(bridgeRect(AVATAR, column)).toEqual({
+      left: 100,
+      right: 144,
+      top: 144,
+      bottom: 156,
+    });
+  });
 });
 
 /**

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -46,6 +46,10 @@ export const containsPoint = (
  * a larger creature's height would hand the window the dead corners beside the
  * pill to swallow presses in.
  *
+ * A call docked to a side of the display stands the pill up under the
+ * creature, and the strip turns with it: the pill's own column wide, and as
+ * tall as the gap between the creature's bottom and the pill's top.
+ *
  * Degenerate when the two overlap, which reads as no bridge at all: the strip's
  * left edge lands past its right, and no point is inside it.
  */
@@ -53,6 +57,14 @@ export const bridgeRect = (
   avatar: SurfaceRect,
   pill: SurfaceRect,
 ): SurfaceRect => {
+  if (pill.top >= avatar.bottom) {
+    return {
+      left: pill.left,
+      right: pill.right,
+      top: avatar.bottom,
+      bottom: pill.top,
+    };
+  }
   const row = { top: pill.top, bottom: pill.bottom };
   return pill.left >= avatar.right
     ? { left: avatar.right, right: pill.left, ...row }

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -18,6 +18,7 @@ import {
 import type { CompanionSurfaceState } from "@vellumai/ipc-contract";
 
 const moveByMock = mock((_dx: number, _dy: number) => undefined);
+const releaseMock = mock(() => undefined);
 const setInteractiveMock = mock((_interactive: boolean) => undefined);
 const activateMock = mock(() => undefined);
 const startVoiceMock = mock(() => undefined);
@@ -134,6 +135,7 @@ mock.module("@/runtime/companion-surface", () => ({
   },
   setCompanionInteractive: setInteractiveMock,
   moveCompanionBy: moveByMock,
+  releaseCompanionSurface: releaseMock,
   activateCompanionApp: activateMock,
   startCompanionVoice: startVoiceMock,
   toggleCompanionWatch: toggleWatchMock,
@@ -164,6 +166,7 @@ afterEach(() => {
   cleanup();
   resetState();
   moveByMock.mockClear();
+  releaseMock.mockClear();
   setInteractiveMock.mockClear();
   activateMock.mockClear();
   startVoiceMock.mockClear();
@@ -508,6 +511,101 @@ describe("the companion surface at two sizes", () => {
 });
 
 describe("dragging the companion surface", () => {
+  /**
+   * Main hears the hand let go after every press, moved or not: mid-call a
+   * drag's release is the drop that docks the bar to an edge, and main is
+   * the side that knows whether this press was one. A press that never
+   * moved lets go too, since a click on the creature is a press main may
+   * have been shown moves for that this window never saw as a drag.
+   */
+  test("tells main when the hand lets go", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 530,
+      screenY: 520,
+      buttons: 1,
+    });
+    expect(releaseMock).not.toHaveBeenCalled();
+    fireEvent.mouseUp(canvas);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+    // A release with no press behind it is nothing to tell main about.
+    fireEvent.mouseUp(canvas);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("tells main about a release this window never saw", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 530,
+      screenY: 520,
+      buttons: 0,
+    });
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("tells main when the host takes the pointer away mid-press", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
+    fireEvent.pointerCancel(canvas);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The edge the bar rests on arrives on the state, like the growths, and
+   * the surface draws the bar for it: a column against a side.
+   */
+  test("stands the call bar up on the side main docked it to", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    pushState({ ...STATE, call: LISTENING_CALL, dock: "left" });
+    await waitFor(() => {
+      if (
+        container.querySelector(".transition-\\[width\\,height\\]") === null
+      ) {
+        throw new Error("Expected the bar to stand up");
+      }
+    });
+    pushState({ ...STATE, call: LISTENING_CALL, dock: "top" });
+    await waitFor(() => {
+      if (container.querySelector(".transition-\\[width\\]") === null) {
+        throw new Error("Expected the bar to lie back down");
+      }
+    });
+  });
+
   /**
    * Both drawn halves are handles. The drag is a window move, so whichever the
    * hand happens to land on takes the whole surface with it, and a creature

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -33,6 +33,7 @@ import {
   getCompanionState,
   listCompanionCaptureSources,
   moveCompanionBy,
+  releaseCompanionSurface,
   setCompanionAnnotating,
   setCompanionAnnotationTool,
   setCompanionInteractive,
@@ -52,6 +53,7 @@ import type {
   CompanionCapturePick,
   CompanionCaptureSources,
   CompanionCardGrowth,
+  CompanionDock,
   CompanionCharacter,
   CompanionGrowth,
   CompanionIntroBeat,
@@ -101,6 +103,10 @@ export function CompanionSurfacePage() {
   // window position and is the only side that knows how much room the display
   // has above the surface.
   const [cardGrowth, setCardGrowth] = useState<CompanionCardGrowth>("up");
+  // Which edge of the display the call's bar rests on. Main's call, like the
+  // growths: it placed the window there and built the canvas for it. Absent
+  // from a shell that predates the docks, which is the bottom.
+  const [dock, setDock] = useState<CompanionDock>("bottom");
   // The creature's box in points and the pill's, which are the surface's whole
   // scale between them. Main sizes the window from both, so they arrive with
   // the state rather than being settings this window reads for itself.
@@ -248,6 +254,7 @@ export function CompanionSurfacePage() {
     const apply = (state: CompanionSurfaceState) => {
       setGrowth(state.growth);
       setCardGrowth(state.cardGrowth);
+      setDock(state.dock ?? "bottom");
       setAvatarBox(state.avatarBox);
       // The creature's box unless the pill has one of its own, which covers a
       // shell that predates the second axis: one box for both is the surface
@@ -570,6 +577,7 @@ export function CompanionSurfacePage() {
     // so the drag is dropped and this move goes on to hit-test normally.
     if (dragRef.current !== null && event.buttons === 0) {
       dragRef.current = null;
+      releaseCompanionSurface();
     }
     // A drag owns the pointer until it is released. Hit-testing through it
     // would collapse the surface the moment the cursor left the pill, which is
@@ -690,14 +698,24 @@ export function CompanionSurfacePage() {
       className="relative h-screen w-screen bg-transparent"
       onMouseMove={onMouseMove}
       onMouseUp={() => {
-        dragRef.current = null;
+        // The hand letting go, which main hears about whether or not the
+        // press moved anything: mid-call, a drag's release is the drop that
+        // docks the bar to an edge, and main is the side that knows whether
+        // this press was one.
+        if (dragRef.current !== null) {
+          dragRef.current = null;
+          releaseCompanionSurface();
+        }
       }}
       onPointerCancel={() => {
         // The capture goes with the pointer when the host takes it, so nothing
         // more reports this press, and a leave that deferred to the drag may
         // never arrive. Give the desktop back the way a leave does; a pointer
         // still on the pill re-arms it on its next move.
-        dragRef.current = null;
+        if (dragRef.current !== null) {
+          dragRef.current = null;
+          releaseCompanionSurface();
+        }
         setHovered(false);
         setInteractive(false);
       }}
@@ -724,6 +742,7 @@ export function CompanionSurfacePage() {
         phase={phase}
         growth={growth}
         cardGrowth={cardGrowth}
+        dock={dock}
         // The two boxes main sized the window for. The surface spends the
         // options one on its own outermost box and uses both to place the pill
         // against a creature that may be a different size from it.

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -763,6 +763,23 @@ export const InCallAssistantTurn: Story = {
   },
 };
 
+/**
+ * Mid-call docked to a side of the display, which stands the bar up.
+ *
+ * The controls run down a column under the creature, their captions and the
+ * activity line stand off it toward the middle of the screen, and the host
+ * builds a canvas symmetric about the creature for it. Compare with `InCall`:
+ * the same controls in the same order, read down rather than across.
+ */
+export const InCallDockedLeft: Story = {
+  args: { phase: "call", call: DEMO_CALL, dock: "left", sharing: true },
+};
+
+/** The same column against the right edge, with everything facing left. */
+export const InCallDockedRight: Story = {
+  args: { phase: "call", call: DEMO_CALL, dock: "right", sharing: true },
+};
+
 /** Mid-call with both mutes on, which is what the two buttons swap to. */
 export const InCallMuted: Story = {
   args: {

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1319,10 +1319,11 @@ describe("the companion surface's call bar docked to a side", () => {
   });
 
   /**
-   * In the column, not beside it: the line is what the bar is saying, and the
-   * captions that stand beside a column are the controls' names.
+   * In the column, not beside it, and running along it: the line is what the
+   * bar is saying, and a line written across would be the widest thing in a
+   * column of icons.
    */
-  test("keeps the activity line in the column, centred over the controls", () => {
+  test("runs the activity line down the column at the row's one length", () => {
     const { container } = render(
       <CompanionSurface
         phase="call"
@@ -1333,9 +1334,9 @@ describe("the companion surface's call bar docked to a side", () => {
     const line = lineOf(container);
     expect(line?.textContent).toContain("Thinking\u2026");
     expect(columnOf(container).contains(line)).toBe(true);
-    expect(line?.className).toContain("text-center");
-    expect(line?.className).not.toContain("translate-x-");
-    expect(line?.style.width).toBe("96px");
+    expect(line?.style.writingMode).toBe("vertical-rl");
+    expect(line?.style.height).toBe("84px");
+    expect(line?.style.width).toBe("");
   });
 
   test("keeps the activity line in the row on the top and bottom", () => {

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1219,6 +1219,146 @@ describe("the companion surface's call bar", () => {
 });
 
 /**
+ * The bar docked to a side of the display, which stands it up. The same
+ * controls in the same order read down a column under the creature, and
+ * everything the row says over or across its controls stands off the column
+ * toward the middle of the screen instead.
+ */
+describe("the companion surface's call bar docked to a side", () => {
+  const columnOf = (container: HTMLElement): HTMLElement => {
+    const column = container.querySelector<HTMLElement>(
+      ".transition-\\[width\\,height\\]",
+    );
+    if (!column) {
+      throw new Error("Expected the column to render");
+    }
+    return column;
+  };
+  const creatureOf = (container: HTMLElement): HTMLElement => {
+    const creature = container.querySelector<HTMLElement>(".size-11");
+    if (!creature) {
+      throw new Error("Expected the creature to render");
+    }
+    return creature;
+  };
+  const lineOf = (container: HTMLElement): HTMLElement | null =>
+    container.querySelector<HTMLElement>("[data-label='line']");
+  const captionsOf = (container: HTMLElement): HTMLElement[] =>
+    Array.from(container.querySelectorAll<HTMLElement>("[data-label='hover']"));
+
+  test("is a column centred on the creature's point", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} dock="left" />,
+    );
+    const column = columnOf(container);
+    expect(column.className).toContain("flex-col");
+    expect(column.style.left).toBe("50%");
+    expect(column.style.top).toBe("50%");
+    expect(column.style.transform).toBe("translate(-50%, -50%)");
+    expect(column.style.height).not.toBe("");
+  });
+
+  test("keeps the row on the top and bottom", () => {
+    for (const dock of ["top", "bottom"] as const) {
+      const { container, unmount } = render(
+        <CompanionSurface phase="call" call={LISTENING_CALL} dock={dock} />,
+      );
+      expect(
+        container.querySelector(".transition-\\[width\\]")?.className,
+      ).toContain("h-11");
+      unmount();
+    }
+  });
+
+  /** Only a call stands the bar up; every other pill hangs off the creature. */
+  test("leaves every other pill a row whatever the dock", () => {
+    const { container } = render(
+      <CompanionSurface phase="watching" watching dock="right" />,
+    );
+    expect(container.querySelector(".transition-\\[width\\]")).not.toBeNull();
+  });
+
+  /**
+   * Half the column back from the centre, then the gap and the creature's
+   * own half box: the step the creature takes beside a row, read up.
+   */
+  test("stands the creature at the column's top end, across the gap", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} dock="right" />,
+    );
+    const half = parseFloat(columnOf(container).style.height) / 2;
+    const creature = creatureOf(container);
+    expect(creature.style.left).toBe("50%");
+    expect(creature.style.top).toBe(`calc(50% - ${half + 34}px)`);
+  });
+
+  test("stands the captions off the column toward the middle of the screen", () => {
+    const left = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} dock="left" />,
+    );
+    for (const caption of captionsOf(left.container)) {
+      expect(caption.className).toContain("translate-x-[calc(50%+22px)]");
+      expect(caption.className).not.toContain("-translate-x-");
+    }
+    left.unmount();
+    const right = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} dock="right" />,
+    );
+    for (const caption of captionsOf(right.container)) {
+      expect(caption.className).toContain("-translate-x-[calc(50%+22px)]");
+    }
+  });
+
+  test("keeps the captions over the controls on a row", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} dock="top" />,
+    );
+    for (const caption of captionsOf(container)) {
+      expect(caption.className).toContain("-translate-y-[calc(50%+22px)]");
+    }
+  });
+
+  test("stands the activity line beside the column, held up", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        call={{ ...LISTENING_CALL, label: "Thinking\u2026" }}
+        dock="left"
+      />,
+    );
+    const line = lineOf(container);
+    expect(line?.textContent).toContain("Thinking\u2026");
+    expect(line?.className).toContain("translate-x-[calc(50%+22px)]");
+    expect(line?.className).toContain("opacity-100");
+  });
+
+  test("keeps the activity line in the row on the top and bottom", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} dock="bottom" />,
+    );
+    expect(lineOf(container)?.style.width).toBe("120px");
+  });
+
+  test("hangs the drawing tools beside the column", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        sharing
+        annotating
+        annotationTool="freehand"
+        dock="left"
+        call={LISTENING_CALL}
+      />,
+    );
+    const strip = container.querySelector<HTMLElement>(
+      "[data-testid='companion-draw-tools']",
+    );
+    expect(strip?.classList).toContain("companion-draw-tools-right");
+    expect(strip?.classList).toContain("flex-col");
+  });
+});
+
+/**
  * What the session is doing, on a bar that does not move while it says it.
  *
  * The line is the one thing in the call row that changes on its own: the

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1318,7 +1318,11 @@ describe("the companion surface's call bar docked to a side", () => {
     }
   });
 
-  test("stands the activity line beside the column, held up", () => {
+  /**
+   * In the column, not beside it: the line is what the bar is saying, and the
+   * captions that stand beside a column are the controls' names.
+   */
+  test("keeps the activity line in the column, centred over the controls", () => {
     const { container } = render(
       <CompanionSurface
         phase="call"
@@ -1328,8 +1332,10 @@ describe("the companion surface's call bar docked to a side", () => {
     );
     const line = lineOf(container);
     expect(line?.textContent).toContain("Thinking\u2026");
-    expect(line?.className).toContain("translate-x-[calc(50%+22px)]");
-    expect(line?.className).toContain("opacity-100");
+    expect(columnOf(container).contains(line)).toBe(true);
+    expect(line?.className).toContain("text-center");
+    expect(line?.className).not.toContain("translate-x-");
+    expect(line?.style.width).toBe("96px");
   });
 
   test("keeps the activity line in the row on the top and bottom", () => {

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -474,11 +474,25 @@ export const FALLBACK_WIDTHS: Record<
 };
 
 /**
- * What a column is drawn at until its body has been measured: one control
- * wide, and the five controls of the handlebar tall. The line is not in the
- * column, since it stands beside it; see {@link CallLine}.
+ * The width of the activity line at the top of a column.
+ *
+ * One width whatever the session is saying, for the reason
+ * {@link CALL_LINE_WIDTH} is one: a column that grew with its words would
+ * breathe on every phase. Narrower than the row's, since the column is one
+ * control wide below it and a line the row's width would make the whole
+ * column a slab; the words are centred and cut short where they run past.
  */
-const FALLBACK_COLUMN = { width: 28, height: 5 * 28 + 4 * 4 };
+const CALL_COLUMN_LINE_WIDTH = 96;
+
+/**
+ * What a column is drawn at until its body has been measured: the line's
+ * width, and the line and the five controls of the handlebar tall, with the
+ * gaps between them.
+ */
+const FALLBACK_COLUMN = {
+  width: CALL_COLUMN_LINE_WIDTH,
+  height: 16 + 5 * 28 + 5 * 4,
+};
 
 /**
  * The keys that make the call row's presses from anywhere on the desktop, as
@@ -2270,25 +2284,25 @@ function CallBody({
  * What the session is doing, in the bar.
  *
  * On a row it is the first thing in the row, one width whatever it says (see
- * {@link CALL_LINE_WIDTH}). On a column the words do not fit across, so they
- * stand beside it as a caption of the controls' kind, held up rather than
- * revealed by the pointer: it is what the bar is saying, not the name of a
- * control. Beside the column's top, which is the end the creature stands at,
- * so the bar reads down from the creature: who is on the call, what they are
- * doing, then the controls. It escapes the column's clipping the way the
- * controls' captions do, by standing absolute in a box that is not
- * positioned, and takes no room in the column's measure.
+ * {@link CALL_LINE_WIDTH}). On a column it is the first thing down the
+ * column, centred over the controls at its own one width (see
+ * {@link CALL_COLUMN_LINE_WIDTH}), so the bar reads down from the creature:
+ * what they are doing, then the controls. In the column rather than beside
+ * it, because it is what the bar is saying and belongs in the bar; the
+ * captions that stand beside a column are the controls' names, revealed by
+ * the pointer, and a line that stood with them would read as one more of
+ * those.
  */
 function CallLine({ vertical, text }: { vertical: boolean; text: string }) {
-  const side = useContext(CaptionSideContext);
-  if (vertical && side !== "above") {
+  if (vertical) {
     return (
-      <Caption
-        label={text}
-        className={`opacity-100 ${CONTROL_CAPTION_BESIDE[side]}`}
-        beak={side === "right" ? "left" : "right"}
+      <span
+        className="shrink-0 truncate text-center text-[12px] text-white/85"
+        style={{ width: CALL_COLUMN_LINE_WIDTH }}
         data-label="line"
-      />
+      >
+        {text}
+      </span>
     );
   }
   return (

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -17,7 +17,14 @@ import {
   X,
 } from "lucide-react";
 import { useReducedMotion } from "motion/react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import type {
   CSSProperties,
   MouseEvent as ReactMouseEvent,
@@ -209,6 +216,39 @@ export type CompanionSurfaceGrowth = "right" | "left";
  * (JARVIS-1548). Main decides, for the same reason it decides the other one.
  */
 export type CompanionSurfaceCardGrowth = "up" | "down";
+
+/**
+ * Which edge of the display a call's bar rests on. See `CompanionDock`.
+ *
+ * `bottom` and `top` keep the bar the row it is everywhere else; `left` and
+ * `right` stand it up as a column under the creature, since a row lying
+ * against a side edge would reach into the middle of the screen. The host
+ * decides, for the same reason it decides the growths: the edge is a fact
+ * about where the window was put, and the canvas a column needs is one the
+ * host has to have built.
+ */
+export type CompanionSurfaceDock = "bottom" | "top" | "left" | "right";
+
+/**
+ * Where a control's caption stands: over the control, or beside it.
+ *
+ * Above is the shape the row is designed around, the way the Dock names an
+ * icon under the pointer. A column has no room above a control that is not
+ * its neighbour's, so its captions stand off to the side, toward the middle
+ * of the screen, where there is a whole display to say the word in.
+ */
+type CaptionSide = "above" | "left" | "right";
+
+/**
+ * Which way the captions go, for every control in the call's bar at once.
+ *
+ * A context rather than a prop on each control, because it is a fact about
+ * the bar: it is a row or a column, and every caption on it stands the same
+ * way. Threading it through six controls to reach the one component that
+ * draws a caption would be six places for one of them to be missed. Provided
+ * around the call's body alone, since no other pill ever stands up.
+ */
+const CaptionSideContext = createContext<CaptionSide>("above");
 
 /** Fallback accent, used until the assistant's own avatar colour is known. */
 const DEFAULT_ACCENT = "#5eead4";
@@ -434,6 +474,13 @@ export const FALLBACK_WIDTHS: Record<
 };
 
 /**
+ * What a column is drawn at until its body has been measured: one control
+ * wide, and the five controls of the handlebar tall. The line is not in the
+ * column, since it stands beside it; see {@link CallLine}.
+ */
+const FALLBACK_COLUMN = { width: 28, height: 5 * 28 + 4 * 4 };
+
+/**
  * The keys that make the call row's presses from anywhere on the desktop, as
  * the caption spells them (`⌥S`). One per control that has a key; the row's
  * other controls have none and are named alone.
@@ -513,6 +560,12 @@ export interface CompanionSurfaceProps {
    * is anchored to. See {@link CompanionSurfaceCardGrowth}.
    */
   cardGrowth?: CompanionSurfaceCardGrowth;
+  /**
+   * Which edge of the display the call's bar rests on. See
+   * {@link CompanionSurfaceDock}. Read only on a call: every other pill hangs
+   * off the creature's side whatever the host remembers.
+   */
+  dock?: CompanionSurfaceDock;
   /**
    * The pill's own element.
    *
@@ -838,6 +891,7 @@ export function CompanionSurface({
   avatarBox = COMPANION_BASE_AVATAR_BOX,
   optionsBox = COMPANION_BASE_AVATAR_BOX,
   cardGrowth = "up",
+  dock = "bottom",
   rootRef,
   restingPillRef,
   avatarRef,
@@ -944,18 +998,25 @@ export function CompanionSurface({
     working || (call !== undefined && ASSISTANT_TURN_PHASES.has(call.phase));
   const reduce = useReducedMotion();
   const contentRef = useRef<HTMLDivElement | null>(null);
-  const [contentWidth, setContentWidth] = useState<number | null>(null);
+  const [contentSize, setContentSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
 
   // The body is measured while it is still clipped, so the pill knows how wide
   // to grow before it starts growing. `scrollWidth` reports the content's own
-  // width regardless of how little the collapsed pill is giving it.
+  // width regardless of how little the collapsed pill is giving it, and
+  // `scrollHeight` its height, which is the length of a column.
   useLayoutEffect(() => {
     const element = contentRef.current;
     if (!element) {
       return;
     }
     const measure = () => {
-      setContentWidth(element.scrollWidth);
+      setContentSize({
+        width: element.scrollWidth,
+        height: element.scrollHeight,
+      });
     };
     measure();
     const observer = new ResizeObserver(measure);
@@ -993,11 +1054,49 @@ export function CompanionSurface({
    */
   const inCall = phase === "call";
 
+  /**
+   * Whether the bar stands up as a column, which a call docked to a side of
+   * the display does. See {@link CompanionSurfaceDock}.
+   */
+  const vertical = inCall && (dock === "left" || dock === "right");
+
+  /**
+   * Where the controls' captions go: over them on a row, and beside them on a
+   * column, on the side facing the middle of the screen.
+   */
+  const captionSide: CaptionSide = !vertical
+    ? "above"
+    : dock === "left"
+      ? "right"
+      : "left";
+
   // The body and the clearance at either end of it, and nothing else: the
   // avatar has a box of its own beside the pill rather than a column inside it.
+  //
+  // A column is measured both ways. Its length is its content's, as the row's
+  // width is, and its width is its content's too: a column of icons is one
+  // icon wide, and a decision with words on its controls is as wide as the
+  // words.
   const width = !expanded
     ? 0
-    : (contentWidth ?? FALLBACK_WIDTHS[phase]) + 2 * INNER_GAP;
+    : vertical
+      ? (contentSize?.width ?? FALLBACK_COLUMN.width) + 2 * INNER_GAP
+      : (contentSize?.width ?? FALLBACK_WIDTHS[phase]) + 2 * INNER_GAP;
+  const height = !expanded
+    ? 0
+    : (contentSize?.height ?? FALLBACK_COLUMN.height) + 2 * INNER_GAP;
+
+  /**
+   * The line the creature stands on, as the CSS edge the surface is drawn
+   * from.
+   *
+   * The host's canvas is not symmetric about the creature, so the line is
+   * measured from the near edge (see `CompanionLayout.lineAt`). Except for a
+   * call docked to a side: a column reaches as far below the creature as
+   * above, so the host builds that canvas symmetric, and the creature stands
+   * on its centre line.
+   */
+  const avatarLine = vertical ? "50%" : lineAt(cardGrowth, 0);
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
   // spot the host positions this window around, and the pill hangs off one side
@@ -1048,13 +1147,15 @@ export function CompanionSurface({
   const style: CSSProperties = inCall
     ? {
         width,
+        // A column has a length of its own; a row is one row tall.
+        ...(vertical ? { height } : {}),
         // **Centred on the creature's own point.** The bar takes the point
         // the creature holds everywhere else and stands on its centre line
         // rather than on its baseline, and the canvas is symmetric about
         // that point, so the host centring the canvas on the display centres
         // the bar.
         left: "50%",
-        top: lineAt(cardGrowth, 0),
+        top: avatarLine,
         transform: "translate(-50%, -50%)",
         transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
       }
@@ -1085,9 +1186,18 @@ export function CompanionSurface({
    * out as the bar unfurls and back as it collapses, over the pill's own
    * duration, so the two read as one object changing shape.
    */
-  const creatureLeft = inCall
-    ? `calc(50% - ${width / 2 + inUnits(avatarHalf + gap)}px)`
-    : "50%";
+  const creatureLeft =
+    inCall && !vertical
+      ? `calc(50% - ${width / 2 + inUnits(avatarHalf + gap)}px)`
+      : "50%";
+  /**
+   * The same step, read up the column: on a side dock the creature stands at
+   * the column's top end, across the gap, and the column is centred on the
+   * creature's point vertically the way the row is horizontally.
+   */
+  const creatureTop = vertical
+    ? `calc(50% - ${height / 2 + inUnits(avatarHalf + gap)}px)`
+    : avatarLine;
 
   return (
     // The box the whole surface is drawn in: the canvas divided by the options
@@ -1117,7 +1227,11 @@ export function CompanionSurface({
         // past that edge, across the gap and over the creature, every time the
         // width lags the content: through the unfurl and instantly on each
         // label reveal.
-        className={`absolute flex h-11 cursor-grab items-center rounded-full transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${!inCall && growth === "left" ? "justify-end" : ""}`}
+        className={`absolute flex cursor-grab items-center rounded-full duration-300 select-none active:cursor-grabbing ${
+          vertical
+            ? "flex-col transition-[width,height] will-change-[width,height]"
+            : "h-11 transition-[width] will-change-[width]"
+        } ${!inCall && growth === "left" ? "justify-end" : ""}`}
         style={style}
         onPointerDown={onSurfacePointerDown}
         onContextMenu={onSurfaceContextMenu}
@@ -1152,15 +1266,26 @@ export function CompanionSurface({
           goes to nothing at rest while the body inside it keeps being
           measured. */}
         <div
-          className="relative flex h-11 shrink-0 items-center"
-          style={{ paddingInline: INNER_GAP }}
+          className={`relative flex shrink-0 items-center ${
+            vertical ? "flex-col" : "h-11"
+          }`}
+          // A column keeps its clearance at its two ends, the way the row
+          // does at its; and the row's own clearance across, since a column
+          // is measured across as well as along.
+          style={
+            vertical
+              ? { paddingBlock: INNER_GAP, paddingInline: INNER_GAP }
+              : { paddingInline: INNER_GAP }
+          }
         >
           <div
             // Not positioned, on purpose: the controls' captions stand above
             // this row and would be clipped by it, and an absolute box escapes
             // its ancestors' clipping only while its containing block is
             // outside them. See `PillButton`.
-            className="flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
+            className={`flex items-center gap-1 overflow-hidden transition-opacity duration-200 ${
+              vertical ? "min-h-0 flex-col" : "min-w-0"
+            }`}
             ref={contentRef}
             // Faded out is not gone: the body stays mounted while collapsed
             // so it can be measured, which would otherwise leave its
@@ -1177,30 +1302,41 @@ export function CompanionSurface({
             }}
           >
             {phase === "call" ? (
-              <CallBody
-                call={call}
-                assistantName={assistantName}
-                watching={watching}
-                watchEnabled={watchEnabled}
-                picking={picking}
-                sharing={sharing}
-                shareEnabled={shareEnabled}
-                sharePicking={sharePicking}
-                annotating={annotating}
-                marked={marked}
-                annotationTool={annotationTool}
-                cardGrowth={cardGrowth}
-                drawToolsRef={drawToolsRef}
-                onAnnotationTool={onAnnotationTool}
-                onControl={onControl}
-                onWatch={onWatch}
-                onTeach={onTeach}
-                onShare={onShare}
-                onStopShare={onStopShare}
-                onAnnotate={onAnnotate}
-                onClearMarks={onClearMarks}
-                shortcuts={shortcuts}
-              />
+              <CaptionSideContext.Provider value={captionSide}>
+                <CallBody
+                  call={call}
+                  assistantName={assistantName}
+                  watching={watching}
+                  watchEnabled={watchEnabled}
+                  picking={picking}
+                  sharing={sharing}
+                  shareEnabled={shareEnabled}
+                  sharePicking={sharePicking}
+                  annotating={annotating}
+                  marked={marked}
+                  annotationTool={annotationTool}
+                  vertical={vertical}
+                  drawToolsPlacement={
+                    vertical
+                      ? dock === "left"
+                        ? "right"
+                        : "left"
+                      : cardGrowth === "up"
+                        ? "above"
+                        : "below"
+                  }
+                  drawToolsRef={drawToolsRef}
+                  onAnnotationTool={onAnnotationTool}
+                  onControl={onControl}
+                  onWatch={onWatch}
+                  onTeach={onTeach}
+                  onShare={onShare}
+                  onStopShare={onStopShare}
+                  onAnnotate={onAnnotate}
+                  onClearMarks={onClearMarks}
+                  shortcuts={shortcuts}
+                />
+              </CaptionSideContext.Provider>
             ) : phase === "dictating" && dictating !== undefined ? (
               <DictatingBody
                 dictating={dictating}
@@ -1260,7 +1396,7 @@ export function CompanionSurface({
           // in the middle of the pill without either one being laid out in
           // terms of the other.
           left: "50%",
-          top: lineAt(cardGrowth, 0),
+          top: avatarLine,
           transform: "translate(-50%, -50%)",
         }}
         onPointerDown={onSurfacePointerDown}
@@ -1314,7 +1450,7 @@ export function CompanionSurface({
         data-companion-name={named ? "shown" : "hidden"}
         style={{
           left: "50%",
-          top: lineAt(cardGrowth, 0),
+          top: avatarLine,
           // Pulled up by the avatar's own half-box (a true point value, so it
           // goes through `inUnits` the way `edgeAt`/`lineAt` do) plus a few
           // flat pixels in the caption's own authored scale: enough that the
@@ -1360,7 +1496,7 @@ export function CompanionSurface({
         restingScale={COMPANION_BASE_AVATAR_BOX / avatarBox}
         style={{
           left: creatureLeft,
-          top: lineAt(cardGrowth, 0),
+          top: creatureTop,
           // Centred on the point the host put the window around, then
           // scaled about that centre by whatever the creature's own size
           // asks for beyond the options scale the box above already carries.
@@ -1377,7 +1513,7 @@ export function CompanionSurface({
           // bar.
           transition: reduce
             ? undefined
-            : "left 300ms cubic-bezier(.2,.8,.2,1)",
+            : "left 300ms cubic-bezier(.2,.8,.2,1), top 300ms cubic-bezier(.2,.8,.2,1)",
         }}
         elementRef={avatarRef}
         onPointerDown={onSurfacePointerDown}
@@ -1444,12 +1580,18 @@ function Caption({
   style,
   label,
   shortcut,
+  beak = "down",
   ...data
 }: {
   className: string;
   style?: CSSProperties;
   label: string;
   shortcut?: string;
+  /**
+   * Which way the beak points, which is toward whatever the caption names:
+   * down from a caption standing over it, sideways from one standing beside.
+   */
+  beak?: "down" | "left" | "right";
 } & Partial<Record<`data-${string}`, string>>) {
   return (
     <span
@@ -1479,10 +1621,21 @@ function Caption({
           from the element entirely, so there is nothing left there for the
           blur to show through. */}
       <span
-        className={`absolute top-full left-1/2 h-1.5 w-2.5 -translate-x-1/2 ${NAME_CAPTION_GLASS}`}
+        className={`absolute ${
+          beak === "down"
+            ? "top-full left-1/2 h-1.5 w-2.5 -translate-x-1/2"
+            : beak === "left"
+              ? "top-1/2 right-full h-2.5 w-1.5 -translate-y-1/2"
+              : "top-1/2 left-full h-2.5 w-1.5 -translate-y-1/2"
+        } ${NAME_CAPTION_GLASS}`}
         style={{
           backgroundColor: NAME_CAPTION_FILL,
-          clipPath: "polygon(0 0, 100% 0, 50% 100%)",
+          clipPath:
+            beak === "down"
+              ? "polygon(0 0, 100% 0, 50% 100%)"
+              : beak === "left"
+                ? "polygon(100% 0, 100% 100%, 0 50%)"
+                : "polygon(0 0, 0 100%, 100% 50%)",
         }}
         aria-hidden
       />
@@ -1929,7 +2082,8 @@ function CallBody({
   annotating,
   marked,
   annotationTool,
-  cardGrowth,
+  vertical,
+  drawToolsPlacement,
   drawToolsRef,
   onAnnotationTool,
   onControl,
@@ -1952,7 +2106,13 @@ function CallBody({
   annotating: boolean;
   marked: boolean;
   annotationTool?: CompanionAnnotationTool;
-  cardGrowth: CompanionSurfaceCardGrowth;
+  /**
+   * Whether the bar is a column. The words the row carries in its line do
+   * not fit across a column, so they stand beside it instead, as a label of
+   * the kind the controls' captions are, and up for as long as the bar is.
+   */
+  vertical: boolean;
+  drawToolsPlacement: DrawToolsPlacement;
   drawToolsRef?: Ref<HTMLDivElement>;
   onAnnotationTool?: (tool: CompanionAnnotationTool) => void;
   onControl?: (action: VoiceActivityControlAction, requestId?: string) => void;
@@ -1973,11 +2133,14 @@ function CallBody({
   if (call === undefined) {
     return (
       <>
-        <span className="ml-1 max-w-[160px] shrink-0 truncate text-[12px] text-white/85">
-          {assistantName === ""
-            ? t("companionSurface.calling")
-            : t("companionSurface.callingNamed", { name: assistantName })}
-        </span>
+        <CallLine
+          vertical={vertical}
+          text={
+            assistantName === ""
+              ? t("companionSurface.calling")
+              : t("companionSurface.callingNamed", { name: assistantName })
+          }
+        />
         <TeachButton
           watching={watching}
           watchEnabled={watchEnabled}
@@ -2020,12 +2183,7 @@ function CallBody({
           to decide how wide to be, and a box that collapsed under pressure
           would measure its own collapsed self: the width and the truncation
           would chase each other down. */}
-      <span
-        className="ml-1 shrink-0 truncate text-[12px] text-white/85"
-        style={{ width: CALL_LINE_WIDTH }}
-      >
-        {line}
-      </span>
+      <CallLine vertical={vertical} text={line} />
       {/* Beside what the session is doing rather than beside the end control:
           two stops next to each other is a misclick that ends the wrong thing,
           and only one of the two is irreversible. Teach rides the call rather
@@ -2056,7 +2214,7 @@ function CallBody({
         annotating={annotating}
         shortcut={shareEnabled ? shortcuts?.draw : undefined}
         tool={annotationTool}
-        cardGrowth={cardGrowth}
+        placement={drawToolsPlacement}
         toolsRef={drawToolsRef}
         onAnnotate={onAnnotate}
         onTool={onAnnotationTool}
@@ -2105,6 +2263,42 @@ function CallBody({
       />
       <EndCallButton onControl={onControl} />
     </>
+  );
+}
+
+/**
+ * What the session is doing, in the bar.
+ *
+ * On a row it is the first thing in the row, one width whatever it says (see
+ * {@link CALL_LINE_WIDTH}). On a column the words do not fit across, so they
+ * stand beside it as a caption of the controls' kind, held up rather than
+ * revealed by the pointer: it is what the bar is saying, not the name of a
+ * control. Beside the column's top, which is the end the creature stands at,
+ * so the bar reads down from the creature: who is on the call, what they are
+ * doing, then the controls. It escapes the column's clipping the way the
+ * controls' captions do, by standing absolute in a box that is not
+ * positioned, and takes no room in the column's measure.
+ */
+function CallLine({ vertical, text }: { vertical: boolean; text: string }) {
+  const side = useContext(CaptionSideContext);
+  if (vertical && side !== "above") {
+    return (
+      <Caption
+        label={text}
+        className={`opacity-100 ${CONTROL_CAPTION_BESIDE[side]}`}
+        beak={side === "right" ? "left" : "right"}
+        data-label="line"
+      />
+    );
+  }
+  return (
+    <span
+      className="ml-1 shrink-0 truncate text-[12px] text-white/85"
+      style={{ width: CALL_LINE_WIDTH }}
+      data-label="line"
+    >
+      {text}
+    </span>
   );
 }
 
@@ -2179,7 +2373,7 @@ function DrawButton({
   annotating,
   shortcut,
   tool,
-  cardGrowth,
+  placement,
   toolsRef,
   onAnnotate,
   onTool,
@@ -2189,7 +2383,7 @@ function DrawButton({
   shortcut?: string;
   /** Absent on a shell with only the pencil, which draws no strip. */
   tool?: CompanionAnnotationTool;
-  cardGrowth: CompanionSurfaceCardGrowth;
+  placement: DrawToolsPlacement;
   toolsRef?: Ref<HTMLDivElement>;
   onAnnotate?: (annotating: boolean) => void;
   onTool?: (tool: CompanionAnnotationTool) => void;
@@ -2214,7 +2408,7 @@ function DrawButton({
       {annotating && tool !== undefined && (
         <DrawTools
           tool={tool}
-          cardGrowth={cardGrowth}
+          placement={placement}
           toolsRef={toolsRef}
           onTool={onTool}
         />
@@ -2224,17 +2418,25 @@ function DrawButton({
 }
 
 /**
+ * Where the drawing tools stand off the Draw control: over or under a row,
+ * beside a column.
+ */
+type DrawToolsPlacement = "above" | "below" | "left" | "right";
+
+/**
  * The drawing tools, in a strip hung off the Draw control: the pencil, a
  * line, a box and a circle, the current one drawn held down.
  *
  * **On the card side of the pill.** The canvas keeps only its own pad on the
  * other side, which a strip standing there would be cut off by, so the strip
  * goes where the introduction's card and the picker go: above the pill where
- * the card grows up, below it where the card grows down. The stylesheet
- * places it against the control by CSS anchor positioning
- * (`.companion-draw-tools`), so nothing here measures where in the row the
- * control ended up, and the row's own clipping cannot take it: its containing
- * block is the row's positioned parent, the same way the captions escape.
+ * the card grows up, below it where the card grows down. Beside a column,
+ * toward the middle of the screen, where its captions go and for the same
+ * reason. The stylesheet places it against the control by CSS anchor
+ * positioning (`.companion-draw-tools`), so nothing here measures where in
+ * the row the control ended up, and the row's own clipping cannot take it:
+ * its containing block is the row's positioned parent, the same way the
+ * captions escape.
  *
  * A press on the strip's own padding is stopped like a press on a control,
  * so the strip is not a drag handle for the surface: it is a menu, and a
@@ -2242,12 +2444,12 @@ function DrawButton({
  */
 function DrawTools({
   tool,
-  cardGrowth,
+  placement,
   toolsRef,
   onTool,
 }: {
   tool: CompanionAnnotationTool;
-  cardGrowth: CompanionSurfaceCardGrowth;
+  placement: DrawToolsPlacement;
   toolsRef?: Ref<HTMLDivElement>;
   onTool?: (tool: CompanionAnnotationTool) => void;
 }) {
@@ -2280,10 +2482,8 @@ function DrawTools({
   ];
   return (
     <div
-      className={`companion-draw-tools absolute flex -translate-x-1/2 items-center gap-0.5 rounded-full border border-white/10 bg-[#17181b]/95 p-0.5 shadow-lg shadow-black/40 ${
-        cardGrowth === "up"
-          ? "companion-draw-tools-above"
-          : "companion-draw-tools-below"
+      className={`companion-draw-tools absolute flex items-center gap-0.5 rounded-full border border-white/10 bg-[#17181b]/95 p-0.5 shadow-lg shadow-black/40 companion-draw-tools-${placement} ${
+        placement === "left" || placement === "right" ? "flex-col" : ""
       }`}
       role="group"
       aria-label={t("companionSurface.drawTools")}
@@ -2460,6 +2660,32 @@ function StopWatchingButton({ onWatch }: { onWatch?: () => void }) {
 const CONTROL_CAPTION_LIFT = "-translate-y-[calc(50%+22px)]";
 
 /**
+ * Where a control's caption sits on a column: standing off the column's edge,
+ * with only its beak crossing into it to point at the control beside it.
+ *
+ * The same 22px, read across: the column is the row stood up, so its half
+ * width is the row's half height, and the caption's own half width carries
+ * its near edge to the column's edge the way its half height carries its
+ * bottom edge to the row's top. Toward the middle of the screen, since a
+ * column stands against a side of the display and the other way is off it.
+ */
+const CONTROL_CAPTION_BESIDE: Record<Exclude<CaptionSide, "above">, string> = {
+  right: "translate-x-[calc(50%+22px)]",
+  left: "-translate-x-[calc(50%+22px)]",
+};
+
+/** The way a caption stands off its control, by which side it stands on. */
+const captionStance = (
+  side: CaptionSide,
+): { className: string; beak: "down" | "left" | "right" } =>
+  side === "above"
+    ? { className: CONTROL_CAPTION_LIFT, beak: "down" }
+    : {
+        className: CONTROL_CAPTION_BESIDE[side],
+        beak: side === "right" ? "left" : "right",
+      };
+
+/**
  * A control in the pill.
  *
  * `label` is always the accessible name. It is drawn in the row only when the
@@ -2517,6 +2743,7 @@ function PillButton({
   className?: string;
   onClick?: () => void;
 }) {
+  const stance = captionStance(useContext(CaptionSideContext));
   return (
     <button
       type="button"
@@ -2549,7 +2776,8 @@ function PillButton({
         <Caption
           label={label}
           shortcut={shortcut}
-          className={`opacity-0 group-hover:opacity-100 ${CONTROL_CAPTION_LIFT}`}
+          className={`opacity-0 group-hover:opacity-100 ${stance.className}`}
+          beak={stance.beak}
           data-label="hover"
         />
       )}

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -474,24 +474,26 @@ export const FALLBACK_WIDTHS: Record<
 };
 
 /**
- * The width of the activity line at the top of a column.
+ * How far the activity line runs down a column, in the units the layout is
+ * authored in.
  *
- * One width whatever the session is saying, for the reason
- * {@link CALL_LINE_WIDTH} is one: a column that grew with its words would
- * breathe on every phase. Narrower than the row's, since the column is one
- * control wide below it and a line the row's width would make the whole
- * column a slab; the words are centred and cut short where they run past.
+ * One length whatever the session is saying, for the reason
+ * {@link CALL_LINE_WIDTH} is one width: a column whose words came and went
+ * would move every control under them on each phase. Shorter than the row's,
+ * since the row spends its width on a line beside five controls and a column
+ * spends its length on one above them, and a longer line would be an empty
+ * stretch above the controls for most of what the session says.
  */
-const CALL_COLUMN_LINE_WIDTH = 96;
+const CALL_COLUMN_LINE_LENGTH = 84;
 
 /**
- * What a column is drawn at until its body has been measured: the line's
- * width, and the line and the five controls of the handlebar tall, with the
- * gaps between them.
+ * What a column is drawn at until its body has been measured: one control
+ * wide, and the line's length and the five controls of the handlebar tall,
+ * with the gaps between them.
  */
 const FALLBACK_COLUMN = {
-  width: CALL_COLUMN_LINE_WIDTH,
-  height: 16 + 5 * 28 + 5 * 4,
+  width: 28,
+  height: CALL_COLUMN_LINE_LENGTH + 5 * 28 + 5 * 4,
 };
 
 /**
@@ -2285,20 +2287,27 @@ function CallBody({
  *
  * On a row it is the first thing in the row, one width whatever it says (see
  * {@link CALL_LINE_WIDTH}). On a column it is the first thing down the
- * column, centred over the controls at its own one width (see
- * {@link CALL_COLUMN_LINE_WIDTH}), so the bar reads down from the creature:
- * what they are doing, then the controls. In the column rather than beside
- * it, because it is what the bar is saying and belongs in the bar; the
- * captions that stand beside a column are the controls' names, revealed by
- * the pointer, and a line that stood with them would read as one more of
- * those.
+ * column and runs along it, the way a title runs down a book's spine: the
+ * same words at one length of their own (see
+ * {@link CALL_COLUMN_LINE_LENGTH}), turned to lie with the controls, so the
+ * column stays one control wide. Written the other way, the line would be
+ * the widest thing in the column by a long way and the whole bar would
+ * widen to it. Top to bottom on either side, which is the way a spine reads.
+ *
+ * In the column rather than beside it, because it is what the bar is saying
+ * and belongs in the bar; the captions that stand beside a column are the
+ * controls' names, revealed by the pointer, and a line that stood with them
+ * would read as one more of those.
  */
 function CallLine({ vertical, text }: { vertical: boolean; text: string }) {
   if (vertical) {
     return (
       <span
-        className="shrink-0 truncate text-center text-[12px] text-white/85"
-        style={{ width: CALL_COLUMN_LINE_WIDTH }}
+        className="mt-1 shrink-0 truncate text-[12px] text-white/85"
+        style={{
+          height: CALL_COLUMN_LINE_LENGTH,
+          writingMode: "vertical-rl",
+        }}
         data-label="line"
       >
         {text}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -503,7 +503,13 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 .companion-draw-tools {
   position-anchor: --companion-draw;
+}
+
+/* Over or under a row, centred on the control. */
+.companion-draw-tools-above,
+.companion-draw-tools-below {
   left: anchor(center);
+  translate: -50% 0;
 }
 
 .companion-draw-tools-above {
@@ -512,6 +518,21 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 .companion-draw-tools-below {
   top: calc(anchor(bottom) + 14px);
+}
+
+/* Beside a column, centred on the control, toward the middle of the screen. */
+.companion-draw-tools-left,
+.companion-draw-tools-right {
+  top: anchor(center);
+  translate: 0 -50%;
+}
+
+.companion-draw-tools-left {
+  right: calc(anchor(left) + 14px);
+}
+
+.companion-draw-tools-right {
+  left: calc(anchor(right) + 14px);
 }
 
 /* The layer the user draws on inside that frame, while a call is being shown

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -406,6 +406,21 @@ export const routeTree = [
         ),
     },
   },
+  // The four edges a call's bar can be dropped on, shown over the display
+  // while the bar is being dragged mid-call. Its own click-through window the
+  // size of the work area, opened and closed by the shell with the drag;
+  // standalone for the reason the frame is.
+  {
+    path: "/assistant/floating/companion-dock-zones",
+    ErrorBoundary: RouteErrorBoundary,
+    HydrateFallback: FloatingHydrateFallback,
+    lazy: {
+      Component: () =>
+        import("@/components/companion-dock-zones-page").then(
+          (m) => m.CompanionDockZonesPage,
+        ),
+    },
+  },
   // The frame's old URL. A shell that predates the rename still opens it,
   // and a renderer newer than its shell has to draw the frame there rather
   // than a not-found page over the desktop. Remove once no shipped shell
@@ -815,9 +830,9 @@ export const routeTree = [
                     path: "personality",
                     lazy: {
                       Component: () =>
-                        import(
-                          "@/domains/settings/pages/personality-page"
-                        ).then((m) => m.SettingsPersonalityPage),
+                        import("@/domains/settings/pages/personality-page").then(
+                          (m) => m.SettingsPersonalityPage,
+                        ),
                     },
                   },
                   { path: "advanced", Component: AdvancedSettingsRedirect },

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -75,6 +75,17 @@ export function moveCompanionBy(dx: number, dy: number): void {
 }
 
 /**
+ * Tell main the hand has let go of the surface.
+ *
+ * After every press, moved or not: main knows whether a drag was in flight
+ * and what its release settles. Mid-call it is the drop that docks the bar
+ * to an edge of the display.
+ */
+export function releaseCompanionSurface(): void {
+  bridge()?.release?.();
+}
+
+/**
  * Ask for a live-voice session, which is what Talk does.
  *
  * The surface is a renderer of its own with no session in it, so the press is

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -405,6 +405,7 @@ declare global {
         onState(callback: (state: CompanionSurfaceState) => void): () => void;
         setInteractive?(interactive: boolean): void;
         moveBy?(dx: number, dy: number): void;
+        release?(): void;
         startVoice?(): void;
         toggleWatch?(pick?: CompanionCapturePick): void;
         listCaptureSources?(): Promise<CompanionCaptureSources>;

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -16,6 +16,7 @@ let savedCompanionIntroSeen: boolean | undefined = undefined;
 let savedCompanionSize: unknown = undefined;
 let savedCompanionAvatarSize: unknown = undefined;
 let savedCompanionOptionsSize: unknown = undefined;
+let savedCompanionCallDock: unknown = undefined;
 let savedTitleBarOverlay: unknown = undefined;
 let workArea = { x: 0, y: 0, width: 1920, height: 1080 };
 const storeSetMock = mock((_key: string, _value: unknown) => {});
@@ -42,6 +43,9 @@ mock.module("electron-store", () => ({
       if (key === "companionOptionsSize") {
         return savedCompanionOptionsSize ?? fallback;
       }
+      if (key === "companionCallDock") {
+        return savedCompanionCallDock ?? fallback;
+      }
       if (key === "titleBarOverlay") return savedTitleBarOverlay ?? fallback;
       if (key === "windows") return savedWindows;
       return fallback;
@@ -65,11 +69,13 @@ mock.module("electron", () => ({
 const {
   restoreBounds,
   track,
+  readCompanionCallDock,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
   readOnboardingActive,
   readTitleBarOverlayTheme,
+  writeCompanionCallDock,
   writeCompanionHidden,
   writeCompanionIntroSeen,
   writeCompanionSize,
@@ -106,6 +112,7 @@ beforeEach(() => {
   savedCompanionSize = undefined;
   savedCompanionAvatarSize = undefined;
   savedCompanionOptionsSize = undefined;
+  savedCompanionCallDock = undefined;
   savedTitleBarOverlay = undefined;
   workArea = { x: 0, y: 0, width: 1920, height: 1080 };
   storeSetMock.mockClear();
@@ -534,6 +541,37 @@ describe("companion surface sizes", () => {
     expect(
       storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
     ).toBe(false);
+  });
+});
+
+/**
+ * The edge the call bar rests on. The same bargain as the sizes: the file is
+ * JSON a user can edit, and the value picks where the window goes, so only an
+ * edge this build knows ever places it.
+ */
+describe("companion call dock", () => {
+  test("absent reads as the bottom, where every build puts the bar", () => {
+    expect(readCompanionCallDock()).toBe("bottom");
+  });
+
+  test("reads the edge the bar was dropped on", () => {
+    savedCompanionCallDock = "left";
+    expect(readCompanionCallDock()).toBe("left");
+  });
+
+  test("an edge this build does not know reads as the bottom", () => {
+    savedCompanionCallDock = "middle";
+    expect(readCompanionCallDock()).toBe("bottom");
+  });
+
+  test("writing persists the edge and skips one already recorded", () => {
+    writeCompanionCallDock("right");
+    expect(storeSetMock).toHaveBeenCalledWith("companionCallDock", "right");
+
+    storeSetMock.mockClear();
+    savedCompanionCallDock = "right";
+    writeCompanionCallDock("right");
+    expect(storeSetMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -2,10 +2,12 @@ import { BrowserWindow, screen, type Rectangle } from "electron";
 import Store from "electron-store";
 
 import {
+  COMPANION_DOCKS,
   COMPANION_SIZE_AXES,
   COMPANION_SIZES,
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
+  type CompanionDock,
   type CompanionSize,
   type CompanionSizeAxis,
   type TitleBarOverlayTheme,
@@ -60,6 +62,11 @@ interface StoreSchema {
   // recorded there would start again from the top every time it did. Optional:
   // absent means it has not run (see `readCompanionIntroSeen`).
   companionIntroSeen?: boolean;
+  // Which edge of the display the companion's call bar rests on, as the user
+  // last dropped it. Main's for the reason the sizes are: the call places the
+  // window and sizes its canvas by it. Optional: absent means the bottom (see
+  // `readCompanionCallDock`).
+  companionCallDock?: CompanionDock;
   // How the Windows title-bar overlay's caption buttons are painted, as last
   // published by the renderer's active theme. A main-process concern for the
   // same reason the flags above are: the overlay's colors are constructor
@@ -210,6 +217,33 @@ export const writeCompanionIntroSeen = (): void => {
 };
 
 /**
+ * Which edge of the display the call bar rests on.
+ *
+ * Validated the way the sizes are: the value picks a placement and a canvas
+ * shape, and one this build does not know would place the bar nowhere. Absent
+ * and unknown both read as the bottom, the one edge every build has put the
+ * bar on.
+ */
+export const readCompanionCallDock = (): CompanionDock => {
+  const stored: CompanionDock | undefined = store().get("companionCallDock");
+  return stored !== undefined && COMPANION_DOCKS.includes(stored)
+    ? stored
+    : "bottom";
+};
+
+/**
+ * Persist the edge the bar was dropped on. No-op when the effective value is
+ * unchanged, so a drop back onto the edge it was already on does not churn the
+ * store file.
+ */
+export const writeCompanionCallDock = (dock: CompanionDock): void => {
+  if (readCompanionCallDock() === dock) {
+    return;
+  }
+  store().set("companionCallDock", dock);
+};
+
+/**
  * Persist one axis's size. No-op only when that axis's own key already says so.
  *
  * The axis's own key rather than the effective value, because that value falls
@@ -318,8 +352,7 @@ const isSavedWindowState = (value: unknown): value is SavedWindowState => {
     isUsableDimension(state.width) &&
     isUsableDimension(state.height) &&
     typeof state.isFullScreen === "boolean" &&
-    (state.isMaximized === undefined ||
-      typeof state.isMaximized === "boolean")
+    (state.isMaximized === undefined || typeof state.isMaximized === "boolean")
   );
 };
 

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -605,6 +605,14 @@ export interface VellumBridge {
     /** Nudge the window, for dragging the surface around the desktop. */
     moveBy(dx: number, dy: number): void;
     /**
+     * The hand has let go of the surface.
+     *
+     * Sent after every press ends, whether or not it moved anything: main
+     * knows whether a drag was in flight and what, if anything, the release
+     * settles. Mid-call, it is the drop that docks the bar to an edge.
+     */
+    release(): void;
+    /**
      * Ask for a live-voice session, which is what Talk does.
      *
      * The surface is its own renderer and holds no session, so the press is

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -195,6 +195,7 @@ export const COMPANION_GET_STATE = "vellum:companion:getState";
 export const COMPANION_STATE_EVENT = "vellum:companion:state";
 export const COMPANION_SET_INTERACTIVE = "vellum:companion:setInteractive";
 export const COMPANION_MOVE_BY = "vellum:companion:moveBy";
+export const COMPANION_RELEASE = "vellum:companion:release";
 export const COMPANION_START_VOICE = "vellum:companion:startVoice";
 export const COMPANION_TOGGLE_WATCH = "vellum:companion:toggleWatch";
 export const COMPANION_LIST_CAPTURE_SOURCES =

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1003,6 +1003,31 @@ export const COMPANION_CARD_GROWTHS = ["up", "down"] as const;
 export type CompanionCardGrowth = (typeof COMPANION_CARD_GROWTHS)[number];
 
 /**
+ * Which edge of the display the call's bar rests on.
+ *
+ * A call takes the surface to an edge the way a meeting's controls sit on one,
+ * and the user picks which by dropping the bar there mid-call. `bottom` is the
+ * shape the bar is designed around. Along the top and bottom the bar keeps its
+ * row; along the sides it stands up as a column, since a row lying against a
+ * side edge would reach into the middle of the screen.
+ *
+ * Main decides and remembers it, for the reason it decides the growths: the
+ * edge is a fact about where the window was put, and the renderer has to be
+ * told it to draw the bar the way the window was placed for.
+ */
+export const COMPANION_DOCKS = ["bottom", "top", "left", "right"] as const;
+
+export type CompanionDock = (typeof COMPANION_DOCKS)[number];
+
+/**
+ * Whether a dock stands the bar up. Named once, since both sides of the bridge
+ * branch on it: main sizes the canvas for the column and the renderer draws
+ * one.
+ */
+export const companionDockIsSide = (dock: CompanionDock): boolean =>
+  dock === "left" || dock === "right";
+
+/**
  * How big the companion is drawn, as a named step rather than a number.
  *
  * Named rather than free, because the avatar's box is not a style: it is the
@@ -2020,6 +2045,26 @@ export interface CompanionSurfaceState {
    * this.
    */
   cardGrowth: CompanionCardGrowth;
+  /**
+   * Which edge of the display the call's bar rests on. See
+   * {@link CompanionDock}.
+   *
+   * Optional, and absence means a shell that predates the docks, which the
+   * renderer reads as `bottom`: the one edge every shell has ever put the bar
+   * on.
+   */
+  dock?: CompanionDock;
+  /**
+   * The edge a call's drag would drop the bar on if the hand let go now, or
+   * absent while no such drag is in flight.
+   *
+   * Set for the length of the drag and cleared on the release, so the window
+   * that shows the four edges as places to drop on knows which one to light.
+   * Absent rather than `null` outside a drag, for the reason `dock` is
+   * optional: a shell that has never heard of docks pushes the same shape as
+   * one between drags.
+   */
+  docking?: CompanionDock;
   /**
    * The avatar's box in points, which is the creature's whole scale.
    *


### PR DESCRIPTION
Closes JARVIS-1791

## What

On a call, the companion's bar can now be dragged to any edge of the display and dropped there. Top and bottom keep the horizontal row; left and right stand the bar up as a column under the creature. The chosen edge is remembered for the next call.

- **Drag mid-call moves freely**, the way an idle drag does. The release is the drop.
- **All four snap areas are shown while the drag is in flight**, in a new click-through window over the display's work area, with the one the drop would land on lit in the call's accent. Main decides which from where the bar is, so the lit edge and the landing edge cannot disagree.
- **Side docks stand the bar up.** Controls run down a column; the captions, the activity line and the drawing tools stand off it toward the middle of the screen.
- **Reset Position mid-call** puts the bar back on the bottom for this call and the next.

## How

- `packages/ipc-contract`: `CompanionDock` and `companionDockIsSide`; `dock` and `docking` on the pushed surface state; a `release` channel and bridge method.
- `packages/electron-desktop`: `companionCallDock` in the window-state store, validated like the sizes.
- `clients/macos`: `geometryFor` takes the dock. A side dock gets a canvas symmetric about the creature (a column reaches as far below it as above, where the ordinary canvas keeps only the near edge below), rebuilt on the way into and out of such a call and on a drop between a side and the top or bottom. `dockedAvatarCentre` and `nearestDock` are pure and tested. The `moveBy` handler arms the dock after a few points of travel during a call; `release` drops. The zones window opens on the first real move and closes on the drop or when the call ends under the drag.
- `clients/web`: the surface takes `dock` and draws a column for a side dock (measured both ways). Captions get a side via a context scoped to the call body, with the beak turned toward the control. `bridgeRect` learned the vertical case so the gap between creature and column stays on the surface. New `companion-dock-zones-page` route. The page sends `release` after every press.

## Not done

- Not verified in the running app: the Storybook stories `InCallDockedLeft` and `InCallDockedRight` show the column and its captions, and the main-process tests cover the drag, drop, canvas rebuild and persistence, but the zones window and the glide to a side edge have not been watched on a real desktop.
- The share picker and the introduction card still place themselves by `cardGrowth` beside a side-docked column. They are not part of a call's usual flow at a side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1ek7Hhr5DGFgdnYsupDi4
