### PR TITLE
feat(computer-use): record per-step timings and cache-read tokens for CU turns

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15956,6 +15956,13 @@ paths:
                   type: string
                 userGuidance:
                   type: string
+                timings:
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: number
+                  description: Per-phase helper timings in milliseconds
               required:
                 - requestId
       responses:

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -230,6 +230,57 @@ describe("HostCuProxy", () => {
       expect(result.content).not.toContain("roundTripMs");
     });
 
+    test("labels each line with its own request, not the latest dispatch", async () => {
+      setup();
+
+      // One model response can dispatch several CU tools, and the agent loop
+      // runs them concurrently. Dispatch two, then answer the first one last.
+      proxy.recordAction("computer_use_click", { element_id: 42 });
+      const firstPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 42 },
+        "session-1",
+        proxy.stepCount,
+      );
+      proxy.recordAction("computer_use_type_text", { text: "hello" });
+      const secondPromise = proxy.request(
+        "computer_use_type_text",
+        { text: "hello" },
+        "session-1",
+        proxy.stepCount,
+      );
+
+      const first = sentMessages[0] as Record<string, unknown>;
+      const second = sentMessages[1] as Record<string, unknown>;
+
+      proxy.processObservation(second.requestId as string, {
+        axTree: "Field [2]",
+        timings: { total: 200 },
+      });
+      proxy.processObservation(first.requestId as string, {
+        axTree: "Button [1]",
+        timings: { total: 400 },
+      });
+      await Promise.all([firstPromise, secondPromise]);
+
+      const logs = stepTimingsLogs();
+      const firstLog = logs.find((l) => l.requestId === first.requestId);
+      const secondLog = logs.find((l) => l.requestId === second.requestId);
+
+      // The click landed after the type_text, so reading current proxy state
+      // would have filed it under computer_use_type_text at step 2.
+      expect(firstLog).toMatchObject({
+        toolName: "computer_use_click",
+        step: 1,
+        helper: { total: 400 },
+      });
+      expect(secondLog).toMatchObject({
+        toolName: "computer_use_type_text",
+        step: 2,
+        helper: { total: 200 },
+      });
+    });
+
     test("an observation without timings resolves normally", async () => {
       setup();
 

--- a/assistant/src/__tests__/host-cu-proxy.test.ts
+++ b/assistant/src/__tests__/host-cu-proxy.test.ts
@@ -36,9 +36,35 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
   },
 }));
 
+// Captured `log.info` payloads, so the step-timings line can be asserted on.
+const infoLogs: { payload: Record<string, unknown>; message: string }[] = [];
+
+const realLogger = await import("../util/logger.js");
+mock.module("../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () => ({
+    info: (payload: unknown, message: unknown) => {
+      infoLogs.push({
+        payload: (payload ?? {}) as Record<string, unknown>,
+        message: String(message),
+      });
+    },
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+    trace: () => {},
+  }),
+}));
+
 // Use the REAL pending-interactions module — the proxy self-registers here.
 const pendingInteractions = await import("../runtime/pending-interactions.js");
 const { HostCuProxy } = await import("../daemon/host-cu-proxy.js");
+
+function stepTimingsLogs(): Record<string, unknown>[] {
+  return infoLogs
+    .filter((entry) => entry.message === "Host CU step timings")
+    .map((entry) => entry.payload);
+}
 
 describe("HostCuProxy", () => {
   let proxy: InstanceType<typeof HostCuProxy>;
@@ -48,6 +74,7 @@ describe("HostCuProxy", () => {
     sentOptions.length = 0;
     mockHasClient = false;
     mockClients = [];
+    infoLogs.length = 0;
     pendingInteractions.clear();
     proxy = new HostCuProxy(maxSteps);
   }
@@ -161,6 +188,73 @@ describe("HostCuProxy", () => {
       setup();
       // Should not throw
       proxy.processObservation("unknown-id", { axTree: "something" });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Step timings
+  // -------------------------------------------------------------------------
+
+  describe("step timings", () => {
+    test("logs helper timings alongside the proxy round trip", async () => {
+      setup();
+      proxy.recordAction("computer_use_click", { element_id: 42 });
+
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 42 },
+        "session-1",
+        1,
+      );
+      const sent = sentMessages[0] as Record<string, unknown>;
+
+      proxy.processObservation(sent.requestId as string, {
+        axTree: "Button [1]",
+        executionResult: "Clicked element 42",
+        timings: { total: 420, axWalk: 120, capture: 240 },
+      });
+
+      const result = await resultPromise;
+      const logs = stepTimingsLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatchObject({
+        requestId: sent.requestId,
+        toolName: "computer_use_click",
+        step: 1,
+        helper: { total: 420, axWalk: 120, capture: 240 },
+      });
+      expect(typeof logs[0].roundTripMs).toBe("number");
+
+      // The timings are observability only: nothing reaches the model.
+      expect(result.content).not.toContain("420");
+      expect(result.content).not.toContain("roundTripMs");
+    });
+
+    test("an observation without timings resolves normally", async () => {
+      setup();
+
+      const resultPromise = proxy.request(
+        "computer_use_click",
+        { element_id: 7 },
+        "session-1",
+        1,
+      );
+      const sent = sentMessages[0] as Record<string, unknown>;
+
+      proxy.processObservation(sent.requestId as string, {
+        axTree: "Button [1]",
+        executionResult: "Clicked element 7",
+      });
+
+      const result = await resultPromise;
+      expect(result.isError).toBe(false);
+      expect(result.content).toContain("Clicked element 7");
+      expect(result.content).toContain("<ax-tree>");
+
+      const logs = stepTimingsLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).not.toHaveProperty("helper");
+      expect(typeof logs[0].roundTripMs).toBe("number");
     });
   });
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -2485,6 +2485,7 @@ export class AgentLoop {
             contentBlocks: response.content.length,
             toolUseCount: modelToolUseBlocks.length,
             durationMs: providerDurationMs,
+            cacheReadInputTokens: response.usage.cacheReadInputTokens,
           },
           "LLM call complete",
         );

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -181,7 +181,7 @@ export class HostCuProxy {
    */
   private _ownedRequests = new Map<
     string,
-    { scoped: boolean; dispatchedAt: number }
+    { scoped: boolean; dispatchedAt: number; toolName: string; step: number }
   >();
 
   constructor(maxSteps = loadConfig().maxStepsPerSession) {
@@ -363,6 +363,8 @@ export class HostCuProxy {
       this._ownedRequests.set(requestId, {
         scoped: scopedObservation,
         dispatchedAt: Date.now(),
+        toolName,
+        step: stepNumber,
       });
 
       pendingInteractions.register(requestId, {
@@ -424,16 +426,25 @@ export class HostCuProxy {
       return undefined;
     }
 
-    log.info(
-      {
-        requestId,
-        toolName: this._actionHistory.at(-1)?.toolName,
-        step: this._stepCount,
-        ...(owned ? { roundTripMs: Date.now() - owned.dispatchedAt } : {}),
-        ...(observation.timings ? { helper: observation.timings } : {}),
-      },
-      "Host CU step timings",
-    );
+    // Label the line from what this request was dispatched with, never from
+    // current proxy state. One model response can dispatch several CU tools,
+    // and the agent loop runs them concurrently, so a later call can advance
+    // the history and the step count before an earlier observation lands.
+    // Reading them here would file each measurement under whichever tool was
+    // dispatched last, and would mislabel computer_use_point_at, which never
+    // records an action at all.
+    if (owned) {
+      log.info(
+        {
+          requestId,
+          toolName: owned.toolName,
+          step: owned.step,
+          roundTripMs: Date.now() - owned.dispatchedAt,
+          ...(observation.timings ? { helper: observation.timings } : {}),
+        },
+        "Host CU step timings",
+      );
+    }
 
     // A targeted snapshot has no comparable action/diff baseline; neither it
     // nor the first desktop observation after it can imply "no visible effect".

--- a/assistant/src/daemon/host-cu-proxy.ts
+++ b/assistant/src/daemon/host-cu-proxy.ts
@@ -113,6 +113,8 @@ export interface CuObservationResult {
   executionResult?: string;
   executionError?: string;
   userGuidance?: string;
+  /** Per-phase helper timings in milliseconds, absent on older helpers. */
+  timings?: Record<string, number>;
 }
 
 export interface ActionRecord {
@@ -172,8 +174,15 @@ export class HostCuProxy {
   private _previousAXTree: string | undefined;
   private _consecutiveUnchangedSteps = 0;
   private _actionHistory: ActionRecord[] = [];
-  /** Owned request IDs mapped to whether their observation is scoped. */
-  private _ownedRequests = new Map<string, boolean>();
+  /**
+   * Owned request IDs mapped to whether their observation is scoped and when
+   * the request was dispatched. The dispatch time gives the round trip, which
+   * is the part of a step the helper's own timings cannot see.
+   */
+  private _ownedRequests = new Map<
+    string,
+    { scoped: boolean; dispatchedAt: number }
+  >();
 
   constructor(maxSteps = loadConfig().maxStepsPerSession) {
     this._maxSteps = maxSteps;
@@ -351,7 +360,10 @@ export class HostCuProxy {
         detachAbort = () => signal.removeEventListener("abort", onAbort);
       }
 
-      this._ownedRequests.set(requestId, scopedObservation);
+      this._ownedRequests.set(requestId, {
+        scoped: scopedObservation,
+        dispatchedAt: Date.now(),
+      });
 
       pendingInteractions.register(requestId, {
         conversationId,
@@ -403,13 +415,25 @@ export class HostCuProxy {
     requestId: string,
     observation: CuObservationResult,
   ): ToolExecutionResult | undefined {
-    const scopedObservation = this._ownedRequests.get(requestId) ?? false;
+    const owned = this._ownedRequests.get(requestId);
+    const scopedObservation = owned?.scoped ?? false;
     this._ownedRequests.delete(requestId);
     const interaction = pendingInteractions.resolve(requestId, "answered");
     if (!interaction?.rpcResolve) {
       log.warn({ requestId }, "No pending host CU request for response");
       return undefined;
     }
+
+    log.info(
+      {
+        requestId,
+        toolName: this._actionHistory.at(-1)?.toolName,
+        step: this._stepCount,
+        ...(owned ? { roundTripMs: Date.now() - owned.dispatchedAt } : {}),
+        ...(observation.timings ? { helper: observation.timings } : {}),
+      },
+      "Host CU step timings",
+    );
 
     // A targeted snapshot has no comparable action/diff baseline; neither it
     // nor the first desktop observation after it can imply "no visible effect".

--- a/assistant/src/runtime/routes/host-cu-routes.ts
+++ b/assistant/src/runtime/routes/host-cu-routes.ts
@@ -36,6 +36,10 @@ const HostCuResultBodySchema = z.object({
   executionError: z.string().optional(),
   secondaryWindows: z.string().optional(),
   userGuidance: z.string().optional(),
+  timings: z
+    .record(z.string(), z.number())
+    .describe("Per-phase helper timings in milliseconds")
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -56,6 +60,7 @@ async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     executionError,
     secondaryWindows,
     userGuidance,
+    timings,
   } = parseBody(HostCuResultBodySchema, body);
 
   const peeked = pendingInteractions.get(requestId);
@@ -119,6 +124,7 @@ async function handleHostCuResult({ body, headers }: RouteHandlerArgs) {
     executionError,
     secondaryWindows,
     userGuidance,
+    timings,
   });
 
   return { accepted: true };

--- a/packages/electron-desktop/src/host-proxy/cu-executor.ts
+++ b/packages/electron-desktop/src/host-proxy/cu-executor.ts
@@ -33,6 +33,7 @@ export const CU_RESULT_SCHEMA = z
     executionResult: z.string().optional(),
     executionError: z.string().optional(),
     secondaryWindows: z.string().optional(),
+    timings: z.record(z.string(), z.number()).optional(),
   })
   .passthrough();
 

--- a/packages/electron-desktop/src/host-proxy/poster.ts
+++ b/packages/electron-desktop/src/host-proxy/poster.ts
@@ -76,6 +76,8 @@ export interface HostCuResultPayload {
   executionError?: string;
   secondaryWindows?: string;
   userGuidance?: string;
+  /** Per-phase helper timings in milliseconds; older helpers send none. */
+  timings?: Record<string, number>;
 }
 
 export type HostAppControlState = "running" | "missing" | "minimized";


### PR DESCRIPTION
## Summary
- Accepts an optional `timings` map from the desktop helper and logs it alongside the proxy round trip, so a computer-use step can be broken into helper time and transport time.
- Logs `cacheReadInputTokens` on every provider call, which is the evidence needed to confirm or drop the suspected prompt-cache prefix rewrite in CU turns.
- Tolerates a helper that sends no timings. Nothing the model sees changes.

Part of plan: hands-off-cu.md (PR 2 of 7)