### PR TITLE
feat(assistant): rehydrate platform ids from validate, not CES

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -211,7 +211,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "persistence/llm-request-log-source-clickhouse.ts", // ClickHouse read source — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped mirror reads
       "persistence/llm-request-log-sink-clickhouse.ts", // ClickHouse write sink — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped log writes
       "persistence/compaction-log-store-clickhouse.ts", // ClickHouse compaction log writer — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped event writes
-      "config/platform-identity.ts", // leftover vault fallback for platform assistant/org/user ids until hatch stops writing them
+      "config/platform-identity.ts", // in-memory platform ids, then vault copies of vellum:platform_*
       "config/platform-rehydration.ts", // startup rehydration of platform base URL from the credential store and ids from platform validate
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
       "workspace/migrations/018-rekey-compound-credential-keys.ts", // re-key compound credential storage keys

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -211,7 +211,8 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "persistence/llm-request-log-source-clickhouse.ts", // ClickHouse read source — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped mirror reads
       "persistence/llm-request-log-sink-clickhouse.ts", // ClickHouse write sink — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped log writes
       "persistence/compaction-log-store-clickhouse.ts", // ClickHouse compaction log writer — lazy lookup of clickhouse:url + clickhouse:password + vellum:platform_assistant_id for self-scoped event writes
-      "config/platform-rehydration.ts", // startup rehydration of platform base URL + IDs from credential store (daemon and schedule worker)
+      "config/platform-identity.ts", // leftover vault fallback for platform assistant/org/user ids until hatch stops writing them
+      "config/platform-rehydration.ts", // startup rehydration of platform base URL from the credential store and ids from platform validate
       "workspace/migrations/006-services-config.ts", // services config migration reads provider API keys
       "workspace/migrations/018-rekey-compound-credential-keys.ts", // re-key compound credential storage keys
       "daemon/conversation-process.ts", // masked provider key display

--- a/assistant/src/__tests__/platform-client-verify-credential.test.ts
+++ b/assistant/src/__tests__/platform-client-verify-credential.test.ts
@@ -19,7 +19,9 @@ mock.module("../providers/platform-proxy/context.js", () => ({
   }),
 }));
 
+const actualEnv = await import("../config/env.js");
 mock.module("../config/env.js", () => ({
+  ...actualEnv,
   getPlatformAssistantId: () => platformAssistantId,
 }));
 

--- a/assistant/src/config/__tests__/platform-identity.test.ts
+++ b/assistant/src/config/__tests__/platform-identity.test.ts
@@ -19,7 +19,10 @@ const USER_ID = "33333333-4444-4555-8666-777777777777";
 describe("fetchPlatformIdentityIds", () => {
   const originalFetch = globalThis.fetch;
   const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
-  let fetchImpl: typeof fetch = async () =>
+  let fetchImpl: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response> = async () =>
     new Response("not found", { status: 404 });
 
   beforeEach(() => {
@@ -32,7 +35,7 @@ describe("fetchPlatformIdentityIds", () => {
       const url = typeof input === "string" ? input : input.toString();
       fetchCalls.push({ url, init });
       return fetchImpl(input, init);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
   });
 
   afterEach(() => {

--- a/assistant/src/config/__tests__/platform-identity.test.ts
+++ b/assistant/src/config/__tests__/platform-identity.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  setPlatformAssistantId,
+  setPlatformOrganizationId,
+  setPlatformUserId,
+} from "../env.js";
+import {
+  fetchPlatformIdentityIds,
+  PLATFORM_IDENTITY_VALIDATE_PATH,
+  resolvePlatformAssistantId,
+} from "../platform-identity.js";
+
+const BASE_URL = "https://platform.vellum.ai";
+const ASSISTANT_ID = "11111111-2222-4333-8444-555555555555";
+const ORG_ID = "22222222-3333-4444-8555-666666666666";
+const USER_ID = "33333333-4444-4555-8666-777777777777";
+
+describe("fetchPlatformIdentityIds", () => {
+  const originalFetch = globalThis.fetch;
+  const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+  let fetchImpl: typeof fetch = async () =>
+    new Response("not found", { status: 404 });
+
+  beforeEach(() => {
+    fetchCalls.length = 0;
+    fetchImpl = async () => new Response("not found", { status: 404 });
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchCalls.push({ url, init });
+      return fetchImpl(input, init);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns the three ids from a successful validate response", async () => {
+    fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          assistant_id: ASSISTANT_ID,
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+          name: "Example Assistant",
+        }),
+        { status: 200 },
+      );
+
+    await expect(
+      fetchPlatformIdentityIds(BASE_URL, "assistant-key"),
+    ).resolves.toEqual({
+      assistantId: ASSISTANT_ID,
+      organizationId: ORG_ID,
+      userId: USER_ID,
+    });
+    expect(fetchCalls[0]?.url).toBe(
+      `${BASE_URL}${PLATFORM_IDENTITY_VALIDATE_PATH}`,
+    );
+    expect(fetchCalls[0]?.init?.method).toBe("POST");
+    const headers = new Headers(fetchCalls[0]?.init?.headers);
+    expect(headers.get("Authorization")).toBe("Api-Key assistant-key");
+  });
+
+  test("strips a trailing slash from the base URL", async () => {
+    fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          assistant_id: ASSISTANT_ID,
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+        }),
+        { status: 200 },
+      );
+
+    await fetchPlatformIdentityIds(`${BASE_URL}/`, "assistant-key");
+    expect(fetchCalls[0]?.url).toBe(
+      `${BASE_URL}${PLATFORM_IDENTITY_VALIDATE_PATH}`,
+    );
+  });
+
+  test("returns null on 401 without throwing", async () => {
+    fetchImpl = async () => new Response("no", { status: 401 });
+    await expect(
+      fetchPlatformIdentityIds(BASE_URL, "assistant-key"),
+    ).resolves.toBeNull();
+  });
+
+  test("returns null on a network error without throwing", async () => {
+    fetchImpl = async () => {
+      throw new Error("network down");
+    };
+    await expect(
+      fetchPlatformIdentityIds(BASE_URL, "assistant-key"),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("resolvePlatformAssistantId", () => {
+  afterEach(() => {
+    setPlatformAssistantId(undefined);
+    setPlatformOrganizationId(undefined);
+    setPlatformUserId(undefined);
+  });
+
+  test("returns the in-memory override", async () => {
+    setPlatformAssistantId(ASSISTANT_ID);
+    await expect(resolvePlatformAssistantId()).resolves.toBe(ASSISTANT_ID);
+  });
+});

--- a/assistant/src/config/__tests__/platform-rehydration.test.ts
+++ b/assistant/src/config/__tests__/platform-rehydration.test.ts
@@ -42,7 +42,10 @@ describe("rehydratePlatformCredentials", () => {
   const originalAssistantApiKeyEnv = process.env.ASSISTANT_API_KEY;
   const originalFetch = globalThis.fetch;
   const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
-  let fetchImpl: typeof fetch = async () =>
+  let fetchImpl: (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => Promise<Response> = async () =>
     new Response("not found", { status: 404 });
 
   beforeEach(() => {
@@ -57,7 +60,7 @@ describe("rehydratePlatformCredentials", () => {
       const url = typeof input === "string" ? input : input.toString();
       fetchCalls.push({ url, init });
       return fetchImpl(input, init);
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     // Env vars take precedence over the rehydrated overrides for some fields;
     // clear them so the credential-store values are what we observe.
     delete process.env.VELLUM_PLATFORM_URL;

--- a/assistant/src/config/__tests__/platform-rehydration.test.ts
+++ b/assistant/src/config/__tests__/platform-rehydration.test.ts
@@ -39,15 +39,31 @@ describe("rehydratePlatformCredentials", () => {
   const originalPlatformUrlEnv = process.env.VELLUM_PLATFORM_URL;
   const originalOrgEnv = process.env.PLATFORM_ORGANIZATION_ID;
   const originalUserEnv = process.env.PLATFORM_USER_ID;
+  const originalAssistantApiKeyEnv = process.env.ASSISTANT_API_KEY;
+  const originalFetch = globalThis.fetch;
+  const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+  let fetchImpl: typeof fetch = async () =>
+    new Response("not found", { status: 404 });
 
   beforeEach(() => {
     mockSecureKeys = {};
     throwForKey = undefined;
+    fetchCalls.length = 0;
+    fetchImpl = async () => new Response("not found", { status: 404 });
+    globalThis.fetch = (async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchCalls.push({ url, init });
+      return fetchImpl(input, init);
+    }) as typeof fetch;
     // Env vars take precedence over the rehydrated overrides for some fields;
     // clear them so the credential-store values are what we observe.
     delete process.env.VELLUM_PLATFORM_URL;
     delete process.env.PLATFORM_ORGANIZATION_ID;
     delete process.env.PLATFORM_USER_ID;
+    delete process.env.ASSISTANT_API_KEY;
     // Reset in-memory overrides between tests.
     setPlatformBaseUrl(undefined);
     setPlatformAssistantId(undefined);
@@ -56,6 +72,7 @@ describe("rehydratePlatformCredentials", () => {
   });
 
   afterEach(() => {
+    globalThis.fetch = originalFetch;
     if (originalPlatformUrlEnv === undefined) {
       delete process.env.VELLUM_PLATFORM_URL;
     } else {
@@ -70,6 +87,11 @@ describe("rehydratePlatformCredentials", () => {
       delete process.env.PLATFORM_USER_ID;
     } else {
       process.env.PLATFORM_USER_ID = originalUserEnv;
+    }
+    if (originalAssistantApiKeyEnv === undefined) {
+      delete process.env.ASSISTANT_API_KEY;
+    } else {
+      process.env.ASSISTANT_API_KEY = originalAssistantApiKeyEnv;
     }
     setPlatformBaseUrl(undefined);
     setPlatformAssistantId(undefined);
@@ -121,5 +143,73 @@ describe("rehydratePlatformCredentials", () => {
     await rehydratePlatformCredentials();
 
     expect(getPlatformAssistantId()).toBe(ASSISTANT_ID);
+  });
+
+  test("trades the assistant API key for ids via platform validate", async () => {
+    mockSecureKeys[credentialKey("vellum", "platform_base_url")] = PROD_URL;
+    mockSecureKeys[credentialKey("vellum", "assistant_api_key")] =
+      "assistant-key";
+    fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          assistant_id: ASSISTANT_ID,
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+        }),
+        { status: 200 },
+      );
+
+    await rehydratePlatformCredentials();
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.url).toBe(
+      `${PROD_URL}/v1/internal/assistants/validate/`,
+    );
+    const headers = new Headers(fetchCalls[0]?.init?.headers);
+    expect(headers.get("Authorization")).toBe("Api-Key assistant-key");
+    expect(getPlatformAssistantId()).toBe(ASSISTANT_ID);
+    expect(getPlatformOrganizationId()).toBe(ORG_ID);
+    expect(getPlatformUserId()).toBe(USER_ID);
+  });
+
+  test("validate ids win over vault leftovers", async () => {
+    mockSecureKeys[credentialKey("vellum", "platform_base_url")] = PROD_URL;
+    mockSecureKeys[credentialKey("vellum", "assistant_api_key")] =
+      "assistant-key";
+    mockSecureKeys[credentialKey("vellum", "platform_assistant_id")] =
+      "asst-from-vault";
+    fetchImpl = async () =>
+      new Response(
+        JSON.stringify({
+          assistant_id: ASSISTANT_ID,
+          organization_id: ORG_ID,
+          user_id: USER_ID,
+        }),
+        { status: 200 },
+      );
+
+    await rehydratePlatformCredentials();
+
+    expect(getPlatformAssistantId()).toBe(ASSISTANT_ID);
+  });
+
+  test("falls back to the credential store when validate is unreachable", async () => {
+    mockSecureKeys[credentialKey("vellum", "platform_base_url")] = PROD_URL;
+    mockSecureKeys[credentialKey("vellum", "assistant_api_key")] =
+      "assistant-key";
+    mockSecureKeys[credentialKey("vellum", "platform_assistant_id")] =
+      ASSISTANT_ID;
+    mockSecureKeys[credentialKey("vellum", "platform_organization_id")] =
+      ORG_ID;
+    mockSecureKeys[credentialKey("vellum", "platform_user_id")] = USER_ID;
+    fetchImpl = async () => {
+      throw new Error("network down");
+    };
+
+    await rehydratePlatformCredentials();
+
+    expect(getPlatformAssistantId()).toBe(ASSISTANT_ID);
+    expect(getPlatformOrganizationId()).toBe(ORG_ID);
+    expect(getPlatformUserId()).toBe(USER_ID);
   });
 });

--- a/assistant/src/config/env.ts
+++ b/assistant/src/config/env.ts
@@ -229,8 +229,8 @@ export function setPlatformAssistantId(value: string | undefined): void {
  * Platform assistant ID — UUID of this assistant on the platform.
  *
  * Resolved from the in-memory override (populated by providers-setup
- * rehydration from the credential store at daemon startup, or by
- * secret-routes when the platform pushes the value).
+ * rehydration via platform validate, or by secret-routes when the
+ * platform pushes the value).
  */
 export function getPlatformAssistantId(): string {
   return _platformAssistantIdOverride ?? "";

--- a/assistant/src/config/platform-identity.ts
+++ b/assistant/src/config/platform-identity.ts
@@ -1,0 +1,144 @@
+/**
+ * Bound platform identity (assistant, organization, user).
+ *
+ * Django maps an assistant API key to these ids via
+ * `POST /v1/internal/assistants/validate/`. Process startup rehydrates from
+ * that endpoint. Vault leftovers (`vellum:platform_*`) are a last-resort
+ * fallback until hatch stops writing them.
+ */
+
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+import {
+  getPlatformAssistantId,
+  getPlatformOrganizationId,
+  getPlatformUserId,
+  setPlatformAssistantId,
+  setPlatformOrganizationId,
+  setPlatformUserId,
+} from "./env.js";
+
+const log = getLogger("platform-identity");
+
+export const PLATFORM_IDENTITY_VALIDATE_PATH =
+  "/v1/internal/assistants/validate/";
+
+const VALIDATE_TIMEOUT_MS = 5_000;
+
+export type PlatformIdentityIds = {
+  assistantId: string;
+  organizationId: string;
+  userId: string;
+};
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function applyPlatformIdentityIds(ids: PlatformIdentityIds): void {
+  if (ids.assistantId) {
+    setPlatformAssistantId(ids.assistantId);
+  }
+  if (ids.organizationId) {
+    setPlatformOrganizationId(ids.organizationId);
+  }
+  if (ids.userId) {
+    setPlatformUserId(ids.userId);
+  }
+}
+
+/**
+ * Trade an assistant API key for the bound platform ids.
+ *
+ * Returns null when the platform is unreachable, refuses the key, or the
+ * body has no ids. Never throws.
+ */
+export async function fetchPlatformIdentityIds(
+  baseUrl: string,
+  apiKey: string,
+): Promise<PlatformIdentityIds | null> {
+  const url = `${baseUrl.replace(/\/+$/, "")}${PLATFORM_IDENTITY_VALIDATE_PATH}`;
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Api-Key ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+      signal: AbortSignal.timeout(VALIDATE_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      log.warn(
+        { status: res.status },
+        "platform identity validate returned non-2xx",
+      );
+      return null;
+    }
+    const body: unknown = await res.json();
+    if (!body || typeof body !== "object") {
+      return null;
+    }
+    const obj = body as Record<string, unknown>;
+    const assistantId = asNonEmptyString(obj.assistant_id);
+    const organizationId = asNonEmptyString(obj.organization_id);
+    const userId = asNonEmptyString(obj.user_id);
+    if (!assistantId && !organizationId && !userId) {
+      return null;
+    }
+    return {
+      assistantId: assistantId ?? "",
+      organizationId: organizationId ?? "",
+      userId: userId ?? "",
+    };
+  } catch (err) {
+    log.warn({ err }, "platform identity validate failed");
+    return null;
+  }
+}
+
+async function readVaultField(field: string): Promise<string> {
+  try {
+    return (
+      (await getSecureKeyAsync(credentialKey("vellum", field)))?.trim() ?? ""
+    );
+  } catch (err) {
+    log.warn(
+      { err, field },
+      "failed to read platform identity from credential store",
+    );
+    return "";
+  }
+}
+
+export async function resolvePlatformAssistantId(): Promise<string> {
+  return (
+    getPlatformAssistantId().trim() ||
+    (await readVaultField("platform_assistant_id"))
+  );
+}
+
+export async function resolvePlatformAssistantIdOrNull(): Promise<
+  string | null
+> {
+  const id = await resolvePlatformAssistantId();
+  return id || null;
+}
+
+export async function resolvePlatformOrganizationId(): Promise<string> {
+  return (
+    getPlatformOrganizationId().trim() ||
+    (await readVaultField("platform_organization_id"))
+  );
+}
+
+export async function resolvePlatformUserId(): Promise<string> {
+  return (
+    getPlatformUserId().trim() || (await readVaultField("platform_user_id"))
+  );
+}

--- a/assistant/src/config/platform-identity.ts
+++ b/assistant/src/config/platform-identity.ts
@@ -3,8 +3,8 @@
  *
  * Django maps an assistant API key to these ids via
  * `POST /v1/internal/assistants/validate/`. Process startup rehydrates from
- * that endpoint. Vault leftovers (`vellum:platform_*`) are a last-resort
- * fallback until hatch stops writing them.
+ * that endpoint. Resolution prefers the in-memory ids, then the vault
+ * copies of `vellum:platform_*`.
  */
 
 import { credentialKey } from "../security/credential-key.js";

--- a/assistant/src/config/platform-rehydration.ts
+++ b/assistant/src/config/platform-rehydration.ts
@@ -1,6 +1,5 @@
 /**
- * Rehydrate the in-memory platform identity/URL overrides from the credential
- * store at process startup.
+ * Rehydrate the in-memory platform identity/URL overrides at process startup.
  *
  * These overrides (`setPlatformBaseUrl` and the platform ID setters in
  * `config/env.ts`) are normally only populated at runtime by the secret-routes
@@ -10,6 +9,11 @@
  * environment default (e.g. dev-platform) while the credential store holds the
  * real production values, and requests are sent to the wrong environment.
  *
+ * Bound platform ids come from `POST /v1/internal/assistants/validate/`,
+ * which trades the assistant API key for assistant/organization/user ids.
+ * Vault leftovers for those three fields are a last-resort fallback so a
+ * validate outage does not drop identity on existing installs.
+ *
  * Each field is best-effort: a credential-store read failure is logged and
  * skipped so a single missing value never blocks startup.
  */
@@ -17,11 +21,19 @@ import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
 import {
+  getPlatformAssistantId,
+  getPlatformBaseUrl,
+  getPlatformOrganizationId,
+  getPlatformUserId,
   setPlatformAssistantId,
   setPlatformBaseUrl,
   setPlatformOrganizationId,
   setPlatformUserId,
 } from "./env.js";
+import {
+  applyPlatformIdentityIds,
+  fetchPlatformIdentityIds,
+} from "./platform-identity.js";
 
 const log = getLogger("platform-rehydration");
 
@@ -45,32 +57,75 @@ async function rehydrateField(
   }
 }
 
+async function readAssistantApiKey(): Promise<string> {
+  try {
+    const stored = (
+      await getSecureKeyAsync(credentialKey("vellum", "assistant_api_key"))
+    )?.trim();
+    if (stored) {
+      return stored;
+    }
+  } catch (err) {
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "Failed to read assistant API key from credential store (non-fatal)",
+    );
+  }
+  return process.env.ASSISTANT_API_KEY?.trim() ?? "";
+}
+
+async function rehydrateIdentityFromValidate(): Promise<boolean> {
+  const apiKey = await readAssistantApiKey();
+  if (!apiKey) {
+    return false;
+  }
+  const baseUrl = getPlatformBaseUrl();
+  if (!baseUrl) {
+    return false;
+  }
+  const ids = await fetchPlatformIdentityIds(baseUrl, apiKey);
+  if (!ids) {
+    return false;
+  }
+  applyPlatformIdentityIds(ids);
+  log.info("Rehydrated platform identity from platform validate");
+  return true;
+}
+
 /**
  * Rehydrate the platform base URL and the related platform IDs (assistant,
- * organization, user) from the credential store into their in-memory
- * overrides. Safe to call more than once.
+ * organization, user). Safe to call more than once.
  */
 export async function rehydratePlatformCredentials(): Promise<void> {
-  // Base URL first so managed proxy activation resolves the correct
-  // environment for the ID lookups and every request that follows.
+  // Base URL first so managed proxy activation and identity validate resolve
+  // the correct environment for every request that follows.
   await rehydrateField(
     "platform_base_url",
     setPlatformBaseUrl,
     "platform base URL",
   );
-  await rehydrateField(
-    "platform_assistant_id",
-    setPlatformAssistantId,
-    "platform assistant ID",
-  );
-  await rehydrateField(
-    "platform_organization_id",
-    setPlatformOrganizationId,
-    "platform organization ID",
-  );
-  await rehydrateField(
-    "platform_user_id",
-    setPlatformUserId,
-    "platform user ID",
-  );
+
+  await rehydrateIdentityFromValidate();
+
+  if (!getPlatformAssistantId()) {
+    await rehydrateField(
+      "platform_assistant_id",
+      setPlatformAssistantId,
+      "platform assistant ID",
+    );
+  }
+  if (!getPlatformOrganizationId()) {
+    await rehydrateField(
+      "platform_organization_id",
+      setPlatformOrganizationId,
+      "platform organization ID",
+    );
+  }
+  if (!getPlatformUserId()) {
+    await rehydrateField(
+      "platform_user_id",
+      setPlatformUserId,
+      "platform user ID",
+    );
+  }
 }

--- a/assistant/src/config/platform-rehydration.ts
+++ b/assistant/src/config/platform-rehydration.ts
@@ -11,8 +11,7 @@
  *
  * Bound platform ids come from `POST /v1/internal/assistants/validate/`,
  * which trades the assistant API key for assistant/organization/user ids.
- * Vault leftovers for those three fields are a last-resort fallback so a
- * validate outage does not drop identity on existing installs.
+ * If validate omits an id, that field is read from the credential store.
  *
  * Each field is best-effort: a credential-store read failure is logged and
  * skipped so a single missing value never blocks startup.

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -18,7 +18,8 @@
  * the platform can register a route that points at this instance.
  */
 
-import { getPlatformAssistantId, getPlatformBaseUrl } from "../config/env.js";
+import { getPlatformBaseUrl } from "../config/env.js";
+import { resolvePlatformAssistantId } from "../config/platform-identity.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { ipcRegisterWebhookRoute } from "../ipc/gateway-client.js";
@@ -45,11 +46,11 @@ export interface PlatformCallbackRegistrationContext {
 
 export async function resolvePlatformCallbackRegistrationContext(): Promise<PlatformCallbackRegistrationContext> {
   const platform = getIsPlatform();
-  const [storedBaseUrlRaw, storedAssistantIdRaw, storedAssistantApiKeyRaw] =
+  const [storedBaseUrlRaw, storedAssistantApiKeyRaw, assistantId] =
     await Promise.all([
       getSecureKeyAsync(credentialKey("vellum", "platform_base_url")),
-      getSecureKeyAsync(credentialKey("vellum", "platform_assistant_id")),
       getSecureKeyAsync(credentialKey("vellum", "assistant_api_key")),
+      resolvePlatformAssistantId(),
     ]);
 
   const storedBaseUrl = storedBaseUrlRaw?.trim();
@@ -57,8 +58,6 @@ export async function resolvePlatformCallbackRegistrationContext(): Promise<Plat
     /\/+$/,
     "",
   );
-  const assistantId =
-    getPlatformAssistantId().trim() || storedAssistantIdRaw?.trim() || "";
   const envAssistantCredential = process.env.ASSISTANT_API_KEY?.trim();
   const assistantCredential =
     storedAssistantApiKeyRaw?.trim() || envAssistantCredential || undefined;

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -19,9 +19,9 @@
  */
 
 import { getPlatformBaseUrl } from "../config/env.js";
-import { resolvePlatformAssistantId } from "../config/platform-identity.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
+import { resolvePlatformAssistantId } from "../config/platform-identity.js";
 import { ipcRegisterWebhookRoute } from "../ipc/gateway-client.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";

--- a/assistant/src/persistence/compaction-log-store-clickhouse.ts
+++ b/assistant/src/persistence/compaction-log-store-clickhouse.ts
@@ -25,8 +25,8 @@
  * on first write so opting in requires no out-of-band DDL.
  */
 import type { AgentEvent } from "../agent/loop.js";
-import { resolvePlatformAssistantIdOrNull } from "../config/platform-identity.js";
 import { getConfig } from "../config/loader.js";
+import { resolvePlatformAssistantIdOrNull } from "../config/platform-identity.js";
 import type { CompactionLogsClickHouseConfig } from "../config/schemas/compaction-logs.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";

--- a/assistant/src/persistence/compaction-log-store-clickhouse.ts
+++ b/assistant/src/persistence/compaction-log-store-clickhouse.ts
@@ -25,6 +25,7 @@
  * on first write so opting in requires no out-of-band DDL.
  */
 import type { AgentEvent } from "../agent/loop.js";
+import { resolvePlatformAssistantIdOrNull } from "../config/platform-identity.js";
 import { getConfig } from "../config/loader.js";
 import type { CompactionLogsClickHouseConfig } from "../config/schemas/compaction-logs.js";
 import { credentialKey } from "../security/credential-key.js";
@@ -136,7 +137,7 @@ export interface ClickHouseCompactionLogStoreDeps {
   resolveUrl?: () => Promise<string | null>;
   /** Override the credential read for `clickhouse:password`. */
   resolvePassword?: () => Promise<string | null>;
-  /** Override the credential read for `vellum:platform_assistant_id`. */
+  /** Override the platform assistant id (in-memory identity, then vault). */
   resolveAssistantId?: () => Promise<string | null>;
   /** Override fetch for testing. */
   fetchImpl?: CompactionLogFetch;
@@ -163,8 +164,7 @@ export class ClickHouseCompactionLogStore {
       deps.resolvePassword ??
       (() => readCredentialOrNull("clickhouse", "password"));
     this.resolveAssistantId =
-      deps.resolveAssistantId ??
-      (() => readCredentialOrNull("vellum", "platform_assistant_id"));
+      deps.resolveAssistantId ?? resolvePlatformAssistantIdOrNull;
     this.fetchImpl = deps.fetchImpl ?? globalThis.fetch.bind(globalThis);
   }
 

--- a/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
@@ -29,8 +29,8 @@
  * Writes are best-effort: a ClickHouse outage logs and is swallowed so it
  * can never abort a turn.
  */
-import { resolvePlatformAssistantIdOrNull } from "../config/platform-identity.js";
 import { getConfigReadOnly } from "../config/loader.js";
+import { resolvePlatformAssistantIdOrNull } from "../config/platform-identity.js";
 import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-request-logs.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";

--- a/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-sink-clickhouse.ts
@@ -29,6 +29,7 @@
  * Writes are best-effort: a ClickHouse outage logs and is swallowed so it
  * can never abort a turn.
  */
+import { resolvePlatformAssistantIdOrNull } from "../config/platform-identity.js";
 import { getConfigReadOnly } from "../config/loader.js";
 import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-request-logs.js";
 import { credentialKey } from "../security/credential-key.js";
@@ -71,7 +72,7 @@ export interface ClickHouseLlmRequestLogSinkDeps {
   resolveUrl?: () => Promise<string | null>;
   /** Override the credential read for `clickhouse:password`. */
   resolvePassword?: () => Promise<string | null>;
-  /** Override the credential read for `vellum:platform_assistant_id`. */
+  /** Override the platform assistant id (in-memory identity, then vault). */
   resolveAssistantId?: () => Promise<string | null>;
   /** Override fetch for testing. */
   fetchImpl?: ClickHouseSinkFetch;
@@ -98,8 +99,7 @@ export class ClickHouseLlmRequestLogSink implements LlmRequestLogWriter {
       deps.resolvePassword ??
       (() => readCredentialOrNull("clickhouse", "password"));
     this.resolveAssistantId =
-      deps.resolveAssistantId ??
-      (() => readCredentialOrNull("vellum", "platform_assistant_id"));
+      deps.resolveAssistantId ?? resolvePlatformAssistantIdOrNull;
     this.fetchImpl = deps.fetchImpl ?? globalThis.fetch.bind(globalThis);
   }
 

--- a/assistant/src/persistence/llm-request-log-source-clickhouse.ts
+++ b/assistant/src/persistence/llm-request-log-source-clickhouse.ts
@@ -15,6 +15,7 @@
  * than the local source. Acceptable for the "internal use while we
  * finetune prompts" use case; revisit when mirror updates are added.
  */
+import { resolvePlatformAssistantIdOrNull } from "../config/platform-identity.js";
 import type { LlmRequestLogsClickHouseConfig } from "../config/schemas/llm-request-logs.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
@@ -104,7 +105,7 @@ export interface ClickHouseLlmRequestLogSourceDeps {
   resolveUrl?: () => Promise<string | null>;
   /** Override the credential read for `clickhouse:password`. */
   resolvePassword?: () => Promise<string | null>;
-  /** Override the credential read for `vellum:platform_assistant_id`. */
+  /** Override the platform assistant id (in-memory identity, then vault). */
   resolveAssistantId?: () => Promise<string | null>;
   /** Override the turn-id resolver (default: `getAssistantMessageIdsInTurn`). */
   resolveTurnMessageIds?: (messageId: string) => string[];
@@ -138,8 +139,7 @@ export class ClickHouseLlmRequestLogSource implements LlmRequestLogSource {
       deps.resolvePassword ??
       (() => readCredentialOrNull("clickhouse", "password"));
     this.resolveAssistantId =
-      deps.resolveAssistantId ??
-      (() => readCredentialOrNull("vellum", "platform_assistant_id"));
+      deps.resolveAssistantId ?? resolvePlatformAssistantIdOrNull;
     this.resolveTurnMessageIds =
       deps.resolveTurnMessageIds ?? getAssistantMessageIdsInTurn;
     this.resolveMessage = deps.resolveMessage ?? getMessageById;

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -24,7 +24,9 @@ mock.module("../providers/platform-proxy/context.js", () => ({
   resolveManagedProxyContext: () => mockResolveManagedProxyContext(),
 }));
 
+const actualEnv = await import("../config/env.js");
 mock.module("../config/env.js", () => ({
+  ...actualEnv,
   getPlatformAssistantId: () => mockAssistantId,
 }));
 

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -7,7 +7,7 @@
 
 import type { PlatformCredentialVerificationStatus } from "@vellumai/service-contracts/platform-credential";
 
-import { getPlatformAssistantId } from "../config/env.js";
+import { resolvePlatformAssistantId } from "../config/platform-identity.js";
 import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
@@ -63,7 +63,7 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
 
   let baseUrl = ctx.enabled ? ctx.platformBaseUrl : "";
   let apiKey = ctx.enabled ? ctx.assistantApiKey : "";
-  let assistantId = getPlatformAssistantId();
+  const assistantId = await resolvePlatformAssistantId();
 
   // Fall back to credential store for values not yet rehydrated (standalone CLI).
   if (!baseUrl) {
@@ -75,14 +75,6 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
     apiKey =
       (await getSecureKeyAsync(credentialKey("vellum", "assistant_api_key"))) ??
       "";
-  }
-  if (!assistantId) {
-    assistantId =
-      (
-        await getSecureKeyAsync(
-          credentialKey("vellum", "platform_assistant_id"),
-        )
-      )?.trim() ?? "";
   }
 
   if (!baseUrl || !apiKey) {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -22,7 +22,7 @@ import { PassThrough, Readable } from "node:stream";
 
 import { z } from "zod";
 
-import { getPlatformAssistantId } from "../../config/env.js";
+import { resolvePlatformAssistantId } from "../../config/platform-identity.js";
 import { invalidateConfigCache } from "../../config/loader.js";
 import { getAssistantName } from "../../daemon/identity-helpers.js";
 import { runAsyncSqlite } from "../../persistence/db-async-query.js";
@@ -236,28 +236,15 @@ interface ExportManifestInputs {
 /**
  * Resolve the `assistant.id` for an export.
  *
- * Mirrors `platform/client.ts`'s precedence: in-memory override (set at
- * daemon startup or by secret-routes) → credential store → daemon-internal
- * fallback. The schema requires `id` to be non-empty, so we fall back to
+ * In-memory identity (validate rehydration or secret-routes) first, then
+ * a vault leftover until hatch stops writing `platform_assistant_id`.
+ * The schema requires `id` to be non-empty, so we fall back to
  * `DAEMON_INTERNAL_ASSISTANT_ID` rather than the empty string.
  */
 async function resolveAssistantId(): Promise<string> {
-  const inMemory = getPlatformAssistantId();
-  if (inMemory) {
-    return inMemory;
-  }
-  try {
-    const stored = await getSecureKeyAsync(
-      credentialKey("vellum", "platform_assistant_id"),
-    );
-    if (stored) {
-      return stored;
-    }
-  } catch (err) {
-    log.warn(
-      { err },
-      "Failed to read platform_assistant_id from credential store; falling back to daemon-internal id",
-    );
+  const resolved = await resolvePlatformAssistantId();
+  if (resolved) {
+    return resolved;
   }
   return DAEMON_INTERNAL_ASSISTANT_ID;
 }

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -22,8 +22,8 @@ import { PassThrough, Readable } from "node:stream";
 
 import { z } from "zod";
 
-import { resolvePlatformAssistantId } from "../../config/platform-identity.js";
 import { invalidateConfigCache } from "../../config/loader.js";
+import { resolvePlatformAssistantId } from "../../config/platform-identity.js";
 import { getAssistantName } from "../../daemon/identity-helpers.js";
 import { runAsyncSqlite } from "../../persistence/db-async-query.js";
 import {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -237,9 +237,9 @@ interface ExportManifestInputs {
  * Resolve the `assistant.id` for an export.
  *
  * In-memory identity (validate rehydration or secret-routes) first, then
- * a vault leftover until hatch stops writing `platform_assistant_id`.
- * The schema requires `id` to be non-empty, so we fall back to
- * `DAEMON_INTERNAL_ASSISTANT_ID` rather than the empty string.
+ * the vault copy of `platform_assistant_id`. The schema requires `id` to be
+ * non-empty, so we fall back to `DAEMON_INTERNAL_ASSISTANT_ID` rather than
+ * the empty string.
  */
 async function resolveAssistantId(): Promise<string> {
   const resolved = await resolvePlatformAssistantId();

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -39,7 +39,17 @@ import {
 } from "@vellumai/service-contracts/platform-credential";
 import { z } from "zod";
 
+import {
+  setPlatformAssistantId,
+  setPlatformBaseUrl,
+  setPlatformOrganizationId,
+  setPlatformUserId,
+} from "../../config/env.js";
 import { isPlatformRemote } from "../../config/env-registry.js";
+import {
+  resolvePlatformOrganizationId,
+  resolvePlatformUserId,
+} from "../../config/platform-identity.js";
 import {
   registerCallbackRoute,
   resolvePlatformCallbackRegistrationContext,
@@ -289,24 +299,12 @@ async function handlePlatformStatus(
 ): Promise<PlatformStatusResponse> {
   const context = await resolvePlatformCallbackRegistrationContext();
 
-  const [orgIdRaw, userIdRaw, webhookSecretRaw] = await Promise.all([
-    getSecureKeyAsync(
-      credentialKey(
-        CREDENTIAL_KEYS.organizationId.service,
-        CREDENTIAL_KEYS.organizationId.field,
-      ),
-    ),
-    getSecureKeyAsync(
-      credentialKey(
-        CREDENTIAL_KEYS.userId.service,
-        CREDENTIAL_KEYS.userId.field,
-      ),
-    ),
+  const [organizationId, userId, webhookSecretRaw] = await Promise.all([
+    resolvePlatformOrganizationId(),
+    resolvePlatformUserId(),
     getSecureKeyAsync(credentialKey("vellum", "webhook_secret")),
   ]);
 
-  const organizationId = orgIdRaw?.trim() ?? "";
-  const userId = userIdRaw?.trim() ?? "";
   const hasWebhookSecret = !!webhookSecretRaw;
 
   return {
@@ -466,6 +464,11 @@ async function handlePlatformDisconnect(
       `Failed to delete credentials: ${failedKeys.join("; ")}`,
     );
   }
+
+  setPlatformBaseUrl(undefined);
+  setPlatformAssistantId(undefined);
+  setPlatformOrganizationId(undefined);
+  setPlatformUserId(undefined);
 
   // Notify connected clients
   broadcastMessage({ type: "platform_disconnected" });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Closed https://github.com/vellum-ai/vellum-assistant/pull/42532. That PR added a gateway `GET /v1/whoami` still backed by CES. The identity API already lives on the platform:

`POST /v1/internal/assistants/validate/` (Django `AssistantIdentityValidationView`). Auth is `Authorization: Api-Key <assistant_api_key>`. Response includes `assistant_id`, `organization_id`, and `user_id`.

This PR cuts the assistant over to that endpoint:

- Startup rehydration trades `vellum:assistant_api_key` (or `ASSISTANT_API_KEY`) plus `platform_base_url` for the three ids.
- Assistant-side CES reads of `vellum:platform_assistant_id`, `vellum:platform_organization_id`, and `vellum:platform_user_id` go through `resolvePlatform*` (in-memory first, vault leftover last).
- Vault leftovers stay as a last-resort fallback so a validate outage does not drop identity on existing installs.

Not in this PR:

- No gateway whoami.
- Hatch/Django still write the three identity fields into CES. Stopping those writes is a later platform PR.
- Gateway edge-auth still reads CES `platform_user_id`.

## Test plan

- `cd assistant && bun test src/config/__tests__/platform-identity.test.ts`
- `cd assistant && bun test src/config/__tests__/platform-rehydration.test.ts`
- `cd assistant && bun test src/platform/client.test.ts`
- `cd assistant && bun test src/__tests__/platform-client-verify-credential.test.ts`
- `cd assistant && bun test src/__tests__/platform-callback-registration.test.ts`
- `cd assistant && bun test src/__tests__/llm-request-log-source-clickhouse.test.ts`
- `cd assistant && bun test src/__tests__/credential-security-invariants.test.ts`

## CLI verb checklist

- No new IPC route. Reuses existing platform rehydration and existing consumers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e7b8efd-9a9e-419e-a6cf-484133b96d98?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e7b8efd-9a9e-419e-a6cf-484133b96d98&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

