### PR TITLE
fix(search): report the degraded content lane instead of an empty list (JARVIS-1321)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -30877,9 +30877,12 @@ paths:
                   results:
                     type: array
                     items: {}
+                  contentSearchAvailable:
+                    type: boolean
                 required:
                   - query
                   - results
+                  - contentSearchAvailable
                 additionalProperties: false
   /v1/search/global:
     get:
@@ -30927,6 +30930,8 @@ paths:
                     type: array
                     items:
                       type: string
+                  contentSearchAvailable:
+                    type: boolean
                   results:
                     type: object
                     properties:
@@ -31050,6 +31055,7 @@ paths:
                 required:
                   - query
                   - queryTokens
+                  - contentSearchAvailable
                   - results
                 additionalProperties: false
   /v1/secret:

--- a/assistant/src/daemon/handlers/conversation-history.ts
+++ b/assistant/src/daemon/handlers/conversation-history.ts
@@ -30,10 +30,11 @@ export async function performConversationSearch(
       matchingMessages: [],
     }));
   }
-  return searchConversations(params.query, {
+  const { results } = await searchConversations(params.query, {
     limit: params.limit,
     maxMessagesPerConversation: params.maxMessagesPerConversation,
   });
+  return results;
 }
 
 export interface MessageContentResult {

--- a/assistant/src/persistence/__tests__/conversation-queries-search.test.ts
+++ b/assistant/src/persistence/__tests__/conversation-queries-search.test.ts
@@ -53,6 +53,10 @@ import { createConversation } from "../conversation-crud.js";
 import { searchConversations } from "../conversation-queries.js";
 import { getDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
+import {
+  _resetQdrantAvailability,
+  markQdrantUnavailable,
+} from "../embeddings/qdrant-availability.js";
 import { rawRun } from "../raw-query.js";
 
 await initializeDb();
@@ -128,6 +132,7 @@ describe("searchConversations · qdrant lexical index", () => {
   beforeEach(() => {
     resetTables();
     memoryEnabled = true;
+    _resetQdrantAvailability();
     // Content search is available once the index is populated: memory enabled
     // + backfill complete. These tests exercise that post-backfill path.
     markBackfillComplete();
@@ -145,7 +150,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns(["m-1"]);
 
-    const results = await searchConversations("flux capacitor");
+    const { results } = await searchConversations("flux capacitor");
 
     expect(searchMessageIdsLexicalMock).toHaveBeenCalledTimes(1);
     // The query text is passed through; the limit is the wide candidate
@@ -169,7 +174,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns(["a-1", "b-1"]);
 
-    const results = await searchConversations("shared token");
+    const { results } = await searchConversations("shared token");
 
     // Exactly one lexical call total — the per-conversation message rows are
     // selected from the already-fetched candidate set, not a fresh query.
@@ -216,7 +221,7 @@ describe("searchConversations · qdrant lexical index", () => {
     // worst case for a message-level cap.
     lexicalReturns([...chattyIds, "other-1"]);
 
-    const results = await searchConversations("flux capacitor");
+    const { results } = await searchConversations("flux capacitor");
 
     expect(searchMessageIdsLexicalMock).toHaveBeenCalledTimes(1);
     // Both distinct visible conversations surface despite chatty dominating
@@ -245,7 +250,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     // Candidate exists in the index, but the conversation is a non-surfaced
     // background row — the visibility SQL must filter it out.
-    expect(await searchConversations("flux capacitor")).toEqual([]);
+    expect((await searchConversations("flux capacitor")).results).toEqual([]);
   });
 
   test("applies the same archived filtering (excludes archived conversations)", async () => {
@@ -255,7 +260,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns(["arch-1"]);
 
-    expect(await searchConversations("flux capacitor")).toEqual([]);
+    expect((await searchConversations("flux capacitor")).results).toEqual([]);
   });
 
   test("includeArchived: true surfaces archived conversations matching on content", async () => {
@@ -272,7 +277,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns(["arch-1", "act-1"]);
 
-    const results = await searchConversations("flux capacitor", {
+    const { results } = await searchConversations("flux capacitor", {
       includeArchived: true,
     });
 
@@ -291,7 +296,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns([]);
 
-    const results = await searchConversations("flux capacitor", {
+    const { results } = await searchConversations("flux capacitor", {
       includeArchived: true,
     });
 
@@ -305,7 +310,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns(["p-1"]);
 
-    expect(await searchConversations("flux capacitor")).toEqual([]);
+    expect((await searchConversations("flux capacitor")).results).toEqual([]);
   });
 
   test("title-only matches still work without any lexical candidates", async () => {
@@ -315,7 +320,7 @@ describe("searchConversations · qdrant lexical index", () => {
     // finds the conversation.
     lexicalReturns([]);
 
-    const results = await searchConversations("Quarterly metrics");
+    const { results } = await searchConversations("Quarterly metrics");
 
     expect(results.map((r) => r.conversationId)).toEqual([conv.id]);
     // No content candidates → no matching messages, just the title hit.
@@ -333,7 +338,7 @@ describe("searchConversations · qdrant lexical index", () => {
       throw new Error("qdrant unreachable");
     });
 
-    const results = await searchConversations("flux capacitor");
+    const { results } = await searchConversations("flux capacitor");
 
     expect(searchMessageIdsLexicalMock).toHaveBeenCalledTimes(1);
     // The content-only conversation is dropped; the title-matched conversation
@@ -351,7 +356,7 @@ describe("searchConversations · qdrant lexical index", () => {
     insertMessage("m-1", conv.id, "flux capacitor in content only");
     lexicalReturns(["m-1"]);
 
-    const results = await searchConversations("flux capacitor");
+    const { results } = await searchConversations("flux capacitor");
 
     expect(searchMessageIdsLexicalMock).toHaveBeenCalledTimes(1);
     expect(results.map((r) => r.conversationId)).toEqual([conv.id]);
@@ -372,7 +377,7 @@ describe("searchConversations · qdrant lexical index", () => {
     const titleMatch = createConversation("Flux capacitor planning");
     lexicalReturns(["m-1"]);
 
-    const results = await searchConversations("flux capacitor");
+    const { results } = await searchConversations("flux capacitor");
 
     expect(searchMessageIdsLexicalMock).not.toHaveBeenCalled();
     expect(results.map((r) => r.conversationId)).toEqual([titleMatch.id]);
@@ -396,7 +401,7 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns(["sb-1"]);
 
-    const results = await searchConversations("flux capacitor");
+    const { results } = await searchConversations("flux capacitor");
 
     expect(results.map((r) => r.conversationId)).toEqual([surfaced.id]);
     expect(results[0]!.matchingMessages.map((m) => m.messageId)).toEqual([
@@ -412,7 +417,7 @@ describe("searchConversations · qdrant lexical index", () => {
     insertMessage("s-1", contentOnly.id, "review the C§ draft");
     const titleMatch = createConversation("C§ symbol reference");
 
-    const results = await searchConversations("C§");
+    const { results } = await searchConversations("C§");
 
     expect(searchMessageIdsLexicalMock).not.toHaveBeenCalled();
     expect(results.map((r) => r.conversationId)).toEqual([titleMatch.id]);
@@ -425,6 +430,99 @@ describe("searchConversations · qdrant lexical index", () => {
 
     lexicalReturns([]);
 
-    expect(await searchConversations("flux capacitor")).toEqual([]);
+    expect((await searchConversations("flux capacitor")).results).toEqual([]);
+  });
+});
+
+describe("searchConversations · contentSearchAvailable", () => {
+  beforeEach(() => {
+    resetTables();
+    memoryEnabled = true;
+    _resetQdrantAvailability();
+    markBackfillComplete();
+    searchMessageIdsLexicalMock.mockClear();
+    searchMessageIdsLexicalMock.mockImplementation(async () => []);
+  });
+
+  test("is true, and content matches, when the index is a usable read source", async () => {
+    // The positive control for every negative case below. Without it, a flag
+    // hard-coded to `false` would satisfy them all.
+    const conv = createConversation("Notes");
+    insertMessage("m-1", conv.id, "the flux capacitor needs recalibration");
+    lexicalReturns(["m-1"]);
+
+    const res = await searchConversations("flux capacitor");
+
+    expect(res.contentSearchAvailable).toBe(true);
+    expect(res.results[0]!.matchingMessages).toHaveLength(1);
+  });
+
+  test("is false when Qdrant never started, and the index is not consulted", async () => {
+    // The JARVIS-1321 shape: a daemon whose local Qdrant failed to start has
+    // no index to ask, so a content-only match is unreachable and the caller
+    // must be told the lane is missing rather than shown a bare empty list.
+    markQdrantUnavailable("start_failed");
+    const contentOnly = createConversation("Notes");
+    insertMessage("m-1", contentOnly.id, "flux capacitor in content only");
+    lexicalReturns(["m-1"]);
+
+    const res = await searchConversations("flux capacitor");
+
+    expect(res.contentSearchAvailable).toBe(false);
+    expect(searchMessageIdsLexicalMock).not.toHaveBeenCalled();
+    expect(res.results).toEqual([]);
+  });
+
+  test("is false when the lexical lookup throws mid-search", async () => {
+    // The pre-flight gate passes and the lookup still fails (Qdrant died after
+    // startup). The flag reports what the search could use, not what it
+    // expected to, so it must drop here too.
+    const contentOnly = createConversation("Notes");
+    insertMessage("m-1", contentOnly.id, "flux capacitor in content only");
+    searchMessageIdsLexicalMock.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+
+    const res = await searchConversations("flux capacitor");
+
+    expect(res.contentSearchAvailable).toBe(false);
+    expect(res.results).toEqual([]);
+  });
+
+  test("is false while the backfill has not drained", async () => {
+    deleteMemoryCheckpoint(LEXICAL_BACKFILL_COMPLETE_KEY);
+
+    const res = await searchConversations("flux capacitor");
+
+    expect(res.contentSearchAvailable).toBe(false);
+  });
+
+  test("stays true for a query that tokenizes to nothing", async () => {
+    // The flag describes the index, not the query. "C§" yields no lexical
+    // tokens so content matching is skipped, but the index is fine and
+    // telling the user content search is unavailable would be wrong.
+    const titleMatch = createConversation("C§ symbol reference");
+
+    const res = await searchConversations("C§");
+
+    expect(res.contentSearchAvailable).toBe(true);
+    expect(searchMessageIdsLexicalMock).not.toHaveBeenCalled();
+    expect(res.results.map((r) => r.conversationId)).toEqual([titleMatch.id]);
+  });
+
+  test("reports the degraded lane even when titles still match", async () => {
+    // The dangerous case is not an empty list, it is a SHORT one: title
+    // matches make the response look like a successful search. The flag has
+    // to be false here or a client has no way to know content was missing.
+    markQdrantUnavailable("start_failed");
+    const titleMatch = createConversation("Flux capacitor planning");
+    const contentOnly = createConversation("Notes");
+    insertMessage("m-1", contentOnly.id, "flux capacitor in content only");
+    lexicalReturns(["m-1"]);
+
+    const res = await searchConversations("flux capacitor");
+
+    expect(res.results.map((r) => r.conversationId)).toEqual([titleMatch.id]);
+    expect(res.contentSearchAvailable).toBe(false);
   });
 });

--- a/assistant/src/persistence/checkpoints.ts
+++ b/assistant/src/persistence/checkpoints.ts
@@ -83,12 +83,16 @@ export const LEXICAL_BACKFILL_COMPLETE_KEY =
  * instance.
  *
  * Gates two things: the one-time startup auto-enqueue (skip when already
- * complete) and — critically — the message-search read backend. An upgraded
- * instance whose backfill has not finished must keep reading from SQLite FTS,
- * because a `qdrant`-backed read against the still-filling `messages_lexical`
- * collection returns an empty result (not a throw), so the Qdrant-error degrade
- * path never fires and content search would silently return nothing. Switch
- * reads to Qdrant only once this marker confirms the index is fully populated.
+ * complete) and, critically, the message-search read backend. A read against
+ * a still-filling `messages_lexical` collection returns an empty result rather
+ * than throwing, so the Qdrant-error degrade path never fires and content
+ * search would silently miss older messages. Treat the index as a read source
+ * only once this marker confirms it is fully populated.
+ *
+ * This is one of two inputs to that decision. The other is whether Qdrant is
+ * running at all (`embeddings/qdrant-availability.ts`); both are required,
+ * because since migration 313 dropped `messages_fts` there is no other source
+ * of message-content matches to fall back to.
  */
 export function isLexicalBackfillComplete(): boolean {
   return getMemoryCheckpoint(LEXICAL_BACKFILL_COMPLETE_KEY) === "1";

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -33,6 +33,7 @@ import {
   UNGROUPED_GROUP_ID,
 } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
+import { getQdrantAvailability } from "./embeddings/qdrant-availability.js";
 import { tokenize } from "./embeddings/sparse-tokenize.js";
 import {
   parseContentRef,
@@ -933,6 +934,21 @@ export interface ConversationSearchResult {
   }>;
 }
 
+export interface ConversationSearchResponse {
+  results: ConversationSearchResult[];
+  /**
+   * Whether message content was a usable source for this search. False means
+   * only conversation titles were matched, so a short or empty `results` is
+   * evidence about the index rather than about the corpus, and a client that
+   * renders it as "no matches" is telling the user something untrue.
+   *
+   * Reports the index, not the query: a term that tokenizes to nothing (`"C++"`,
+   * a single non-ASCII character) also skips content matching, but the index was
+   * fine and this stays true.
+   */
+  contentSearchAvailable: boolean;
+}
+
 interface ConversationSearchMsgRow {
   id: string;
   role: string;
@@ -955,16 +971,24 @@ function likeContainsPattern(query: string): string {
 }
 
 /**
- * Whether the sparse Qdrant `messages_lexical` index — the only source of
- * message-content matches — is a safe read source. Content matching is
- * unavailable (title matches only) until the one-time upgrade backfill has
- * fully drained: a partially populated collection would silently miss older
- * content (an empty result — not a throw). Indexing itself is unconditional
- * host infrastructure, so completion is the only gate; the recall read site
- * applies the same one via the shared {@link isLexicalBackfillComplete}.
+ * Whether the sparse Qdrant `messages_lexical` index, the only source of
+ * message-content matches, is a safe read source.
+ *
+ * Two conditions, both required, because migration 313 dropped `messages_fts`
+ * and left no other content source to fall back to:
+ *
+ * 1. The one-time upgrade backfill has fully drained. A partially populated
+ *    collection silently misses older content, returning an empty result
+ *    rather than throwing, so the Qdrant-error degrade path never fires.
+ * 2. Qdrant came up on this daemon at all. A daemon whose local Qdrant never
+ *    started has no index to ask, and every content lookup will throw.
+ *
+ * Both are cheap synchronous reads, so callers may consult this per query.
+ * The recall read site applies condition 1 via the shared
+ * {@link isLexicalBackfillComplete}.
  */
 function isMessageContentSearchAvailable(): boolean {
-  return isLexicalBackfillComplete();
+  return isLexicalBackfillComplete() && getQdrantAvailability().available;
 }
 
 /**
@@ -1004,9 +1028,9 @@ export async function searchConversations(
      */
     includeArchived?: boolean;
   },
-): Promise<ConversationSearchResult[]> {
+): Promise<ConversationSearchResponse> {
   if (!query.trim()) {
-    return [];
+    return { results: [], contentSearchAvailable: true };
   }
 
   ensureGroupMigration();
@@ -1016,7 +1040,10 @@ export async function searchConversations(
   const maxMsgsPerConv = opts?.maxMessagesPerConversation ?? 3;
 
   const hasTokens = hasLexicalTokens(trimmed);
-  const contentSearchAvailable = isMessageContentSearchAvailable();
+  // Starts from the pre-flight gate and drops to false if the lookup below
+  // throws, so the flag reports what this search could actually use rather
+  // than what it expected to.
+  let contentSearchAvailable = isMessageContentSearchAvailable();
 
   // LIKE pattern for title matching (message-content indexes don't cover titles).
   const titlePattern = likeContainsPattern(query);
@@ -1048,9 +1075,10 @@ export async function searchConversations(
         QDRANT_SEARCH_CANDIDATE_LIMIT,
       );
     } catch (err) {
+      contentSearchAvailable = false;
       log.warn(
         { err, query: query.slice(0, 80) },
-        "searchConversations: Qdrant lexical query failed — returning title matches only",
+        "searchConversations: Qdrant lexical query failed, returning title matches only",
       );
     }
 
@@ -1156,7 +1184,7 @@ export async function searchConversations(
   }
 
   if (contentConvIds.size === 0) {
-    return [];
+    return { results: [], contentSearchAvailable };
   }
 
   // Fetch the matching conversation rows, ordered by updatedAt, capped at limit.
@@ -1178,7 +1206,7 @@ export async function searchConversations(
   );
 
   if (matchingConversations.length === 0) {
-    return [];
+    return { results: [], contentSearchAvailable };
   }
 
   const results: ConversationSearchResult[] = [];
@@ -1231,7 +1259,7 @@ export async function searchConversations(
     });
   }
 
-  return results;
+  return { results, contentSearchAvailable };
 }
 
 /**

--- a/assistant/src/persistence/embeddings/__tests__/qdrant-availability.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/qdrant-availability.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  _resetQdrantAvailability,
+  getQdrantAvailability,
+  markQdrantAvailable,
+  markQdrantUnavailable,
+} from "../qdrant-availability.js";
+
+describe("qdrant availability", () => {
+  beforeEach(() => {
+    _resetQdrantAvailability();
+  });
+
+  test("defaults to available so an unreached startup path behaves as before", () => {
+    // A daemon that never runs the memory startup (memory plugin disabled,
+    // a worker process) publishes no verdict. Defaulting to unavailable would
+    // silently switch message-content search off on those processes.
+    expect(getQdrantAvailability()).toEqual({ available: true });
+  });
+
+  test("carries the reason a read site can report", () => {
+    markQdrantUnavailable("start_failed");
+
+    expect(getQdrantAvailability()).toEqual({
+      available: false,
+      reason: "start_failed",
+    });
+  });
+
+  test("clears the reason when the store comes back", () => {
+    markQdrantUnavailable("start_failed");
+    markQdrantAvailable();
+
+    // A stale reason alongside `available: true` would let a caller render a
+    // failure explanation for a healthy store.
+    expect(getQdrantAvailability()).toEqual({ available: true });
+  });
+});

--- a/assistant/src/persistence/embeddings/qdrant-availability.ts
+++ b/assistant/src/persistence/embeddings/qdrant-availability.ts
@@ -1,0 +1,59 @@
+/**
+ * Whether the local Qdrant vector store came up on this daemon.
+ *
+ * Read sites that have no fallback need to distinguish "the index answered and
+ * matched nothing" from "there is no index to ask". Message-content search is
+ * the sharp case: migration `313-drop-messages-fts.ts` dropped the `messages_fts`
+ * table, so `messages_lexical` is the only source of content matches. When Qdrant
+ * is not running, `searchConversations` degrades to matching conversation titles
+ * and returns a short list that is indistinguishable from "nothing matched".
+ *
+ * Deliberately NOT the Qdrant circuit breaker
+ * (`qdrant-circuit-breaker.ts`). That breaker answers a different question:
+ * whether recent operations failed often enough to fail fast. It reads closed
+ * before the first call, so on a daemon whose Qdrant never started it reports
+ * healthy right up until a read fails, which is exactly the window this fact
+ * covers. The breaker also gates the v1 collection, so forcing it open here
+ * would change v1 read behaviour well beyond this concern.
+ *
+ * Set once by the memory plugin's startup after the Qdrant start attempts
+ * settle, so it only carries a verdict in the daemon process (the memory worker
+ * runs its own process and never calls `runMemoryStartup`; see
+ * `job-handlers/message-lexical.ts`). Until PR 2 adds a supervisor there is no
+ * path that restarts Qdrant mid-process, so a start failure is terminal for the
+ * daemon's lifetime and this fact does not need to change back.
+ *
+ * Defaults to available so a daemon that never reaches the memory startup path
+ * behaves exactly as it did before this fact existed. On that daemon the
+ * backfill sentinel is unset anyway, which is what actually gates the read.
+ */
+
+/** Why the vector store is not a usable read source. */
+export type QdrantUnavailableReason = "start_failed";
+
+interface QdrantAvailability {
+  available: boolean;
+  reason?: QdrantUnavailableReason;
+}
+
+let state: QdrantAvailability = { available: true };
+
+/** Record that the local Qdrant store is up and serving. */
+export function markQdrantAvailable(): void {
+  state = { available: true };
+}
+
+/** Record that the local Qdrant store is not usable, with the reason why. */
+export function markQdrantUnavailable(reason: QdrantUnavailableReason): void {
+  state = { available: false, reason };
+}
+
+/** The current verdict, for read sites deciding whether to trust the index. */
+export function getQdrantAvailability(): Readonly<QdrantAvailability> {
+  return state;
+}
+
+/** @internal Test-only: restore the default (available) verdict. */
+export function _resetQdrantAvailability(): void {
+  state = { available: true };
+}

--- a/assistant/src/plugins/defaults/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/conversation-queries.test.ts
@@ -898,7 +898,7 @@ describe("searchConversations · surfaced conversations", () => {
     });
     setSurfaced(surfaced.id);
 
-    const results = await searchConversations("Quarterly metrics");
+    const { results } = await searchConversations("Quarterly metrics");
 
     expect(results.map((r) => r.conversationId)).toEqual([surfaced.id]);
   });
@@ -909,7 +909,9 @@ describe("searchConversations · surfaced conversations", () => {
       conversationType: "background",
     });
 
-    expect(await searchConversations("Quarterly metrics")).toEqual([]);
+    expect((await searchConversations("Quarterly metrics")).results).toEqual(
+      [],
+    );
   });
 
   test("private conversations are never included, even with surfaced_at set", async () => {
@@ -917,7 +919,9 @@ describe("searchConversations · surfaced conversations", () => {
     setConversationType(priv.id, "private");
     setSurfaced(priv.id);
 
-    expect(await searchConversations("Quarterly metrics")).toEqual([]);
+    expect((await searchConversations("Quarterly metrics")).results).toEqual(
+      [],
+    );
   });
 
   test("surfaced subagent runs stay excluded from title search", async () => {
@@ -928,7 +932,9 @@ describe("searchConversations · surfaced conversations", () => {
     });
     setSurfaced(subagent.id);
 
-    expect(await searchConversations("Quarterly metrics")).toEqual([]);
+    expect((await searchConversations("Quarterly metrics")).results).toEqual(
+      [],
+    );
   });
 });
 

--- a/assistant/src/plugins/defaults/memory/startup.ts
+++ b/assistant/src/plugins/defaults/memory/startup.ts
@@ -38,6 +38,10 @@ import {
   MESSAGES_LEXICAL_COLLECTION,
 } from "../../../persistence/embeddings/messages-lexical-index.js";
 import {
+  markQdrantAvailable,
+  markQdrantUnavailable,
+} from "../../../persistence/embeddings/qdrant-availability.js";
+import {
   clearRebuildSentinel,
   initQdrantClient,
 } from "../../../persistence/embeddings/qdrant-client.js";
@@ -46,6 +50,7 @@ import {
   enqueueMemoryJob,
   isMemoryEnabled,
 } from "../../../persistence/jobs-store.js";
+import { recordWatchdogEvent } from "../../../telemetry/watchdog-events-store.js";
 import { resolveQdrantUrl } from "./embeddings.js";
 import { startMemoryJobsWorker } from "./jobs-worker.js";
 import { getLogger } from "./logging.js";
@@ -97,6 +102,12 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
   }
 
   if (qdrantStarted) {
+    // Publish the verdict before any Qdrant-dependent step runs. Read sites
+    // with no fallback consult it so a missing index reads as "search is
+    // unavailable" rather than "nothing matched"; see
+    // `persistence/embeddings/qdrant-availability.ts`.
+    markQdrantAvailable();
+
     // ---- v1 (legacy engine) — delete with v1 ----
     // Stays ahead of the shared embedding-identity reconcile below: that
     // reconcile persists a new `memory.qdrant.vectorSize` on a commit-fresh or
@@ -241,6 +252,17 @@ export async function runMemoryStartup(config: AssistantConfig): Promise<void> {
         "Concept page frontmatter sweep threw — continuing startup",
       );
     }
+  } else {
+    markQdrantUnavailable("start_failed");
+    // Nothing else reports this failure anywhere a fleet-wide view can see it:
+    // the daemon has no Sentry integration and the warn above lands only in the
+    // local rotating log. Mirrors how the schedule worker reports being down
+    // (`schedule/scheduler.ts`).
+    recordWatchdogEvent({
+      checkName: "qdrant_unavailable",
+      value: QDRANT_START_MAX_ATTEMPTS,
+      detail: { reason: "start_failed", attempts: QDRANT_START_MAX_ATTEMPTS },
+    });
   }
 
   // ---- shared infra ----

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -3568,7 +3568,7 @@ async function handleSearchConversations({
     ? Number(queryParams.maxMessagesPerConversation)
     : undefined;
 
-  const results = await searchConversations(query, {
+  const { results, contentSearchAvailable } = await searchConversations(query, {
     ...(limit !== undefined && !isNaN(limit) ? { limit } : {}),
     ...(maxMessagesPerConversation !== undefined &&
     !isNaN(maxMessagesPerConversation)
@@ -3576,7 +3576,7 @@ async function handleSearchConversations({
       : {}),
   });
 
-  return { query, results };
+  return { query, results, contentSearchAvailable };
 }
 
 // ---------------------------------------------------------------------------
@@ -3824,6 +3824,11 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       query: z.string(),
       results: z.array(z.unknown()),
+      /**
+       * Whether message content was a usable source. False means title-only
+       * matching, so a short result list says nothing about the corpus.
+       */
+      contentSearchAvailable: z.boolean(),
     }),
     handler: handleSearchConversations,
   },

--- a/assistant/src/runtime/routes/global-search-routes.ts
+++ b/assistant/src/runtime/routes/global-search-routes.ts
@@ -74,6 +74,16 @@ const globalSearchResponseSchema = z.object({
    * uses. Clients highlight these instead of re-tokenizing client-side.
    */
   queryTokens: z.array(z.string()),
+  /**
+   * Whether message content was a usable source for the conversation results.
+   * False means only conversation titles were matched, so an empty or short
+   * list is evidence about the index rather than about the corpus. Clients
+   * must say so instead of rendering a bare "no results".
+   *
+   * True when conversations were not searched at all (the category was not
+   * requested): there is no degraded content lane to report.
+   */
+  contentSearchAvailable: z.boolean(),
   results: z.object({
     conversations: z.array(globalSearchConversationSchema),
     memories: z.array(globalSearchMemorySchema),
@@ -308,13 +318,16 @@ async function handleGlobalSearch({
     contacts: [],
   };
 
+  let contentSearchAvailable = true;
+
   if (categories.has("conversations")) {
-    const convResults = await searchConversations(term, {
+    const convSearch = await searchConversations(term, {
       limit,
       maxMessagesPerConversation: 1,
       includeArchived,
     });
-    results.conversations = convResults.map((c) => ({
+    contentSearchAvailable = convSearch.contentSearchAvailable;
+    results.conversations = convSearch.results.map((c) => ({
       id: c.conversationId,
       title: c.conversationTitle,
       updatedAt: c.conversationUpdatedAt,
@@ -356,7 +369,12 @@ async function handleGlobalSearch({
     }));
   }
 
-  return { query: term, queryTokens: tokenize(term), results };
+  return {
+    query: term,
+    queryTokens: tokenize(term),
+    contentSearchAvailable,
+    results,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/components/command-palette/command-palette-window-page.tsx
+++ b/clients/web/src/components/command-palette/command-palette-window-page.tsx
@@ -129,6 +129,7 @@ export function CommandPaletteWindowPage() {
         selectedIndex={commandPalette.selectedIndex}
         sections={mergedSections}
         isSearching={commandPalette.isSearching}
+        contentSearchAvailable={commandPalette.contentSearchAvailable}
         onItemSelect={selectItem}
         onKeyDown={commandPalette.handleKeyDown}
       />

--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -435,3 +435,71 @@ describe("CommandPalette keyboard hints", () => {
     expect(keyboardHints()).toEqual([]);
   });
 });
+
+describe("CommandPalette degraded content search", () => {
+  /** Palette with the content lane reported down, rendering `sections`. */
+  function degradedPalette(sections: typeof SECTIONS | [] = SECTIONS) {
+    return (
+      <CommandPalette
+        isOpen
+        onClose={() => undefined}
+        query="flux"
+        onQueryChange={() => undefined}
+        selectedIndex={0}
+        sections={sections}
+        contentSearchAvailable={false}
+        onKeyDown={() => undefined}
+      />
+    );
+  }
+
+  test("says nothing when the content lane is healthy", () => {
+    // The control: without it, a notice rendered unconditionally would still
+    // satisfy every assertion below.
+    render(paletteElement(true));
+
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  test("replaces the no-results claim when content matching is down", () => {
+    // "No results" asserts something about the corpus that a title-only
+    // search cannot support, which is the bug this surface exists to fix.
+    render(degradedPalette([]));
+
+    expect(screen.queryByText("No results")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain(
+      "Showing title matches only",
+    );
+  });
+
+  test("still warns when title matches came back", () => {
+    // The dangerous case: a short list that looks like a complete answer.
+    render(degradedPalette());
+
+    expect(screen.getByText("New Conversation")).toBeTruthy();
+    expect(screen.getByRole("status").textContent).toContain(
+      "Showing title matches only",
+    );
+  });
+
+  test("holds the warning while a new search is in flight", () => {
+    // The flag still describes the previous search until the next one lands,
+    // so showing it here would attach a stale warning to a pending query.
+    render(
+      <CommandPalette
+        isOpen
+        onClose={() => undefined}
+        query="flux"
+        onQueryChange={() => undefined}
+        selectedIndex={0}
+        sections={[]}
+        contentSearchAvailable={false}
+        isSearching
+        onKeyDown={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByText("Searching\u2026")).toBeTruthy();
+  });
+});

--- a/clients/web/src/components/command-palette/command-palette.tsx
+++ b/clients/web/src/components/command-palette/command-palette.tsx
@@ -93,6 +93,13 @@ export interface CommandPaletteProps {
   sections: CommandPaletteSection[];
   /** Whether a server search is currently in-flight. */
   isSearching?: boolean;
+  /**
+   * Whether the daemon could match message content for `sections`. False means
+   * it matched conversation titles only, so the list is short for a reason the
+   * user cannot see and the palette says so instead of implying nothing
+   * matched. Defaults to true so hosts that pass no search state are unchanged.
+   */
+  contentSearchAvailable?: boolean;
   /** Called when an item is selected (clicked or Enter pressed). */
   onItemSelect?: (item: CommandPaletteItemData, index: number) => void;
   /** Key-down handler from useCommandPalette for keyboard navigation. */
@@ -188,6 +195,7 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
   selectedIndex,
   sections,
   isSearching = false,
+  contentSearchAvailable = true,
   onItemSelect,
   onKeyDown,
   surface = "overlay",
@@ -351,17 +359,38 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
       }
       role="listbox"
     >
-      {sections.length === 0 ? (
-        <div className="px-3 py-6 text-center">
+      {/* A degraded content lane is worth saying even when titles matched: a
+          short list otherwise reads as a complete answer. Suppressed while a
+          search is in flight, when the flag still describes the previous one. */}
+      {!contentSearchAvailable && !isSearching ? (
+        <div
+          role="status"
+          className="mx-1 mb-1 rounded-md bg-[var(--background-tertiary)] px-3 py-2"
+        >
           <Typography
-            variant="body-medium-lighter"
-            className="text-[var(--content-tertiary)]"
+            variant="body-small-default"
+            className="text-[var(--content-secondary)]"
           >
-            {isSearching
-              ? t("commandPalette.searching")
-              : t("commandPalette.noResults")}
+            {t("commandPalette.contentSearchUnavailable")}
           </Typography>
         </div>
+      ) : null}
+      {sections.length === 0 ? (
+        // With content matching down, "No results" would be a claim about the
+        // corpus this search cannot support; the notice above already explains
+        // the empty list, so do not contradict it.
+        !contentSearchAvailable && !isSearching ? null : (
+          <div className="px-3 py-6 text-center">
+            <Typography
+              variant="body-medium-lighter"
+              className="text-[var(--content-tertiary)]"
+            >
+              {isSearching
+                ? t("commandPalette.searching")
+                : t("commandPalette.noResults")}
+            </Typography>
+          </div>
+        )
       ) : (
         sections.map((section) => (
           <div key={section.id} role="group" aria-label={section.label}>

--- a/clients/web/src/components/command-palette/use-command-palette.ts
+++ b/clients/web/src/components/command-palette/use-command-palette.ts
@@ -38,6 +38,12 @@ export interface UseCommandPaletteReturn {
    * highlighting.
    */
   searchTokens: string[];
+  /**
+   * Whether the daemon could match message content for the current results.
+   * False means titles only, so an empty or short list must not be rendered
+   * as "nothing matched". True whenever no search is in play.
+   */
+  contentSearchAvailable: boolean;
   open: () => void;
   close: () => void;
   toggle: () => void;
@@ -73,6 +79,7 @@ export function useCommandPalette({
   const [searchResults, setSearchResults] =
     useState<GlobalSearchResponse | null>(null);
   const [searchTokens, setSearchTokens] = useState<string[]>(NO_TOKENS);
+  const [contentSearchAvailable, setContentSearchAvailable] = useState(true);
 
   const itemCountGetterRef = useRef<() => number>(() => 0);
   useLayoutEffect(() => {
@@ -109,6 +116,7 @@ export function useCommandPalette({
     setIsSearching(false);
     setSearchResults(null);
     setSearchTokens(NO_TOKENS);
+    setContentSearchAvailable(true);
     cancelSearch();
     onClose?.();
   }, [storeClose, cancelSearch, onClose]);
@@ -130,6 +138,7 @@ export function useCommandPalette({
       setIsSearching(false);
       setSearchResults(null);
       setSearchTokens(NO_TOKENS);
+      setContentSearchAvailable(true);
       cancelSearch();
     }
   }, [isOpen, cancelSearch]);
@@ -147,6 +156,7 @@ export function useCommandPalette({
         setIsSearching(false);
         setSearchResults(null);
         setSearchTokens(NO_TOKENS);
+        setContentSearchAvailable(true);
         return;
       }
 
@@ -166,6 +176,7 @@ export function useCommandPalette({
             if (abortControllerRef.current === controller) {
               setSearchResults(outcome.results);
               setSearchTokens(outcome.queryTokens);
+              setContentSearchAvailable(outcome.contentSearchAvailable);
               setIsSearching(false);
             }
           })
@@ -241,6 +252,7 @@ export function useCommandPalette({
     isSearching,
     searchResults,
     searchTokens,
+    contentSearchAvailable,
     open,
     close,
     toggle,

--- a/clients/web/src/domains/chat/api/global-search.ts
+++ b/clients/web/src/domains/chat/api/global-search.ts
@@ -21,6 +21,17 @@ export interface GlobalSearchOutcome {
   query: string;
   queryTokens: string[];
   results: GlobalSearchResponse;
+  /**
+   * Whether message content was a usable source for the conversation results.
+   * False means the daemon matched conversation titles only, so a short or
+   * empty list says nothing about what the corpus holds and the palette must
+   * say so rather than render "no results".
+   *
+   * Defaults to true on a failed or aborted request: the whole outcome is
+   * empty there, and claiming a degraded content lane would explain a
+   * transport failure as an index problem.
+   */
+  contentSearchAvailable: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -38,6 +49,7 @@ const EMPTY_OUTCOME: GlobalSearchOutcome = {
   query: "",
   queryTokens: [],
   results: EMPTY_RESULTS,
+  contentSearchAvailable: true,
 };
 
 /** Whitespace-token fallback for daemons that predate `queryTokens`. */
@@ -84,6 +96,10 @@ export async function searchGlobal(
       query: data.query,
       queryTokens: tokensWithFallback(data.queryTokens, data.query),
       results: data.results,
+      // `?? true` covers a daemon predating the field, matching how
+      // `queryTokens` degrades: assume the lane is healthy rather than warn
+      // about a degradation this daemon cannot report either way.
+      contentSearchAvailable: data.contentSearchAvailable ?? true,
     };
   } catch (err) {
     // AbortError is expected when debounced queries supersede each other.

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -1370,6 +1370,7 @@ export function ChatLayout({
             selectedIndex={commandPalette.selectedIndex}
             sections={mergedSections}
             isSearching={commandPalette.isSearching}
+            contentSearchAvailable={commandPalette.contentSearchAvailable}
             onItemSelect={handleItemSelect}
             onKeyDown={commandPalette.handleKeyDown}
           />

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -130,6 +130,7 @@
     "clear": "Clear",
     "clearSearch": "Clear search",
     "closeSearch": "Close search",
+    "contentSearchUnavailable": "Message content search is unavailable. Showing title matches only.",
     "noResults": "No results",
     "placeholder": "Search conversations, memories…",
     "searchAriaLabel": "Search",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -130,6 +130,7 @@
     "clear": "Borrar",
     "clearSearch": "Borrar búsqueda",
     "closeSearch": "Cerrar búsqueda",
+    "contentSearchUnavailable": "La búsqueda en el contenido de los mensajes no está disponible. Mostrando solo coincidencias de título.",
     "noResults": "Sin resultados",
     "placeholder": "Buscar conversaciones, recuerdos…",
     "searchAriaLabel": "Buscar",

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -130,6 +130,7 @@
     "clear": "清除",
     "clearSearch": "清除搜尋",
     "closeSearch": "關閉搜尋",
+    "contentSearchUnavailable": "訊息內容搜尋不可用。僅顯示標題符合項目。",
     "noResults": "沒有結果",
     "placeholder": "搜尋對話、記憶…",
     "searchAriaLabel": "搜尋",

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -130,6 +130,7 @@
     "clear": "清除",
     "clearSearch": "清除搜索",
     "closeSearch": "关闭搜索",
+    "contentSearchUnavailable": "消息内容搜索不可用。仅显示标题匹配项。",
     "noResults": "无结果",
     "placeholder": "搜索对话、记忆…",
     "searchAriaLabel": "搜索",


### PR DESCRIPTION
## TL;DR

When the bundled Qdrant fails to start, conversation search silently degrades to matching conversation titles and returns a short list that looks exactly like "nothing matched". This PR makes that state visible: the daemon now knows whether its vector store came up, the search response says whether message content was actually searchable, the command palette says so instead of rendering "No results", and one watchdog event reports the failure so we can see how often it happens across the fleet.

No behaviour change while Qdrant is healthy.

## Why this, and why now

Migration `313-drop-messages-fts.ts` dropped the `messages_fts` FTS5 table. `conversation-queries.ts` states the consequence plainly:

> Content matching is index-only, there is no `messages.content` scan fallback and no other content source.

So a failed Qdrant does not merely cost semantic memory. It costs conversation search. The user types a phrase they remember from a conversation, gets nothing back, and reasonably concludes the conversation is not there.

Part of JARVIS-1321.

## What changes for the user

| Situation | Before | After |
| --- | --- | --- |
| Qdrant healthy | Content and title matches | Unchanged |
| Qdrant never started, nothing matches by title | "No results" | "Message content search is unavailable. Showing title matches only." |
| Qdrant never started, some titles match | A short list that looks complete | The same list, with the notice above it |
| Qdrant dies mid-session | Title matches only, silently | Same results, with the notice |
| Backfill still draining | Title matches only, silently | Same results, with the notice |
| Query with no lexical tokens (`C++`, `你`) | Title matches only | Unchanged, and deliberately **no** notice: the index was fine |

## Design notes

**Why a new fact and not the circuit breaker.** `qdrant-circuit-breaker.ts` answers "have recent operations failed often enough to fail fast". It reads closed before the first call, which is exactly the window a never-started Qdrant occupies, so it reports healthy right up until a read fails. It also gates the v1 collection, so forcing it open from a startup failure would change v1 read behaviour well beyond this concern. The new `embeddings/qdrant-availability.ts` holds one fact, set once by the memory plugin's startup, defaulting to available so a process that never runs that startup behaves exactly as before.

**Why the flag reports the index and not the query.** A term that tokenizes to nothing also skips content matching, but nothing is wrong and telling the user content search is unavailable would be false. The flag starts from the pre-flight gate and drops only if the lexical lookup actually throws, so it describes what this search could use rather than what it expected to.

**Why the copy names no fix.** The flag is a boolean and carries no cause to the client, so the notice states the situation and stops. This follows the bar `memory-unavailable-copy.ts` already sets: name a fix only when you are sure it applies.

**Why `watchdog` and not a new event type.** Per `src/telemetry/AGENTS.md`, a new telemetry type starts platform-side and lands here last. `watchdog` is already on the wire contract and is what `schedule_worker_down` uses for exactly this shape of subsystem failure, so this needs no cross-repo change.

## Why this is safe

- Every new code path is reachable only when content search is already degraded. On a healthy daemon `getQdrantAvailability()` returns the default and the gate evaluates as it did before.
- `searchConversations` changing from an array to `{ results, contentSearchAvailable }` is a compile-time break caught at all three call sites; there is no wire-format break, because both HTTP routes only gain a field.
- `contentSearchAvailable` defaults to `true` in the web client when a daemon predates the field, matching how `queryTokens` already degrades. Assuming health avoids warning about a degradation the daemon cannot report either way.
- The watchdog event is metadata only (reason and attempt count) and inherits `recordTelemetryEvent`'s consent gating.
- `assistant/openapi.yaml` is regenerated, not hand-edited. `clients/web/src/generated` is gitignored and rebuilt by `pretypecheck`.

## Tests

New tests assert the invariant rather than the presence of a field, each with a positive control so a hard-coded `false` would fail:

- Healthy index: flag true **and** content matches present.
- Qdrant never started: flag false, index never consulted, no results.
- Lookup throws mid-search: flag false.
- Backfill not drained: flag false.
- Non-tokenizable query: flag stays **true**.
- Titles match but content is down: flag false alongside a non-empty list. This is the case the surface exists for.
- Palette: no notice when healthy, notice replaces "No results" when down, notice shown alongside title matches, and suppressed while a search is in flight.

## Deferred

- **`QDRANT_VERSION` upgrade gap.** `installBinary` runs only when the binary file is absent, and no version marker is written, so bumping the pinned version would not replace an already-installed binary. `QDRANT_VERSION` has not moved from `1.13.2` since Feb 2026 (`eeefed2d17`), so this is latent rather than a live defect. Out of scope here; worth fixing before the next bump.
- **Supervising the Qdrant process.** The current three-attempt loop kills a Qdrant that is merely slow to load and gives up permanently for the process lifetime. The daemon already has `createWorkerSupervisor` plus process-tree ownership from ATL-1349, and Qdrant is the only long-lived child not using them. Held as PR 2 deliberately: we have one dogfood occurrence whose original FD-limit diagnosis does not reproduce, and one unattributed report. The watchdog event added here is what will show whether that work is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->