### PR TITLE
Report requested and effective ACP spawn models

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -596,6 +596,16 @@ paths:
                     type: string
                   agent:
                     type: string
+                  requestedModel:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: The model explicitly requested for this spawn, if any.
+                  effectiveModel:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: The top-level session model reported by the ACP adapter, if any.
                   modelWarning:
                     description: Why the requested model was not applied. The session is running on the agent's own model.
                     type: string
@@ -603,6 +613,8 @@ paths:
                   - acpSessionId
                   - protocolSessionId
                   - agent
+                  - requestedModel
+                  - effectiveModel
                 additionalProperties: false
   /v1/activation/dismiss:
     post:

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -246,11 +246,12 @@ describe("AcpSessionManager: model selection at spawn", () => {
   }): Promise<{
     state: AcpSessionState;
     sent: AssistantEvent[];
+    effectiveModel?: string;
     modelWarning?: string;
   }> {
     const manager = new AcpSessionManager(5);
     const sent: AssistantEvent[] = [];
-    const { acpSessionId, modelWarning } = await manager.spawn(
+    const { acpSessionId, effectiveModel, modelWarning } = await manager.spawn(
       opts.agentId ?? "agent-model",
       { command: "echo", args: ["hi"], model: opts.agentModel },
       "task",
@@ -262,6 +263,7 @@ describe("AcpSessionManager: model selection at spawn", () => {
     return {
       state: manager.getStatus(acpSessionId) as AcpSessionState,
       sent,
+      effectiveModel,
       modelWarning,
     };
   }
@@ -274,9 +276,12 @@ describe("AcpSessionManager: model selection at spawn", () => {
   test("state carries the model and options the adapter reported", async () => {
     scriptedConfigOptions = [[modelOption("opus")]];
 
-    const { state } = await spawnWithModel({ conversationId: "conv-report" });
+    const { effectiveModel, state } = await spawnWithModel({
+      conversationId: "conv-report",
+    });
 
     expect(state.model).toBe("opus");
+    expect(effectiveModel).toBe("opus");
     expect(state.availableModels).toEqual(MODEL_OPTION_MODELS);
     // Nothing was requested and the adapter is already on a model, so it was
     // never asked to change.
@@ -372,12 +377,13 @@ describe("AcpSessionManager: model selection at spawn", () => {
     // The adapter resolves the alias it was handed to a full model id.
     setConfigOptionResult = [modelOption("claude-opus-4-5")];
 
-    const { state } = await spawnWithModel({
+    const { effectiveModel, state } = await spawnWithModel({
       conversationId: "conv-pin",
       requestedModel: "opus",
     });
 
     expect(state.model).toBe("claude-opus-4-5");
+    expect(effectiveModel).toBe("claude-opus-4-5");
   });
 
   test("an inherited model the adapter refuses warns nobody", async () => {
@@ -417,6 +423,7 @@ describe("AcpSessionManager: model selection at spawn", () => {
     expect(result.modelWarning).toBe(
       "Invalid value for config option model: nope",
     );
+    expect(result.effectiveModel).toBe("opus");
     const state = manager.getStatus(result.acpSessionId) as AcpSessionState;
     // The run is live on whatever the adapter chose for itself.
     expect(state.status).toBe("running");

--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -246,23 +246,26 @@ describe("AcpSessionManager: model selection at spawn", () => {
   }): Promise<{
     state: AcpSessionState;
     sent: AssistantEvent[];
+    requestedModel?: string;
     effectiveModel?: string;
     modelWarning?: string;
   }> {
     const manager = new AcpSessionManager(5);
     const sent: AssistantEvent[] = [];
-    const { acpSessionId, effectiveModel, modelWarning } = await manager.spawn(
-      opts.agentId ?? "agent-model",
-      { command: "echo", args: ["hi"], model: opts.agentModel },
-      "task",
-      "/tmp",
-      opts.conversationId,
-      (msg) => sent.push(msg),
-      opts.requestedModel ? { model: opts.requestedModel } : {},
-    );
+    const { acpSessionId, requestedModel, effectiveModel, modelWarning } =
+      await manager.spawn(
+        opts.agentId ?? "agent-model",
+        { command: "echo", args: ["hi"], model: opts.agentModel },
+        "task",
+        "/tmp",
+        opts.conversationId,
+        (msg) => sent.push(msg),
+        opts.requestedModel ? { model: opts.requestedModel } : {},
+      );
     return {
       state: manager.getStatus(acpSessionId) as AcpSessionState,
       sent,
+      requestedModel,
       effectiveModel,
       modelWarning,
     };
@@ -286,6 +289,24 @@ describe("AcpSessionManager: model selection at spawn", () => {
     // Nothing was requested and the adapter is already on a model, so it was
     // never asked to change.
     expect(setConfigOptionCalls).toEqual([]);
+  });
+
+  test("the spawn result owns requested-model normalization", async () => {
+    scriptedConfigOptions = [[modelOption("default")]];
+
+    const manager = new AcpSessionManager(5);
+    const result = await manager.spawn(
+      "agent-model",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "conv-normalized-request",
+      () => {},
+      { model: "  opus  " },
+    );
+
+    expect(result.requestedModel).toBe("opus");
+    expect(selectedValue()).toBe("opus");
   });
 
   test("the model event follows the spawned event", async () => {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -284,6 +284,7 @@ export class AcpSessionManager {
    * The prompt is fired in the background — results stream via sessionUpdate
    * callbacks and completion/error messages are sent when the prompt finishes.
    *
+   * `requestedModel` is the normalized explicit request this spawn acted on.
    * `effectiveModel` is the model the adapter reports for the live session.
    * `modelWarning` comes back when the adapter refused the model the session
    * was asked for: the caller relays the reason rather than treating the spawn
@@ -301,6 +302,7 @@ export class AcpSessionManager {
   ): Promise<{
     acpSessionId: string;
     protocolSessionId: string;
+    requestedModel?: string;
     effectiveModel?: string;
     modelWarning?: string;
   }> {
@@ -431,6 +433,7 @@ export class AcpSessionManager {
     return {
       acpSessionId,
       protocolSessionId: state.acpSessionId,
+      requestedModel,
       effectiveModel: state.model,
       ...(modelWarning ? { modelWarning } : {}),
     };

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -284,9 +284,10 @@ export class AcpSessionManager {
    * The prompt is fired in the background — results stream via sessionUpdate
    * callbacks and completion/error messages are sent when the prompt finishes.
    *
+   * `effectiveModel` is the model the adapter reports for the live session.
    * `modelWarning` comes back when the adapter refused the model the session
-   * was asked for: the run is live on the adapter's own default, and the
-   * caller relays the reason rather than treating the spawn as failed.
+   * was asked for: the caller relays the reason rather than treating the spawn
+   * as failed.
    */
   async spawn(
     agentId: string,
@@ -300,6 +301,7 @@ export class AcpSessionManager {
   ): Promise<{
     acpSessionId: string;
     protocolSessionId: string;
+    effectiveModel?: string;
     modelWarning?: string;
   }> {
     this.assertCapacity();
@@ -429,6 +431,7 @@ export class AcpSessionManager {
     return {
       acpSessionId,
       protocolSessionId: state.acpSessionId,
+      effectiveModel: state.model,
       ...(modelWarning ? { modelWarning } : {}),
     };
   }

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -29,6 +29,8 @@ Claude runs on Opus unless the user names a model; every other agent starts on i
 
 When the user does name one, pass it as `model` on `acp_spawn`. Model names are the agent's own vocabulary, not Assistant model ids: an alias such as `default`, `sonnet`, `opus`, `haiku`, `fable`, or `opusplan` for Claude, or a full model id. Pass what the user said and let the agent resolve it.
 
+The spawn result reports `requestedModel` and `effectiveModel`. Treat `effectiveModel` as authoritative for the top-level ACP session. Never infer that model from the task text or from a nested subagent. When `requestedModel` is non-null and differs from `effectiveModel`, state which model the session is actually running on and relay `modelWarning` when present.
+
 If the agent refuses the model, or advertises no model selector, the spawn result says so: relay it in one sentence and carry on, because the session is live on the agent's own model.
 
 A session runs on the model it started on, so a different model means a new `acp_spawn`. A standing default per agent lives in the config at `acp.agents.<id>.model`.

--- a/assistant/src/config/bundled-skills/acp/TOOLS.json
+++ b/assistant/src/config/bundled-skills/acp/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "acp_spawn",
-      "description": "Spawn an external coding agent (e.g. Claude Code, Codex) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`) and `codex` (`codex-acp`); the assistant resolves the agent id to the right binary. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant installs it once via a sandboxed bun global install and proceeds in the same call; if that fails (e.g. bun unavailable), an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries.",
+      "description": "Spawn an external coding agent (e.g. Claude Code, Codex) via ACP to work on a task. Default profiles ship for `claude` (`claude-agent-acp`) and `codex` (`codex-acp`); the assistant resolves the agent id to the right binary. The result reports `requestedModel` and the adapter-reported `effectiveModel`; treat `effectiveModel` as authoritative for the top-level ACP session. The agent runs as a subprocess and streams results back. Use this when you want to delegate a coding task to an external agent that has its own tools, file editing, and terminal access. If a default agent's binary is missing, the assistant installs it once via a sandboxed bun global install and proceeds in the same call; if that fails (e.g. bun unavailable), an actionable install hint is returned - do NOT alter `agents.<id>.command` to swap binaries.",
       "category": "orchestration",
       "risk": "high",
       "input_schema": {

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -63,12 +63,14 @@ let fakeInMemorySessions: FakeSessionState[] = [];
 interface SpawnResult {
   acpSessionId: string;
   protocolSessionId: string;
+  effectiveModel?: string;
   modelWarning?: string;
 }
 
 const DEFAULT_SPAWN_RESULT: SpawnResult = {
   acpSessionId: "acp-route-session",
   protocolSessionId: "proto-route-session",
+  effectiveModel: "opus",
 };
 let spawnResult: SpawnResult = DEFAULT_SPAWN_RESULT;
 const spawnMock = mock(async () => spawnResult);
@@ -651,6 +653,8 @@ describe("POST /v1/acp/spawn: sandboxed bun auto-install on missing binary", () 
       acpSessionId: "acp-route-session",
       protocolSessionId: "proto-route-session",
       agent: "claude",
+      requestedModel: null,
+      effectiveModel: "opus",
     });
     expect(spawnMock).toHaveBeenCalledTimes(1);
     // The real adapter binary is spawned, not a `bun x` wrapper.
@@ -755,7 +759,9 @@ describe("POST /v1/acp/spawn: sandboxed bun auto-install on missing binary", () 
 describe("POST /v1/acp/spawn: model selection", () => {
   test("threads the requested model to the session manager", async () => {
     const handler = getSpawnHandler();
-    await handler({ body: { ...SPAWN_BODY, model: "opus" } });
+    const body = (await handler({
+      body: { ...SPAWN_BODY, model: "opus" },
+    })) as Record<string, unknown>;
 
     expect(confirmationRequests).toHaveLength(1);
     expect(confirmationRequests[0]?.input).toEqual({
@@ -768,6 +774,9 @@ describe("POST /v1/acp/spawn: model selection", () => {
     expect((spawnMock.mock.calls[0] as unknown[])[6]).toEqual({
       model: "opus",
     });
+
+    expect(body.requestedModel).toBe("opus");
+    expect(body.effectiveModel).toBe("opus");
   });
 
   test("a spawn that names no model asks the manager for none", async () => {
@@ -800,6 +809,8 @@ describe("POST /v1/acp/spawn: model selection", () => {
       acpSessionId: "acp-route-session",
       protocolSessionId: "proto-route-session",
       agent: "claude",
+      requestedModel: "nope",
+      effectiveModel: "opus",
       modelWarning: "Invalid value for config option model: nope",
     });
   });

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -63,6 +63,7 @@ let fakeInMemorySessions: FakeSessionState[] = [];
 interface SpawnResult {
   acpSessionId: string;
   protocolSessionId: string;
+  requestedModel?: string;
   effectiveModel?: string;
   modelWarning?: string;
 }
@@ -73,7 +74,13 @@ const DEFAULT_SPAWN_RESULT: SpawnResult = {
   effectiveModel: "opus",
 };
 let spawnResult: SpawnResult = DEFAULT_SPAWN_RESULT;
-const spawnMock = mock(async () => spawnResult);
+const spawnMock = mock(async (...args: unknown[]) => {
+  const options = args[6] as { model?: string } | undefined;
+  return {
+    ...spawnResult,
+    requestedModel: options?.model?.trim() || undefined,
+  };
+});
 
 const defaultSteerOrResumeImpl = async (
   _id: string,
@@ -777,6 +784,18 @@ describe("POST /v1/acp/spawn: model selection", () => {
 
     expect(body.requestedModel).toBe("opus");
     expect(body.effectiveModel).toBe("opus");
+  });
+
+  test("reports the manager-normalized requested model", async () => {
+    const handler = getSpawnHandler();
+    const body = (await handler({
+      body: { ...SPAWN_BODY, model: "  opus  " },
+    })) as Record<string, unknown>;
+
+    expect((spawnMock.mock.calls[0] as unknown[])[6]).toEqual({
+      model: "  opus  ",
+    });
+    expect(body.requestedModel).toBe("opus");
   });
 
   test("a spawn that names no model asks the manager for none", async () => {

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -287,15 +287,16 @@ async function spawnSession({ body, abortSignal }: RouteHandlerArgs) {
   );
 
   const manager = getAcpSessionManager();
-  const { acpSessionId, protocolSessionId, modelWarning } = await manager.spawn(
-    agent,
-    agentConfig,
-    task,
-    cwd,
-    conversationId,
-    broadcastMessage,
-    { model },
-  );
+  const { acpSessionId, protocolSessionId, effectiveModel, modelWarning } =
+    await manager.spawn(
+      agent,
+      agentConfig,
+      task,
+      cwd,
+      conversationId,
+      broadcastMessage,
+      { model },
+    );
 
   log.info({ acpSessionId, protocolSessionId, agent }, "ACP spawn succeeded");
   // A refused model is a warning, not a failed spawn: the session is live on
@@ -304,6 +305,8 @@ async function spawnSession({ body, abortSignal }: RouteHandlerArgs) {
     acpSessionId,
     protocolSessionId,
     agent,
+    requestedModel: model?.trim() || null,
+    effectiveModel: effectiveModel ?? null,
     ...(modelWarning ? { modelWarning } : {}),
   };
 }
@@ -679,6 +682,16 @@ export const ROUTES: RouteDefinition[] = [
       acpSessionId: z.string(),
       protocolSessionId: z.string(),
       agent: z.string(),
+      requestedModel: z
+        .string()
+        .nullable()
+        .describe("The model explicitly requested for this spawn, if any."),
+      effectiveModel: z
+        .string()
+        .nullable()
+        .describe(
+          "The top-level session model reported by the ACP adapter, if any.",
+        ),
       modelWarning: z
         .string()
         .optional()

--- a/assistant/src/runtime/routes/acp-routes.ts
+++ b/assistant/src/runtime/routes/acp-routes.ts
@@ -287,16 +287,21 @@ async function spawnSession({ body, abortSignal }: RouteHandlerArgs) {
   );
 
   const manager = getAcpSessionManager();
-  const { acpSessionId, protocolSessionId, effectiveModel, modelWarning } =
-    await manager.spawn(
-      agent,
-      agentConfig,
-      task,
-      cwd,
-      conversationId,
-      broadcastMessage,
-      { model },
-    );
+  const {
+    acpSessionId,
+    protocolSessionId,
+    requestedModel,
+    effectiveModel,
+    modelWarning,
+  } = await manager.spawn(
+    agent,
+    agentConfig,
+    task,
+    cwd,
+    conversationId,
+    broadcastMessage,
+    { model },
+  );
 
   log.info({ acpSessionId, protocolSessionId, agent }, "ACP spawn succeeded");
   // A refused model is a warning, not a failed spawn: the session is live on
@@ -305,7 +310,7 @@ async function spawnSession({ body, abortSignal }: RouteHandlerArgs) {
     acpSessionId,
     protocolSessionId,
     agent,
-    requestedModel: model?.trim() || null,
+    requestedModel: requestedModel ?? null,
     effectiveModel: effectiveModel ?? null,
     ...(modelWarning ? { modelWarning } : {}),
   };

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -125,9 +125,15 @@ const spawnMock = mock(
     _parentConversationId: string,
     _sendToVellum: (msg: unknown) => void,
     _options?: { parentToolUseId?: string; model?: string },
-  ) => ({
+  ): Promise<{
+    acpSessionId: string;
+    protocolSessionId: string;
+    effectiveModel?: string;
+    modelWarning?: string;
+  }> => ({
     acpSessionId: "acp-session-test",
     protocolSessionId: "proto-session-test",
+    effectiveModel: "opus",
   }),
 );
 
@@ -201,6 +207,8 @@ describe("executeAcpSpawn - happy path", () => {
     const payload = JSON.parse(result.content);
     expect(payload.acpSessionId).toBe("acp-session-test");
     expect(payload.status).toBe("running");
+    expect(payload.requestedModel).toBeNull();
+    expect(payload.effectiveModel).toBe("opus");
     // The real adapter binary is spawned (no `bun x` wrapper).
     const agentConfigArg = spawnMock.mock.calls[0][1] as { command: string };
     expect(agentConfigArg.command).toBe("claude-agent-acp");
@@ -472,6 +480,12 @@ describe("executeAcpSpawn - model selection", () => {
       parentToolUseId: "toolu_model",
       model: "opus",
     });
+    const payload = JSON.parse(result.content);
+    expect(payload.requestedModel).toBe("opus");
+    expect(payload.effectiveModel).toBe("opus");
+    expect(payload.message).toContain(
+      'The top-level ACP session reports "opus" as its effective model.',
+    );
   });
 
   test("a null model is treated as omitted", async () => {
@@ -489,6 +503,7 @@ describe("executeAcpSpawn - model selection", () => {
     spawnMock.mockImplementationOnce(async () => ({
       acpSessionId: "acp-session-test",
       protocolSessionId: "proto-session-test",
+      effectiveModel: "opus",
       modelWarning: "Unknown model: nope",
     }));
 
@@ -502,6 +517,8 @@ describe("executeAcpSpawn - model selection", () => {
     expect(payload.message).toContain(
       "The requested model was not applied: Unknown model: nope",
     );
+    expect(payload.requestedModel).toBe("nope");
+    expect(payload.effectiveModel).toBe("opus");
   });
 
   test("the note relays a no-selector warning without calling it a refusal", async () => {
@@ -532,6 +549,25 @@ describe("executeAcpSpawn - model selection", () => {
     const payload = JSON.parse(result.content);
     expect(payload.message).not.toContain(
       "The requested model was not applied",
+    );
+  });
+
+  test("reports when the adapter does not identify the effective model", async () => {
+    spawnMock.mockImplementationOnce(async () => ({
+      acpSessionId: "acp-session-test",
+      protocolSessionId: "proto-session-test",
+    }));
+
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something", model: "sonnet" },
+      makeContext(),
+    );
+
+    const payload = JSON.parse(result.content);
+    expect(payload.requestedModel).toBe("sonnet");
+    expect(payload.effectiveModel).toBeNull();
+    expect(payload.message).toContain(
+      "The top-level ACP session did not report an effective model.",
     );
   });
 });

--- a/assistant/src/tools/acp/spawn.test.ts
+++ b/assistant/src/tools/acp/spawn.test.ts
@@ -128,13 +128,18 @@ const spawnMock = mock(
   ): Promise<{
     acpSessionId: string;
     protocolSessionId: string;
+    requestedModel?: string;
     effectiveModel?: string;
     modelWarning?: string;
-  }> => ({
-    acpSessionId: "acp-session-test",
-    protocolSessionId: "proto-session-test",
-    effectiveModel: "opus",
-  }),
+  }> => {
+    const requestedModel = _options?.model?.trim() || undefined;
+    return {
+      acpSessionId: "acp-session-test",
+      protocolSessionId: "proto-session-test",
+      requestedModel,
+      effectiveModel: "opus",
+    };
+  },
 );
 
 // Spread the real module's exports so transitive importers that pull other
@@ -488,6 +493,19 @@ describe("executeAcpSpawn - model selection", () => {
     );
   });
 
+  test("reports the manager-normalized requested model", async () => {
+    const result = await executeAcpSpawn(
+      { agent: "claude", task: "do something", model: "  opus  " },
+      makeContext(),
+    );
+
+    expect(spawnMock.mock.calls[0][6]).toEqual({
+      parentToolUseId: undefined,
+      model: "  opus  ",
+    });
+    expect(JSON.parse(result.content).requestedModel).toBe("opus");
+  });
+
   test("a null model is treated as omitted", async () => {
     const result = await executeAcpSpawn(
       { agent: "claude", task: "do something", model: null },
@@ -503,6 +521,7 @@ describe("executeAcpSpawn - model selection", () => {
     spawnMock.mockImplementationOnce(async () => ({
       acpSessionId: "acp-session-test",
       protocolSessionId: "proto-session-test",
+      requestedModel: "nope",
       effectiveModel: "opus",
       modelWarning: "Unknown model: nope",
     }));
@@ -525,6 +544,7 @@ describe("executeAcpSpawn - model selection", () => {
     spawnMock.mockImplementationOnce(async () => ({
       acpSessionId: "acp-session-test",
       protocolSessionId: "proto-session-test",
+      requestedModel: "opus",
       modelWarning:
         'Agent "claude" does not support model selection, so the session is running on the agent\'s own model.',
     }));
@@ -556,6 +576,7 @@ describe("executeAcpSpawn - model selection", () => {
     spawnMock.mockImplementationOnce(async () => ({
       acpSessionId: "acp-session-test",
       protocolSessionId: "proto-session-test",
+      requestedModel: "sonnet",
     }));
 
     const result = await executeAcpSpawn(

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -67,6 +67,7 @@ export async function executeAcpSpawn(
   }
   const agent = parsedInput.data.agent || "claude";
   const task = parsedInput.data.task;
+  const requestedModel = parsedInput.data.model?.trim() || undefined;
 
   if (!task) {
     return { content: '"task" is required.', isError: true };
@@ -125,7 +126,7 @@ export async function executeAcpSpawn(
     // Recheck: the auto-install and the agent-env preparation above are both
     // awaits, and this is the point a long-lived subprocess starts.
     throwIfCancelled(context);
-    const { acpSessionId, protocolSessionId, modelWarning } =
+    const { acpSessionId, protocolSessionId, effectiveModel, modelWarning } =
       await manager.spawn(
         agent,
         agentConfig,
@@ -133,7 +134,7 @@ export async function executeAcpSpawn(
         cwd,
         context.conversationId,
         sendToClient,
-        { parentToolUseId: context.toolUseId, model: parsedInput.data.model },
+        { parentToolUseId: context.toolUseId, model: requestedModel },
         // The manager rechecks after its own protocol handshake and session
         // creation, so a turn stopped in that window tears the child process
         // down instead of handing it the task.
@@ -157,16 +158,21 @@ export async function executeAcpSpawn(
     const modelNote = modelWarning
       ? ` The requested model was not applied: ${modelWarning}`
       : "";
+    const effectiveModelNote = effectiveModel
+      ? ` The top-level ACP session reports "${effectiveModel}" as its effective model.`
+      : " The top-level ACP session did not report an effective model.";
     const payload = JSON.stringify({
       acpSessionId,
       protocolSessionId,
       agent,
       cwd,
+      requestedModel: requestedModel ?? null,
+      effectiveModel: effectiveModel ?? null,
       status: "running",
       message:
         `ACP agent "${agent}" spawned (session: ${protocolSessionId}). ` +
         `Results stream back via SSE. You will be notified when it completes.` +
-        `${installNote}${modelNote}${resumeHint}`,
+        `${installNote}${modelNote}${effectiveModelNote}${resumeHint}`,
     });
 
     return { content: payload, isError: false };

--- a/assistant/src/tools/acp/spawn.ts
+++ b/assistant/src/tools/acp/spawn.ts
@@ -67,7 +67,7 @@ export async function executeAcpSpawn(
   }
   const agent = parsedInput.data.agent || "claude";
   const task = parsedInput.data.task;
-  const requestedModel = parsedInput.data.model?.trim() || undefined;
+  const model = parsedInput.data.model;
 
   if (!task) {
     return { content: '"task" is required.', isError: true };
@@ -126,20 +126,25 @@ export async function executeAcpSpawn(
     // Recheck: the auto-install and the agent-env preparation above are both
     // awaits, and this is the point a long-lived subprocess starts.
     throwIfCancelled(context);
-    const { acpSessionId, protocolSessionId, effectiveModel, modelWarning } =
-      await manager.spawn(
-        agent,
-        agentConfig,
-        task,
-        cwd,
-        context.conversationId,
-        sendToClient,
-        { parentToolUseId: context.toolUseId, model: requestedModel },
-        // The manager rechecks after its own protocol handshake and session
-        // creation, so a turn stopped in that window tears the child process
-        // down instead of handing it the task.
-        context.signal ? { signal: context.signal } : undefined,
-      );
+    const {
+      acpSessionId,
+      protocolSessionId,
+      requestedModel,
+      effectiveModel,
+      modelWarning,
+    } = await manager.spawn(
+      agent,
+      agentConfig,
+      task,
+      cwd,
+      context.conversationId,
+      sendToClient,
+      { parentToolUseId: context.toolUseId, model },
+      // The manager rechecks after its own protocol handshake and session
+      // creation, so a turn stopped in that window tears the child process
+      // down instead of handing it the task.
+      context.signal ? { signal: context.signal } : undefined,
+    );
 
     // Claude Code-only resume hint; empty for other adapters. Keyed off the
     // resolved command basename (always the real adapter binary). See

--- a/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-acp-content.tsx
@@ -158,7 +158,9 @@ export function SkillsReferenceACPContent() {
               and every other agent starts on its own default. Say which model a session should run
               on, for example &ldquo;use sonnet&rdquo;, and it starts there. A session keeps the
               model it started on, so ask for a new one to change it. A standing default per agent
-              lives in your Assistant config as <code>acp.agents.&lt;id&gt;.model</code>.
+              lives in your Assistant config as <code>acp.agents.&lt;id&gt;.model</code>. The spawn
+              result reports both the requested model and the model the top-level ACP session says
+              it is actually using. The latter is authoritative.
             </li>
           </ul>
         </section>

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -3,7 +3,7 @@
   "skills": {
     "acp": {
       "docsSlug": "acp",
-      "sha256": "5eab3cfce6afecdc6fc8c0c25cf7e3070c31b9fc276030290ebb73a6a5659ad2"
+      "sha256": "afacaedef9be08a21b6c193944ffd1e5a8f0224c838a0aaa9f23b08ef4120f17"
     },
     "app-builder": {
       "docsSlug": "app-builder",


### PR DESCRIPTION
## Summary

- Return the explicitly requested model and adapter-reported effective model from ACP spawn receipts.
- Tell the assistant to treat the effective top-level model as authoritative instead of inferring it from task text or nested subagents.
- Keep the HTTP contract, OpenAPI specification, bundled skill, and public documentation aligned.

## Why

An ACP session can run on one top-level model while invoking a nested subagent on another. Reporting both values prevents the assistant from claiming that the top-level session used a model merely because the task text or a nested tool named it.

Follow-up to #42377.

## Validation

- 114 focused ACP and contract tests passed on current main.
- Assistant TypeScript type-check passed.
- Docs TypeScript type-check passed.
- Assistant and docs lint passed before the clean rebase.
- OpenAPI and skill documentation fingerprints regenerated.