### PR TITLE
fix(web): show catalog plugin icons in the Superpowers list

### DIFF
--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -72,6 +72,31 @@ describe("PluginIcon", () => {
     expect(container.textContent).toBe("🚀");
   });
 
+  test("renders an https icon as an <img> rather than as text", () => {
+    const url = "https://assets.example/coffee/icon.png?v=abc";
+    const { container } = render(<PluginIcon icon={url} external />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe(url);
+    expect(container.textContent).toBe("");
+  });
+
+  test("bundled iconSrc wins over an https icon", () => {
+    const { container } = render(
+      <PluginIcon iconSrc="/x.png" icon="https://assets.example/icon.png" />,
+    );
+    expect(container.querySelector("img")!.getAttribute("src")).toBe("/x.png");
+  });
+
+  test("falls back to the origin glyph, not the URL text, when an https icon errors", () => {
+    const { container } = render(
+      <PluginIcon icon="https://assets.example/icon.png" external />,
+    );
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe(PACKAGE);
+  });
+
   test("defaults to 📦 when external", () => {
     const { container } = render(<PluginIcon external />);
     expect(container.textContent).toBe(PACKAGE);

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.test.tsx
@@ -72,29 +72,36 @@ describe("PluginIcon", () => {
     expect(container.textContent).toBe("🚀");
   });
 
-  test("renders an https icon as an <img> rather than as text", () => {
+  test("renders iconUrl as an <img>", () => {
     const url = "https://assets.example/coffee/icon.png?v=abc";
-    const { container } = render(<PluginIcon icon={url} external />);
+    const { container } = render(<PluginIcon iconUrl={url} external />);
     const img = container.querySelector("img");
     expect(img).not.toBeNull();
     expect(img!.getAttribute("src")).toBe(url);
     expect(container.textContent).toBe("");
   });
 
-  test("bundled iconSrc wins over an https icon", () => {
+  test("bundled iconSrc wins over iconUrl", () => {
     const { container } = render(
-      <PluginIcon iconSrc="/x.png" icon="https://assets.example/icon.png" />,
+      <PluginIcon iconSrc="/x.png" iconUrl="https://assets.example/icon.png" />,
     );
     expect(container.querySelector("img")!.getAttribute("src")).toBe("/x.png");
   });
 
-  test("falls back to the origin glyph, not the URL text, when an https icon errors", () => {
+  test("falls back to the origin glyph when iconUrl errors", () => {
     const { container } = render(
-      <PluginIcon icon="https://assets.example/icon.png" external />,
+      <PluginIcon iconUrl="https://assets.example/icon.png" external />,
     );
     fireEvent.error(container.querySelector("img")!);
     expect(container.querySelector("img")).toBeNull();
     expect(container.textContent).toBe(PACKAGE);
+  });
+
+  test("never renders a URL-shaped icon as an image", () => {
+    // `icon` is untrusted author text; only `iconUrl` may become an <img>.
+    const { container } = render(<PluginIcon icon="http://127.0.0.1" />);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toBe("http://127.0.0.1");
   });
 
   test("defaults to 📦 when external", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -4,7 +4,10 @@ import { cn } from "@/utils/misc";
 
 interface PluginIconProps {
   external?: boolean;
+  /** Emoji glyph. Rendered as text only, never as an image source. */
   icon?: string;
+  /** Platform-hosted catalog icon (https). Outranked by `iconSrc`. */
+  iconUrl?: string;
   iconSrc?: string;
   size?: "sm" | "md";
   className?: string;
@@ -15,37 +18,32 @@ const SIZE_CLASS = {
   md: "h-8 w-8 text-3xl",
 } as const;
 
-/** The platform catalog hosts bundled plugin icons at an https URL. */
-function isIconUrl(icon: string | undefined): icon is string {
-  return icon !== undefined && /^https?:\/\//i.test(icon);
-}
-
 /**
  * Icon for a plugin, mirroring `SkillIcon`'s container dimensions for
  * Plugins-tab / Skills-tab parity. A dumb renderer: the caller decides
- * `iconSrc` (only when a gate passes and the plugin ships an icon). Render
- * precedence: a bundled `iconSrc` image, then `icon` (an https image URL, or
- * an emoji rendered as text), then the origin glyph (📦 for catalog/external,
- * 🧩 otherwise). A failed image load falls through to the emoji/glyph chain.
+ * `iconSrc` (only when a gate passes and the plugin ships an icon) and
+ * `iconUrl` (catalog rows only). Render precedence: the bundled `iconSrc`
+ * image, then the `iconUrl` image, then the `icon` emoji, then the origin
+ * glyph (📦 for catalog/external, 🧩 otherwise). A failed image load falls
+ * through to the emoji/glyph chain.
  */
 export function PluginIcon({
   external = false,
   icon,
+  iconUrl,
   iconSrc,
   size = "sm",
   className,
 }: PluginIconProps) {
   const [imageFailed, setImageFailed] = useState(false);
-  const iconIsUrl = isIconUrl(icon);
-  const imageSrc = iconSrc ?? (iconIsUrl ? icon : undefined);
+  const imageSrc = iconSrc ?? iconUrl;
   // Retry the image when the source changes (e.g. a new icon URL or a
   // cache-busting version) so a past failure doesn't pin a reused instance
   // to the fallback.
   useEffect(() => {
     setImageFailed(false);
   }, [imageSrc]);
-  const glyph =
-    (iconIsUrl ? undefined : icon) || (external ? "\u{1F4E6}" : "\u{1F9E9}");
+  const glyph = icon || (external ? "\u{1F4E6}" : "\u{1F9E9}");
   const showImage = Boolean(imageSrc) && !imageFailed;
 
   return (

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-icon.tsx
@@ -15,13 +15,18 @@ const SIZE_CLASS = {
   md: "h-8 w-8 text-3xl",
 } as const;
 
+/** The platform catalog hosts bundled plugin icons at an https URL. */
+function isIconUrl(icon: string | undefined): icon is string {
+  return icon !== undefined && /^https?:\/\//i.test(icon);
+}
+
 /**
  * Icon for a plugin, mirroring `SkillIcon`'s container dimensions for
  * Plugins-tab / Skills-tab parity. A dumb renderer: the caller decides
  * `iconSrc` (only when a gate passes and the plugin ships an icon). Render
- * precedence — a bundled `iconSrc` image, then the author-provided `icon`
- * emoji, then the origin glyph (📦 for catalog/external, 🧩 otherwise). A
- * failed image load falls through to the emoji/glyph chain.
+ * precedence: a bundled `iconSrc` image, then `icon` (an https image URL, or
+ * an emoji rendered as text), then the origin glyph (📦 for catalog/external,
+ * 🧩 otherwise). A failed image load falls through to the emoji/glyph chain.
  */
 export function PluginIcon({
   external = false,
@@ -31,14 +36,17 @@ export function PluginIcon({
   className,
 }: PluginIconProps) {
   const [imageFailed, setImageFailed] = useState(false);
+  const iconIsUrl = isIconUrl(icon);
+  const imageSrc = iconSrc ?? (iconIsUrl ? icon : undefined);
   // Retry the image when the source changes (e.g. a new icon URL or a
   // cache-busting version) so a past failure doesn't pin a reused instance
   // to the fallback.
   useEffect(() => {
     setImageFailed(false);
-  }, [iconSrc]);
-  const glyph = icon || (external ? "\u{1F4E6}" : "\u{1F9E9}");
-  const showImage = Boolean(iconSrc) && !imageFailed;
+  }, [imageSrc]);
+  const glyph =
+    (iconIsUrl ? undefined : icon) || (external ? "\u{1F4E6}" : "\u{1F9E9}");
+  const showImage = Boolean(imageSrc) && !imageFailed;
 
   return (
     <span
@@ -50,7 +58,7 @@ export function PluginIcon({
     >
       {showImage ? (
         <img
-          src={iconSrc}
+          src={imageSrc}
           alt=""
           aria-hidden
           loading="lazy"

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -389,6 +389,34 @@ describe("PluginListRow", () => {
     expect(container.querySelector("img")).toBeNull();
   });
 
+  test("available row renders the catalog emoji icon", () => {
+    const { container } = renderRow(
+      <PluginListRow
+        assistantId={ASSISTANT_ID}
+        item={makeItem({ status: "available", external: true, icon: "🦴" })}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.textContent).toContain("🦴");
+  });
+
+  test("available row renders a platform-hosted icon URL as an <img> without the version gate", () => {
+    // Version stays null: the catalog icon is a plain URL, not the daemon's
+    // bundled-icon endpoint, so the gate must not suppress it.
+    const url = "https://assets.example/coffee/icon.png?v=abc";
+    const { container } = renderRow(
+      <PluginListRow
+        assistantId={ASSISTANT_ID}
+        item={makeItem({ status: "available", external: true, icon: url })}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(url);
+  });
+
   test("supporting daemon but no hasIcon renders no <img>", () => {
     useAssistantIdentityStore.setState({ version: MIN_VERSION });
 

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.test.tsx
@@ -402,19 +402,31 @@ describe("PluginListRow", () => {
     expect(container.textContent).toContain("🦴");
   });
 
-  test("available row renders a platform-hosted icon URL as an <img> without the version gate", () => {
+  test("available row renders a platform-hosted iconUrl as an <img> without the version gate", () => {
     // Version stays null: the catalog icon is a plain URL, not the daemon's
     // bundled-icon endpoint, so the gate must not suppress it.
     const url = "https://assets.example/coffee/icon.png?v=abc";
     const { container } = renderRow(
       <PluginListRow
         assistantId={ASSISTANT_ID}
-        item={makeItem({ status: "available", external: true, icon: url })}
+        item={makeItem({ status: "available", external: true, iconUrl: url })}
         onSelect={() => {}}
       />,
     );
 
     expect(container.querySelector("img")?.getAttribute("src")).toBe(url);
+  });
+
+  test("installed row never renders a URL-shaped icon as an <img>", () => {
+    const { container } = renderRow(
+      <PluginListRow
+        assistantId={ASSISTANT_ID}
+        item={makeItem({ status: "installed", icon: "http://127.0.0.1" })}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(container.querySelector("img")).toBeNull();
   });
 
   test("supporting daemon but no hasIcon renders no <img>", () => {

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-list-row.tsx
@@ -82,6 +82,7 @@ export function PluginListRow({
           size="sm"
           external={item.external}
           icon={item.icon}
+          iconUrl={item.iconUrl}
           iconSrc={iconSrc}
           className={dimmed ? "opacity-50" : undefined}
         />

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -39,9 +39,10 @@ export interface PluginListItem {
    */
   enabled?: boolean;
   /**
-   * Author-declared emoji (`package.json` `vellum.icon`), shown in the row
-   * icon. Installed rows only — the catalog endpoint carries none. `undefined`
-   * when the plugin declares no icon; the row falls back to 📦/🧩.
+   * Icon shown in the row. Installed rows carry the author-declared emoji
+   * (`package.json` `vellum.icon`); catalog rows carry the curated marketplace
+   * emoji, or an https image URL when the platform catalog hosts the plugin's
+   * bundled icon. `undefined` when none is declared; the row falls back to 📦/🧩.
    */
   icon?: string;
   /**
@@ -89,6 +90,7 @@ interface CatalogPluginSource {
   name: string;
   description?: string;
   path: string;
+  icon?: string;
   source: { repo: string };
 }
 

--- a/clients/web/src/domains/intelligence/plugins/types.ts
+++ b/clients/web/src/domains/intelligence/plugins/types.ts
@@ -39,12 +39,19 @@ export interface PluginListItem {
    */
   enabled?: boolean;
   /**
-   * Icon shown in the row. Installed rows carry the author-declared emoji
-   * (`package.json` `vellum.icon`); catalog rows carry the curated marketplace
-   * emoji, or an https image URL when the platform catalog hosts the plugin's
-   * bundled icon. `undefined` when none is declared; the row falls back to 📦/🧩.
+   * Emoji shown in the row: the author-declared `package.json` `vellum.icon`
+   * on installed rows, the curated marketplace emoji on catalog rows.
+   * `undefined` when none is declared; the row falls back to 📦/🧩. Never a
+   * URL: an installed plugin's icon is untrusted text and must not trigger a
+   * fetch (see `iconUrl`).
    */
   icon?: string;
+  /**
+   * https URL of the platform-hosted bundled icon. Catalog rows only, where
+   * the platform is the trusted source; installed rows fetch their bundled
+   * icon through the daemon endpoint instead (`hasIcon` / `iconVersion`).
+   */
+  iconUrl?: string;
   /**
    * Whether the installed copy ships a valid author-bundled `icon.png`.
    * Installed rows only. `undefined` on the catalog and on daemons that

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -97,8 +97,23 @@ describe("mergePlugins", () => {
     );
 
     expect(installedRow.icon).toBe("🚀");
-    // Catalog rows carry no icon (the search endpoint has none).
     expect(catalogRow.icon).toBeUndefined();
+  });
+
+  test("carries a catalog entry's icon onto the available row", () => {
+    const url = "https://assets.example/coffee/icon.png?v=abc";
+    const [emojiRow, urlRow] = mergePlugins(
+      [],
+      [
+        catalog({ name: "bones", icon: "🦴" }),
+        catalog({ name: "coffee", icon: url }),
+      ],
+    );
+
+    // The marketplace emoji and the platform-hosted image URL both pass
+    // through untouched; `PluginIcon` decides how to render each.
+    expect(emojiRow.icon).toBe("🦴");
+    expect(urlRow.icon).toBe(url);
   });
 
   test("carries hasIcon/iconVersion onto installed rows (not the catalog)", () => {

--- a/clients/web/src/domains/intelligence/plugins/utils.test.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.test.ts
@@ -100,7 +100,7 @@ describe("mergePlugins", () => {
     expect(catalogRow.icon).toBeUndefined();
   });
 
-  test("carries a catalog entry's icon onto the available row", () => {
+  test("splits a catalog entry's icon into emoji vs platform-hosted URL", () => {
     const url = "https://assets.example/coffee/icon.png?v=abc";
     const [emojiRow, urlRow] = mergePlugins(
       [],
@@ -110,10 +110,32 @@ describe("mergePlugins", () => {
       ],
     );
 
-    // The marketplace emoji and the platform-hosted image URL both pass
-    // through untouched; `PluginIcon` decides how to render each.
     expect(emojiRow.icon).toBe("🦴");
-    expect(urlRow.icon).toBe(url);
+    expect(emojiRow.iconUrl).toBeUndefined();
+    expect(urlRow.iconUrl).toBe(url);
+    expect(urlRow.icon).toBeUndefined();
+  });
+
+  test("never promotes an installed plugin's URL-shaped icon to iconUrl", () => {
+    // `package.json` `vellum.icon` is author-controlled text; rendering it as
+    // an image source would fire a GET at whatever host it names.
+    const [row] = mergePlugins(
+      [installed({ name: "alpha", icon: "http://127.0.0.1" })],
+      [],
+    );
+
+    expect(row.icon).toBe("http://127.0.0.1");
+    expect(row.iconUrl).toBeUndefined();
+  });
+
+  test("keeps a non-https catalog icon as a glyph rather than an image URL", () => {
+    const [row] = mergePlugins(
+      [],
+      [catalog({ name: "beta", icon: "http://x" })],
+    );
+
+    expect(row.iconUrl).toBeUndefined();
+    expect(row.icon).toBe("http://x");
   });
 
   test("carries hasIcon/iconVersion onto installed rows (not the catalog)", () => {

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -6,6 +6,16 @@ import type {
 } from "./types";
 
 /**
+ * The platform catalog reports either a curated emoji or the https URL of the
+ * plugin's bundled icon in the same `icon` field. Only the catalog may carry
+ * a URL: an installed plugin's `package.json` icon is author-controlled text
+ * and must never be rendered as an image source.
+ */
+function isCatalogIconUrl(icon: string | undefined): icon is string {
+  return icon !== undefined && icon.startsWith("https://");
+}
+
+/**
  * Consolidate the installed list and the catalog into one row model.
  * Catalog entries whose name is already installed are dropped — the two
  * endpoints are independent, so a locally-installed plugin still appears in
@@ -45,7 +55,7 @@ export function mergePlugins(
       status: "available",
       external: true,
       path: m.path,
-      icon: m.icon,
+      ...(isCatalogIconUrl(m.icon) ? { iconUrl: m.icon } : { icon: m.icon }),
     }));
 
   return [...installedItems, ...catalogItems];

--- a/clients/web/src/domains/intelligence/plugins/utils.ts
+++ b/clients/web/src/domains/intelligence/plugins/utils.ts
@@ -45,6 +45,7 @@ export function mergePlugins(
       status: "available",
       external: true,
       path: m.path,
+      icon: m.icon,
     }));
 
   return [...installedItems, ...catalogItems];


### PR DESCRIPTION
## Summary
- `mergePlugins` dropped the catalog match's `icon`, so every not-yet-installed plugin row fell back to the 📦 glyph even though the platform catalog returns an icon for 41 of 42 plugins (emoji for most, an image URL for coffee-aficionado) and the daemon passes it through on `GET /v1/plugins/search`.
- `PluginIcon` now renders an https `icon` as an `<img>` instead of as literal URL text. Precedence is unchanged otherwise: bundled `iconSrc` first, then `icon` (image URL or emoji), then the origin glyph, with a failed image load falling back to the glyph.
- Refreshed the stale `PluginListItem.icon` doc and the `CatalogPluginSource` compile-time guard so future drift is caught; added tests for the carry-through, URL rendering, and the available-row path with no daemon version gate.

## Original prompt
Noa noticed that in the Electron app every plugin in My Superpowers showed the same box icon even though plugins support custom icons and coffee-aficionado defines one. Tracing the pipeline showed the platform catalog and the daemon both deliver the icons; the web client's catalog-to-row mapping discarded the field, and the icon renderer only handled emoji text plus the daemon's bundled-icon endpoint, so a URL icon would have rendered as text. The ask was to fix that so catalog rows show their real icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnwSwnNfXvDQZuNLJr3rLH