### PR TITLE
feat(mac-helper): yield to live user input and restore the cursor after a click

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperCore/UserActivityGate.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperCore/UserActivityGate.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Decides whether the person at the keyboard is using the machine right now,
+/// so computer use can stand down instead of fighting them for the pointer.
+public enum UserActivityGate {
+    /// A synthetic event we posted also refreshes the system's "last input"
+    /// clock, so recency alone cannot tell the user apart from us. Anything
+    /// that lands within `syntheticEpsilon` of our own last post is ours.
+    public static func userIsActive(
+        now: Date,
+        lastSyntheticPostAt: Date?,
+        secondsSinceLastInput: Double,
+        quietWindow: TimeInterval = 1.0,
+        syntheticEpsilon: TimeInterval = 0.25
+    ) -> Bool {
+        guard secondsSinceLastInput <= quietWindow else { return false }
+        let lastInputAt = now.addingTimeInterval(-secondsSinceLastInput)
+        if let ours = lastSyntheticPostAt,
+           abs(lastInputAt.timeIntervalSince(ours)) <= syntheticEpsilon {
+            return false
+        }
+        return true
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
@@ -62,13 +62,20 @@ final class ActionExecutor {
         Self.lastSyntheticPostAt = Date()
     }
 
+    /// `kCGAnyInputEventType`, which no Swift overlay constant exposes. Asking
+    /// about one event type at a time misses whichever kinds are left off the
+    /// list: a drag past the quiet window reports `.leftMouseDragged` and not
+    /// `.mouseMoved`, so watching moves and clicks alone would call a person
+    /// who is mid-gesture idle and inject into the gesture.
+    private static let anyInputEventType = CGEventType(rawValue: ~UInt32(0))!
+
     /// True when the person at the machine is typing or moving the mouse right
     /// now, which is when we should stand down rather than fight for the pointer.
     private func userIsCurrentlyActive() -> Bool {
-        let watched: [CGEventType] = [.mouseMoved, .leftMouseDown, .keyDown, .scrollWheel]
-        let secondsSinceLastInput = watched
-            .map { CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: $0) }
-            .min() ?? .greatestFiniteMagnitude
+        let secondsSinceLastInput = CGEventSource.secondsSinceLastEventType(
+            .combinedSessionState,
+            eventType: Self.anyInputEventType
+        )
         return UserActivityGate.userIsActive(
             now: Date(),
             lastSyntheticPostAt: Self.lastSyntheticPostAt,

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
@@ -70,17 +70,32 @@ final class ActionExecutor {
     private static let anyInputEventType = CGEventType(rawValue: ~UInt32(0))!
 
     /// True when the person at the machine is typing or moving the mouse right
-    /// now, which is when we should stand down rather than fight for the pointer.
-    private func userIsCurrentlyActive() -> Bool {
+    /// now, which is when we should stand down rather than fight them for it.
+    static func userIsCurrentlyActive() -> Bool {
         let secondsSinceLastInput = CGEventSource.secondsSinceLastEventType(
             .combinedSessionState,
-            eventType: Self.anyInputEventType
+            eventType: anyInputEventType
         )
         return UserActivityGate.userIsActive(
             now: Date(),
-            lastSyntheticPostAt: Self.lastSyntheticPostAt,
+            lastSyntheticPostAt: lastSyntheticPostAt,
             secondsSinceLastInput: secondsSinceLastInput
         )
+    }
+
+    /// Whether running `type` takes the machine away from whoever is using it.
+    /// Posting to the global tap does, and so does activating an app: it moves
+    /// keyboard focus, so the next thing the user types lands somewhere they
+    /// were not looking. `runAppleScript` stays out because it is the one path
+    /// that asks an app to do something instead of seizing the input devices,
+    /// and gating it would leave the polite route as blocked as the rude one.
+    static func takesOverFromUser(_ type: ActionType) -> Bool {
+        switch type {
+        case .click, .doubleClick, .rightClick, .type, .key, .scroll, .drag, .openApp:
+            return true
+        case .runAppleScript, .wait, .done, .respond:
+            return false
+        }
     }
 
     /// Runs `body` and puts the pointer back where the user left it, whether or
@@ -281,16 +296,10 @@ final class ActionExecutor {
 
     @discardableResult
     func execute(_ action: AgentAction) async throws -> String? {
-        switch action.type {
-        case .click, .doubleClick, .rightClick, .type, .key, .scroll, .drag:
-            // These all post to the global event tap, so they take the pointer
-            // and the keyboard away from whoever is using them.
-            if userIsCurrentlyActive() { throw ExecutorError.userIsActive }
-        case .openApp, .runAppleScript, .wait, .done, .respond:
-            // None of these fight the user for the pointer.
-            break
-        }
-
+        // The activity gate deliberately does not live here. HostCuActionRunner
+        // checks it before ActionVerifier records the step, so a refusal the
+        // model is told to retry cannot fill the verifier's history with
+        // actions that never ran and trip its repeat detector.
         switch action.type {
         case .click:
             guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/ActionExecutor.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import AppKit
 import ApplicationServices
+import MacHelperCore
 import os
 
 enum ExecutorError: LocalizedError {
@@ -15,6 +16,7 @@ enum ExecutorError: LocalizedError {
     case appleScriptMissingScript
     case appleScriptTimeout
     case clipboardMismatch
+    case userIsActive
 
     var errorDescription: String? {
         switch self {
@@ -29,6 +31,9 @@ enum ExecutorError: LocalizedError {
         case .appleScriptMissingScript: return "run_applescript requires a script"
         case .appleScriptTimeout: return "AppleScript timed out after 5 seconds"
         case .clipboardMismatch: return "Clipboard contents changed before paste injection; aborting to prevent wrong text from being typed"
+        // Reaches the model verbatim as `executionError`, so it has to say what
+        // happened and what to do next.
+        case .userIsActive: return "The user is using the keyboard or mouse right now. Nothing was done. Wait for them to finish, then retry."
         }
     }
 }
@@ -40,6 +45,48 @@ final class ActionExecutor {
 
     init() {
         eventSource = CGEventSource(stateID: .hidSystemState)
+    }
+
+    // MARK: - Yielding to the user
+
+    /// When we last posted an event of our own. Static because a fresh
+    /// `ActionExecutor` is built for every computer-use step, and the post this
+    /// has to recognize is usually the previous step's, not this one's. Only
+    /// ever touched from the main actor via `HostCuActionRunner`.
+    private nonisolated(unsafe) static var lastSyntheticPostAt: Date?
+
+    /// Every synthetic event goes through here so the last-post clock can never
+    /// drift out of sync with what we actually put on the wire.
+    private func postSynthetic(_ event: CGEvent, tap: CGEventTapLocation = .cghidEventTap) {
+        event.post(tap: tap)
+        Self.lastSyntheticPostAt = Date()
+    }
+
+    /// True when the person at the machine is typing or moving the mouse right
+    /// now, which is when we should stand down rather than fight for the pointer.
+    private func userIsCurrentlyActive() -> Bool {
+        let watched: [CGEventType] = [.mouseMoved, .leftMouseDown, .keyDown, .scrollWheel]
+        let secondsSinceLastInput = watched
+            .map { CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: $0) }
+            .min() ?? .greatestFiniteMagnitude
+        return UserActivityGate.userIsActive(
+            now: Date(),
+            lastSyntheticPostAt: Self.lastSyntheticPostAt,
+            secondsSinceLastInput: secondsSinceLastInput
+        )
+    }
+
+    /// Runs `body` and puts the pointer back where the user left it, whether or
+    /// not `body` got as far as the event it was moving there to post.
+    private func restoringCursor(_ body: () throws -> Void) rethrows {
+        let saved = CGEvent(source: nil)?.location
+        defer {
+            if let saved {
+                CGWarpMouseCursorPosition(saved)
+                CGAssociateMouseAndMouseCursorPosition(1)
+            }
+        }
+        try body()
     }
 
     static func checkAccessibilityPermission(prompt: Bool = false) -> Bool {
@@ -57,13 +104,13 @@ final class ActionExecutor {
         guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: point, mouseButton: .left) else {
             throw ExecutorError.eventCreationFailed
         }
-        mouseDown.post(tap: .cghidEventTap)
+        postSynthetic(mouseDown)
         usleep(50_000)
 
         guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) else {
             throw ExecutorError.eventCreationFailed
         }
-        mouseUp.post(tap: .cghidEventTap)
+        postSynthetic(mouseUp)
     }
 
     func doubleClick(at point: CGPoint) throws {
@@ -74,14 +121,14 @@ final class ActionExecutor {
             throw ExecutorError.eventCreationFailed
         }
         mouseDown.setIntegerValueField(.mouseEventClickState, value: 2)
-        mouseDown.post(tap: .cghidEventTap)
+        postSynthetic(mouseDown)
         usleep(50_000)
 
         guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: point, mouseButton: .left) else {
             throw ExecutorError.eventCreationFailed
         }
         mouseUp.setIntegerValueField(.mouseEventClickState, value: 2)
-        mouseUp.post(tap: .cghidEventTap)
+        postSynthetic(mouseUp)
     }
 
     func rightClick(at point: CGPoint) throws {
@@ -91,20 +138,20 @@ final class ActionExecutor {
         guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .rightMouseDown, mouseCursorPosition: point, mouseButton: .right) else {
             throw ExecutorError.eventCreationFailed
         }
-        mouseDown.post(tap: .cghidEventTap)
+        postSynthetic(mouseDown)
         usleep(50_000)
 
         guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .rightMouseUp, mouseCursorPosition: point, mouseButton: .right) else {
             throw ExecutorError.eventCreationFailed
         }
-        mouseUp.post(tap: .cghidEventTap)
+        postSynthetic(mouseUp)
     }
 
     private func mouseMove(to point: CGPoint) throws {
         guard let moveEvent = CGEvent(mouseEventSource: eventSource, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left) else {
             throw ExecutorError.eventCreationFailed
         }
-        moveEvent.post(tap: .cghidEventTap)
+        postSynthetic(moveEvent)
     }
 
     // MARK: - Keyboard Actions
@@ -189,14 +236,14 @@ final class ActionExecutor {
             throw ExecutorError.eventCreationFailed
         }
         keyDown.flags = modifiers
-        keyDown.post(tap: .cghidEventTap)
+        postSynthetic(keyDown)
         usleep(50_000)
 
         guard let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: keyCode, keyDown: false) else {
             throw ExecutorError.eventCreationFailed
         }
         keyUp.flags = modifiers
-        keyUp.post(tap: .cghidEventTap)
+        postSynthetic(keyUp)
     }
 
     // MARK: - Scroll
@@ -220,7 +267,7 @@ final class ActionExecutor {
         guard let scrollEvent = CGEvent(scrollWheelEvent2Source: eventSource, units: .pixel, wheelCount: 2, wheel1: dy, wheel2: dx, wheel3: 0) else {
             throw ExecutorError.eventCreationFailed
         }
-        scrollEvent.post(tap: .cgSessionEventTap)
+        postSynthetic(scrollEvent, tap: .cgSessionEventTap)
     }
 
     // MARK: - Dispatch
@@ -228,9 +275,22 @@ final class ActionExecutor {
     @discardableResult
     func execute(_ action: AgentAction) async throws -> String? {
         switch action.type {
+        case .click, .doubleClick, .rightClick, .type, .key, .scroll, .drag:
+            // These all post to the global event tap, so they take the pointer
+            // and the keyboard away from whoever is using them.
+            if userIsCurrentlyActive() { throw ExecutorError.userIsActive }
+        case .openApp, .runAppleScript, .wait, .done, .respond:
+            // None of these fight the user for the pointer.
+            break
+        }
+
+        switch action.type {
         case .click:
             guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
-            try click(at: CGPoint(x: x, y: y))
+            try restoringCursor { try click(at: CGPoint(x: x, y: y)) }
+        // No cursor restore on doubleClick, rightClick or drag. A context menu
+        // and a drag both track the pointer, so warping it away afterwards
+        // changes what the action did.
         case .doubleClick:
             guard let x = action.x, let y = action.y else { throw ExecutorError.missingCoordinates }
             try doubleClick(at: CGPoint(x: x, y: y))
@@ -248,7 +308,7 @@ final class ActionExecutor {
             let y = action.y ?? 0
             let direction = action.scrollDirection ?? "down"
             let amount = action.scrollAmount ?? 3
-            try scroll(at: CGPoint(x: x, y: y), direction: direction, amount: amount)
+            try restoringCursor { try scroll(at: CGPoint(x: x, y: y), direction: direction, amount: amount) }
         case .drag:
             guard let fromX = action.x, let fromY = action.y else { throw ExecutorError.missingCoordinates }
             guard let endX = action.toX, let endY = action.toY else { throw ExecutorError.missingCoordinates }
@@ -329,7 +389,7 @@ final class ActionExecutor {
         guard let mouseDown = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDown, mouseCursorPosition: startPoint, mouseButton: .left) else {
             throw ExecutorError.eventCreationFailed
         }
-        mouseDown.post(tap: .cghidEventTap)
+        postSynthetic(mouseDown)
         usleep(50_000)
 
         // Interpolate drag path for smooth movement
@@ -343,14 +403,14 @@ final class ActionExecutor {
             guard let dragEvent = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseDragged, mouseCursorPosition: point, mouseButton: .left) else {
                 throw ExecutorError.eventCreationFailed
             }
-            dragEvent.post(tap: .cghidEventTap)
+            postSynthetic(dragEvent)
             usleep(10_000)
         }
 
         guard let mouseUp = CGEvent(mouseEventSource: eventSource, mouseType: .leftMouseUp, mouseCursorPosition: endPoint, mouseButton: .left) else {
             throw ExecutorError.eventCreationFailed
         }
-        mouseUp.post(tap: .cghidEventTap)
+        postSynthetic(mouseUp)
     }
 
     // MARK: - Open App

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -87,13 +87,12 @@ enum HostCuActionRunner {
                 return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
             }
 
-            // Stand down while the person at the machine is using it. This runs
-            // before the verifier so a refusal the model is told to retry never
-            // reaches ActionVerifier.actionHistory: recording it would let three
-            // waits in a row trip the repeat detector and block the action for
-            // good, long after the user went idle. Checking it here also skips
-            // the AX walk that coordinate resolution would otherwise do.
-            if ActionExecutor.takesOverFromUser(agentAction.type), ActionExecutor.userIsCurrentlyActive() {
+            // Stand down while the person at the machine is using it. Both
+            // checks run before the verifier, because it records every action
+            // it allows: a refusal banked there would let three of the retries
+            // this error asks for trip the repeat detector and block the action
+            // for good, long after the user went idle.
+            let standDown: () async -> HostCuResultPayload = {
                 log.info("[\(stepNumber)] Standing down: the user is using the machine")
                 let obs = await buildObservation(
                     enumerator: enumerator,
@@ -104,6 +103,13 @@ enum HostCuActionRunner {
                     conversationId: conversationId
                 )
                 return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+            let takesOver = ActionExecutor.takesOverFromUser(agentAction.type)
+
+            // Refuse early when we can, which also skips the AX walk that
+            // coordinate resolution would otherwise do on the way to nothing.
+            if takesOver, ActionExecutor.userIsCurrentlyActive() {
+                return await standDown()
             }
 
             // Resolve element IDs to coordinates if needed
@@ -144,6 +150,14 @@ enum HostCuActionRunner {
                     conversationId: conversationId
                 )
                 return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+
+            // Check again. Resolution above awaits an accessibility walk that
+            // can run for seconds, and the machine is not ours during it, so a
+            // person who started typing midway through would otherwise be
+            // interrupted by an action cleared before they touched anything.
+            if takesOver, ActionExecutor.userIsCurrentlyActive() {
+                return await standDown()
             }
 
             // VERIFY (local safety check)

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -87,6 +87,25 @@ enum HostCuActionRunner {
                 return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
             }
 
+            // Stand down while the person at the machine is using it. This runs
+            // before the verifier so a refusal the model is told to retry never
+            // reaches ActionVerifier.actionHistory: recording it would let three
+            // waits in a row trip the repeat detector and block the action for
+            // good, long after the user went idle. Checking it here also skips
+            // the AX walk that coordinate resolution would otherwise do.
+            if ActionExecutor.takesOverFromUser(agentAction.type), ActionExecutor.userIsCurrentlyActive() {
+                log.info("[\(stepNumber)] Standing down: the user is using the machine")
+                let obs = await buildObservation(
+                    enumerator: enumerator,
+                    screenCapture: screenCapture,
+                    executionResult: nil,
+                    executionError: ExecutorError.userIsActive.errorDescription,
+                    stepNumber: stepNumber,
+                    conversationId: conversationId
+                )
+                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+            }
+
             // Resolve element IDs to coordinates if needed
             guard let resolvedAction = await resolveCoordinatesIfNeeded(for: agentAction, enumerator: enumerator, stepNumber: stepNumber) else {
                 let obs = await buildObservation(

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/ComputerUse/HostCuExecutor.swift
@@ -170,9 +170,10 @@ enum HostCuActionRunner {
                     executionResult: nil,
                     executionError: ExecutorError.userIsActive.errorDescription,
                     stepNumber: stepNumber,
-                    conversationId: conversationId
+                    conversationId: conversationId,
+                    timer: timer
                 )
-                return buildResultPayload(requestId: requestId, conversationId: conversationId, observation: obs)
+                return finish(obs)
             }
             let takesOver = ActionExecutor.takesOverFromUser(agentAction.type)
 

--- a/clients/macos/native/mac-helper/Tests/MacHelperCoreTests/UserActivityGateTests.swift
+++ b/clients/macos/native/mac-helper/Tests/MacHelperCoreTests/UserActivityGateTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+
+@testable import MacHelperCore
+
+@Suite("UserActivityGate.userIsActive")
+struct UserActivityGateTests {
+    /// The reference date itself, so every offset below is an exact binary
+    /// fraction and the boundary cases land on the comparison, not on the
+    /// rounding of a large timestamp.
+    private let now = Date(timeIntervalSinceReferenceDate: 0)
+
+    @Test("a machine nobody has touched is free to drive")
+    func idleUser() {
+        // The common case: the user asked for something and went back to
+        // reading, so the last input is minutes old.
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: nil,
+                secondsSinceLastInput: 120
+            ) == false
+        )
+    }
+
+    @Test("our own last post is not the user")
+    func recentEventIsOurs() {
+        // The click we posted a moment ago refreshed the system's last-input
+        // clock. Recency alone would read it back as a person typing.
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: now.addingTimeInterval(-0.25),
+                secondsSinceLastInput: 0.25
+            ) == false
+        )
+    }
+
+    @Test("a recent event with nothing of ours to blame is the user")
+    func recentEventWithNoSyntheticPost() {
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: nil,
+                secondsSinceLastInput: 0.25
+            )
+        )
+    }
+
+    @Test("an event well after our last post is the user")
+    func recentEventAfterOurPost() {
+        // We posted 5 seconds ago and something happened a quarter second ago.
+        // The gap is far wider than the epsilon, so that something was a person.
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: now.addingTimeInterval(-5),
+                secondsSinceLastInput: 0.25
+            )
+        )
+    }
+
+    @Test("an event at exactly the quiet window still counts as activity")
+    func boundaryQuietWindow() {
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: nil,
+                secondsSinceLastInput: 1.0
+            )
+        )
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: nil,
+                secondsSinceLastInput: 1.25
+            ) == false
+        )
+    }
+
+    @Test("an event exactly an epsilon from our post is still ours")
+    func boundarySyntheticEpsilon() {
+        // A quarter second either side of our post is attributed to us; wider
+        // than that is the user.
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: now.addingTimeInterval(-0.25),
+                secondsSinceLastInput: 0.5
+            ) == false
+        )
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: now.addingTimeInterval(-0.125),
+                secondsSinceLastInput: 0.5
+            )
+        )
+    }
+
+    @Test("the epsilon is symmetric around our post")
+    func epsilonIsSymmetric() {
+        // Our post can be stamped either side of the clock the system reports,
+        // so the comparison has to hold in both directions.
+        let inputAgo = 0.5
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: now.addingTimeInterval(-(inputAgo - 0.125)),
+                secondsSinceLastInput: inputAgo
+            ) == false
+        )
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: now.addingTimeInterval(-(inputAgo + 0.125)),
+                secondsSinceLastInput: inputAgo
+            ) == false
+        )
+    }
+
+    @Test("the caller can widen or narrow both windows")
+    func customWindows() {
+        // Two seconds is quiet by default and loud with a wider window.
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: nil,
+                secondsSinceLastInput: 2.0
+            ) == false
+        )
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: nil,
+                secondsSinceLastInput: 2.0,
+                quietWindow: 3.0
+            )
+        )
+        // With no epsilon, our own post is indistinguishable from the user.
+        #expect(
+            UserActivityGate.userIsActive(
+                now: now,
+                lastSyntheticPostAt: now.addingTimeInterval(-0.5),
+                secondsSinceLastInput: 0.25,
+                syntheticEpsilon: 0
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Refuses to post synthetic input while the user is actively typing or moving the mouse, and tells the model why in words it can act on.
- Puts the pointer back where the user left it after a click or a scroll, so a computer-use step no longer strands their cursor.
- The decision lives in `MacHelperCore` as a pure function with unit tests, because the executable target has none.

Part of plan: hands-off-cu.md (PR 3 of 7)