### PR TITLE
fix(gmail): cap concurrent oauth request CLIs at 4

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -323,7 +323,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T18:19:51.000Z"
+      "updatedAt": "2026-09-12T13:17:35.000Z"
     },
     {
       "id": "gmail-trigger",
@@ -1215,7 +1215,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-11T19:32:45.000Z"
+      "updatedAt": "2026-09-12T11:45:18.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -295,9 +295,11 @@ When a user asks to declutter, clean up, or organize their email - start scannin
 
 ### Inbox Recon (run before cleanup passes)
 
-Before starting category-specific cleanup, understand the inbox:
+Before starting category-specific cleanup, understand the inbox.
 
-1. **Broad scan**: Run `bun run scripts/gmail-scan.ts sender-digest --query "in:inbox"` with `--max-senders 75`. This surfaces the top senders across ALL categories — not just promotions.
+**Never run more than one `gmail-scan.ts` command in the same turn.** Each scan already fans out authenticated Gmail requests. Parallel bash calls multiply that. Run the broad scan, then promotions, then the general-noise scan, one after another.
+
+1. **Broad scan**: Run `bun run scripts/gmail-scan.ts sender-digest --query "in:inbox"` with `--max-senders 75`. This surfaces the top senders across ALL categories, not just promotions.
 2. **Identify cleanup buckets**: Group the results mentally:
    - Newsletters/promotions (`hasUnsubscribe: true`) → handle in promotions pass
    - Mailing lists / automated forwards (group addresses like `devops@`, `alerts@`, `noreply@`) → handle in general noise pass

--- a/skills/gmail/scripts/gmail-scan.ts
+++ b/skills/gmail/scripts/gmail-scan.ts
@@ -200,7 +200,7 @@ async function senderDigest(args: Record<string, string | boolean>) {
   const account = optionalArg(args, "account");
 
   const allMessageIds: string[] = [];
-  const fetchPromises: Promise<GmailMessage[]>[] = [];
+  const messages: GmailMessage[] = [];
   const fetchAbort = new AbortController();
   let pageToken: string | undefined = inputPageToken;
   let truncated = false;
@@ -214,7 +214,7 @@ async function senderDigest(args: Record<string, string | boolean>) {
   }, TIME_BUDGET_MS);
 
   try {
-    // Pagination pipeline: list IDs and fire metadata fetches concurrently
+    // List one page, then fetch that page's metadata before listing the next.
     while (allMessageIds.length < maxMessages) {
       if (Date.now() - startTime > TIME_BUDGET_MS) {
         truncated = true;
@@ -258,17 +258,28 @@ async function senderDigest(args: Record<string, string | boolean>) {
 
       allMessageIds.push(...ids);
 
-      // Fire metadata fetch for this batch immediately (latency hiding)
-      fetchPromises.push(
-        batchFetchMessages(
+      try {
+        const pageMessages = await batchFetchMessages(
           ids,
           "metadata",
           metadataHeaders,
           account,
           fetchAbort.signal,
           "id,internalDate,payload/headers",
-        ),
-      );
+        );
+        messages.push(...pageMessages);
+      } catch (e) {
+        if (isRateLimitError(e)) {
+          rateLimited = true;
+          truncated = true;
+          break;
+        }
+        if (isAbortError(e)) {
+          truncated = true;
+          break;
+        }
+        throw e;
+      }
 
       pageToken = listResp.data.nextPageToken ?? undefined;
       if (!pageToken) break;
@@ -292,23 +303,7 @@ async function senderDigest(args: Record<string, string | boolean>) {
       return;
     }
 
-    // Settle all fetch promises — collect successes and tolerate 429/abort
-    const settled = await Promise.allSettled(fetchPromises);
     clearTimeout(deadlineTimer);
-
-    const messages: GmailMessage[] = [];
-    for (const result of settled) {
-      if (result.status === "fulfilled") {
-        messages.push(...result.value);
-      } else if (isRateLimitError(result.reason)) {
-        rateLimited = true;
-        truncated = true;
-      } else if (isAbortError(result.reason)) {
-        truncated = true;
-      } else {
-        throw result.reason;
-      }
-    }
 
     // Group by sender email
     const senderMap = new Map<string, SenderAggregation>();
@@ -462,7 +457,7 @@ async function outreachScan(args: Record<string, string | boolean>) {
   const query = `in:inbox -has:unsubscribe newer_than:${timeRange}`;
 
   const allMessageIds: string[] = [];
-  const fetchPromises: Promise<GmailMessage[]>[] = [];
+  const messages: GmailMessage[] = [];
   const fetchAbort = new AbortController();
   let pageToken: string | undefined = inputPageToken;
   let truncated = false;
@@ -476,7 +471,7 @@ async function outreachScan(args: Record<string, string | boolean>) {
   }, TIME_BUDGET_MS);
 
   try {
-    // Pagination pipeline: list IDs and fire metadata fetches concurrently
+    // List one page, then fetch that page's metadata before listing the next.
     while (allMessageIds.length < maxMessages) {
       if (Date.now() - startTime > TIME_BUDGET_MS) {
         truncated = true;
@@ -520,17 +515,28 @@ async function outreachScan(args: Record<string, string | boolean>) {
 
       allMessageIds.push(...ids);
 
-      // Fire metadata fetch for this batch immediately (latency hiding)
-      fetchPromises.push(
-        batchFetchMessages(
+      try {
+        const pageMessages = await batchFetchMessages(
           ids,
           "metadata",
           metadataHeaders,
           account,
           fetchAbort.signal,
           "id,internalDate,payload/headers",
-        ),
-      );
+        );
+        messages.push(...pageMessages);
+      } catch (e) {
+        if (isRateLimitError(e)) {
+          rateLimited = true;
+          truncated = true;
+          break;
+        }
+        if (isAbortError(e)) {
+          truncated = true;
+          break;
+        }
+        throw e;
+      }
 
       pageToken = listResp.data.nextPageToken ?? undefined;
       if (!pageToken) break;
@@ -551,23 +557,6 @@ async function outreachScan(args: Record<string, string | boolean>) {
         ...(truncated ? { truncated: true } : {}),
       });
       return;
-    }
-
-    // Settle all fetch promises — collect successes and tolerate 429/abort
-    const settled = await Promise.allSettled(fetchPromises);
-
-    const messages: GmailMessage[] = [];
-    for (const result of settled) {
-      if (result.status === "fulfilled") {
-        messages.push(...result.value);
-      } else if (isRateLimitError(result.reason)) {
-        rateLimited = true;
-        truncated = true;
-      } else if (isAbortError(result.reason)) {
-        truncated = true;
-      } else {
-        throw result.reason;
-      }
     }
 
     // Aggregate by sender
@@ -636,13 +625,13 @@ async function outreachScan(args: Record<string, string | boolean>) {
       .slice(0, maxSenders * 3);
 
     // Enrich with prior-reply signal: check if user has ever sent to each sender.
-    // Uses bounded concurrency (waves of 10) and AbortController for time budget.
+    // Uses bounded concurrency (waves of 4) and AbortController for time budget.
     //
     // Three-valued enrichment:
     //   true  = confirmed prior reply (enrichment succeeded, found replies)
     //   false = confirmed no prior reply (enrichment succeeded, no replies)
     //   null  = unknown (enrichment skipped — rate-limited or timed out)
-    const ENRICHMENT_CONCURRENCY = 10;
+    const ENRICHMENT_CONCURRENCY = 4;
     const priorReplyMap = new Map<string, boolean>();
 
     if (!rateLimited) {

--- a/skills/gmail/scripts/lib/gmail-client.test.ts
+++ b/skills/gmail/scripts/lib/gmail-client.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+
+import { gmailRequest } from "./gmail-client.ts";
+import { resetOauthRequestSlotForTests } from "./oauth-request-slot.ts";
+
+afterEach(() => {
+  resetOauthRequestSlotForTests();
+});
+
+function mockOauthProcess(onStart: () => void, onExit: () => void) {
+  const payload = JSON.stringify({
+    ok: true,
+    status: 200,
+    headers: {},
+    body: { id: "msg-1" },
+  });
+  const stdout = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(payload));
+      controller.close();
+    },
+  });
+  const stderr = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+  onStart();
+  return {
+    stdout,
+    stderr,
+    exited: (async () => {
+      await Bun.sleep(20);
+      onExit();
+      return 0;
+    })(),
+  } as ReturnType<typeof Bun.spawn>;
+}
+
+describe("gmailRequest oauth spawn cap", () => {
+  test("runs at most 4 assistant oauth request processes at a time", async () => {
+    let current = 0;
+    let peak = 0;
+    const spawn = spyOn(Bun, "spawn").mockImplementation((() =>
+      mockOauthProcess(
+        () => {
+          current += 1;
+          peak = Math.max(peak, current);
+        },
+        () => {
+          current -= 1;
+        },
+      )) as typeof Bun.spawn);
+
+    try {
+      await Promise.all(
+        Array.from({ length: 12 }, (_, i) =>
+          gmailRequest({ method: "GET", path: `/messages/${i}` }),
+        ),
+      );
+      expect(peak).toBe(4);
+      expect(current).toBe(0);
+      expect(spawn.mock.calls.length).toBe(12);
+    } finally {
+      spawn.mockRestore();
+    }
+  });
+});

--- a/skills/gmail/scripts/lib/gmail-client.ts
+++ b/skills/gmail/scripts/lib/gmail-client.ts
@@ -5,6 +5,11 @@
  * Uses `assistant oauth request` under the hood for portable OAuth.
  */
 
+import {
+  MAX_CONCURRENT_OAUTH_REQUESTS,
+  withOauthRequestSlot,
+} from "./oauth-request-slot.js";
+
 export interface GmailRequestOptions {
   method?: string;
   path: string;
@@ -61,7 +66,7 @@ const IDEMPOTENT_METHODS = new Set([
   "OPTIONS",
   "PATCH",
 ]);
-const BATCH_CONCURRENCY = 10;
+const BATCH_CONCURRENCY = MAX_CONCURRENT_OAUTH_REQUESTS;
 
 /**
  * Thrown when Gmail returns a 403 indicating the daily sending/read quota
@@ -130,22 +135,32 @@ export async function gmailRequest<T = unknown>(
     args.push(path);
     args.push("--json");
 
-    let proc: ReturnType<typeof Bun.spawn>;
-    try {
-      proc = Bun.spawn(args, {
-        windowsHide: true,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-    } catch (err) {
-      throw new Error(
-        `Failed to spawn assistant oauth request: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    const { stdout, stderr, exitCode } = await withOauthRequestSlot(
+      async () => {
+        let proc: ReturnType<typeof Bun.spawn>;
+        try {
+          proc = Bun.spawn(args, {
+            windowsHide: true,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+        } catch (err) {
+          throw new Error(
+            `Failed to spawn assistant oauth request: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
 
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
-    const exitCode = await proc.exited;
+        const [out, err] = await Promise.all([
+          new Response(proc.stdout).text(),
+          new Response(proc.stderr).text(),
+        ]);
+        return {
+          stdout: out,
+          stderr: err,
+          exitCode: await proc.exited,
+        };
+      },
+    );
 
     let result: {
       ok: boolean;
@@ -237,7 +252,7 @@ export async function gmailDelete(
 
 /**
  * Fetch multiple messages individually with bounded concurrency.
- * Processes messages in waves of BATCH_CONCURRENCY (10) at a time.
+ * Processes messages in waves of BATCH_CONCURRENCY at a time.
  * Supports AbortSignal for cancellation between waves.
  */
 export async function batchFetchMessages(

--- a/skills/gmail/scripts/lib/oauth-request-slot.test.ts
+++ b/skills/gmail/scripts/lib/oauth-request-slot.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  MAX_CONCURRENT_OAUTH_REQUESTS,
+  resetOauthRequestSlotForTests,
+  withOauthRequestSlot,
+} from "./oauth-request-slot.ts";
+
+afterEach(() => {
+  resetOauthRequestSlotForTests();
+});
+
+describe("withOauthRequestSlot", () => {
+  test("never admits more than MAX_CONCURRENT_OAUTH_REQUESTS holders", async () => {
+    let current = 0;
+    let peak = 0;
+
+    await Promise.all(
+      Array.from({ length: 20 }, async () => {
+        await withOauthRequestSlot(async () => {
+          current += 1;
+          peak = Math.max(peak, current);
+          await Bun.sleep(15);
+          current -= 1;
+        });
+      }),
+    );
+
+    expect(MAX_CONCURRENT_OAUTH_REQUESTS).toBe(4);
+    expect(peak).toBe(4);
+    expect(current).toBe(0);
+  });
+
+  test("releases the slot when the work throws", async () => {
+    await expect(
+      withOauthRequestSlot(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    let entered = false;
+    await withOauthRequestSlot(async () => {
+      entered = true;
+    });
+    expect(entered).toBe(true);
+  });
+});

--- a/skills/gmail/scripts/lib/oauth-request-slot.ts
+++ b/skills/gmail/scripts/lib/oauth-request-slot.ts
@@ -1,0 +1,49 @@
+/**
+ * Each `assistant oauth request` is a full CLI process (~80-130 MiB).
+ * Cap in-flight spawns so a scan cannot fan out enough children to OOM
+ * a 3 Gi cgroup.
+ */
+
+export const MAX_CONCURRENT_OAUTH_REQUESTS = 4;
+
+let inFlight = 0;
+const waiters: Array<() => void> = [];
+
+export async function acquireOauthRequestSlot(): Promise<void> {
+  if (inFlight < MAX_CONCURRENT_OAUTH_REQUESTS) {
+    inFlight += 1;
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    waiters.push(resolve);
+  });
+}
+
+export function releaseOauthRequestSlot(): void {
+  const next = waiters.shift();
+  if (next) {
+    next();
+    return;
+  }
+  inFlight -= 1;
+}
+
+export async function withOauthRequestSlot<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  await acquireOauthRequestSlot();
+  try {
+    return await fn();
+  } finally {
+    releaseOauthRequestSlot();
+  }
+}
+
+export function oauthRequestSlotsInFlight(): number {
+  return inFlight;
+}
+
+export function resetOauthRequestSlotForTests(): void {
+  inFlight = 0;
+  waiters.length = 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

CAS-091: managed instance `clear-ibis-qycy4l` OOM-killed twice on 2026-08-29 while auto-approved bash ran `gmail-scan.ts sender-digest`. Each Gmail API call from the skill is a full `assistant oauth request` CLI (~80-130 MiB). `batchFetchMessages` ran waves of 10, pages overlapped, and the model launched 2-3 scans in one turn. Snapshot at 04:44 showed 21 `src-index` children on a 3 Gi cgroup.

This PR bounds that fan-out in the Gmail skill:

- Process-wide semaphore: at most 4 in-flight `assistant oauth request` spawns
- `sender-digest` and `outreach-scan` fetch one page of metadata before listing the next
- SKILL.md: never run more than one `gmail-scan.ts` in the same turn

This does not raise the cgroup, add an approval mode, or materialize OAuth tokens into the skill. Parallel scans in separate bash processes still each get their own cap of 4. The skill text is the guard against that. A later PR can batch Gmail metadata fetches so scans stay fast under the cap.

## Test plan

- [x] `bun test skills/gmail/scripts/lib/oauth-request-slot.test.ts`
- [x] `bun test skills/gmail/scripts/lib/gmail-client.test.ts` (mocked `Bun.spawn`, 12 parallel requests, peak concurrency 4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d8ecbc9-5990-4a60-9bcd-4a1171ff6724?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d8ecbc9-5990-4a60-9bcd-4a1171ff6724&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

