### PR TITLE
fix(daemon): the queue drains carry their sender on the per-turn field only

### DIFF
--- a/assistant/docs/architecture/turn-actor.md
+++ b/assistant/docs/architecture/turn-actor.md
@@ -60,14 +60,21 @@ and restore the prior value afterwards, each guarding the restore so a turn that
 started in between is not clobbered. They are supplying the acting actor for
 their run, and are covered by this contract.
 
-A queued message commits to a run at its drain, not at its enqueue. The drains
-(`drainSingleMessage` and `drainBatch` in `conversation-process.ts`) stamp the
-queued sender the way `processMessage` stamps its committing actor, and re-scope
-the resident history to them, so a turn drained behind another actor's turn
-runs as its sender everywhere the resting actor is read, not only in the
-per-turn snapshot. A steered drain skips the re-scope: its sender owned the
-turn it cut off, and the resident history may carry the in-memory repair of the
-abandoned `tool_use`.
+The queue drains are deliberately not in that set. `drainSingleMessage` and
+`drainBatch` carry the queued sender on the per-turn field and into the run,
+and leave the resting slot alone: at the point they stamp, the drain has not
+yet proved it holds the processing lock. Its `isProcessing()` check is a
+time-of-check guard whose documented backstop is the persist that can still
+fail busy, and the requeue on that path restores the queue and the steer flag
+only. A drain that stamped the slot would therefore leave the conversation
+attributed to a sender whose turn never ran.
+
+The consequence is that a cross-actor drain runs against history scoped for the
+previous actor, because `ensureActorScopedHistory` reads the slot. That is a
+real defect and it is LUM-3344's, which owns the fix: scope the transcript at
+assembly time from the turn's actor, rather than mutating a shared transcript
+and tracking who it was scoped for. Do not close it by making the drain stamp
+the slot first.
 
 `call-controller` keeps its own `trustContext` on its own object and never reads
 the conversation's. It is outside this contract.

--- a/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
+++ b/assistant/src/__tests__/conversation-process-app-control-preactivation.test.ts
@@ -161,12 +161,6 @@ function makeFakeContext(opts: {
       trustClass: "guardian" as const,
       guardianPrincipalId: "user-1",
     },
-    setTrustContext(
-      this: { trustContext?: TrustContext },
-      trustContext: TrustContext | null,
-    ) {
-      this.trustContext = trustContext ?? undefined;
-    },
     setTransportHints() {},
     applyHostEnvFromTransport() {},
     ensureHostProxiesForTurn() {},
@@ -415,10 +409,10 @@ describe("drainQueue preactivation re-add for host-proxy interfaces", () => {
       "U-contact",
     );
     expect(ctx.currentTurnTrustContext?.sourceChannel).toBe("slack");
-    // The drain is where a queued message commits to a run, so the resting
-    // slot names the sender too: history is scoped from it, and a slot still
-    // naming the guardian would hand the contact's turn the guardian's rows.
-    expect(ctx.trustContext).toBe(contactTrust);
+    // The slot itself is left alone; only the turn's view is corrected. A
+    // drain stamping it would attribute the conversation to a sender whose
+    // turn can still lose the processing lock at persist time.
+    expect(ctx.trustContext?.trustClass).toBe("guardian");
   });
 
   test("buildPassthroughBatch refuses to coalesce two channel senders", async () => {

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -450,17 +450,6 @@ async function waitForCondition(
   }
 }
 
-/** Count the history reloads a conversation performs from this point on. */
-function countHistoryReloads(conversation: Conversation): () => number {
-  const originalLoad = conversation.loadFromDb.bind(conversation);
-  let reloads = 0;
-  conversation.loadFromDb = async () => {
-    reloads++;
-    return originalLoad();
-  };
-  return () => reloads;
-}
-
 /**
  * Resolve the Nth pending AgentLoop.run() call. Fires the minimal events
  * that `runAgentLoop` expects (usage + message_complete) so the conversation
@@ -726,176 +715,12 @@ describe("Conversation message queue", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
-  test("a drained turn commits its sender as the resting actor and re-scopes history", async () => {
-    // A contact's channel turn leaves the resting slot, and the resident
-    // history scoped from it, naming the contact. The guardian's message
-    // queued behind that turn must run as the guardian everywhere the slot is
-    // read, not only in the per-turn snapshot: the `<turn_context>` actor
-    // section is derived at turn start and history is scoped from the slot,
-    // so a drain that stamped only the snapshot rendered the guardian's own
-    // web turn as a trusted contact's and hid the guardian's rows from it.
-    const conversation = makeConversation();
-    await conversation.loadFromDb();
-
-    conversation.setTrustContext({
-      trustClass: "trusted_contact",
-      sourceChannel: "slack",
-      requesterExternalUserId: "U-contact",
-    });
-
-    const p1 = conversation.processMessage({
-      content: "msg-1",
-      attachments: [],
-      onEvent: () => {},
-      requestId: "req-1",
-    });
-    await waitForPendingRun(1);
-
-    const guardian = {
-      trustClass: "guardian" as const,
-      sourceChannel: "vellum" as const,
-      requesterExternalUserId: "guardian-principal",
-    };
-    const reloads = countHistoryReloads(conversation);
-    conversation.enqueueMessage({
-      content: "msg-2",
-      requestId: "req-2",
-      trustContext: guardian,
-    });
-
-    await resolveRun(0);
-    await p1;
-    await waitForPendingRun(2);
-
-    // Read while run 2 is in flight: the slot, the snapshot, and the frozen
-    // actor section all describe the guardian, and the history was reloaded
-    // for that scope exactly once.
-    expect(conversation.getTrustContext()).toBe(guardian);
-    expect(conversation.currentTurnTrustContext).toBe(guardian);
-    expect(conversation.currentTurnInboundActorContext).toBeNull();
-    expect(reloads()).toBe(1);
-
-    await resolveRun(1);
-    await new Promise((r) => setTimeout(r, 10));
-  });
-
-  test("a batched drain commits the head's sender as the resting actor", async () => {
-    // Same commitment on the batched path, which coalesces only messages that
-    // share a trust identity, so the head's sender is the batch's actor.
-    const conversation = makeConversation();
-    await conversation.loadFromDb();
-
-    conversation.setTrustContext({
-      trustClass: "trusted_contact",
-      sourceChannel: "slack",
-      requesterExternalUserId: "U-contact",
-    });
-
-    const p1 = conversation.processMessage({
-      content: "msg-1",
-      attachments: [],
-      onEvent: () => {},
-      requestId: "req-1",
-    });
-    await waitForPendingRun(1);
-
-    const guardian = {
-      trustClass: "guardian" as const,
-      sourceChannel: "vellum" as const,
-      requesterExternalUserId: "guardian-principal",
-    };
-    const reloads = countHistoryReloads(conversation);
-    conversation.enqueueMessage({
-      content: "msg-2",
-      requestId: "req-2",
-      trustContext: guardian,
-    });
-    conversation.enqueueMessage({
-      content: "msg-3",
-      requestId: "req-3",
-      trustContext: guardian,
-    });
-
-    await resolveRun(0);
-    await p1;
-    await waitForPendingRun(2);
-
-    // One batched run for both siblings, committed as the guardian.
-    expect(pendingRuns.length).toBe(2);
-    expect(conversation.getTrustContext()).toBe(guardian);
-    expect(conversation.currentTurnTrustContext).toBe(guardian);
-    expect(conversation.currentTurnInboundActorContext).toBeNull();
-    expect(reloads()).toBe(1);
-
-    await resolveRun(1);
-    await new Promise((r) => setTimeout(r, 10));
-  });
-
-  test("a drained turn keeps its sender when the slot moves during the history reload", async () => {
-    // The commit captures the sender before the reload awaits. A writer that
-    // moves the slot inside that await (a wake's stamp, a pointer elevation)
-    // must not become the turn's actor: the history was reloaded for the
-    // sender, and running someone else's trust over it is the escalation.
-    const conversation = makeConversation();
-    await conversation.loadFromDb();
-
-    conversation.setTrustContext({
-      trustClass: "trusted_contact",
-      sourceChannel: "slack",
-      requesterExternalUserId: "U-contact",
-    });
-
-    const p1 = conversation.processMessage({
-      content: "msg-1",
-      attachments: [],
-      onEvent: () => {},
-      requestId: "req-1",
-    });
-    await waitForPendingRun(1);
-
-    const guardian = {
-      trustClass: "guardian" as const,
-      sourceChannel: "vellum" as const,
-      requesterExternalUserId: "guardian-principal",
-    };
-    const intruder = {
-      trustClass: "unknown" as const,
-      sourceChannel: "telegram" as const,
-      requesterExternalUserId: "T-stranger",
-    };
-    conversation.enqueueMessage({
-      content: "msg-2",
-      requestId: "req-2",
-      trustContext: guardian,
-    });
-
-    // The drain's reload is the await the writer lands inside.
-    const originalLoad = conversation.loadFromDb.bind(conversation);
-    let movedDuringReload = false;
-    conversation.loadFromDb = async () => {
-      const result = await originalLoad();
-      conversation.setTrustContext(intruder);
-      movedDuringReload = true;
-      return result;
-    };
-
-    await resolveRun(0);
-    await p1;
-    await waitForPendingRun(2);
-
-    expect(movedDuringReload).toBe(true);
-    expect(conversation.getTrustContext()).toBe(intruder);
-    expect(conversation.currentTurnTrustContext).toBe(guardian);
-    expect(conversation.currentTurnInboundActorContext).toBeNull();
-
-    await resolveRun(1);
-    await new Promise((r) => setTimeout(r, 10));
-  });
-
-  test("a drain whose history reload fails puts the resting actor back", async () => {
-    // A reload that fails starts no turn: the message is requeued for the
-    // next drain, so the slot must not keep naming a sender whose turn never
-    // began, or conversation-level readers report an owner that is not there.
+  test("the turn-context actor section describes the turn's actor, not the conversation's resting actor", async () => {
+    // The drain carries its sender on the per-turn field and leaves the
+    // resting slot naming the previous actor. The actor section is frozen at
+    // turn start, so it has to read the turn's actor: reading the slot is what
+    // told the guardian's own drained turn it was talking to a trusted
+    // contact.
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
@@ -925,39 +750,34 @@ describe("Conversation message queue", () => {
       trustContext: guardian,
     });
 
-    let reloadAttempts = 0;
-    conversation.loadFromDb = async () => {
-      reloadAttempts++;
-      throw new Error("history store exploded");
-    };
-
-    // Finish the first turn; the drain (and its one retry) fail on the reload.
     await resolveRun(0);
     await p1;
-    await waitForCondition(() => reloadAttempts >= 2);
-    await new Promise((r) => setTimeout(r, 20));
+    await waitForPendingRun(2);
 
-    expect(pendingRuns.length).toBe(1);
-    expect(conversation.getQueueDepth()).toBe(1);
+    // Guard the test itself: the slot must disagree with the turn, or the
+    // assertion below passes for the wrong reason.
     expect(conversation.getTrustContext()).toBe(contact);
+    expect(conversation.currentTurnTrustContext).toBe(guardian);
+    // A guardian turn renders no actor section, whatever the slot says.
+    expect(conversation.currentTurnInboundActorContext).toBeNull();
+
+    await resolveRun(1);
+    await new Promise((r) => setTimeout(r, 10));
   });
 
-  test("the turn-context actor section follows the turn's actor when the slot moves before the loop opens", async () => {
-    // The actor section is frozen at turn start from the turn's own actor,
-    // not from the resting slot. The drain stamps the slot and then awaits
-    // (persist) before the loop opens; an out-of-band writer landing in that
-    // window (pointer elevation restore, a wake's restore) moves the slot
-    // without owning the turn, and a read of the slot there would describe
-    // that writer's actor to the model.
+  test("the actor section names the drained contact while the slot holds the guardian", async () => {
+    // The inverse direction, so the assertion above cannot pass merely because
+    // the section is always absent: a contact's message drained behind the
+    // guardian's turn must be described as that contact.
     const conversation = makeConversation();
     await conversation.loadFromDb();
 
-    const contact = {
-      trustClass: "trusted_contact" as const,
-      sourceChannel: "slack" as const,
-      requesterExternalUserId: "U-contact",
+    const guardian = {
+      trustClass: "guardian" as const,
+      sourceChannel: "vellum" as const,
+      requesterExternalUserId: "guardian-principal",
     };
-    conversation.setTrustContext(contact);
+    conversation.setTrustContext(guardian);
 
     const p1 = conversation.processMessage({
       content: "msg-1",
@@ -967,46 +787,28 @@ describe("Conversation message queue", () => {
     });
     await waitForPendingRun(1);
 
-    const guardian = {
-      trustClass: "guardian" as const,
-      sourceChannel: "vellum" as const,
-      requesterExternalUserId: "guardian-principal",
+    const contact = {
+      trustClass: "trusted_contact" as const,
+      sourceChannel: "slack" as const,
+      requesterExternalUserId: "U-contact",
     };
     conversation.enqueueMessage({
       content: "msg-2",
       requestId: "req-2",
-      trustContext: guardian,
+      trustContext: contact,
     });
-
-    // Land the out-of-band slot write inside the drain's window, after its
-    // stamp and before the loop opens: the drain awaits persistUserMessage
-    // there. The resting slot alone is moved; the per-turn snapshot is the
-    // drain's to carry into the run.
-    const originalPersist = conversation.persistUserMessage.bind(conversation);
-    let slotMoved = false;
-    (
-      conversation as unknown as {
-        persistUserMessage: typeof conversation.persistUserMessage;
-      }
-    ).persistUserMessage = async (opts) => {
-      const result = await originalPersist(opts);
-      conversation.setTrustContext(contact);
-      slotMoved = true;
-      return result;
-    };
 
     await resolveRun(0);
     await p1;
     await waitForPendingRun(2);
 
-    // Guard the test itself: the injection must have run, and the slot must
-    // disagree with the turn, or the assertion below passes for the wrong
-    // reason.
-    expect(slotMoved).toBe(true);
-    expect(conversation.getTrustContext()).toBe(contact);
-    expect(conversation.currentTurnTrustContext).toBe(guardian);
-    // The guardian's turn renders no actor section, whatever the slot says.
-    expect(conversation.currentTurnInboundActorContext).toBeNull();
+    expect(conversation.getTrustContext()).toBe(guardian);
+    expect(conversation.currentTurnTrustContext).toBe(contact);
+    expect(conversation.currentTurnInboundActorContext).toMatchObject({
+      trustClass: "trusted_contact",
+      sourceChannel: "slack",
+      canonicalActorIdentity: "U-contact",
+    });
 
     await resolveRun(1);
     await new Promise((r) => setTimeout(r, 10));

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -814,6 +814,45 @@ describe("Conversation message queue", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
+  test("a processMessage turn whose history reload fails puts the resting actor back", async () => {
+    // `processMessage` is the commitment point, so it stamps the slot before
+    // scoping history. A reload that throws starts no turn, and leaving the
+    // stamp would attribute the conversation to a sender that never ran: an
+    // actorless dispatch afterwards (a deferred wake) resolves the resting
+    // slot and would inherit it.
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    const contact = {
+      trustClass: "trusted_contact" as const,
+      sourceChannel: "slack" as const,
+      requesterExternalUserId: "U-contact",
+    };
+    conversation.setTrustContext(contact);
+
+    conversation.loadFromDb = async () => {
+      throw new Error("history store exploded");
+    };
+
+    const guardian = {
+      trustClass: "guardian" as const,
+      sourceChannel: "vellum" as const,
+      requesterExternalUserId: "guardian-principal",
+    };
+    await expect(
+      conversation.processMessage({
+        content: "msg-1",
+        attachments: [],
+        onEvent: () => {},
+        requestId: "req-1",
+        trustContext: guardian,
+      }),
+    ).rejects.toThrow("history store exploded");
+
+    expect(conversation.getTrustContext()).toBe(contact);
+    expect(pendingRuns.length).toBe(0);
+  });
+
   test("a processMessage turn keeps its turn-start trust when the slot moves before the loop opens", async () => {
     // processMessage is the third turn entry point, and the one a web turn
     // takes on an idle conversation (the route only enqueues while

--- a/assistant/src/__tests__/drain-kick-guard.test.ts
+++ b/assistant/src/__tests__/drain-kick-guard.test.ts
@@ -79,8 +79,6 @@ function makeFakeConversation(
     getTurnInterfaceContext: () => null,
     setTurnInterfaceContext: () => {},
     setTransportHints: () => {},
-    setTrustContext: () => {},
-    ensureActorScopedHistory: async () => {},
     emitActivityState: () => {
       if (activityFailures > 0) {
         activityFailures -= 1;

--- a/assistant/src/__tests__/drain-requeue-on-contention.test.ts
+++ b/assistant/src/__tests__/drain-requeue-on-contention.test.ts
@@ -78,12 +78,6 @@ function makeFakeConversation(options: {
     setTransportHints: () => {
       mutationCalls.push("setTransportHints");
     },
-    setTrustContext: () => {
-      mutationCalls.push("setTrustContext");
-    },
-    ensureActorScopedHistory: async () => {
-      mutationCalls.push("ensureActorScopedHistory");
-    },
     emitActivityState: () => {
       mutationCalls.push("emitActivityState");
     },

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -1840,6 +1840,7 @@ export async function processMessage(
     metadata: callerMetadata,
     trustContext: committingTrustContext,
   } = options;
+  const priorRestingTrust = restingTrust(conversation);
   if (committingTrustContext) {
     conversation.setTrustContext(committingTrustContext);
   }
@@ -1852,7 +1853,24 @@ export async function processMessage(
   // land in.
   const turnTrustContext = restingTrust(conversation);
   conversation.currentTurnTrustContext = turnTrustContext;
-  await conversation.ensureActorScopedHistory();
+  try {
+    await conversation.ensureActorScopedHistory();
+  } catch (err) {
+    // This is the commitment point for the turn, so the stamp above is
+    // correct, but a reload that fails starts no turn: the conversation must
+    // not be left attributed to a sender that never ran. Guarded on identity
+    // so a writer that legitimately moved the slot across the await keeps it.
+    // Only the resting slot needs putting back; `runAgentLoopImpl` re-seeds
+    // the per-turn field at the head of every turn, so no later dispatch can
+    // inherit it.
+    if (
+      committingTrustContext &&
+      restingTrust(conversation) === committingTrustContext
+    ) {
+      conversation.setTrustContext(priorRestingTrust ?? null);
+    }
+    throw err;
+  }
   conversation.currentTurnAuthContext = conversation.authContext;
   conversation.currentTurnSourceActorPrincipalId =
     sourceActorPrincipalId ?? conversation.authContext?.actorPrincipalId;

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -646,52 +646,6 @@ export async function kickQueueDrain(
   }
 }
 
-/**
- * Commit `actor` as the actor the turn about to start runs for: the resting
- * slot names them, so the history is scoped to them and every reader of the
- * slot (the `<turn_context>` actor section, memory retrieval, the Slack
- * transcript filters) describes them rather than whoever sent last, and the
- * per-turn snapshot then reads back that same actor, which is also returned
- * for callers that must hold it in a local. A caller with no actor of its own
- * (internal dispatch, or a queued message whose enqueue found the slot empty)
- * passes `undefined`, and the resting actor stands.
- *
- * `reloadHistory` is off only for a steered drain, which keeps its resident
- * history: a steer comes from the actor whose turn it cut off, and that
- * history may hold the in-memory repair of the abandoned `tool_use`, which a
- * reload would discard.
- *
- * The committed actor is captured and snapshotted before the reload awaits:
- * the slot is writable out-of-band across that await (a wake's stamp, a
- * pointer elevation), and a read after it would hand the turn that writer's
- * actor. A reload that fails starts no turn, so the slot is put back to what
- * it held before, guarded so a writer that legitimately moved it in between
- * is left alone.
- */
-async function commitTurnActor(
-  conversation: Conversation,
-  actor: TrustContext | undefined,
-  options: { reloadHistory: boolean },
-): Promise<TrustContext | undefined> {
-  const prior = restingTrust(conversation);
-  if (actor) {
-    conversation.setTrustContext(actor);
-  }
-  const turnTrustContext = restingTrust(conversation);
-  conversation.currentTurnTrustContext = turnTrustContext;
-  if (options.reloadHistory) {
-    try {
-      await conversation.ensureActorScopedHistory();
-    } catch (err) {
-      if (actor && restingTrust(conversation) === actor) {
-        conversation.setTrustContext(prior ?? null);
-      }
-      throw err;
-    }
-  }
-  return turnTrustContext;
-}
-
 async function drainSingleMessage(
   conversation: Conversation,
   next: QueuedMessage,
@@ -794,12 +748,11 @@ async function drainSingleMessage(
   // a different actor's context if a concurrent request mutates the live fields.
   // Trust comes from the queued message, not the live slot: the slot holds
   // whichever actor sent most recently, which is this sender only when nobody
-  // else sent while this message waited.
-  const turnTrustContext = await commitTurnActor(
-    conversation,
-    next.trustContext,
-    { reloadHistory: !steered },
-  );
+  // else sent while this message waited. Held in a local as well, because the
+  // field is writable out-of-band across the awaits between here and the loop
+  // call below.
+  const turnTrustContext = next.trustContext ?? restingTrust(conversation);
+  conversation.currentTurnTrustContext = turnTrustContext;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
 
@@ -1407,12 +1360,9 @@ async function drainBatch(
   // The head's trust governs the batch, which is sound only because
   // `buildPassthroughBatch` refuses to coalesce messages from different
   // actors; without that boundary this would run a tail under the head's
-  // trust.
-  const turnTrustContext = await commitTurnActor(
-    conversation,
-    head.trustContext,
-    { reloadHistory: true },
-  );
+  // trust. Held in a local for the same reason as the single-message drain.
+  const turnTrustContext = head.trustContext ?? restingTrust(conversation);
+  conversation.currentTurnTrustContext = turnTrustContext;
   conversation.currentTurnChannelCapabilities =
     conversation.channelCapabilities;
 
@@ -1890,16 +1840,19 @@ export async function processMessage(
     metadata: callerMetadata,
     trustContext: committingTrustContext,
   } = options;
+  if (committingTrustContext) {
+    conversation.setTrustContext(committingTrustContext);
+  }
   // Held in a local as well as on the conversation: the field is writable
   // out-of-band while this turn is in flight (`agent-wake` stamps it and
   // restores the prior value in a `finally`), so reading it back at the agent
   // loop call below would reintroduce the late read this capture exists to
-  // avoid. The local is what the loop runs under.
-  const turnTrustContext = await commitTurnActor(
-    conversation,
-    committingTrustContext,
-    { reloadHistory: true },
-  );
+  // avoid. The local is what the loop runs under. Captured before the history
+  // reload for the same reason: that await is one of the windows a writer can
+  // land in.
+  const turnTrustContext = restingTrust(conversation);
+  conversation.currentTurnTrustContext = turnTrustContext;
+  await conversation.ensureActorScopedHistory();
   conversation.currentTurnAuthContext = conversation.authContext;
   conversation.currentTurnSourceActorPrincipalId =
     sourceActorPrincipalId ?? conversation.authContext?.actorPrincipalId;


### PR DESCRIPTION
Part of LUM-3344
Part of LUM-3582

## TL;DR

#42517 shipped two changes. One fixes LUM-3579 and stays. The other made the queue drains stamp the conversation's resting trust slot and reload history before the turn ran, which is the shape LUM-3344 exists to reject. This removes that half.

Not a revert of the merge commit: the actor-section fix and its coverage are kept, so this is a forward change off current main.

## Why the drain half has to go

LUM-3344 closed #40914 for this approach and named the window:

> the drain-level stamp ran before the processing lock was provably held and `requeueDrainedMessages` restores only the queue and the steer flag, so a message that lost the lock left the conversation stamped for a sender that never ran.

That window is in what merged. `drainSingleMessage`'s `isProcessing()` check is a time-of-check guard whose documented backstop is the persist, which can still throw `CONVERSATION_BUSY_MESSAGE` ("Another turn took the lock between this drain's dequeue and its persist"). That path calls `requeueDrainedMessages`, which puts the message back and emits `message_requeued`, and touches no trust. So a queued contact message could leave the conversation attributed to the contact, with the resident history scoped to the contact, for a turn that never ran. The guarded restore added in the follow-up commit covers a reload that throws, not a persist that loses the lock.

Both review bots flagged the adjacent mid-await race independently on that PR, which LUM-3344 also predicted would happen at each placement.

## What changes

| | Before this PR | After |
| --- | --- | --- |
| Drained turn's actor | per-turn field, and the resting slot | per-turn field only, as since #40458 |
| Resident history on a cross-actor drain | reloaded for the queued sender | left as the previous turn loaded it, which is LUM-3344's open defect |
| Conversation attribution after a drain that loses the lock | names a sender whose turn never ran | unchanged by the drain |
| `<turn_context>` actor section | the turn's actor | unchanged, the turn's actor |
| `processMessage` | stamp and snapshot via the shared helper | its own inline stamp and snapshot, as before #42517 |

The cross-actor history leak is real and stays open deliberately. It is LUM-3344's, its design is settled there (scope the transcript at assembly time from the turn's actor, as a pure function of rows plus actor), and closing it by stamping the slot first is what that ticket refuses.

## What is kept

`resolveTurnInboundActorContext(turnOrRestingTrust(ctx))` in `conversation-agent-loop.ts`. This is the actual LUM-3579 fix: the actor section was reading the resting slot raw, which is why a guardian's drained turn was described to the model as a trusted contact. It reads the per-turn field the drains have set since #40458, so it never needed drain-side stamping.

One thing is also kept from the removed helper: both drains and `processMessage` capture the turn's trust into a local before the awaits that precede the agent-loop call, rather than re-reading the field afterwards. That was the Codex P1 on #42517 and it is correct independently of where the stamp lives. Restoring the literal pre-#42517 lines would have reintroduced a known late read.

## Tests

Four tests asserting the drain stamps the slot or reloads history are removed, since they pinned the behaviour being withdrawn. Two replace them, both on a real `Conversation`:

- a guardian's message drained behind a contact's turn: the slot still names the contact, the turn names the guardian, and no actor section is rendered.
- the inverse, so the first cannot pass merely because the section is always absent: a contact's message drained behind the guardian's turn is described as that contact.

Both fail with the actor section reading `ctx.trustContext` and pass with `turnOrRestingTrust(ctx)`, verified by reinstating the old read locally.

`conversation-process-app-control-preactivation.test.ts` goes back to asserting the drain leaves the slot alone, with the reason in-line. Two drain doubles lose the methods they only needed while the drains called them.

14 suites covering the drain, agent-loop, wake, voice and slash paths pass per file. Typecheck, eslint and the pinned prettier are clean.

## Doc

`turn-actor.md` said the drains stamp for a run. It now says they deliberately do not, gives the lock reason, and points the history question at LUM-3344 with an explicit "do not close it by making the drain stamp the slot first".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->